### PR TITLE
Protocol identification heuristics.

### DIFF
--- a/src/analyzer/Manager.cc
+++ b/src/analyzer/Manager.cc
@@ -401,6 +401,14 @@ bool Manager::BuildInitialAnalyzerTree(Connection* conn)
 			{
 			int resp_port = ntohs(conn->RespPort());
 			tag_set* ports = LookupPort(conn->ConnTransport(), resp_port, false);
+			if ( ! ports )
+				{
+				int orig_port = ntohs(conn->OrigPort());
+				if ( orig_port < resp_port )
+					{
+						ports = LookupPort(conn->ConnTransport(), orig_port, false);
+					}
+				}
 
 			if ( ports )
 				{


### PR DESCRIPTION
In case request is missing and Bro sees only response, it will use only destination port of response for analyzer lookup, which is incorrect in this case.

This attempts to solve that problem, by allowing Bro to use the packet origin port for lookup of relevant analyzers under certain circumstances (analyzer for destination port, which is higher than origin port, has not been found).

It might make sense to limit this to UDP only.
