### PR TITLE
BloomFilter.cc fix to Clear()

### DIFF
--- a/src/probabilistic/BloomFilter.cc
+++ b/src/probabilistic/BloomFilter.cc
@@ -72,7 +72,7 @@ bool BasicBloomFilter::Empty() const
 
 void BasicBloomFilter::Clear()
 	{
-	bits->Clear();
+	bits->Reset();
 	}
 
 bool BasicBloomFilter::Merge(const BloomFilter* other)
@@ -190,7 +190,7 @@ bool CountingBloomFilter::Empty() const
 
 void CountingBloomFilter::Clear()
 	{
-	cells->Clear();
+	cells->Reset();
 	}
 
 bool CountingBloomFilter::Merge(const BloomFilter* other)


### PR DESCRIPTION
Previously, calls the BitVector->Clear() function, which deallocates all the bits.  This change makes it so Clear resets all bits to zero, as the documentation says it should.
