### PR TITLE
Intel::ADDR indicators in http host field

### DIFF
--- a/scripts/policy/frameworks/intel/seen/http-headers.bro
+++ b/scripts/policy/frameworks/intel/seen/http-headers.bro
@@ -21,7 +21,6 @@ event http_header(c: connection, is_orig: bool, name: string, value: string)
                                                      $where=HTTP::IN_HOST_HEADER]);
                         break;
 
-
 			case "REFERER":
 			Intel::seen([$indicator=sub(value, /^.*:\/\//, ""),
 			             $indicator_type=Intel::URL,


### PR DESCRIPTION
After reviewing the http logs for our Bro deployment, I noticed many instances where the host field contains an IP address. We track a lot of IP addresses as intel indicators and have seen them appear as domains in past incidents... this change does an IP check on the host field value and, if it passes, looks for the value in Intel::ADDR.
