### PR TITLE
Do not repeat hex-code of decoded quoted-printable.

### DIFF
--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -1044,6 +1044,7 @@ void MIME_Entity::DecodeQuotedPrintable(int len, const char* data)
 						{
 						DataOctet((a << 4) + b);
 						legal = 1;
+						i += 2;
 						}
 					}
 


### PR DESCRIPTION
Original behavior (bug): "=XY" -> "CXY"
Corrected behavior: "=XY" -> "C"

(where X,Y are hex digits and C is character represented by =XY quoted printable)
