### PR TITLE
Flip roles if [Syn,Ack] is seen as a first packet in TCP communication.

### DIFF
--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -626,6 +626,11 @@ void TCP_Analyzer::UpdateInactiveState(double t,
 				{
 				Weird("connection_originator_SYN_ack");
 				endpoint->SetState(TCP_ENDPOINT_SYN_ACK_SENT);
+				// Roles should be flipped, because [SYN, ACK] is seen from server ==> !is_orig
+				if ( peer->state == TCP_ENDPOINT_INACTIVE )
+					{
+					Conn()->FlipRoles();
+					}
 				}
 			else
 				endpoint->SetState(TCP_ENDPOINT_SYN_SENT);


### PR DESCRIPTION
If bro does not see initial SYN from client, it considers server to be originator of connection and marks client as a server. Roles should be flipped in this case.
