### PR TITLE
BIFScanner: Make filename->symbol transformation more robust

### DIFF
--- a/src/builtin-func.l
+++ b/src/builtin-func.l
@@ -1,4 +1,5 @@
 %{
+#include <ctype.h>
 #include <string.h>
 #include <unistd.h>
 #include "bif_arg.h"
@@ -223,7 +224,7 @@ void init_alternative_mode()
 
 	for ( char* p = guard; *p; p++ )
 		{
-		if ( strchr("/.-", *p) )
+		if ( !isalnum (*p) )
 			*p = '_';
 		}
 


### PR DESCRIPTION
When trying to build bro from a path that contained a plus sign, an
invalid symbol name for the #ifdef guard was generated.
