### PR TITLE
Update main.bro to add Origin header

### DIFF
--- a/scripts/base/protocols/http/main.bro
+++ b/scripts/base/protocols/http/main.bro
@@ -46,6 +46,8 @@ export {
 		version:		string	   &log &optional;
 		## Value of the User-Agent header from the client.
 		user_agent:              string    &log &optional;
+                ## Value of the Origin header from the client.
+                origin:              string    &log &optional;		
 		## Actual uncompressed content size of the data transferred from
 		## the client.
 		request_body_len:        count     &log &default=0;
@@ -258,8 +260,8 @@ event http_header(c: connection, is_orig: bool, name: string, value: string) &pr
 		else if ( name == "RANGE" )
 			c$http$range_request = T;
 
-		else if ( name == "USER-AGENT" )
-			c$http$user_agent = value;
+		else if ( name == "ORIGIN" )
+			c$http$origin = value;
 
 		else if ( name in proxy_headers )
 				{

--- a/scripts/base/protocols/http/main.bro
+++ b/scripts/base/protocols/http/main.bro
@@ -263,6 +263,9 @@ event http_header(c: connection, is_orig: bool, name: string, value: string) &pr
 		else if ( name == "ORIGIN" )
 			c$http$origin = value;
 
+		else if ( name == "USER-AGENT" )
+			c$http$user_agent = value;
+
 		else if ( name in proxy_headers )
 				{
 				if ( ! c$http?$proxied )


### PR DESCRIPTION
The HTTP "Origin" header is a useful header for CSRF, Chrome plugins making requests, and other scenarios where referrer may not be present.
Reference:
https://tools.ietf.org/html/rfc6454#section-7  ---- "In some sense, the origin granularity is a historical artifact of how the security model evolved."
Especially useful if origin/referrer is a "file://" ---- https://tools.ietf.org/html/rfc6454#section-4