### PR TITLE
GH-227: Improve LibreSSL support

### DIFF
--- a/src/file_analysis/analyzer/x509/OCSP.cc
+++ b/src/file_analysis/analyzer/x509/OCSP.cc
@@ -44,7 +44,7 @@ static Val* get_ocsp_type(RecordVal* args, const char* name)
 
 static bool OCSP_RESPID_bio(OCSP_BASICRESP* basic_resp, BIO* bio)
 	{
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	ASN1_OCTET_STRING* key  = nullptr;
 	X509_NAME*         name = nullptr;
 
@@ -423,7 +423,7 @@ void file_analysis::OCSP::ParseRequest(OCSP_REQUEST* req, const char* fid)
 
 	uint64 version = 0;
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	if ( req->tbsRequest->version )
 		version = (uint64)ASN1_INTEGER_get(req->tbsRequest->version);
 #else
@@ -495,7 +495,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val, const char* fid)
 	if ( !basic_resp )
 		goto clean_up;
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	resp_data = basic_resp->tbsResponseData;
 	if ( !resp_data )
 		goto clean_up;
@@ -506,7 +506,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val, const char* fid)
 	vl->append(resp_val->Ref());
 	vl->append(status_val);
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	vl->append(new Val((uint64)ASN1_INTEGER_get(resp_data->version), TYPE_COUNT));
 #else
 	vl->append(parse_basic_resp_data_version(basic_resp));
@@ -526,7 +526,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val, const char* fid)
 		}
 
 	// producedAt
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	produced_at = resp_data->producedAt;
 #else
 	produced_at = OCSP_resp_get0_produced_at(basic_resp);
@@ -551,7 +551,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val, const char* fid)
 		// cert id
 		const OCSP_CERTID* cert_id = nullptr;
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 		cert_id = single_resp->certId;
 #else
 		cert_id = OCSP_SINGLERESP_get0_id(single_resp);
@@ -618,7 +618,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val, const char* fid)
 			}
 		}
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	i2a_ASN1_OBJECT(bio, basic_resp->signatureAlgorithm->algorithm);
 	len = BIO_read(bio, buf, sizeof(buf));
 	vl->append(new StringVal(len, buf));
@@ -635,7 +635,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val, const char* fid)
 	certs_vector = new VectorVal(internal_type("x509_opaque_vector")->AsVectorType());
 	vl->append(certs_vector);
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	certs = basic_resp->certs;
 #else
 	certs = OCSP_resp_get0_certs(basic_resp);

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -290,7 +290,7 @@ void file_analysis::X509::ParseSAN(X509_EXTENSION* ext)
 				continue;
 				}
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 			const char* name = (const char*) ASN1_STRING_data(gen->d.ia5);
 #else
 			const char* name = (const char*) ASN1_STRING_get0_data(gen->d.ia5);

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -8,23 +8,26 @@
 #include "Val.h"
 #include "X509Common.h"
 
-#if (OPENSSL_VERSION_NUMBER < 0x10002000L || LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10002000L ) || defined(LIBRESSL_VERSION_NUMBER)
 
 #define X509_get_signature_nid(x) OBJ_obj2nid((x)->sig_alg->algorithm)
 
 #endif
 
-#if (OPENSSL_VERSION_NUMBER < 0x1010000fL || LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x1010000fL ) || defined(LIBRESSL_VERSION_NUMBER)
 
 #define X509_OBJECT_new()   (X509_OBJECT*)malloc(sizeof(X509_OBJECT))
 #define X509_OBJECT_free(a) free(a)
 
-#define OCSP_SINGLERESP_get0_id(s) (s)->certId
 #define OCSP_resp_get0_certs(x)    (x)->certs
 
 #define EVP_PKEY_get0_DSA(p)    ((p)->pkey.dsa)
 #define EVP_PKEY_get0_EC_KEY(p) ((p)->pkey.ec)
 #define EVP_PKEY_get0_RSA(p)    ((p)->pkey.rsa)
+
+#if !defined(LIBRESSL_VERSION_NUMBER) || ( LIBRESSL_VERSION_NUMBER < 0x2070000fL )
+
+#define OCSP_SINGLERESP_get0_id(s) (s)->certId
 
 static X509 *X509_OBJECT_get0_X509(const X509_OBJECT *a)
 {
@@ -54,6 +57,8 @@ static void RSA_get0_key(const RSA *r,
 	if ( d != nullptr )
 		*d = r->d;
 }
+
+#endif
 
 #endif
 

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -115,7 +115,7 @@ X509* x509_get_ocsp_signer(const STACK_OF(X509)* certs,
 	const ASN1_OCTET_STRING* key  = nullptr;
 	const X509_NAME*         name = nullptr;
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	OCSP_RESPID* resp_id = basic_resp->tbsResponseData->responderId;
 
 	if ( resp_id->type == V_OCSP_RESPID_NAME )
@@ -348,7 +348,7 @@ function x509_ocsp_verify%(certs: x509_opaque_vector, ocsp_reply: string, root_c
 
 	// Because we actually want to be able to give nice error messages that show why we were
 	// not able to verify the OCSP response - do our own verification logic first.
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	signer = x509_get_ocsp_signer(basic->certs, basic);
 #else
 	signer = x509_get_ocsp_signer(OCSP_resp_get0_certs(basic), basic);
@@ -714,7 +714,7 @@ function sct_verify%(cert: opaque of x509, logid: string, log_key: string, signa
 	uint32 cert_length;
 	if ( precert )
 		{
-#if (OPENSSL_VERSION_NUMBER < 0x10002000L || LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10002000L ) || defined(LIBRESSL_VERSION_NUMBER)
 		x->cert_info->enc.modified = 1;
 		cert_length = i2d_X509_CINF(x->cert_info, &cert_out);
 #else


### PR DESCRIPTION
This fixes the build against LibreSSL reported in #227.

The tests pass with `Broker::disable_ssl = T`, but otherwise triggers a "cannot set anonymous cipher" exception in CAF, but I didn't immediately understand why that is or what to do about improving CAF's LibreSSL support.