### PR TITLE
GH-167: improve error message for unclosed function at EOF

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -43,11 +43,16 @@ int_list if_stack;
 
 int line_number = 1;
 const char* filename = 0; // Absolute path of file currently being parsed.
+const char* last_filename = 0; // Absolute path of last file parsed.
 static const char* last_id_tok = 0;
 
+const char* last_tok_filename = 0;
+const char* last_last_tok_filename = 0;
 char last_tok[128];
 
-#define YY_USER_ACTION	strncpy(last_tok, yytext, sizeof(last_tok) - 1);
+#define YY_USER_ACTION	strncpy(last_tok, yytext, sizeof(last_tok) - 1); \
+                        last_last_tok_filename = last_tok_filename; \
+                        last_tok_filename = ::filename;
 #define YY_USER_INIT	last_tok[0] = '\0';
 
 // We define our own YY_INPUT because we want to trap the case where
@@ -899,6 +904,8 @@ void add_to_name_list(char* s, char delim, name_list& nl)
 
 int yywrap()
 	{
+	last_filename = ::filename;
+
 	if ( reporter->Errors() > 0 )
 		return 1;
 

--- a/testing/btest/Baseline/language.eof-parse-errors/output1
+++ b/testing/btest/Baseline/language.eof-parse-errors/output1
@@ -1,0 +1,1 @@
+error: syntax error, at end of file ./a.bro

--- a/testing/btest/Baseline/language.eof-parse-errors/output2
+++ b/testing/btest/Baseline/language.eof-parse-errors/output2
@@ -1,0 +1,1 @@
+error in ./b.bro, line 1: syntax error, at or near "module" or end of file ./a.bro

--- a/testing/btest/language/eof-parse-errors.bro
+++ b/testing/btest/language/eof-parse-errors.bro
@@ -1,0 +1,21 @@
+# @TEST-EXEC-FAIL: bro -b a.bro >output1 2>&1
+# @TEST-EXEC-FAIL: bro -b a.bro b.bro >output2 2>&1
+# @TEST-EXEC: btest-diff output1
+# @TEST-EXEC: btest-diff output2
+
+@TEST-START-FILE a.bro
+module A;
+
+event bro_init()
+	{
+	print "a";
+@TEST-END-FILE
+
+@TEST-START-FILE b.bro
+module B;
+
+event bro_init()
+	{
+	print "b";
+	}
+@TEST-END-FILE


### PR DESCRIPTION
Fixes #167

Maybe there's a better way to modify the parsing so it can properly tell you about the particular unclosed function/expression, but this is easy enough and should work such that the error message won't lead you to the wrong spot.