### PR TITLE
Add fuid to SSL:Invalid_Server_Cert notice

### DIFF
--- a/scripts/policy/protocols/ssl/validate-certs.bro
+++ b/scripts/policy/protocols/ssl/validate-certs.bro
@@ -190,7 +190,8 @@ hook ssl_finishing(c: connection) &priority=20
 		{
 		local message = fmt("SSL certificate validation failed with (%s)", c$ssl$validation_status);
 		NOTICE([$note=Invalid_Server_Cert, $msg=message,
-		        $sub=c$ssl$cert_chain[0]$x509$certificate$subject, $conn=c,
-		        $identifier=cat(c$id$resp_h,c$id$resp_p,hash,c$ssl$validation_code)]);
+		        $sub=c$ssl$cert_chain[0]$x509$certificate$subject, $conn=c, 
+				$fuid=c$ssl$cert_chain[0]$fuid, 
+				$identifier=cat(c$id$resp_h,c$id$resp_p,hash,c$ssl$validation_code)]);
 		}
 	}


### PR DESCRIPTION
This is a very basid quality of life improvement. It should make it
much easier to find additional information about the certificate
in question.