### PR TITLE
Smb2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 tmp
 *.gcov
+.idea*

--- a/scripts/base/protocols/smb/smb2-main.bro
+++ b/scripts/base/protocols/smb/smb2-main.bro
@@ -204,6 +204,11 @@ event smb2_read_request(c: connection, hdr: SMB2::Header, file_id: SMB2::GUID, o
 	SMB::write_file_log(c$smb_state);
 	}
 
+event smb2_read_response(c: connection, hdr: SMB2::Header) &priority=-5
+	{ 
+	SMB::write_file_log(c$smb_state);
+	}
+
 event smb2_write_request(c: connection, hdr: SMB2::Header, file_id: SMB2::GUID, offset: count, length: count) &priority=5
 	{
 	SMB::set_current_file(c$smb_state, file_id$persistent+file_id$volatile);
@@ -227,6 +232,11 @@ event smb2_write_request(c: connection, hdr: SMB2::Header, file_id: SMB2::GUID, 
 
 event smb2_write_request(c: connection, hdr: SMB2::Header, file_id: SMB2::GUID, offset: count, length: count) &priority=-5
 	{
+	SMB::write_file_log(c$smb_state);
+	}
+
+event smb2_write_response(c: connection, hdr: SMB2::Header) &priority=-5
+	{ 
 	SMB::write_file_log(c$smb_state);
 	}
 

--- a/src/analyzer/protocol/smb/smb2-com-read.pac
+++ b/src/analyzer/protocol/smb/smb2-com-read.pac
@@ -55,6 +55,13 @@ refine connection SMB_Conn += {
 			                 bro_analyzer()->Conn(), h->is_orig());
 			}
 
+		if ( smb2_read_request )
+			{
+			BifEvent::generate_smb2_read_response(bro_analyzer(),
+			                                     bro_analyzer()->Conn(),
+			                                     BuildSMB2HeaderVal(h));
+			}
+
 		return true;
 		%}
 

--- a/src/analyzer/protocol/smb/smb2-com-write.pac
+++ b/src/analyzer/protocol/smb/smb2-com-write.pac
@@ -24,6 +24,12 @@ refine connection SMB_Conn += {
 
 	function proc_smb2_write_response(h: SMB2_Header, val: SMB2_write_response) : bool
 		%{
+		if ( smb2_write_response )
+			{
+			BifEvent::generate_smb2_write_response(bro_analyzer(),
+			                                      bro_analyzer()->Conn(),
+			                                      BuildSMB2HeaderVal(h));
+			}
 		return true;
 		%}
 

--- a/src/analyzer/protocol/smb/smb2_com_read.bif
+++ b/src/analyzer/protocol/smb/smb2_com_read.bif
@@ -16,3 +16,16 @@
 ##
 ## .. bro:see:: smb2_message
 event smb2_read_request%(c: connection, hdr: SMB2::Header, file_id: SMB2::GUID, offset: count, length: count%);
+
+## Generated for :abbr:`SMB (Server Message Block)`/:abbr:`CIFS (Common Internet File System)`
+## version 2 requests of type *read*. This is sent by the server in response to a read request operation on
+## a specified file.
+##
+## For more information, see MS-SMB2:2.2.20
+##
+## c: The connection.
+##
+## hdr: The parsed header of the :abbr:`SMB (Server Message Block)` version 2 message.
+##
+## .. bro:see:: smb2_message
+event smb2_read_response%(c: connection, hdr: SMB2::Header);

--- a/src/analyzer/protocol/smb/smb2_com_read.bif
+++ b/src/analyzer/protocol/smb/smb2_com_read.bif
@@ -28,4 +28,4 @@ event smb2_read_request%(c: connection, hdr: SMB2::Header, file_id: SMB2::GUID, 
 ## hdr: The parsed header of the :abbr:`SMB (Server Message Block)` version 2 message.
 ##
 ## .. bro:see:: smb2_message
-event smb2_read_response%(c: connection, hdr: SMB2::Header);
+event smb2_read_response%(c: connection, hdr: SMB2::Header%);

--- a/src/analyzer/protocol/smb/smb2_com_write.bif
+++ b/src/analyzer/protocol/smb/smb2_com_write.bif
@@ -28,4 +28,4 @@ event smb2_write_request%(c: connection, hdr: SMB2::Header, file_id: SMB2::GUID,
 ## hdr: The parsed header of the :abbr:`SMB (Server Message Block)` version 2 message.
 ##
 ## .. bro:see:: smb2_message
-event smb2_write_response%(c: connection, hdr: SMB2::Header);
+event smb2_write_response%(c: connection, hdr: SMB2::Header%);

--- a/src/analyzer/protocol/smb/smb2_com_write.bif
+++ b/src/analyzer/protocol/smb/smb2_com_write.bif
@@ -16,3 +16,16 @@
 ##
 ## .. bro:see:: smb2_message
 event smb2_write_request%(c: connection, hdr: SMB2::Header, file_id: SMB2::GUID, offset: count, length: count%);
+
+## Generated for :abbr:`SMB (Server Message Block)`/:abbr:`CIFS (Common Internet File System)`
+## version 2 requests of type *write*. This is sent by the server in response to a write request or
+## named pipe on the server.
+##
+## For more information, see MS-SMB2:2.2.22
+##
+## c: The connection.
+##
+## hdr: The parsed header of the :abbr:`SMB (Server Message Block)` version 2 message.
+##
+## .. bro:see:: smb2_message
+event smb2_write_response%(c: connection, hdr: SMB2::Header);

--- a/src/main.cc
+++ b/src/main.cc
@@ -494,7 +494,6 @@ static void find_old_comm_usages()
 int main(int argc, char** argv)
 	{
 
-	fprintf(stdout,"This is myzeek...\n");
 	std::set_new_handler(bro_new_handler);
 
 	double time_start = current_time(true);

--- a/src/main.cc
+++ b/src/main.cc
@@ -493,6 +493,8 @@ static void find_old_comm_usages()
 
 int main(int argc, char** argv)
 	{
+
+	fprintf(stdout,"This is myzeek...\n");
 	std::set_new_handler(bro_new_handler);
 
 	double time_start = current_time(true);

--- a/src/main.cc
+++ b/src/main.cc
@@ -493,7 +493,6 @@ static void find_old_comm_usages()
 
 int main(int argc, char** argv)
 	{
-
 	std::set_new_handler(bro_new_handler);
 
 	double time_start = current_time(true);


### PR DESCRIPTION
I added two events to the smb2 analyzer:

smb2-read-response
smb2-write-response

These events are useful for example to detect and log a file transferred in a single read or write response packet.