### PR TITLE
Add linux netfilter NFLOG capture functionality

### DIFF
--- a/src/iosource/BPF_Program.cc
+++ b/src/iosource/BPF_Program.cc
@@ -104,6 +104,13 @@ bool BPF_Program::Compile(int snaplen, int linktype, const char* filter,
 	{
 	FreeCode();
 
+	if ( linktype == DLT_NFLOG ) //hacky way to support nflog but not bpf 
+		{
+		m_compiled = true;
+		m_matches_anything = true;
+		return true;
+		}
+
 #ifdef LIBPCAP_PCAP_COMPILE_NOPCAP_HAS_ERROR_PARAMETER
 	char my_error[PCAP_ERRBUF_SIZE];
 

--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -247,6 +247,11 @@ bool PcapSource::SetFilter(int index)
 		return false;
 		}
 
+	//if the filter matches anything, return true
+	if ( code->MatchesAnything() ) 
+		{
+		return true;
+		}
 	if ( pcap_setfilter(pd, code->GetProgram()) < 0 )
 		{
 		PcapError();


### PR DESCRIPTION
Hi There,

I've added NFLOG linktype support to zeek, and was hoping to have this incorporated into the project. NFLOG linktypes don't support bpf, and so I've had to alter the bpf filtering for this specific linktype to always set m_matches_anything to true, and add some functionality that honors that flag in the SetFilter function. NFLOG linktypes COULD support the bpf filter, but theres an oversight in the libpcap source that states the packets cannot be filtered because a payload is indeterminate, but the logic in libpcap only retrieves packets via nflog if it contains a payload.... 

In any case, looking forward to making changes as necessary to provide this additional functionality for tapping packets off of iptables.

Respectfully,
Ryan Denniston