### PR TITLE
Implement lstrip and rstrip functions.

### DIFF
--- a/src/strings.bif
+++ b/src/strings.bif
@@ -900,7 +900,7 @@ function to_upper%(str: string%): string
 ##
 ## If the string does not yet have a trailing NUL, one is added internally.
 ##
-## In contrast to :bro:id:`escape_string`, this encoding is *not* fully reversible.` 
+## In contrast to :bro:id:`escape_string`, this encoding is *not* fully reversible.`
 ##
 ## str: The string to escape.
 ##
@@ -957,7 +957,7 @@ function is_ascii%(str: string%): bool
 ##     - values not in *[32, 126]* to ``\xXX``
 ##     - ``\`` to ``\\``
 ##
-## In contrast to :bro:id:`clean`, this encoding is fully reversible.` 
+## In contrast to :bro:id:`clean`, this encoding is fully reversible.`
 ##
 ## str: The string to escape.
 ##
@@ -1079,6 +1079,49 @@ function strip%(str: string%): string
 		++sp;
 
 	return new StringVal(new BroString(sp, (e - sp + 1), 1));
+	%}
+
+## Removes all combinations of characters in the chars argument starting at the
+## beginning of the string until first mismatch.
+##
+## str: The string to strip characters from
+## remove_str: A string consisting of the characters to be removed
+##
+## Returns: A copy of *str* with the characters in *remove_str* removed.
+function lstrip%(str: string, remove_str: string%): string
+	%{
+	const u_char* s = str->Bytes();
+	const u_char* r = remove_str->Bytes();
+	int n = str->Len();
+	int rn = str->Len();
+
+	if ( n == 0 )
+		// Empty string.
+		return new StringVal(new BroString(s, n, 1));
+
+	//pointers to beginning and end of string
+	const u_char* sp = s;
+	const u_char* e = sp + n - 1;
+	const u_char* rp = r;
+	const u_char* re = rp + rn - 1;
+
+	bool match = true;
+	while (sp < e && match) {
+		match = false;
+		// reset the r pointer to the beginning
+		rp = r;
+		// check if *s is one of matchable characters
+		while (rp <= re){
+			if (*rp == *sp) {
+				match = true;
+				break;
+			}
+			++rp;
+		}
+		sp++;
+	}
+
+	return new StringVal(new BroString(sp - 1, (e - sp + 2), 1));
 	%}
 
 ## Generates a string of a given size and fills it with repetitions of a source

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -1081,13 +1081,14 @@ function strip%(str: string%): string
 	return new StringVal(new BroString(sp, (e - sp + 1), 1));
 	%}
 
-## Removes all combinations of characters in the chars argument starting at the
-## beginning of the string until first mismatch.
+## Removes all combinations of characters in the remove_str argument
+## starting at the beginning of the string until first mismatch.
 ##
 ## str: The string to strip characters from
 ## remove_str: A string consisting of the characters to be removed
 ##
-## Returns: A copy of *str* with the characters in *remove_str* removed.
+## Returns: A copy of *str* with the characters in *remove_str* removed from
+## the beginning.
 function lstrip%(str: string, remove_str: string%): string
 	%{
 	const u_char* s = str->Bytes();
@@ -1110,7 +1111,7 @@ function lstrip%(str: string, remove_str: string%): string
 		match = false;
 		// reset the r pointer to the beginning
 		rp = r;
-		// check if *s is one of matchable characters
+		// check if *s is one of the matchable characters
 		while (rp <= re){
 			if (*rp == *sp) {
 				match = true;
@@ -1121,6 +1122,49 @@ function lstrip%(str: string, remove_str: string%): string
 		sp++;
 	}
 	return new StringVal(new BroString(sp - 1, (e - sp + 2), 1));
+	%}
+
+## Removes all combinations of characters in the remove_str argument
+## starting at the end of the string until first mismatch.
+##
+## str: The string to strip characters from
+## remove_str: A string consisting of the characters to be removed
+##
+## Returns: A copy of *str* with the characters in *remove_str* removed from
+## the end.
+function rstrip%(str: string, remove_str: string%): string
+	%{
+	const u_char* s = str->Bytes();
+	const u_char* r = remove_str->Bytes();
+	int n = str->Len();
+	int rn = str->Len();
+
+	// empty input string
+	if ( n == 0 )
+		return new StringVal(new BroString(s, n, 1));
+
+	// pointers to beginning and end of the input strings
+	const u_char* sp = s;
+	const u_char* e = sp + n - 1;
+	const u_char* rp = r;
+	const u_char* re = rp + rn - 1;
+
+	bool match = true;
+	while (e > sp && match) {
+		match = false;
+		// reset the r pointer to the beginning
+		rp = r;
+		// check if *s is one of the matchable characters
+		while (rp <= re){
+			if (*rp == *e) {
+				match = true;
+				break;
+			}
+			++rp;
+		}
+		--e;
+	}
+	return new StringVal(new BroString(sp, (e - sp + 2), 1));
 	%}
 
 ## Generates a string of a given size and fills it with repetitions of a source

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -1095,11 +1095,11 @@ function lstrip%(str: string, remove_str: string%): string
 	int n = str->Len();
 	int rn = str->Len();
 
+	// empty input string
 	if ( n == 0 )
-		// Empty string.
 		return new StringVal(new BroString(s, n, 1));
 
-	//pointers to beginning and end of string
+	// pointers to beginning and end of the input strings
 	const u_char* sp = s;
 	const u_char* e = sp + n - 1;
 	const u_char* rp = r;
@@ -1120,7 +1120,6 @@ function lstrip%(str: string, remove_str: string%): string
 		}
 		sp++;
 	}
-
 	return new StringVal(new BroString(sp - 1, (e - sp + 2), 1));
 	%}
 

--- a/testing/btest/Baseline/language.lstrip/out
+++ b/testing/btest/Baseline/language.lstrip/out
@@ -1,5 +1,5 @@
-*www.zeek.org*
-*dcab*
-**
-*https://www.zeek.org*
-*dog*
+www.zeek.org
+dcab
+
+https://www.zeek.org
+dog

--- a/testing/btest/Baseline/language.lstrip/out
+++ b/testing/btest/Baseline/language.lstrip/out
@@ -1,0 +1,5 @@
+*www.zeek.org*
+*dcab*
+**
+*https://www.zeek.org*
+*dog*

--- a/testing/btest/Baseline/language.rstrip/out
+++ b/testing/btest/Baseline/language.rstrip/out
@@ -1,0 +1,5 @@
+https://www.zeek
+abcd
+
+https://www.zeek.org
+dog

--- a/testing/btest/language/lstrip.bro
+++ b/testing/btest/language/lstrip.bro
@@ -1,0 +1,17 @@
+#
+# @TEST-EXEC: bro -b %INPUT >out
+# @TEST-EXEC: btest-diff out
+
+event bro_init()
+	{
+  local link_test = "https://www.zeek.org";
+  local one_side = "abcdcab";
+  local nothing = "";
+  local strange_chars = "ådog";
+
+  print fmt("%s", lstrip(link_test, "htps:/"));
+  print fmt("%s", lstrip(one_side,"abc"));
+  print fmt("%s", lstrip("","å"));
+  print fmt("%s", lstrip(link_test,""));
+  print fmt("%s", lstrip(strange_chars,"å"));
+	}

--- a/testing/btest/language/rstrip.bro
+++ b/testing/btest/language/rstrip.bro
@@ -1,0 +1,17 @@
+#
+# @TEST-EXEC: bro -b %INPUT >out
+# @TEST-EXEC: btest-diff out
+
+event bro_init()
+	{
+  local link_test = "https://www.zeek.org";
+  local one_side = "abcdcab";
+  local nothing = "";
+  local strange_chars = "dogå";
+
+  print fmt("%s", rstrip(link_test, "org."));
+  print fmt("%s", rstrip(one_side,"abc"));
+  print fmt("%s", rstrip("","å"));
+  print fmt("%s", rstrip(link_test,""));
+  print fmt("%s", rstrip(strange_chars,"å"));
+	}


### PR DESCRIPTION
Implements `lstrip` and `rstrip` per zeek/zeek#178.

Right now there is a fair bit of redundancy in `strings.bif` between `lstrip` `rstrip` and `strip`. It might be worthwhile to move all of these to one more general `strip` function in `BroString` that these could call.

I'd be happy to take that up next, but for the moment I've implemented them in `strings.bif` despite the redundancy because `BroString` seems like a fairly important component. I'm not sure what constitutes an appropriate modification. If there is a different way to have them call a more general function that's more appropriate, please let me know.

This is my first commit on this repository, so I'm a little unfamiliar with the code structure, and happy to make modifications as needed.