### PR TITLE
Defer initialization of Dicts and Lists

### DIFF
--- a/src/List.cc
+++ b/src/List.cc
@@ -6,33 +6,27 @@
 #include "List.h"
 #include "util.h"
 
-static const int DEFAULT_CHUNK_SIZE = 10;
+#define DEFAULT_LIST_SIZE 10
+#define GROWTH_FACTOR 2
 
 BaseList::BaseList(int size)
 	{
-	chunk_size = DEFAULT_CHUNK_SIZE;
+	num_entries = 0;
+	max_entries = 0;
+	entry = 0;
 
-	if ( size < 0 )
-		{
-		num_entries = max_entries = 0;
-		entry = 0;
-		}
-	else
-		{
-		if ( size > 0 )
-			chunk_size = size;
+	if ( size <= 0 )
+		return;
 
-		num_entries = 0;
-		entry = (ent *) safe_malloc(chunk_size * sizeof(ent));
-		max_entries = chunk_size;
-		}
+	max_entries = size;
+
+	entry = (ent *) safe_malloc(max_entries * sizeof(ent));
 	}
 
 
 BaseList::BaseList(BaseList& b)
 	{
 	max_entries = b.max_entries;
-	chunk_size = b.chunk_size;
 	num_entries = b.num_entries;
 
 	if ( max_entries )
@@ -58,7 +52,6 @@ void BaseList::operator=(BaseList& b)
 		free(entry);
 
 	max_entries = b.max_entries;
-	chunk_size = b.chunk_size;
 	num_entries = b.num_entries;
 
 	if ( max_entries )
@@ -74,8 +67,7 @@ void BaseList::insert(ent a)
 	{
 	if ( num_entries == max_entries )
 		{
-		resize(max_entries + chunk_size);	// make more room
-		chunk_size *= 2;
+		resize(max_entries==0 ? DEFAULT_LIST_SIZE : max_entries*GROWTH_FACTOR);	// make more room
 		}
 
 	for ( int i = num_entries; i > 0; --i )
@@ -95,8 +87,7 @@ void BaseList::sortedinsert(ent a, list_cmp_func cmp_func)
 	// First append element.
 	if ( num_entries == max_entries )
 		{
-		resize(max_entries + chunk_size);
-		chunk_size *= 2;
+		resize(max_entries==0 ? DEFAULT_LIST_SIZE : max_entries*GROWTH_FACTOR);
 		}
 
 	entry[num_entries++] = a;
@@ -142,8 +133,7 @@ void BaseList::append(ent a)
 	{
 	if ( num_entries == max_entries )
 		{
-		resize(max_entries + chunk_size);	// make more room
-		chunk_size *= 2;
+		resize(max_entries==0 ? DEFAULT_LIST_SIZE : max_entries*GROWTH_FACTOR);	// make more room
 		}
 
 	entry[num_entries++] = a;
@@ -168,7 +158,6 @@ void BaseList::clear()
 		}
 
 	num_entries = max_entries = 0;
-	chunk_size = DEFAULT_CHUNK_SIZE;
 	}
 
 ent BaseList::replace(int ent_index, ent new_ent)

--- a/src/List.h
+++ b/src/List.h
@@ -11,7 +11,7 @@
 //	element up, and resizing the list, which involves getting new space
 //	and moving the data.  Resizing occurs automatically when inserting
 //	more elements than the list can currently hold.  Automatic
-//	resizing is done one "chunk_size" of elements at a time and
+//	resizing is done by growing by GROWTH_FACTOR at a time and
 //	always increases the size of the list.  Resizing to zero
 //	(or to less than the current value of num_entries)
 //	will decrease the size of the list to the current number of
@@ -32,7 +32,6 @@ public:
 
 	void clear();		// remove all entries
 	int length() const	{ return num_entries; }
-	int chunk() const	{ return chunk_size; }
 	int max() const		{ return max_entries; }
 	int resize(int = 0);	// 0 => size to fit current number of entries
 
@@ -79,7 +78,6 @@ protected:
 	void operator=(BaseList&);
 
 	ent* entry;
-	int chunk_size;		// increase size by this amount when necessary
 	int max_entries;
 	int num_entries;
 	};


### PR DESCRIPTION
This is half the changes that were in #274.  This contains just the changes to defer initialization and leaves the initial size and growth factors alone.  It doesn't save as much memory as the combined changes, but the runtime stays the same and all the tests pass.

The results for this following test:

```
global crap: table[count] of table[count] of count;

global items: count=0 &redef;

event bro_init()
{
    local i=0;
    local n=0;
    while(++i < 3000000) {
        crap[i] = table();
        n=0;
        while(++n <= items) {
            crap[i][n]=n;
        }
    }
}
```
```
for x in `seq 0 15` 20 25 30; do
echo -n  "$x ";
echo -n $(/usr/bin/time -v bro.orig mem "items=$x" 2>&1 |egrep -e wall -e Max | rev|cut -d ' ' -f 1|rev) ""
sleep 1
echo $(/usr/bin/time -v bro mem "items=$x" 2>&1 |egrep -e wall -e Max | rev|cut -d ' ' -f 1|rev)
sleep 1
done
```

are


3m tables of | Orig time | Orig KB | Patched time | Patched KB | MB Reduction | % Reduction
-- | -- | -- | -- | -- | -- | --
0 | 0:07.49 | 2,310,508 | 0:06.95 | 1,574,416 | 719 | 31.86%
1 | 0:10.52 | 2,863,440 | 0:10.95 | 2,552,868 | 303 | 10.85%
2 | 0:12.94 | 3,416,292 | 0:13.21 | 2,768,436 | 633 | 18.96%
3 | 0:14.95 | 3,969,316 | 0:15.34 | 3,562,732 | 397 | 10.24%
4 | 0:18.54 | 4,522,448 | 0:17.06 | 3,778,476 | 727 | 16.45%
5 | 0:20.09 | 5,075,452 | 0:20.53 | 4,573,004 | 491 | 9.90%
6 | 0:23.62 | 5,291,068 | 0:22.13 | 4,788,544 | 491 | 9.50%
7 | 0:24.65 | 5,843,904 | 0:24.84 | 5,293,376 | 538 | 9.42%
8 | 0:27.93 | 6,733,844 | 0:27.01 | 5,509,188 | 1,196 | 18.19%
9 | 0:29.84 | 6,949,636 | 0:29.23 | 6,014,260 | 913 | 13.46%
10 | 0:30.98 | 6,490,832 | 0:34.90 | 5,940,468 | 537 | 8.48%
11 | 0:34.13 | 8,055,332 | 0:34.63 | 7,024,080 | 1,007 | 12.80%
12 | 0:39.20 | 8,608,300 | 0:37.57 | 6,661,236 | 1,901 | 22.62%
13 | 0:39.94 | 8,824,132 | 0:38.21 | 7,166,312 | 1,619 | 18.79%
14 | 0:41.02 | 8,702,480 | 0:40.49 | 8,250,120 | 442 | 5.20%
15 | 0:43.63 | 8,580,968 | 0:44.31 | 8,465,496 | 113 | 1.35%
20 | 0:55.10 | 10,333,668 | 0:54.59 | 9,254,752 | 1,054 | 10.44%
25 | 1:06.94 | 13,098,252 | 1:07.92 | 12,069,008 | 1,005 | 7.86%
30 | 1:22.44 | 14,177,028 | 1:21.08 | 13,147,648 | 1,005 | 7.26%

This saves far less memory than also setting DEFAULT_DICT_SIZE to 1, but that was running 10% slower at larger table sizes and needs more testing.  The greatest win is for empty tables which is actually the most common table size.