### PR TITLE
Be more liberal with whitespaces for ip-addresses, subnets, etc.

### DIFF
--- a/src/threading/formatters/Ascii.cc
+++ b/src/threading/formatters/Ascii.cc
@@ -227,9 +227,11 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, TypeTag
 		}
 
 	case TYPE_BOOL:
-		if ( s == "T" || s == "1" )
+		{
+		auto stripped = strstrip(s);
+		if ( stripped == "T" || stripped == "1" )
 			val->val.int_val = 1;
-		else if ( s == "F" || s == "0" )
+		else if ( stripped == "F" || stripped == "0" )
 			val->val.int_val = 0;
 		else
 			{
@@ -238,6 +240,7 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, TypeTag
 			goto parse_error;
 			}
 		break;
+		}
 
 	case TYPE_INT:
 		val->val.int_val = strtoll(start, &end, 10);
@@ -262,12 +265,13 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, TypeTag
 
 	case TYPE_PORT:
 		{
+		auto stripped = strstrip(s);
 		val->val.port_val.proto = TRANSPORT_UNKNOWN;
-		pos = s.find('/');
+		pos = stripped.find('/');
 		string numberpart;
-		if ( pos != std::string::npos && s.length() > pos + 1 )
+		if ( pos != std::string::npos && stripped.length() > pos + 1 )
 			{
-			auto proto = s.substr(pos+1);
+			auto proto = stripped.substr(pos+1);
 			if ( strtolower(proto) == "tcp" )
 				val->val.port_val.proto = TRANSPORT_TCP;
 			else if ( strtolower(proto) == "udp" )
@@ -282,7 +286,7 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, TypeTag
 
 		if ( pos != std::string::npos && pos > 0 )
 			{
-			numberpart = s.substr(0, pos);
+			numberpart = stripped.substr(0, pos);
 			start = numberpart.c_str();
 			}
 		val->val.port_val.port = strtoull(start, &end, 10);
@@ -293,7 +297,7 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, TypeTag
 
 	case TYPE_SUBNET:
 		{
-		string unescaped = get_unescaped_string(s);
+		string unescaped = strstrip(get_unescaped_string(s));
 		size_t pos = unescaped.find("/");
 		if ( pos == unescaped.npos )
 			{
@@ -316,7 +320,7 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, TypeTag
 
 	case TYPE_ADDR:
 		{
-		string unescaped = get_unescaped_string(s);
+		string unescaped = strstrip(get_unescaped_string(s));
 		val->val.addr_val = ParseAddr(unescaped);
 		break;
 		}

--- a/testing/btest/Baseline/scripts.base.frameworks.input.config.spaces/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.config.spaces/out
@@ -1,0 +1,11 @@
+testbool, F
+testcount, 1
+testint, -1
+testportandproto, 45/udp
+testaddr, 127.0.0.3
+test_set, {
+127.0.0.2,
+127.0.0.1,
+127.0.0.3
+}
+test_vector, [10.0.0.1/32, 10.0.0.0/16, 10.0.0.0/8]

--- a/testing/btest/scripts/base/frameworks/input/config/spaces.bro
+++ b/testing/btest/scripts/base/frameworks/input/config/spaces.bro
@@ -1,0 +1,59 @@
+# @TEST-EXEC: btest-bg-run bro bro -b %INPUT
+# @TEST-EXEC: btest-bg-wait 10
+# @TEST-EXEC: btest-diff out
+
+redef exit_only_after_terminate = T;
+redef InputConfig::empty_field = "EMPTY";
+
+@TEST-START-FILE configfile
+testbool F    
+testcount    1   
+testint		-1   
+testportandproto  45/udp 
+testaddr 127.0.0.3 
+test_set 127.0.0.1,    127.0.0.2,  127.0.0.3 
+test_vector 10.0.0.1/32,  10.0.0.1/16,  10.0.0.1/8
+@TEST-END-FILE
+
+@load base/protocols/ssh
+@load base/protocols/conn
+
+global outfile: file;
+
+export {
+	option testbool: bool = T;
+	option testcount: count = 0;
+	option testint: int = 0;
+	option testportandproto = 42/tcp;
+	option testaddr = 127.0.0.1;
+	option test_set: set[addr] = {};
+	option test_vector: vector of subnet = {};
+}
+
+type Idx: record {
+	option_name: string;
+};
+
+type Val: record {
+	option_val: string;
+};
+
+global currconfig: table[string] of string = table();
+
+event InputConfig::new_value(name: string, source: string, id: string, value: any)
+	{
+	print outfile, id, value;
+	}
+
+event Input::end_of_data(name: string, source:string)
+	{
+	close(outfile);
+	terminate();
+	}
+
+event bro_init()
+	{
+	outfile = open("../out");
+	Input::add_table([$reader=Input::READER_CONFIG, $source="../configfile", $name="configuration", $idx=Idx, $val=Val, $destination=currconfig, $want_record=F]);
+	}
+


### PR DESCRIPTION
This change ignores leading/trailing whitespaces for a couple of data-types (bool, port, subnet, addr) and just parses them as if the whitespace was not present.