### PR TITLE
Support SMB filenames in the intel framework

### DIFF
--- a/scripts/policy/frameworks/intel/seen/__load__.bro
+++ b/scripts/policy/frameworks/intel/seen/__load__.bro
@@ -9,3 +9,4 @@
 @load ./smtp
 @load ./smtp-url-extraction
 @load ./x509
+@load ./smb-filenames

--- a/scripts/policy/frameworks/intel/seen/smb-filenames.bro
+++ b/scripts/policy/frameworks/intel/seen/smb-filenames.bro
@@ -14,7 +14,7 @@ event file_new(f: fa_file)
             Intel::seen([$indicator=c$smb_state$current_file$name,
                         $indicator_type=Intel::FILE_NAME,
                         $f=f,
-                        $where=Files::IN_NAME]);
+                        $where=SMB::IN_FILE_NAME]);
             }
         }
     }

--- a/scripts/policy/frameworks/intel/seen/smb-filenames.bro
+++ b/scripts/policy/frameworks/intel/seen/smb-filenames.bro
@@ -1,0 +1,20 @@
+@load base/frameworks/intel
+@load ./where-locations
+
+event file_new(f: fa_file)
+    {
+    if ( f$source != "SMB" )
+        return;
+
+    for ( id in f$conns )
+        {
+        local c = f$conns[id];
+        if ( c?$smb_state && c$smb_state?$current_file && c$smb_state$current_file?$name )
+            {
+            Intel::seen([$indicator=c$smb_state$current_file$name,
+                        $indicator_type=Intel::FILE_NAME,
+                        $f=f,
+                        $where=Files::IN_NAME]);
+            }
+        }
+    }

--- a/scripts/policy/frameworks/intel/seen/smb-filenames.bro
+++ b/scripts/policy/frameworks/intel/seen/smb-filenames.bro
@@ -11,7 +11,9 @@ event file_new(f: fa_file)
         local c = f$conns[id];
         if ( c?$smb_state && c$smb_state?$current_file && c$smb_state$current_file?$name )
             {
-            Intel::seen([$indicator=c$smb_state$current_file$name,
+            local split_fname = split_string(c$smb_state$current_file$name, /\\/);
+            local fname = split_fname[|split_fname|-1];
+            Intel::seen([$indicator=fname,
                         $indicator_type=Intel::FILE_NAME,
                         $f=f,
                         $where=SMB::IN_FILE_NAME]);

--- a/scripts/policy/frameworks/intel/seen/where-locations.bro
+++ b/scripts/policy/frameworks/intel/seen/where-locations.bro
@@ -26,5 +26,6 @@ export {
 		SSL::IN_SERVER_NAME,
 		SMTP::IN_HEADER,
 		X509::IN_CERT,
+		SMB::IN_FILE_NAME,
 	};
 }


### PR DESCRIPTION
This is a pretty simple change to add support for observing SMB filenames within the Intel framework.