### PR TITLE
Minor fixes DNP3-protocol.pac

### DIFF
--- a/src/analyzer/protocol/dnp3/dnp3-protocol.pac
+++ b/src/analyzer/protocol/dnp3/dnp3-protocol.pac
@@ -73,7 +73,7 @@ type DNP3_Response = record {
 		default -> unknown: Debug_Byte;
 	};
 } &byteorder = bigendian
-  &length= 9 + addin_header.len - 5 - 1'
+  &length= 9 + addin_header.len - 5 - 1;
 
 type DNP3_Application_Request_Header = record {
 	empty: bytestring &length = 0; # Work-around BinPAC problem.
@@ -117,7 +117,7 @@ type Response_Objects(function_code: uint8) = record {
 		0x0301 -> diwoflag: Response_Data_Object(function_code, object_header.qualifier_field, object_header.object_type_field )[ ( object_header.number_of_item / 8 ) + 1*( object_header.number_of_item > ( (object_header.number_of_item / 8)*8 ) ) ];
 		0x0a01 -> bowoflag: Response_Data_Object(function_code, object_header.qualifier_field, object_header.object_type_field )[ ( object_header.number_of_item / 8 ) + 1*( object_header.number_of_item > ( (object_header.number_of_item / 8)*8 ) )];
 		0x0c03 -> bocmd_PM: Response_Data_Object(function_code, object_header.qualifier_field, object_header.object_type_field )[ ( object_header.number_of_item / 8 ) + 1*( object_header.number_of_item > ( (object_header.number_of_item / 8)*8 ) )];
-		default -> ojbects: Response_Data_Object(function_code, object_header.qualifier_field, object_header.object_type_field )[ object_header.number_of_item];
+		default -> objects: Response_Data_Object(function_code, object_header.qualifier_field, object_header.object_type_field )[ object_header.number_of_item];
 	};
 };
 


### PR DESCRIPTION
Line 76: Replaced  ' for ;
Line 120: Replaced ojbects to objects

I tested it on my cloned repo and everything seems to compile without errors (Ubuntu Bionic Beaver) regarding the DNP3 Protocol