### PR TITLE
Add for-loops that iterate over key-value pairs

### DIFF
--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -337,6 +337,8 @@ protected:
 class ForStmt : public ExprStmt {
 public:
 	ForStmt(id_list* loop_vars, Expr* loop_expr);
+	// Special constructor for key value for loop.
+	ForStmt(id_list* loop_vars, Expr* loop_expr, ID* val_var);
 	~ForStmt() override;
 
 	void AddBody(Stmt* arg_body)	{ body = arg_body; }
@@ -361,6 +363,9 @@ protected:
 
 	id_list* loop_vars;
 	Stmt* body;
+	// Stores the value variable being used for a key value for loop.
+	// Always set to nullptr unless special constructor is called.
+	ID* value_var = nullptr;
 };
 
 class NextStmt : public Stmt {

--- a/src/parse.y
+++ b/src/parse.y
@@ -1592,7 +1592,7 @@ for_head:
 			if ( loop_var )
 				{
 				if ( loop_var->IsGlobal() )
-					loop_var->Error("global used in for loop");
+					loop_var->Error("global variable used in for loop");
 				}
 
 			else
@@ -1606,8 +1606,61 @@ for_head:
 			}
 	|
 		TOK_FOR '(' '[' local_id_list ']' TOK_IN expr ')'
-			{ $$ = new ForStmt($4, $7); }
-		;
+			{
+				$$ = new ForStmt($4, $7);
+			}
+|
+		TOK_FOR '(' TOK_ID ',' TOK_ID TOK_IN expr ')'
+		{
+			set_location(@1, @8);
+			const char* module = current_module.c_str();
+
+			// Check for previous definitions of key and
+			// value variables.
+			ID* key_var = lookup_ID($3, module);
+			ID* val_var = lookup_ID($5, module);
+
+			// Validate previous definitions as needed.
+			if ( key_var ) {
+				if ( key_var->IsGlobal() ) {
+						key_var->Error("global variable used in for loop");
+				}
+			} else {
+				key_var = install_ID($3, module, false, false);
+			}
+			if ( val_var ) {
+				if ( val_var->IsGlobal() ) {
+						val_var->Error("global variable used in for loop");
+				}
+			} else {
+				val_var = install_ID($5, module, false, false);
+			}
+
+			id_list* loop_vars = new id_list;
+			loop_vars->append(key_var);
+
+			$$ = new ForStmt(loop_vars, $7, val_var);
+		}
+		|
+			TOK_FOR '(' '[' local_id_list ']' ',' TOK_ID TOK_IN expr ')'
+				{
+					set_location(@1, @10);
+					const char* module = current_module.c_str();
+
+					// Validate value variable
+					ID* val_var = lookup_ID($7, module);
+
+					if ( val_var ) {
+						if ( val_var->IsGlobal() ) {
+								val_var->Error("global variable used in for loop");
+						}
+					} else {
+						val_var = install_ID($7, module, false, false);
+					}
+
+					$$ = new ForStmt($4, $9, val_var);
+				}
+	;
 
 local_id_list:
 		local_id_list ',' local_id

--- a/testing/btest/Baseline/language.for/out
+++ b/testing/btest/Baseline/language.for/out
@@ -1,3 +1,4 @@
 for loop (PASS)
 for loop with break (PASS)
 for loop with next (PASS)
+keys that are tuples (PASS)

--- a/testing/btest/Baseline/language.key-value-for/out
+++ b/testing/btest/Baseline/language.key-value-for/out
@@ -1,0 +1,4 @@
+1, hello
+55, goodbye
+goodbye, world, 55
+hello, world, 1

--- a/testing/btest/language/for.bro
+++ b/testing/btest/language/for.bro
@@ -13,7 +13,7 @@ event bro_init()
 	local vv: vector of string = vector( "a", "b", "c" );
 	local ct: count = 0;
 
-	# Test a "for" loop without "break" or "next" 
+	# Test a "for" loop without "break" or "next"
 
 	ct = 0;
 	for ( i in vv ) ++ct;
@@ -40,5 +40,16 @@ event bro_init()
 		test_case("Error: this should not happen", F);
 	}
 	test_case("for loop with next", ct == 3 );
-}
 
+  # Test keys that are tuples
+
+  local t: table[count, count] of string = table();
+  t[1, 2] = "hi";
+
+  local s1: string = "";
+  for ( [i, j] in t )
+      s1 = fmt("%d %d %s", i, j, t[i,j]);
+  test_case("keys that are tuples", s1 == "1 2 hi");
+
+  # Tests for key value for loop are in key-value-for.bro
+}

--- a/testing/btest/language/key-value-for.bro
+++ b/testing/btest/language/key-value-for.bro
@@ -1,0 +1,23 @@
+# @TEST-EXEC: bro -b %INPUT >out
+# @TEST-EXEC: btest-diff out
+
+
+event bro_init() {
+	# Test single keys
+
+	local t: table[count] of string = table();
+	t[1] = "hello";
+	t[55] = "goodbye";
+	for (key, value in t){
+		print key, value;
+	}
+
+	# Test multiple keys
+
+	local tkk: table[string, string] of count = table();
+	tkk["hello", "world"] = 1;
+	tkk["goodbye", "world"] = 55;
+	for ([k1, k2], val in tkk) {
+		print k1, k2, val;
+	}
+}


### PR DESCRIPTION
Adds support for key-value pairs in for loops with Python inspired syntax per #154 

Currently, when looping over a table, the values are exposed for free and a separate lookup is done to get the associated key:

```
HashKey* k;
IterCookie* c = loop_vals->InitForIteration();
        // loop_vals->NextEntry returns the value at that entry
	while ( loop_vals->NextEntry(k, c) )
		{
		ListVal* ind_lv = tv->RecoverIndex(k);
                delete k;
                // ...
```

This captures the value and uses it appropriately if prompted by the syntax. Syntax is python inspired and discussed in #154.

For tables indexed by a single variable:
```
local t: table[count] of string = table();
t[1] = "hello";
t[55] = "goodbye";
for (key, value in t){
	print key, value;
}
```
```
1, hello
55, goodbye
```

For tables indexed by multiple variables:
```
local tkk: table[string, string] of count = table();
tkk["hello", "world"] = 1;
tkk["goodbye", "world"] = 55;
for ([k1, k2], val in tkk) {
	print k1, k2, val;
}
```
```
hello, world, 1
goodbye, world, 55
```

This adds an alternate constructor to the existing for loop so as to limit the amount of changes made to the traditional for. Regular for loops run exactly as before except for small checks to see if there is a value variable to be handled.

I'm still a little shaky on when its necessary to `delete`/`Ref`/`Unref` a variable and would love critique on my memory management , code style, and any other issues. Thanks.