### PR TITLE
Fix geo-data to log remote_location data when auth is successful.

### DIFF
--- a/scripts/policy/protocols/ssh/geo-data.bro
+++ b/scripts/policy/protocols/ssh/geo-data.bro
@@ -35,9 +35,6 @@ event ssh_auth_successful(c: connection, auth_method_none: bool) &priority=3
 	if ( ! c$ssh?$direction )
 		return;
 
-	# Add the location data to the SSH record.
-	c$ssh$remote_location = get_location(c);
-
 	if ( c$ssh$remote_location?$country_code && c$ssh$remote_location$country_code in watched_countries )
 		{
 		NOTICE([$note=Watched_Country_Login,
@@ -48,7 +45,7 @@ event ssh_auth_successful(c: connection, auth_method_none: bool) &priority=3
 		}
 	}
 
-event ssh_auth_failed(c: connection) &priority=3
+event ssh_auth_attempted(c: connection, authenticated: bool) &priority=3
 	{
 	if ( ! c$ssh?$direction )
 		return;


### PR DESCRIPTION
We discovered that the geo data was not being logged when authentication was successful.  I believe this is because the ssh.log is written during the ssh_auth_attempt event.  The auth_failed event had time to get the location data, but auth_successful did not.  Moving the get_location() call to ssh_auth_attempt seems to fix the issue.

