### PR TITLE
Reduce weird-stats overhead

### DIFF
--- a/scripts/policy/misc/weird-stats.bro
+++ b/scripts/policy/misc/weird-stats.bro
@@ -84,6 +84,8 @@ function observe_weird_stats()
 # less synchronized?
 event SumStats::cluster_ss_request(uid: string, ss_name: string, cleanup: bool) &priority=10
 	{
+	if ( ss_name != "weirds.statistics" )
+		return;
 	observe_weird_stats();
 	}
 


### PR DESCRIPTION
observe_weird_stats only needs to be called when cluster_ss_request is
called for the weirds.statistics stat, not for all of them.