### PR TITLE
Improve PE file analysis

### DIFF
--- a/src/file_analysis/analyzer/pe/CMakeLists.txt
+++ b/src/file_analysis/analyzer/pe/CMakeLists.txt
@@ -6,5 +6,12 @@ include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}
 bro_plugin_begin(Bro PE)
 bro_plugin_cc(PE.cc Plugin.cc)
 bro_plugin_bif(events.bif)
-bro_plugin_pac(pe.pac pe-file.pac pe-analyzer.pac)
+bro_plugin_pac(
+  pe.pac
+  pe-analyzer.pac
+  pe-file-headers.pac
+  pe-file-idata.pac
+  pe-file.pac
+  pe-file-types.pac
+)
 bro_plugin_end()

--- a/src/file_analysis/analyzer/pe/PE.cc
+++ b/src/file_analysis/analyzer/pe/PE.cc
@@ -20,7 +20,8 @@ PE::~PE()
 bool PE::DeliverStream(const u_char* data, uint64 len)
 	{
 	if ( conn->is_done() )
-		return true;
+		return false;
+
 	try
 		{
 		interp->NewData(data, data + len);
@@ -30,7 +31,7 @@ bool PE::DeliverStream(const u_char* data, uint64 len)
 		return false;
 		}
 
-	return true;
+	return ! conn->is_done();
 	}
 
 bool PE::EndOfFile()


### PR DESCRIPTION
Generally helps prevent processing/buffering non-PE data or PE data after the headers that it doesn't otherwise need to look at.