### PR TITLE
Add a binpac flowbuffer policy mechanism

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -893,7 +893,11 @@ int main(int argc, char** argv)
 
 	// Must come after plugin activation (and also after hash
 	// initialization).
-	binpac::init();
+	binpac::FlowBuffer::Policy flowbuffer_policy;
+	flowbuffer_policy.max_capacity = 10 * 1024 * 1024;
+	flowbuffer_policy.min_capacity = 512;
+	flowbuffer_policy.contract_threshold = 2 * 1024 * 1024;
+	binpac::init(&flowbuffer_policy);
 
 	init_event_handlers();
 


### PR DESCRIPTION
The `topic/jsiwek/flowbuffer-policy` is in both `zeek` and `binpac` repos to be merged with this PR.

More details in the commit message, but generally helps prevent poor flowbuffer / incremental parsing behavior.  I came up with this in the context of investigating issues related to #327.