### PR TITLE
Prevent topk_merge from crashing when second argument is empty set

### DIFF
--- a/src/probabilistic/Topk.cc
+++ b/src/probabilistic/Topk.cc
@@ -78,6 +78,13 @@ TopkVal::~TopkVal()
 
 void TopkVal::Merge(const TopkVal* value, bool doPrune)
 	{
+	if (!value->type)
+		{
+		// Merge-from is empty. Nothing to do.
+		assert(value->numElements == 0);
+		return;
+		}
+
 	if ( type == 0 )
 		{
 		assert(numElements == 0);

--- a/testing/btest/scripts/base/frameworks/sumstats/topk.bro
+++ b/testing/btest/scripts/base/frameworks/sumstats/topk.bro
@@ -5,6 +5,11 @@ event bro_init() &priority=5
 	{
 	local r1: SumStats::Reducer = [$stream="test.metric", 
 	                               $apply=set(SumStats::TOPK)];
+	# Merge two empty sets
+	local topk1: opaque of topk = topk_init(4);
+	local topk2: opaque of topk = topk_init(4);
+	topk_merge(topk1, topk2);
+
 	SumStats::create([$name="topk-test",
 	                  $epoch=3secs,
 	                  $reducers=set(r1),


### PR DESCRIPTION
`topk_merge` (in the top-k.bif) calls TopkVal::Merge with the left hand side as `this`, and the right-hand-side as the argument. If the right-hand-side is empty (nothing has been `topk_add`d to it), zeek dumps core. This issue exists from 2.5.5 to current master and this patch should apply to any version. Easy fix is just to do nothing if the right-hand-side is empty: nothing to merge.

Without the patch to Topk.cc, the included test will cause a segmentation violation by dereferencing the NULL `value->type` pointer.
