### PR TITLE
Cleanup/improve Plist usage and Event API

### DIFF
--- a/src/Anon.cc
+++ b/src/Anon.cc
@@ -415,7 +415,7 @@ void log_anonymization_mapping(ipaddr32_t input, ipaddr32_t output)
 	{
 	if ( anonymization_mapping )
 		{
-		mgr.QueueEvent(anonymization_mapping, {
+		mgr.QueueEventFast(anonymization_mapping, {
 			new AddrVal(input),
 			new AddrVal(output)
 		});

--- a/src/Anon.cc
+++ b/src/Anon.cc
@@ -415,10 +415,10 @@ void log_anonymization_mapping(ipaddr32_t input, ipaddr32_t output)
 	{
 	if ( anonymization_mapping )
 		{
-		val_list* vl = new val_list;
-		vl->append(new AddrVal(input));
-		vl->append(new AddrVal(output));
-		mgr.QueueEvent(anonymization_mapping, vl);
+		mgr.QueueEvent(anonymization_mapping, {
+			new AddrVal(input),
+			new AddrVal(output)
+		});
 		}
 	}
 

--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -141,7 +141,7 @@ Attributes::~Attributes()
 void Attributes::AddAttr(Attr* attr)
 	{
 	if ( ! attrs )
-		attrs = new attr_list;
+		attrs = new attr_list(1);
 
 	if ( ! attr->RedundantAttrOkay() )
 		// We overwrite old attributes by deleting them first.

--- a/src/BroList.h
+++ b/src/BroList.h
@@ -13,10 +13,6 @@ class ID;
 declare(PList,ID);
 typedef PList(ID) id_list;
 
-class HashKey;
-declare(PList,HashKey);
-typedef PList(HashKey) hash_key_list;
-
 class Val;
 declare(PList,Val);
 typedef PList(Val) val_list;
@@ -29,28 +25,12 @@ class BroType;
 declare(PList,BroType);
 typedef PList(BroType) type_list;
 
-class TypeDecl;
-declare(PList,TypeDecl);
-typedef PList(TypeDecl) type_decl_list;
-
-class Case;
-declare(PList,Case);
-typedef PList(Case) case_list;
-
 class Attr;
 declare(PList,Attr);
 typedef PList(Attr) attr_list;
 
-class Scope;
-declare(PList,Scope);
-typedef PList(Scope) scope_list;
-
 class Timer;
 declare(PList,Timer);
 typedef PList(Timer) timer_list;
-
-class DNS_Mgr_Request;
-declare(PList,DNS_Mgr_Request);
-typedef PList(DNS_Mgr_Request) DNS_mgr_request_list;
 
 #endif

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -181,6 +181,8 @@ public:
 				val_list* vl);
 	void ConnectionEvent(EventHandlerPtr f, analyzer::Analyzer* analyzer,
 				val_list vl);
+	void ConnectionEventFast(EventHandlerPtr f, analyzer::Analyzer* analyzer,
+				val_list vl);
 
 	void Weird(const char* name, const char* addl = "");
 	bool DidWeird() const	{ return weird != 0; }

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -174,13 +174,39 @@ public:
 	int UnparsedVersionFoundEvent(const IPAddr& addr,
 			const char* full_descr, int len, analyzer::Analyzer* analyzer);
 
+	// If a handler exists for 'f', an event will be generated.  If 'name' is
+	// given that event's first argument will be it, and it's second will be
+	// the connection value.  If 'name' is null, then the event's first
+	// argument is the connection value.
 	void Event(EventHandlerPtr f, analyzer::Analyzer* analyzer, const char* name = 0);
+
+	// If a handler exists for 'f', an event will be generated.  In any case,
+	// 'v1' and 'v2' reference counts get decremented.  The event's first
+	// argument is the connection value, second argument is 'v1', and if 'v2'
+	// is given that will be it's third argument.
 	void Event(EventHandlerPtr f, analyzer::Analyzer* analyzer, Val* v1, Val* v2 = 0);
 
-	void ConnectionEvent(EventHandlerPtr f, analyzer::Analyzer* analyzer,
-				val_list* vl);
+	// If a handler exists for 'f', an event will be generated.  In any case,
+	// reference count for each element in the 'vl' list are decremented.  The
+	// arguments used for the event are whatevever is provided in 'vl'.
 	void ConnectionEvent(EventHandlerPtr f, analyzer::Analyzer* analyzer,
 				val_list vl);
+
+	// Same as ConnectionEvent, except taking the event's argument list via a
+	// pointer instead of by value.  This function takes ownership of the
+	// memory pointed to by 'vl' and also for decrementing the reference count
+	// of each of its elements.
+	void ConnectionEvent(EventHandlerPtr f, analyzer::Analyzer* analyzer,
+				val_list* vl);
+
+	// Queues an event without first checking if there's any available event
+	// handlers (or remote consumes).  If it turns out there's actually nothing
+	// that will consume the event, then this may leak memory due to failing to
+	// decrement the reference count of each element in 'vl'.  i.e. use this
+	// function instead of ConnectionEvent() if you've already guarded against
+	// the case where there's no handlers (one usually also does that because
+	// it would be a waste of effort to construct all the event arguments when
+	// there's no handlers to consume them).
 	void ConnectionEventFast(EventHandlerPtr f, analyzer::Analyzer* analyzer,
 				val_list vl);
 

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -176,8 +176,11 @@ public:
 
 	void Event(EventHandlerPtr f, analyzer::Analyzer* analyzer, const char* name = 0);
 	void Event(EventHandlerPtr f, analyzer::Analyzer* analyzer, Val* v1, Val* v2 = 0);
+
 	void ConnectionEvent(EventHandlerPtr f, analyzer::Analyzer* analyzer,
 				val_list* vl);
+	void ConnectionEvent(EventHandlerPtr f, analyzer::Analyzer* analyzer,
+				val_list vl);
 
 	void Weird(const char* name, const char* addl = "");
 	bool DidWeird() const	{ return weird != 0; }

--- a/src/DFA.h
+++ b/src/DFA.h
@@ -111,9 +111,6 @@ private:
 	PDict(CacheEntry) states;
 };
 
-declare(PList,DFA_State);
-typedef PList(DFA_State) DFA_state_list;
-
 class DFA_Machine : public BroObj {
 public:
 	DFA_Machine(NFA_Machine* n, EquivClass* ec);

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -704,7 +704,7 @@ void DNS_Mgr::Event(EventHandlerPtr e, DNS_Mapping* dm)
 	if ( ! e )
 		return;
 
-	mgr.QueueEvent(e, {BuildMappingVal(dm)});
+	mgr.QueueEventFast(e, {BuildMappingVal(dm)});
 	}
 
 void DNS_Mgr::Event(EventHandlerPtr e, DNS_Mapping* dm, ListVal* l1, ListVal* l2)
@@ -715,7 +715,7 @@ void DNS_Mgr::Event(EventHandlerPtr e, DNS_Mapping* dm, ListVal* l1, ListVal* l2
 	Unref(l1);
 	Unref(l2);
 
-	mgr.QueueEvent(e, {
+	mgr.QueueEventFast(e, {
 		BuildMappingVal(dm),
 		l1->ConvertToSet(),
 		l2->ConvertToSet(),
@@ -727,7 +727,7 @@ void DNS_Mgr::Event(EventHandlerPtr e, DNS_Mapping* old_dm, DNS_Mapping* new_dm)
 	if ( ! e )
 		return;
 
-	mgr.QueueEvent(e, {
+	mgr.QueueEventFast(e, {
 		BuildMappingVal(old_dm),
 		BuildMappingVal(new_dm),
 	});

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -699,25 +699,27 @@ int DNS_Mgr::Save()
 	return 1;
 	}
 
+void DNS_Mgr::Event(EventHandlerPtr e, DNS_Mapping* dm)
+	{
+	if ( ! e )
+		return;
+
+	mgr.QueueEvent(e, {BuildMappingVal(dm)});
+	}
+
 void DNS_Mgr::Event(EventHandlerPtr e, DNS_Mapping* dm, ListVal* l1, ListVal* l2)
 	{
 	if ( ! e )
 		return;
 
-	val_list* vl = new val_list;
-	vl->append(BuildMappingVal(dm));
+	Unref(l1);
+	Unref(l2);
 
-	if ( l1 )
-		{
-		vl->append(l1->ConvertToSet());
-		if ( l2 )
-			vl->append(l2->ConvertToSet());
-
-		Unref(l1);
-		Unref(l2);
-		}
-
-	mgr.QueueEvent(e, vl);
+	mgr.QueueEvent(e, {
+		BuildMappingVal(dm),
+		l1->ConvertToSet(),
+		l2->ConvertToSet(),
+	});
 	}
 
 void DNS_Mgr::Event(EventHandlerPtr e, DNS_Mapping* old_dm, DNS_Mapping* new_dm)
@@ -725,10 +727,10 @@ void DNS_Mgr::Event(EventHandlerPtr e, DNS_Mapping* old_dm, DNS_Mapping* new_dm)
 	if ( ! e )
 		return;
 
-	val_list* vl = new val_list;
-	vl->append(BuildMappingVal(old_dm));
-	vl->append(BuildMappingVal(new_dm));
-	mgr.QueueEvent(e, vl);
+	mgr.QueueEvent(e, {
+		BuildMappingVal(old_dm),
+		BuildMappingVal(new_dm),
+	});
 	}
 
 Val* DNS_Mgr::BuildMappingVal(DNS_Mapping* dm)

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -9,7 +9,7 @@
 #include <utility>
 
 #include "util.h"
-#include "BroList.h"
+#include "List.h"
 #include "Dict.h"
 #include "EventHandler.h"
 #include "iosource/IOSource.h"
@@ -22,6 +22,9 @@ class Func;
 class EventHandler;
 class RecordType;
 class DNS_Mgr_Request;
+
+declare(PList,DNS_Mgr_Request);
+typedef PList(DNS_Mgr_Request) DNS_mgr_request_list;
 
 struct nb_dns_info;
 struct nb_dns_result;
@@ -96,8 +99,8 @@ protected:
 	friend class LookupCallback;
 	friend class DNS_Mgr_Request;
 
-	void Event(EventHandlerPtr e, DNS_Mapping* dm,
-			ListVal* l1 = 0, ListVal* l2 = 0);
+	void Event(EventHandlerPtr e, DNS_Mapping* dm);
+	void Event(EventHandlerPtr e, DNS_Mapping* dm, ListVal* l1, ListVal* l2);
 	void Event(EventHandlerPtr e, DNS_Mapping* old_dm, DNS_Mapping* new_dm);
 
 	Val* BuildMappingVal(DNS_Mapping* dm);

--- a/src/Discard.cc
+++ b/src/Discard.cc
@@ -33,20 +33,17 @@ int Discarder::NextPacket(const IP_Hdr* ip, int len, int caplen)
 
 	if ( check_ip )
 		{
-		val_list* args = new val_list;
-		args->append(ip->BuildPktHdrVal());
+		val_list args{ip->BuildPktHdrVal()};
 
 		try
 			{
-			discard_packet = check_ip->Call(args)->AsBool();
+			discard_packet = check_ip->Call(&args)->AsBool();
 			}
 
 		catch ( InterpreterException& e )
 			{
 			discard_packet = false;
 			}
-
-		delete args;
 
 		if ( discard_packet )
 			return discard_packet;
@@ -88,21 +85,20 @@ int Discarder::NextPacket(const IP_Hdr* ip, int len, int caplen)
 			const struct tcphdr* tp = (const struct tcphdr*) data;
 			int th_len = tp->th_off * 4;
 
-			val_list* args = new val_list;
-			args->append(ip->BuildPktHdrVal());
-			args->append(BuildData(data, th_len, len, caplen));
+			val_list args{
+				ip->BuildPktHdrVal(),
+				BuildData(data, th_len, len, caplen),
+			};
 
 			try
 				{
-				discard_packet = check_tcp->Call(args)->AsBool();
+				discard_packet = check_tcp->Call(&args)->AsBool();
 				}
 
 			catch ( InterpreterException& e )
 				{
 				discard_packet = false;
 				}
-
-			delete args;
 			}
 		}
 
@@ -113,21 +109,20 @@ int Discarder::NextPacket(const IP_Hdr* ip, int len, int caplen)
 			const struct udphdr* up = (const struct udphdr*) data;
 			int uh_len = sizeof (struct udphdr);
 
-			val_list* args = new val_list;
-			args->append(ip->BuildPktHdrVal());
-			args->append(BuildData(data, uh_len, len, caplen));
+			val_list args{
+				ip->BuildPktHdrVal(),
+				BuildData(data, uh_len, len, caplen),
+			};
 
 			try
 				{
-				discard_packet = check_udp->Call(args)->AsBool();
+				discard_packet = check_udp->Call(&args)->AsBool();
 				}
 
 			catch ( InterpreterException& e )
 				{
 				discard_packet = false;
 				}
-
-			delete args;
 			}
 		}
 
@@ -137,20 +132,17 @@ int Discarder::NextPacket(const IP_Hdr* ip, int len, int caplen)
 			{
 			const struct icmp* ih = (const struct icmp*) data;
 
-			val_list* args = new val_list;
-			args->append(ip->BuildPktHdrVal());
+			val_list args{ip->BuildPktHdrVal()};
 
 			try
 				{
-				discard_packet = check_icmp->Call(args)->AsBool();
+				discard_packet = check_icmp->Call(&args)->AsBool();
 				}
 
 			catch ( InterpreterException& e )
 				{
 				discard_packet = false;
 				}
-
-			delete args;
 			}
 		}
 

--- a/src/Event.cc
+++ b/src/Event.cc
@@ -128,7 +128,7 @@ void EventMgr::QueueEvent(Event* event)
 void EventMgr::Drain()
 	{
 	if ( event_queue_flush_point )
-		QueueEvent(event_queue_flush_point, val_list{});
+		QueueEventFast(event_queue_flush_point, val_list{});
 
 	SegmentProfiler(segment_logger, "draining-events");
 

--- a/src/Event.cc
+++ b/src/Event.cc
@@ -13,28 +13,27 @@ EventMgr mgr;
 uint64 num_events_queued = 0;
 uint64 num_events_dispatched = 0;
 
+Event::Event(EventHandlerPtr arg_handler, val_list arg_args,
+		SourceID arg_src, analyzer::ID arg_aid, TimerMgr* arg_mgr,
+		BroObj* arg_obj)
+	: handler(arg_handler),
+	  args(std::move(arg_args)),
+	  src(arg_src),
+	  aid(arg_aid),
+	  mgr(arg_mgr ? arg_mgr : timer_mgr),
+	  obj(arg_obj),
+	  next_event(nullptr)
+	{
+	if ( obj )
+		Ref(obj);
+	}
+
 Event::Event(EventHandlerPtr arg_handler, val_list* arg_args,
 		SourceID arg_src, analyzer::ID arg_aid, TimerMgr* arg_mgr,
 		BroObj* arg_obj)
+	: Event(arg_handler, std::move(*arg_args), arg_src, arg_aid, arg_mgr, arg_obj)
 	{
-	handler = arg_handler;
-	args = arg_args;
-	src = arg_src;
-	mgr = arg_mgr ? arg_mgr : timer_mgr; // default is global
-	aid = arg_aid;
-	obj = arg_obj;
-
-	if ( obj )
-		Ref(obj);
-
-	next_event = 0;
-	}
-
-Event::~Event()
-	{
-	// We don't Unref() the individual arguments by using delete_vals()
-	// here, because Func::Call already did that.
-	delete args;
+	delete arg_args;
 	}
 
 void Event::Describe(ODesc* d) const
@@ -49,7 +48,7 @@ void Event::Describe(ODesc* d) const
 
 	if ( ! d->IsBinary() )
 		d->Add("(");
-	describe_vals(args, d);
+	describe_vals(&args, d);
 	if ( ! d->IsBinary() )
 		d->Add("(");
 	}
@@ -62,7 +61,7 @@ void Event::Dispatch(bool no_remote)
 	if ( event_serializer )
 		{
 		SerialInfo info(event_serializer);
-		event_serializer->Serialize(&info, handler->Name(), args);
+		event_serializer->Serialize(&info, handler->Name(), &args);
 		}
 
 	if ( handler->ErrorHandler() )
@@ -70,7 +69,7 @@ void Event::Dispatch(bool no_remote)
 
 	try
 		{
-		handler->Call(args, no_remote);
+		handler->Call(&args, no_remote);
 		}
 
 	catch ( InterpreterException& e )
@@ -129,7 +128,7 @@ void EventMgr::QueueEvent(Event* event)
 void EventMgr::Drain()
 	{
 	if ( event_queue_flush_point )
-		QueueEvent(event_queue_flush_point, new val_list());
+		QueueEvent(event_queue_flush_point, val_list{});
 
 	SegmentProfiler(segment_logger, "draining-events");
 

--- a/src/Event.h
+++ b/src/Event.h
@@ -58,6 +58,14 @@ public:
 	EventMgr();
 	~EventMgr() override;
 
+	// Queues an event without first checking if there's any available event
+	// handlers (or remote consumers).  If it turns out there's actually
+	// nothing that will consume the event, then this may leak memory due to
+	// failing to decrement the reference count of each element in 'vl'.  i.e.
+	// use this function instead of QueueEvent() if you've already guarded
+	// against the case where there's no handlers (one usually also does that
+	// because it would be a waste of effort to construct all the event
+	// arguments when there's no handlers to consume them).
 	void QueueEventFast(const EventHandlerPtr &h, val_list vl,
 			SourceID src = SOURCE_LOCAL, analyzer::ID aid = 0,
 			TimerMgr* mgr = 0, BroObj* obj = 0)
@@ -65,6 +73,12 @@ public:
 		QueueEvent(new Event(h, std::move(vl), src, aid, mgr, obj));
 		}
 
+	// Queues an event if there's an event handler (or remote consumer).  This
+	// function always takes ownership of decrementing the reference count of
+	// each element of 'vl', even if there's no event handler.  If you've
+	// checked for event handler existence, you may wish to call
+	// QueueEventFast() instead of this function to prevent the redundant
+	// existence check.
 	void QueueEvent(const EventHandlerPtr &h, val_list vl,
 			SourceID src = SOURCE_LOCAL, analyzer::ID aid = 0,
 			TimerMgr* mgr = 0, BroObj* obj = 0)
@@ -78,6 +92,10 @@ public:
 			}
 		}
 
+	// Same as QueueEvent, except taking the event's argument list via a
+	// pointer instead of by value.  This function takes ownership of the
+	// memory pointed to by 'vl' as well as decrementing the reference count of
+	// each of its elements.
 	void QueueEvent(const EventHandlerPtr &h, val_list* vl,
 			SourceID src = SOURCE_LOCAL, analyzer::ID aid = 0,
 			TimerMgr* mgr = 0, BroObj* obj = 0)

--- a/src/Event.h
+++ b/src/Event.h
@@ -58,6 +58,13 @@ public:
 	EventMgr();
 	~EventMgr() override;
 
+	void QueueEventFast(const EventHandlerPtr &h, val_list vl,
+			SourceID src = SOURCE_LOCAL, analyzer::ID aid = 0,
+			TimerMgr* mgr = 0, BroObj* obj = 0)
+		{
+		QueueEvent(new Event(h, std::move(vl), src, aid, mgr, obj));
+		}
+
 	void QueueEvent(const EventHandlerPtr &h, val_list vl,
 			SourceID src = SOURCE_LOCAL, analyzer::ID aid = 0,
 			TimerMgr* mgr = 0, BroObj* obj = 0)

--- a/src/EventHandler.cc
+++ b/src/EventHandler.cc
@@ -172,11 +172,10 @@ void EventHandler::NewEvent(val_list* vl)
 		vargs->Assign(i, rec);
 		}
 
-	val_list* mvl = new val_list(2);
-	mvl->append(new StringVal(name));
-	mvl->append(vargs);
-
-	Event* ev = new Event(new_event, mvl);
+	Event* ev = new Event(new_event, {
+		new StringVal(name),
+		vargs,
+	});
 	mgr.Dispatch(ev);
 	}
 

--- a/src/EventRegistry.cc
+++ b/src/EventRegistry.cc
@@ -73,7 +73,7 @@ EventRegistry::string_list* EventRegistry::UsedHandlers()
 
 EventRegistry::string_list* EventRegistry::AllHandlers()
 	{
-	string_list* names = new string_list;
+	string_list* names = new string_list(handlers.Length());
 
 	IterCookie* c = handlers.InitForIteration();
 

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -937,7 +937,7 @@ public:
 
 protected:
 	EventHandlerPtr event;
-	val_list* args;
+	val_list args;
 	TimerMgr* tmgr;
 };
 

--- a/src/File.cc
+++ b/src/File.cc
@@ -65,10 +65,8 @@ void RotateTimer::Dispatch(double t, int is_expire)
 		{
 		if ( raise )
 			{
-			val_list* vl = new val_list;
 			Ref(file);
-			vl->append(new Val(file));
-			mgr.QueueEvent(rotate_interval, vl);
+			mgr.QueueEvent(rotate_interval, {new Val(file)});
 			}
 
 		file->InstallRotateTimer();
@@ -641,19 +639,15 @@ void BroFile::CloseCachedFiles()
 		// Send final rotate events (immediately).
 		if ( f->rotate_interval )
 			{
-			val_list* vl = new val_list;
 			Ref(f);
-			vl->append(new Val(f));
-			Event* event = new Event(::rotate_interval, vl);
+			Event* event = new Event(::rotate_interval, {new Val(f)});
 			mgr.Dispatch(event, true);
 			}
 
 		if ( f->rotate_size )
 			{
-			val_list* vl = new val_list;
 			Ref(f);
-			vl->append(new Val(f));
-			Event* event = new ::Event(::rotate_size, vl);
+			Event* event = new ::Event(::rotate_size, {new Val(f)});
 			mgr.Dispatch(event, true);
 			}
 
@@ -801,9 +795,7 @@ int BroFile::Write(const char* data, int len)
 
 	if ( rotate_size && current_size < rotate_size && current_size + len >= rotate_size )
 		{
-		val_list* vl = new val_list;
-		vl->append(new Val(this));
-		mgr.QueueEvent(::rotate_size, vl);
+		mgr.QueueEvent(::rotate_size, {new Val(this)});
 		}
 
 	// This does not work if we seek around. But none of the logs does that
@@ -818,10 +810,8 @@ void BroFile::RaiseOpenEvent()
 	if ( ! ::file_opened )
 		return;
 
-	val_list* vl = new val_list;
 	Ref(this);
-	vl->append(new Val(this));
-	Event* event = new ::Event(::file_opened, vl);
+	Event* event = new ::Event(::file_opened, {new Val(this)});
 	mgr.Dispatch(event, true);
 	}
 

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -258,8 +258,7 @@ void ID::MakeDeprecated()
 	if ( IsDeprecated() )
 		return;
 
-	attr_list* attr = new attr_list;
-	attr->append(new Attr(ATTR_DEPRECATED));
+	attr_list* attr = new attr_list{new Attr(ATTR_DEPRECATED)};
 	AddAttrs(new Attributes(attr, Type(), false));
 	}
 
@@ -305,8 +304,7 @@ void ID::SetOption()
 	// option implied redefinable
 	if ( ! IsRedefinable() )
 		{
-		attr_list* attr = new attr_list;
-		attr->append(new Attr(ATTR_REDEF));
+		attr_list* attr = new attr_list{new Attr(ATTR_REDEF)};
 		AddAttrs(new Attributes(attr, Type(), false));
 		}
 	}

--- a/src/List.cc
+++ b/src/List.cc
@@ -12,11 +12,13 @@
 BaseList::BaseList(int size)
 	{
 	num_entries = 0;
-	max_entries = 0;
-	entry = 0;
 
 	if ( size <= 0 )
+		{
+		max_entries = 0;
+		entry = 0;
 		return;
+		}
 
 	max_entries = size;
 
@@ -24,7 +26,7 @@ BaseList::BaseList(int size)
 	}
 
 
-BaseList::BaseList(BaseList& b)
+BaseList::BaseList(const BaseList& b)
 	{
 	max_entries = b.max_entries;
 	num_entries = b.num_entries;
@@ -36,6 +38,23 @@ BaseList::BaseList(BaseList& b)
 
 	for ( int i = 0; i < num_entries; ++i )
 		entry[i] = b.entry[i];
+	}
+
+BaseList::BaseList(BaseList&& b)
+	{
+	entry = b.entry;
+	num_entries = b.num_entries;
+	max_entries = b.max_entries;
+
+	b.entry = 0;
+	b.num_entries = b.max_entries = 0;
+	}
+
+BaseList::BaseList(const ent* arr, int n)
+	{
+	num_entries = max_entries = n;
+	entry = (ent*) safe_malloc(max_entries * sizeof(ent));
+	memcpy(entry, arr, n * sizeof(ent));
 	}
 
 void BaseList::sort(list_cmp_func cmp_func)
@@ -43,13 +62,12 @@ void BaseList::sort(list_cmp_func cmp_func)
 	qsort(entry, num_entries, sizeof(ent), cmp_func);
 	}
 
-void BaseList::operator=(BaseList& b)
+BaseList& BaseList::operator=(const BaseList& b)
 	{
 	if ( this == &b )
-		return;	// i.e., this already equals itself
+		return *this;
 
-	if ( entry )
-		free(entry);
+	free(entry);
 
 	max_entries = b.max_entries;
 	num_entries = b.num_entries;
@@ -61,6 +79,23 @@ void BaseList::operator=(BaseList& b)
 
 	for ( int i = 0; i < num_entries; ++i )
 		entry[i] = b.entry[i];
+
+	return *this;
+	}
+
+BaseList& BaseList::operator=(BaseList&& b)
+	{
+	if ( this == &b )
+		return *this;
+
+	free(entry);
+	entry = b.entry;
+	num_entries = b.num_entries;
+	max_entries = b.max_entries;
+
+	b.entry = 0;
+	b.num_entries = b.max_entries = 0;
+	return *this;
 	}
 
 void BaseList::insert(ent a)
@@ -145,12 +180,8 @@ ent BaseList::get()
 
 void BaseList::clear()
 	{
-	if ( entry )
-		{
-		free(entry);
-		entry = 0;
-		}
-
+	free(entry);
+	entry = 0;
 	num_entries = max_entries = 0;
 	}
 

--- a/src/PersistenceSerializer.cc
+++ b/src/PersistenceSerializer.cc
@@ -201,7 +201,8 @@ void PersistenceSerializer::RaiseFinishedSendState()
 void PersistenceSerializer::GotEvent(const char* name, double time,
 					EventHandlerPtr event, val_list* args)
 	{
-	mgr.QueueEvent(event, args);
+	mgr.QueueEvent(event, std::move(*args));
+	delete args;
 	}
 
 void PersistenceSerializer::GotFunctionCall(const char* name, double time,

--- a/src/RE.h
+++ b/src/RE.h
@@ -229,9 +229,6 @@ protected:
 	Specific_RE_Matcher* re_exact;
 };
 
-declare(PList, RE_Matcher);
-typedef PList(RE_Matcher) re_matcher_list;
-
 extern RE_Matcher* RE_Matcher_conjunction(const RE_Matcher* re1, const RE_Matcher* re2);
 extern RE_Matcher* RE_Matcher_disjunction(const RE_Matcher* re1, const RE_Matcher* re2);
 

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -506,9 +506,9 @@ void Reporter::DoLog(const char* prefix, EventHandlerPtr event, FILE* out,
 			}
 
 		if ( conn )
-			conn->ConnectionEvent(event, 0, std::move(vl));
+			conn->ConnectionEventFast(event, 0, std::move(vl));
 		else
-			mgr.QueueEvent(event, std::move(vl));
+			mgr.QueueEventFast(event, std::move(vl));
 		}
 	else
 		{

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -216,36 +216,30 @@ void Reporter::Syslog(const char* fmt, ...)
 
 void Reporter::WeirdHelper(EventHandlerPtr event, Val* conn_val, file_analysis::File* f, const char* addl, const char* fmt_name, ...)
 	{
-	val_list* vl = new val_list(1);
+	val_list vl(2);
 
 	if ( conn_val )
-		vl->append(conn_val);
+		vl.append(conn_val);
 	else if ( f )
-		vl->append(f->GetVal()->Ref());
+		vl.append(f->GetVal()->Ref());
 
 	if ( addl )
-		vl->append(new StringVal(addl));
+		vl.append(new StringVal(addl));
 
 	va_list ap;
 	va_start(ap, fmt_name);
-	DoLog("weird", event, 0, 0, vl, false, false, 0, fmt_name, ap);
+	DoLog("weird", event, 0, 0, &vl, false, false, 0, fmt_name, ap);
 	va_end(ap);
-
-	delete vl;
 	}
 
 void Reporter::WeirdFlowHelper(const IPAddr& orig, const IPAddr& resp, const char* fmt_name, ...)
 	{
-	val_list* vl = new val_list(2);
-	vl->append(new AddrVal(orig));
-	vl->append(new AddrVal(resp));
+	val_list vl{new AddrVal(orig), new AddrVal(resp)};
 
 	va_list ap;
 	va_start(ap, fmt_name);
-	DoLog("weird", flow_weird, 0, 0, vl, false, false, 0, fmt_name, ap);
+	DoLog("weird", flow_weird, 0, 0, &vl, false, false, 0, fmt_name, ap);
 	va_end(ap);
-
-	delete vl;
 	}
 
 void Reporter::UpdateWeirdStats(const char* name)
@@ -489,29 +483,32 @@ void Reporter::DoLog(const char* prefix, EventHandlerPtr event, FILE* out,
 
 	if ( raise_event && event && via_events && ! in_error_handler )
 		{
-		val_list* vl = new val_list;
+		auto vl_size = 1 + (bool)time + (bool)location + (bool)conn +
+		               (addl ? addl->length() : 0);
+
+		val_list vl(vl_size);
 
 		if ( time )
-			vl->append(new Val((bro_start_network_time != 0.0) ? network_time : 0, TYPE_TIME));
+			vl.append(new Val((bro_start_network_time != 0.0) ? network_time : 0, TYPE_TIME));
 
-		vl->append(new StringVal(buffer));
+		vl.append(new StringVal(buffer));
 
 		if ( location )
-			vl->append(new StringVal(loc_str.c_str()));
+			vl.append(new StringVal(loc_str.c_str()));
 
 		if ( conn )
-			vl->append(conn->BuildConnVal());
+			vl.append(conn->BuildConnVal());
 
 		if ( addl )
 			{
 			loop_over_list(*addl, i)
-				vl->append((*addl)[i]);
+				vl.append((*addl)[i]);
 			}
 
 		if ( conn )
-			conn->ConnectionEvent(event, 0, vl);
+			conn->ConnectionEvent(event, 0, std::move(vl));
 		else
-			mgr.QueueEvent(event, vl);
+			mgr.QueueEvent(event, std::move(vl));
 		}
 	else
 		{

--- a/src/RuleAction.cc
+++ b/src/RuleAction.cc
@@ -17,16 +17,11 @@ void RuleActionEvent::DoAction(const Rule* parent, RuleEndpointState* state,
 	{
 	if ( signature_match )
 		{
-		val_list* vl = new val_list;
-		vl->append(rule_matcher->BuildRuleStateValue(parent, state));
-		vl->append(new StringVal(msg));
-
-		if ( data )
-			vl->append(new StringVal(len, (const char*)data));
-		else
-			vl->append(val_mgr->GetEmptyString());
-
-		mgr.QueueEvent(signature_match, vl);
+		mgr.QueueEvent(signature_match, {
+			rule_matcher->BuildRuleStateValue(parent, state),
+			new StringVal(msg),
+			data ? new StringVal(len, (const char*)data) : val_mgr->GetEmptyString(),
+		});
 		}
 	}
 

--- a/src/RuleAction.cc
+++ b/src/RuleAction.cc
@@ -17,7 +17,7 @@ void RuleActionEvent::DoAction(const Rule* parent, RuleEndpointState* state,
 	{
 	if ( signature_match )
 		{
-		mgr.QueueEvent(signature_match, {
+		mgr.QueueEventFast(signature_match, {
 			rule_matcher->BuildRuleStateValue(parent, state),
 			new StringVal(msg),
 			data ? new StringVal(len, (const char*)data) : val_mgr->GetEmptyString(),

--- a/src/RuleCondition.cc
+++ b/src/RuleCondition.cc
@@ -162,7 +162,7 @@ bool RuleConditionEval::DoMatch(Rule* rule, RuleEndpointState* state,
 		return id->ID_Val()->AsBool();
 
 	// Call function with a signature_state value as argument.
-	val_list args;
+	val_list args(2);
 	args.append(rule_matcher->BuildRuleStateValue(rule, state));
 
 	if ( data )

--- a/src/Scope.cc
+++ b/src/Scope.cc
@@ -7,6 +7,9 @@
 #include "Scope.h"
 #include "Reporter.h"
 
+declare(PList,Scope);
+typedef PList(Scope) scope_list;
+
 static scope_list scopes;
 static Scope* top_scope;
 

--- a/src/Serializer.cc
+++ b/src/Serializer.cc
@@ -365,7 +365,7 @@ bool Serializer::UnserializeCall(UnserialInfo* info)
 	d.SetIncludeStats(true);
 	d.SetShort();
 
-	val_list* args = new val_list;
+	val_list* args = new val_list(len);
 	for ( int i = 0; i < len; ++i )
 		{
 		Val* v = Val::Unserialize(info);
@@ -996,7 +996,8 @@ void EventPlayer::GotEvent(const char* name, double time,
 	{
 	ne_time = time;
 	ne_handler = event;
-	ne_args = args;
+	ne_args = std::move(*args);
+	delete args;
 	}
 
 void EventPlayer::GotFunctionCall(const char* name, double time,
@@ -1054,7 +1055,7 @@ void EventPlayer::Process()
 	if ( ! (io && ne_time) )
 		return;
 
-	Event* event = new Event(ne_handler, ne_args);
+	Event* event = new Event(ne_handler, std::move(ne_args));
 	mgr.Dispatch(event);
 
 	ne_time = 0;

--- a/src/Serializer.h
+++ b/src/Serializer.h
@@ -353,7 +353,7 @@ protected:
 	// Next event waiting to be dispatched.
 	double ne_time;
 	EventHandlerPtr ne_handler;
-	val_list* ne_args;
+	val_list ne_args;
 
 };
 

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -171,11 +171,7 @@ void NetSessions::NextPacket(double t, const Packet* pkt)
 	SegmentProfiler(segment_logger, "dispatching-packet");
 
 	if ( raw_packet )
-		{
-		val_list* vl = new val_list();
-		vl->append(pkt->BuildPktHdrVal());
-		mgr.QueueEvent(raw_packet, vl);
-		}
+		mgr.QueueEvent(raw_packet, {pkt->BuildPktHdrVal()});
 
 	if ( pkt_profiler )
 		pkt_profiler->ProfilePkt(t, pkt->cap_len);
@@ -415,11 +411,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 		{
 		dump_this_packet = 1;
 		if ( esp_packet )
-			{
-			val_list* vl = new val_list();
-			vl->append(ip_hdr->BuildPktHdrVal());
-			mgr.QueueEvent(esp_packet, vl);
-			}
+			mgr.QueueEvent(esp_packet, {ip_hdr->BuildPktHdrVal()});
 
 		// Can't do more since upper-layer payloads are going to be encrypted.
 		return;
@@ -439,11 +431,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 			}
 
 		if ( mobile_ipv6_message )
-			{
-			val_list* vl = new val_list();
-			vl->append(ip_hdr->BuildPktHdrVal());
-			mgr.QueueEvent(mobile_ipv6_message, vl);
-			}
+			mgr.QueueEvent(mobile_ipv6_message, {ip_hdr->BuildPktHdrVal()});
 
 		if ( ip_hdr->NextProto() != IPPROTO_NONE )
 			Weird("mobility_piggyback", pkt, encapsulation);
@@ -1329,10 +1317,10 @@ Connection* NetSessions::NewConn(HashKey* k, double t, const ConnID* id,
 
 		if ( external )
 			{
-			val_list* vl = new val_list(2);
-			vl->append(conn->BuildConnVal());
-			vl->append(new StringVal(conn->GetTimerMgr()->GetTag().c_str()));
-			conn->ConnectionEvent(connection_external, 0, vl);
+			conn->ConnectionEvent(connection_external, 0, {
+				conn->BuildConnVal(),
+				new StringVal(conn->GetTimerMgr()->GetTag().c_str()),
+			});
 			}
 		}
 

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -171,7 +171,7 @@ void NetSessions::NextPacket(double t, const Packet* pkt)
 	SegmentProfiler(segment_logger, "dispatching-packet");
 
 	if ( raw_packet )
-		mgr.QueueEvent(raw_packet, {pkt->BuildPktHdrVal()});
+		mgr.QueueEventFast(raw_packet, {pkt->BuildPktHdrVal()});
 
 	if ( pkt_profiler )
 		pkt_profiler->ProfilePkt(t, pkt->cap_len);
@@ -411,7 +411,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 		{
 		dump_this_packet = 1;
 		if ( esp_packet )
-			mgr.QueueEvent(esp_packet, {ip_hdr->BuildPktHdrVal()});
+			mgr.QueueEventFast(esp_packet, {ip_hdr->BuildPktHdrVal()});
 
 		// Can't do more since upper-layer payloads are going to be encrypted.
 		return;
@@ -1315,9 +1315,9 @@ Connection* NetSessions::NewConn(HashKey* k, double t, const ConnID* id,
 		{
 		conn->Event(new_connection, 0);
 
-		if ( external )
+		if ( external && connection_external )
 			{
-			conn->ConnectionEvent(connection_external, 0, {
+			conn->ConnectionEventFast(connection_external, 0, {
 				conn->BuildConnVal(),
 				new StringVal(conn->GetTimerMgr()->GetTag().c_str()),
 			});

--- a/src/StateAccess.cc
+++ b/src/StateAccess.cc
@@ -536,7 +536,7 @@ void StateAccess::Replay()
 
 	if ( remote_state_access_performed )
 		{
-		mgr.QueueEvent(remote_state_access_performed, {
+		mgr.QueueEventFast(remote_state_access_performed, {
 			new StringVal(target.id->Name()),
 			target.id->ID_Val()->Ref(),
 		});

--- a/src/StateAccess.cc
+++ b/src/StateAccess.cc
@@ -192,12 +192,12 @@ bool StateAccess::CheckOld(const char* op, ID* id, Val* index,
 	else
 		arg3 = new StringVal("<none>");
 
-	val_list* args = new val_list;
-	args->append(new StringVal(op));
-	args->append(arg1);
-	args->append(arg2);
-	args->append(arg3);
-	mgr.QueueEvent(remote_state_inconsistency, args);
+	mgr.QueueEvent(remote_state_inconsistency, {
+		new StringVal(op),
+		arg1,
+		arg2,
+		arg3,
+	});
 
 	return false;
 	}
@@ -219,12 +219,12 @@ bool StateAccess::CheckOldSet(const char* op, ID* id, Val* index,
 	Val* arg2 = new StringVal(should ? "set" : "not set");
 	Val* arg3 = new StringVal(is ? "set" : "not set");
 
-	val_list* args = new val_list;
-	args->append(new StringVal(op));
-	args->append(arg1);
-	args->append(arg2);
-	args->append(arg3);
-	mgr.QueueEvent(remote_state_inconsistency, args);
+	mgr.QueueEvent(remote_state_inconsistency, {
+		new StringVal(op),
+		arg1,
+		arg2,
+		arg3,
+	});
 
 	return false;
 	}
@@ -514,12 +514,12 @@ void StateAccess::Replay()
 					d.SetShort();
 					op1.val->Describe(&d);
 
-					val_list* args = new val_list;
-					args->append(new StringVal("read"));
-					args->append(new StringVal(fmt("%s[%s]", target.id->Name(), d.Description())));
-					args->append(new StringVal("existent"));
-					args->append(new StringVal("not existent"));
-					mgr.QueueEvent(remote_state_inconsistency, args);
+					mgr.QueueEvent(remote_state_inconsistency, {
+						new StringVal("read"),
+						new StringVal(fmt("%s[%s]", target.id->Name(), d.Description())),
+						new StringVal("existent"),
+						new StringVal("not existent"),
+					});
 					}
 				}
 			}
@@ -536,10 +536,10 @@ void StateAccess::Replay()
 
 	if ( remote_state_access_performed )
 		{
-		val_list* vl = new val_list;
-		vl->append(new StringVal(target.id->Name()));
-		vl->append(target.id->ID_Val()->Ref());
-		mgr.QueueEvent(remote_state_access_performed, vl);
+		mgr.QueueEvent(remote_state_access_performed, {
+			new StringVal(target.id->Name()),
+			target.id->ID_Val()->Ref(),
+		});
 		}
 	}
 
@@ -943,8 +943,7 @@ void NotifierRegistry::Register(ID* id, NotifierRegistry::Notifier* notifier)
 		}
 	else
 		{
-		attr_list* a = new attr_list;
-		a->append(attr);
+		attr_list* a = new attr_list{attr};
 		id->SetAttrs(new Attributes(a, id->Type(), false));
 		}
 

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -310,11 +310,11 @@ void ProfileLogger::Log()
 	// (and for consistency we dispatch it *now*)
 	if ( profiling_update )
 		{
-		val_list* vl = new val_list;
 		Ref(file);
-		vl->append(new Val(file));
-		vl->append(val_mgr->GetBool(expensive));
-		mgr.Dispatch(new Event(profiling_update, vl));
+		mgr.Dispatch(new Event(profiling_update, {
+			new Val(file),
+			val_mgr->GetBool(expensive),
+		}));
 		}
 	}
 
@@ -369,12 +369,11 @@ void SampleLogger::SegmentProfile(const char* /* name */,
 					const Location* /* loc */,
 					double dtime, int dmem)
 	{
-	val_list* vl = new val_list(2);
-	vl->append(load_samples->Ref());
-	vl->append(new IntervalVal(dtime, Seconds));
-	vl->append(val_mgr->GetInt(dmem));
-
-	mgr.QueueEvent(load_sample, vl);
+	mgr.QueueEvent(load_sample, {
+		load_samples->Ref(),
+		new IntervalVal(dtime, Seconds),
+		val_mgr->GetInt(dmem)
+	});
 	}
 
 void SegmentProfiler::Init()

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -369,11 +369,12 @@ void SampleLogger::SegmentProfile(const char* /* name */,
 					const Location* /* loc */,
 					double dtime, int dmem)
 	{
-	mgr.QueueEvent(load_sample, {
-		load_samples->Ref(),
-		new IntervalVal(dtime, Seconds),
-		val_mgr->GetInt(dmem)
-	});
+	if ( load_sample )
+		mgr.QueueEventFast(load_sample, {
+			load_samples->Ref(),
+			new IntervalVal(dtime, Seconds),
+			val_mgr->GetInt(dmem)
+		});
 	}
 
 void SegmentProfiler::Init()

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -292,13 +292,14 @@ Val* PrintStmt::DoExec(val_list* vals, stmt_flow_type& /* flow */) const
 
 		if ( print_hook )
 			{
-			val_list* vl = new val_list(2);
 			::Ref(f);
-			vl->append(new Val(f));
-			vl->append(new StringVal(d.Len(), d.Description()));
 
 			// Note, this doesn't do remote printing.
-			mgr.Dispatch(new Event(print_hook, vl), true);
+			mgr.Dispatch(
+			    new Event(
+			        print_hook,
+			        {new Val(f), new StringVal(d.Len(), d.Description())}),
+			    true);
 			}
 
 		if ( remote_serializer )
@@ -704,7 +705,7 @@ bool Case::DoUnserialize(UnserialInfo* info)
 	if ( ! UNSERIALIZE(&len) )
 		return false;
 
-	type_cases = new id_list;
+	type_cases = new id_list(len);
 
 	while ( len-- )
 		{
@@ -1198,7 +1199,10 @@ Val* EventStmt::Exec(Frame* f, stmt_flow_type& flow) const
 	val_list* args = eval_list(f, event_expr->Args());
 
 	if ( args )
-		mgr.QueueEvent(event_expr->Handler(), args);
+		{
+		mgr.QueueEvent(event_expr->Handler(), std::move(*args));
+		delete args;
+		}
 
 	flow = FLOW_NEXT;
 
@@ -1633,7 +1637,7 @@ bool ForStmt::DoUnserialize(UnserialInfo* info)
 	if ( ! UNSERIALIZE(&len) )
 		return false;
 
-	loop_vars = new id_list;
+	loop_vars = new id_list(len);
 
 	while ( len-- )
 		{
@@ -2149,7 +2153,7 @@ bool InitStmt::DoUnserialize(UnserialInfo* info)
 	if ( ! UNSERIALIZE(&len) )
 		return false;
 
-	inits = new id_list;
+	inits = new id_list(len);
 
 	while ( len-- )
 		{

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -213,6 +213,9 @@ protected:
 	Stmt* s;
 };
 
+declare(PList,Case);
+typedef PList(Case) case_list;
+
 class SwitchStmt : public ExprStmt {
 public:
 	SwitchStmt(Expr* index, case_list* cases);

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -2266,7 +2266,7 @@ BroType* merge_types(const BroType* t1, const BroType* t2)
 		if ( rt1->NumFields() != rt2->NumFields() )
 			return 0;
 
-		type_decl_list* tdl3 = new type_decl_list;
+		type_decl_list* tdl3 = new type_decl_list(rt1->NumFields());
 
 		for ( int i = 0; i < rt1->NumFields(); ++i )
 			{

--- a/src/Type.h
+++ b/src/Type.h
@@ -460,6 +460,9 @@ public:
 	const char* id;
 };
 
+declare(PList,TypeDecl);
+typedef PList(TypeDecl) type_decl_list;
+
 class RecordType : public BroType {
 public:
 	explicit RecordType(type_decl_list* types);

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -325,8 +325,7 @@ static void transfer_arg_defaults(RecordType* args, RecordType* recv)
 
 		if ( ! recv_i->attrs )
 			{
-			attr_list* a = new attr_list();
-			a->append(def);
+			attr_list* a = new attr_list{def};
 			recv_i->attrs = new Attributes(a, recv_i->type, true);
 			}
 

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -662,16 +662,19 @@ void Analyzer::ProtocolConfirmation(Tag arg_tag)
 	if ( protocol_confirmed )
 		return;
 
+	protocol_confirmed = true;
+
+	if ( ! protocol_confirmation )
+		return;
+
 	EnumVal* tval = arg_tag ? arg_tag.AsEnumVal() : tag.AsEnumVal();
 	Ref(tval);
 
-	mgr.QueueEvent(protocol_confirmation, {
+	mgr.QueueEventFast(protocol_confirmation, {
 		BuildConnVal(),
 		tval,
 		val_mgr->GetCount(id),
 	});
-
-	protocol_confirmed = true;
 	}
 
 void Analyzer::ProtocolViolation(const char* reason, const char* data, int len)
@@ -689,10 +692,13 @@ void Analyzer::ProtocolViolation(const char* reason, const char* data, int len)
 	else
 		r = new StringVal(reason);
 
+	if ( ! protocol_violation )
+		return;
+
 	EnumVal* tval = tag.AsEnumVal();
 	Ref(tval);
 
-	mgr.QueueEvent(protocol_violation, {
+	mgr.QueueEventFast(protocol_violation, {
 		BuildConnVal(),
 		tval,
 		val_mgr->GetCount(id),
@@ -785,6 +791,11 @@ void Analyzer::ConnectionEvent(EventHandlerPtr f, val_list* vl)
 void Analyzer::ConnectionEvent(EventHandlerPtr f, val_list vl)
 	{
 	conn->ConnectionEvent(f, this, std::move(vl));
+	}
+
+void Analyzer::ConnectionEventFast(EventHandlerPtr f, val_list vl)
+	{
+	conn->ConnectionEventFast(f, this, std::move(vl));
 	}
 
 void Analyzer::Weird(const char* name, const char* addl)

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -665,11 +665,11 @@ void Analyzer::ProtocolConfirmation(Tag arg_tag)
 	EnumVal* tval = arg_tag ? arg_tag.AsEnumVal() : tag.AsEnumVal();
 	Ref(tval);
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(tval);
-	vl->append(val_mgr->GetCount(id));
-	mgr.QueueEvent(protocol_confirmation, vl);
+	mgr.QueueEvent(protocol_confirmation, {
+		BuildConnVal(),
+		tval,
+		val_mgr->GetCount(id),
+	});
 
 	protocol_confirmed = true;
 	}
@@ -692,12 +692,12 @@ void Analyzer::ProtocolViolation(const char* reason, const char* data, int len)
 	EnumVal* tval = tag.AsEnumVal();
 	Ref(tval);
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(tval);
-	vl->append(val_mgr->GetCount(id));
-	vl->append(r);
-	mgr.QueueEvent(protocol_violation, vl);
+	mgr.QueueEvent(protocol_violation, {
+		BuildConnVal(),
+		tval,
+		val_mgr->GetCount(id),
+		r,
+	});
 	}
 
 void Analyzer::AddTimer(analyzer_timer_func timer, double t,
@@ -780,6 +780,11 @@ void Analyzer::Event(EventHandlerPtr f, Val* v1, Val* v2)
 void Analyzer::ConnectionEvent(EventHandlerPtr f, val_list* vl)
 	{
 	conn->ConnectionEvent(f, this, vl);
+	}
+
+void Analyzer::ConnectionEvent(EventHandlerPtr f, val_list vl)
+	{
+	conn->ConnectionEvent(f, this, std::move(vl));
 	}
 
 void Analyzer::Weird(const char* name, const char* addl)

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -548,6 +548,12 @@ public:
 	void ConnectionEvent(EventHandlerPtr f, val_list vl);
 
 	/**
+	 * Convenience function that forwards directly to
+	 * Connection::ConnectionEventFast().
+	 */
+	void ConnectionEventFast(EventHandlerPtr f, val_list vl);
+
+	/**
 	 * Convenience function that forwards directly to the corresponding
 	 * Connection::Weird().
 	 */

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -542,6 +542,12 @@ public:
 	void ConnectionEvent(EventHandlerPtr f, val_list* vl);
 
 	/**
+	 * Convenience function that forwards directly to
+	 * Connection::ConnectionEvent().
+	 */
+	void ConnectionEvent(EventHandlerPtr f, val_list vl);
+
+	/**
 	 * Convenience function that forwards directly to the corresponding
 	 * Connection::Weird().
 	 */

--- a/src/analyzer/protocol/arp/ARP.cc
+++ b/src/analyzer/protocol/arp/ARP.cc
@@ -190,13 +190,13 @@ void ARP_Analyzer::BadARP(const struct arp_pkthdr* hdr, const char* msg)
 	if ( ! bad_arp )
 		return;
 
-	val_list* vl = new val_list;
-	vl->append(ConstructAddrVal(ar_spa(hdr)));
-	vl->append(EthAddrToStr((const u_char*) ar_sha(hdr)));
-	vl->append(ConstructAddrVal(ar_tpa(hdr)));
-	vl->append(EthAddrToStr((const u_char*) ar_tha(hdr)));
-	vl->append(new StringVal(msg));
-	mgr.QueueEvent(bad_arp, vl);
+	mgr.QueueEvent(bad_arp, {
+		ConstructAddrVal(ar_spa(hdr)),
+		EthAddrToStr((const u_char*) ar_sha(hdr)),
+		ConstructAddrVal(ar_tpa(hdr)),
+		EthAddrToStr((const u_char*) ar_tha(hdr)),
+		new StringVal(msg),
+	});
 	}
 
 void ARP_Analyzer::Corrupted(const char* msg)
@@ -212,18 +212,14 @@ void ARP_Analyzer::RREvent(EventHandlerPtr e,
 	if ( ! e )
 		return;
 
-	// init the val_list
-	val_list* vl = new val_list;
-
-	// prepare the event arguments
-	vl->append(EthAddrToStr(src));
-	vl->append(EthAddrToStr(dst));
-	vl->append(ConstructAddrVal(spa));
-	vl->append(EthAddrToStr((const u_char*) sha));
-	vl->append(ConstructAddrVal(tpa));
-	vl->append(EthAddrToStr((const u_char*) tha));
-
-	mgr.QueueEvent(e, vl);
+	mgr.QueueEvent(e, {
+		EthAddrToStr(src),
+		EthAddrToStr(dst),
+		ConstructAddrVal(spa),
+		EthAddrToStr((const u_char*) sha),
+		ConstructAddrVal(tpa),
+		EthAddrToStr((const u_char*) tha),
+	});
 	}
 
 AddrVal* ARP_Analyzer::ConstructAddrVal(const void* addr)

--- a/src/analyzer/protocol/arp/ARP.cc
+++ b/src/analyzer/protocol/arp/ARP.cc
@@ -190,7 +190,7 @@ void ARP_Analyzer::BadARP(const struct arp_pkthdr* hdr, const char* msg)
 	if ( ! bad_arp )
 		return;
 
-	mgr.QueueEvent(bad_arp, {
+	mgr.QueueEventFast(bad_arp, {
 		ConstructAddrVal(ar_spa(hdr)),
 		EthAddrToStr((const u_char*) ar_sha(hdr)),
 		ConstructAddrVal(ar_tpa(hdr)),
@@ -212,7 +212,7 @@ void ARP_Analyzer::RREvent(EventHandlerPtr e,
 	if ( ! e )
 		return;
 
-	mgr.QueueEvent(e, {
+	mgr.QueueEventFast(e, {
 		EthAddrToStr(src),
 		EthAddrToStr(dst),
 		ConstructAddrVal(spa),

--- a/src/analyzer/protocol/backdoor/BackDoor.cc
+++ b/src/analyzer/protocol/backdoor/BackDoor.cc
@@ -246,7 +246,10 @@ void BackDoorEndpoint::RloginSignatureFound(int len)
 
 	rlogin_checking_done = 1;
 
-	endp->TCP()->ConnectionEvent(rlogin_signature_found, {
+	if ( ! rlogin_signature_found )
+		return;
+
+	endp->TCP()->ConnectionEventFast(rlogin_signature_found, {
 		endp->TCP()->BuildConnVal(),
 		val_mgr->GetBool(endp->IsOrig()),
 		val_mgr->GetCount(rlogin_num_null),
@@ -337,7 +340,10 @@ void BackDoorEndpoint::CheckForTelnet(uint64 /* seq */, int len, const u_char* d
 
 void BackDoorEndpoint::TelnetSignatureFound(int len)
 	{
-	endp->TCP()->ConnectionEvent(telnet_signature_found, {
+	if ( ! telnet_signature_found )
+		return;
+
+	endp->TCP()->ConnectionEventFast(telnet_signature_found, {
 		endp->TCP()->BuildConnVal(),
 		val_mgr->GetBool(endp->IsOrig()),
 		val_mgr->GetCount(len),
@@ -641,12 +647,15 @@ void BackDoorEndpoint::CheckForHTTPProxy(uint64 /* seq */, int len,
 
 void BackDoorEndpoint::SignatureFound(EventHandlerPtr e, int do_orig)
 	{
+	if ( ! e )
+		return;
+
 	if ( do_orig )
-		endp->TCP()->ConnectionEvent(e,
+		endp->TCP()->ConnectionEventFast(e,
 		    {endp->TCP()->BuildConnVal(), val_mgr->GetBool(endp->IsOrig())});
 
 	else
-		endp->TCP()->ConnectionEvent(e, {endp->TCP()->BuildConnVal()});
+		endp->TCP()->ConnectionEventFast(e, {endp->TCP()->BuildConnVal()});
 	}
 
 
@@ -773,7 +782,10 @@ void BackDoor_Analyzer::StatTimer(double t, int is_expire)
 
 void BackDoor_Analyzer::StatEvent()
 	{
-	TCP()->ConnectionEvent(backdoor_stats, {
+	if ( ! backdoor_stats )
+		return;
+
+	TCP()->ConnectionEventFast(backdoor_stats, {
 		TCP()->BuildConnVal(),
 		orig_endp->BuildStats(),
 		resp_endp->BuildStats(),
@@ -782,7 +794,10 @@ void BackDoor_Analyzer::StatEvent()
 
 void BackDoor_Analyzer::RemoveEvent()
 	{
-	TCP()->ConnectionEvent(backdoor_remove_conn, {TCP()->BuildConnVal()});
+	if ( ! backdoor_remove_conn )
+		return;
+
+	TCP()->ConnectionEventFast(backdoor_remove_conn, {TCP()->BuildConnVal()});
 	}
 
 BackDoorTimer::BackDoorTimer(double t, BackDoor_Analyzer* a)

--- a/src/analyzer/protocol/backdoor/BackDoor.cc
+++ b/src/analyzer/protocol/backdoor/BackDoor.cc
@@ -246,13 +246,12 @@ void BackDoorEndpoint::RloginSignatureFound(int len)
 
 	rlogin_checking_done = 1;
 
-	val_list* vl = new val_list;
-	vl->append(endp->TCP()->BuildConnVal());
-	vl->append(val_mgr->GetBool(endp->IsOrig()));
-	vl->append(val_mgr->GetCount(rlogin_num_null));
-	vl->append(val_mgr->GetCount(len));
-
-	endp->TCP()->ConnectionEvent(rlogin_signature_found, vl);
+	endp->TCP()->ConnectionEvent(rlogin_signature_found, {
+		endp->TCP()->BuildConnVal(),
+		val_mgr->GetBool(endp->IsOrig()),
+		val_mgr->GetCount(rlogin_num_null),
+		val_mgr->GetCount(len),
+	});
 	}
 
 void BackDoorEndpoint::CheckForTelnet(uint64 /* seq */, int len, const u_char* data)
@@ -338,12 +337,11 @@ void BackDoorEndpoint::CheckForTelnet(uint64 /* seq */, int len, const u_char* d
 
 void BackDoorEndpoint::TelnetSignatureFound(int len)
 	{
-	val_list* vl = new val_list;
-	vl->append(endp->TCP()->BuildConnVal());
-	vl->append(val_mgr->GetBool(endp->IsOrig()));
-	vl->append(val_mgr->GetCount(len));
-
-	endp->TCP()->ConnectionEvent(telnet_signature_found, vl);
+	endp->TCP()->ConnectionEvent(telnet_signature_found, {
+		endp->TCP()->BuildConnVal(),
+		val_mgr->GetBool(endp->IsOrig()),
+		val_mgr->GetCount(len),
+	});
 	}
 
 void BackDoorEndpoint::CheckForSSH(uint64 seq, int len, const u_char* data)
@@ -643,13 +641,12 @@ void BackDoorEndpoint::CheckForHTTPProxy(uint64 /* seq */, int len,
 
 void BackDoorEndpoint::SignatureFound(EventHandlerPtr e, int do_orig)
 	{
-	val_list* vl = new val_list;
-	vl->append(endp->TCP()->BuildConnVal());
-
 	if ( do_orig )
-		vl->append(val_mgr->GetBool(endp->IsOrig()));
+		endp->TCP()->ConnectionEvent(e,
+		    {endp->TCP()->BuildConnVal(), val_mgr->GetBool(endp->IsOrig())});
 
-	endp->TCP()->ConnectionEvent(e, vl);
+	else
+		endp->TCP()->ConnectionEvent(e, {endp->TCP()->BuildConnVal()});
 	}
 
 
@@ -776,20 +773,16 @@ void BackDoor_Analyzer::StatTimer(double t, int is_expire)
 
 void BackDoor_Analyzer::StatEvent()
 	{
-	val_list* vl = new val_list;
-	vl->append(TCP()->BuildConnVal());
-	vl->append(orig_endp->BuildStats());
-	vl->append(resp_endp->BuildStats());
-
-	TCP()->ConnectionEvent(backdoor_stats, vl);
+	TCP()->ConnectionEvent(backdoor_stats, {
+		TCP()->BuildConnVal(),
+		orig_endp->BuildStats(),
+		resp_endp->BuildStats(),
+	});
 	}
 
 void BackDoor_Analyzer::RemoveEvent()
 	{
-	val_list* vl = new val_list;
-	vl->append(TCP()->BuildConnVal());
-
-	TCP()->ConnectionEvent(backdoor_remove_conn, vl);
+	TCP()->ConnectionEvent(backdoor_remove_conn, {TCP()->BuildConnVal()});
 	}
 
 BackDoorTimer::BackDoorTimer(double t, BackDoor_Analyzer* a)

--- a/src/analyzer/protocol/bittorrent/BitTorrent.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrent.cc
@@ -120,10 +120,10 @@ void BitTorrent_Analyzer::DeliverWeird(const char* msg, bool orig)
 	{
 	if ( bittorrent_peer_weird )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(msg));
-		ConnectionEvent(bittorrent_peer_weird, vl);
+		ConnectionEvent(bittorrent_peer_weird, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(msg),
+		});
 		}
 	}

--- a/src/analyzer/protocol/bittorrent/BitTorrent.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrent.cc
@@ -120,7 +120,7 @@ void BitTorrent_Analyzer::DeliverWeird(const char* msg, bool orig)
 	{
 	if ( bittorrent_peer_weird )
 		{
-		ConnectionEvent(bittorrent_peer_weird, {
+		ConnectionEventFast(bittorrent_peer_weird, {
 			BuildConnVal(),
 			val_mgr->GetBool(orig),
 			new StringVal(msg),

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -247,7 +247,7 @@ void BitTorrentTracker_Analyzer::DeliverWeird(const char* msg, bool orig)
 	{
 	if ( bt_tracker_weird )
 		{
-		ConnectionEvent(bt_tracker_weird, {
+		ConnectionEventFast(bt_tracker_weird, {
 			BuildConnVal(),
 			val_mgr->GetBool(orig),
 			new StringVal(msg),
@@ -348,11 +348,12 @@ void BitTorrentTracker_Analyzer::EmitRequest(void)
 	{
 	ProtocolConfirmation();
 
-	ConnectionEvent(bt_tracker_request, {
-		BuildConnVal(),
-		req_val_uri,
-		req_val_headers,
-	});
+	if ( bt_tracker_request )
+		ConnectionEventFast(bt_tracker_request, {
+			BuildConnVal(),
+			req_val_uri,
+			req_val_headers,
+		});
 
 	req_val_uri = 0;
 	req_val_headers = 0;
@@ -401,11 +402,12 @@ bool BitTorrentTracker_Analyzer::ParseResponse(char* line)
 			{
 			if ( res_status != 200 )
 				{
-				ConnectionEvent(bt_tracker_response_not_ok, {
-					BuildConnVal(),
-					val_mgr->GetCount(res_status),
-					res_val_headers,
-				});
+				if ( bt_tracker_response_not_ok )
+					ConnectionEventFast(bt_tracker_response_not_ok, {
+						BuildConnVal(),
+						val_mgr->GetCount(res_status),
+						res_val_headers,
+					});
 				res_val_headers = 0;
 				res_buf_pos = res_buf + res_buf_len;
 				res_state = BTT_RES_DONE;
@@ -787,13 +789,14 @@ void BitTorrentTracker_Analyzer::EmitResponse(void)
 	{
 	ProtocolConfirmation();
 
-	ConnectionEvent(bt_tracker_response, {
-		BuildConnVal(),
-		val_mgr->GetCount(res_status),
-		res_val_headers,
-		res_val_peers,
-		res_val_benc,
-	});
+	if ( bt_tracker_response )
+		ConnectionEventFast(bt_tracker_response, {
+			BuildConnVal(),
+			val_mgr->GetCount(res_status),
+			res_val_headers,
+			res_val_peers,
+			res_val_benc,
+		});
 
 	res_val_headers = 0;
 	res_val_peers = 0;

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -247,11 +247,11 @@ void BitTorrentTracker_Analyzer::DeliverWeird(const char* msg, bool orig)
 	{
 	if ( bt_tracker_weird )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(msg));
-		ConnectionEvent(bt_tracker_weird, vl);
+		ConnectionEvent(bt_tracker_weird, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(msg),
+		});
 		}
 	}
 
@@ -346,19 +346,16 @@ void BitTorrentTracker_Analyzer::RequestGet(char* uri)
 
 void BitTorrentTracker_Analyzer::EmitRequest(void)
 	{
-	val_list* vl;
-
 	ProtocolConfirmation();
 
-	vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(req_val_uri);
-	vl->append(req_val_headers);
+	ConnectionEvent(bt_tracker_request, {
+		BuildConnVal(),
+		req_val_uri,
+		req_val_headers,
+	});
 
 	req_val_uri = 0;
 	req_val_headers = 0;
-
-	ConnectionEvent(bt_tracker_request, vl);
 	}
 
 bool BitTorrentTracker_Analyzer::ParseResponse(char* line)
@@ -404,11 +401,11 @@ bool BitTorrentTracker_Analyzer::ParseResponse(char* line)
 			{
 			if ( res_status != 200 )
 				{
-				val_list* vl = new val_list;
-				vl->append(BuildConnVal());
-				vl->append(val_mgr->GetCount(res_status));
-				vl->append(res_val_headers);
-				ConnectionEvent(bt_tracker_response_not_ok, vl);
+				ConnectionEvent(bt_tracker_response_not_ok, {
+					BuildConnVal(),
+					val_mgr->GetCount(res_status),
+					res_val_headers,
+				});
 				res_val_headers = 0;
 				res_buf_pos = res_buf + res_buf_len;
 				res_state = BTT_RES_DONE;
@@ -790,16 +787,15 @@ void BitTorrentTracker_Analyzer::EmitResponse(void)
 	{
 	ProtocolConfirmation();
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(val_mgr->GetCount(res_status));
-	vl->append(res_val_headers);
-	vl->append(res_val_peers);
-	vl->append(res_val_benc);
+	ConnectionEvent(bt_tracker_response, {
+		BuildConnVal(),
+		val_mgr->GetCount(res_status),
+		res_val_headers,
+		res_val_peers,
+		res_val_benc,
+	});
 
 	res_val_headers = 0;
 	res_val_peers = 0;
 	res_val_benc = 0;
-
-	ConnectionEvent(bt_tracker_response, vl);
 	}

--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -47,11 +47,11 @@ void ConnSize_Analyzer::ThresholdEvent(EventHandlerPtr f, uint64 threshold, bool
 	if ( ! f )
 		return;
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(val_mgr->GetCount(threshold));
-	vl->append(val_mgr->GetBool(is_orig));
-	ConnectionEvent(f, vl);
+	ConnectionEvent(f, {
+		BuildConnVal(),
+		val_mgr->GetCount(threshold),
+		val_mgr->GetBool(is_orig),
+	});
 	}
 
 void ConnSize_Analyzer::CheckSizes(bool is_orig)

--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -47,7 +47,7 @@ void ConnSize_Analyzer::ThresholdEvent(EventHandlerPtr f, uint64 threshold, bool
 	if ( ! f )
 		return;
 
-	ConnectionEvent(f, {
+	ConnectionEventFast(f, {
 		BuildConnVal(),
 		val_mgr->GetCount(threshold),
 		val_mgr->GetBool(is_orig),

--- a/src/analyzer/protocol/dns/DNS.h
+++ b/src/analyzer/protocol/dns/DNS.h
@@ -182,7 +182,7 @@ public:
 	Val* BuildHdrVal();
 	Val* BuildAnswerVal();
 	Val* BuildEDNS_Val();
-	Val* BuildTSIG_Val();
+	Val* BuildTSIG_Val(struct TSIG_DATA*);
 	Val* BuildRRSIG_Val(struct RRSIG_DATA*);
 	Val* BuildDNSKEY_Val(struct DNSKEY_DATA*);
 	Val* BuildNSEC3_Val(struct NSEC3_DATA*);
@@ -214,10 +214,6 @@ public:
 				///< identical answer, there may be problems
 	// uint32* addr;	///< cache value to pass back results
 				///< for forward lookups
-
-	// More values for spesific DNS types.
-	//struct EDNS_ADDITIONAL* edns;
-	struct TSIG_DATA* tsig;
 };
 
 

--- a/src/analyzer/protocol/file/File.cc
+++ b/src/analyzer/protocol/file/File.cc
@@ -77,10 +77,11 @@ void File_Analyzer::Identify()
 	                     &matches);
 	string match = matches.empty() ? "<unknown>"
 	                               : *(matches.begin()->second.begin());
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(new StringVal(buffer_len, buffer));
-	vl->append(new StringVal("<unknown>"));
-	vl->append(new StringVal(match));
-	ConnectionEvent(file_transferred, vl);
+
+	ConnectionEvent(file_transferred, {
+		BuildConnVal(),
+		new StringVal(buffer_len, buffer),
+		new StringVal("<unknown>"),
+		new StringVal(match),
+	});
 	}

--- a/src/analyzer/protocol/file/File.cc
+++ b/src/analyzer/protocol/file/File.cc
@@ -78,10 +78,11 @@ void File_Analyzer::Identify()
 	string match = matches.empty() ? "<unknown>"
 	                               : *(matches.begin()->second.begin());
 
-	ConnectionEvent(file_transferred, {
-		BuildConnVal(),
-		new StringVal(buffer_len, buffer),
-		new StringVal("<unknown>"),
-		new StringVal(match),
-	});
+	if ( file_transferred )
+		ConnectionEventFast(file_transferred, {
+			BuildConnVal(),
+			new StringVal(buffer_len, buffer),
+			new StringVal("<unknown>"),
+			new StringVal(match),
+		});
 	}

--- a/src/analyzer/protocol/finger/Finger.cc
+++ b/src/analyzer/protocol/finger/Finger.cc
@@ -68,7 +68,7 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 
 		if ( finger_request )
 			{
-			ConnectionEvent(finger_request, {
+			ConnectionEventFast(finger_request, {
 				BuildConnVal(),
 				val_mgr->GetBool(long_cnt),
 				new StringVal(at - line, line),
@@ -87,7 +87,7 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 		if ( ! finger_reply )
 			return;
 
-		ConnectionEvent(finger_reply, {
+		ConnectionEventFast(finger_reply, {
 			BuildConnVal(),
 			new StringVal(end_of_line - line, line),
 		});

--- a/src/analyzer/protocol/finger/Finger.cc
+++ b/src/analyzer/protocol/finger/Finger.cc
@@ -66,14 +66,15 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 		else
 			host = at + 1;
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(long_cnt));
-		vl->append(new StringVal(at - line, line));
-		vl->append(new StringVal(end_of_line - host, host));
-
 		if ( finger_request )
-			ConnectionEvent(finger_request, vl);
+			{
+			ConnectionEvent(finger_request, {
+				BuildConnVal(),
+				val_mgr->GetBool(long_cnt),
+				new StringVal(at - line, line),
+				new StringVal(end_of_line - host, host),
+			});
+			}
 
 		Conn()->Match(Rule::FINGER, (const u_char *) line,
 			  end_of_line - line, true, true, 1, true);
@@ -86,10 +87,9 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 		if ( ! finger_reply )
 			return;
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(new StringVal(end_of_line - line, line));
-
-		ConnectionEvent(finger_reply, vl);
+		ConnectionEvent(finger_reply, {
+			BuildConnVal(),
+			new StringVal(end_of_line - line, line),
+		});
 		}
 	}

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -73,8 +73,7 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 		// Could emit "ftp empty request/reply" weird, but maybe not worth it.
 		return;
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
+	val_list vl;
 
 	EventHandlerPtr f;
 	if ( orig )
@@ -95,8 +94,11 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 		else
 			cmd_str = (new StringVal(cmd_len, cmd))->ToUpper();
 
-		vl->append(cmd_str);
-		vl->append(new StringVal(end_of_line - line, line));
+		vl = val_list{
+			BuildConnVal(),
+			cmd_str,
+			new StringVal(end_of_line - line, line),
+		};
 
 		f = ftp_request;
 		ProtocolConfirmation();
@@ -171,14 +173,17 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 				}
 			}
 
-		vl->append(val_mgr->GetCount(reply_code));
-		vl->append(new StringVal(end_of_line - line, line));
-		vl->append(val_mgr->GetBool(cont_resp));
+		vl = val_list{
+			BuildConnVal(),
+			val_mgr->GetCount(reply_code),
+			new StringVal(end_of_line - line, line),
+			val_mgr->GetBool(cont_resp),
+		};
 
 		f = ftp_reply;
 		}
 
-	ConnectionEvent(f, vl);
+	ConnectionEvent(f, std::move(vl));
 
 	ForwardStream(length, data, orig);
 	}

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -59,9 +59,9 @@ void Gnutella_Analyzer::Done()
 	if ( ! sent_establish && (gnutella_establish || gnutella_not_establish) )
 		{
 		if ( Established() && gnutella_establish )
-			ConnectionEvent(gnutella_establish, {BuildConnVal()});
+			ConnectionEventFast(gnutella_establish, {BuildConnVal()});
 		else if ( ! Established () && gnutella_not_establish )
-			ConnectionEvent(gnutella_not_establish, {BuildConnVal()});
+			ConnectionEventFast(gnutella_not_establish, {BuildConnVal()});
 		}
 
 	if ( gnutella_partial_binary_msg )
@@ -72,7 +72,7 @@ void Gnutella_Analyzer::Done()
 			{
 			if ( ! p->msg_sent && p->msg_pos )
 				{
-				ConnectionEvent(gnutella_partial_binary_msg, {
+				ConnectionEventFast(gnutella_partial_binary_msg, {
 					BuildConnVal(),
 					new StringVal(p->msg),
 					val_mgr->GetBool((i == 0)),
@@ -121,7 +121,7 @@ int Gnutella_Analyzer::IsHTTP(string header)
 
 	if ( gnutella_http_notify )
 		{
-		ConnectionEvent(gnutella_http_notify, {BuildConnVal()});
+		ConnectionEventFast(gnutella_http_notify, {BuildConnVal()});
 		}
 
 	analyzer::Analyzer* a = analyzer_mgr->InstantiateAnalyzer("HTTP", Conn());
@@ -181,7 +181,7 @@ void Gnutella_Analyzer::DeliverLines(int len, const u_char* data, bool orig)
 			{
 			if ( gnutella_text_msg )
 				{
-				ConnectionEvent(gnutella_text_msg, {
+				ConnectionEventFast(gnutella_text_msg, {
 					BuildConnVal(),
 					val_mgr->GetBool(orig),
 					new StringVal(ms->headers.data()),
@@ -195,7 +195,7 @@ void Gnutella_Analyzer::DeliverLines(int len, const u_char* data, bool orig)
 				{
 				sent_establish = 1;
 
-				ConnectionEvent(gnutella_establish, {BuildConnVal()});
+				ConnectionEventFast(gnutella_establish, {BuildConnVal()});
 				}
 			}
 		}
@@ -221,7 +221,7 @@ void Gnutella_Analyzer::SendEvents(GnutellaMsgState* p, bool is_orig)
 
 	if ( gnutella_binary_msg )
 		{
-		ConnectionEvent(gnutella_binary_msg, {
+		ConnectionEventFast(gnutella_binary_msg, {
 			BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 			val_mgr->GetCount(p->msg_type),

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -58,16 +58,10 @@ void Gnutella_Analyzer::Done()
 
 	if ( ! sent_establish && (gnutella_establish || gnutella_not_establish) )
 		{
-		val_list* vl = new val_list;
-
-		vl->append(BuildConnVal());
-
 		if ( Established() && gnutella_establish )
-			ConnectionEvent(gnutella_establish, vl);
+			ConnectionEvent(gnutella_establish, {BuildConnVal()});
 		else if ( ! Established () && gnutella_not_establish )
-			ConnectionEvent(gnutella_not_establish, vl);
-		else
-			delete_vals(vl);
+			ConnectionEvent(gnutella_not_establish, {BuildConnVal()});
 		}
 
 	if ( gnutella_partial_binary_msg )
@@ -78,14 +72,12 @@ void Gnutella_Analyzer::Done()
 			{
 			if ( ! p->msg_sent && p->msg_pos )
 				{
-				val_list* vl = new val_list;
-
-				vl->append(BuildConnVal());
-				vl->append(new StringVal(p->msg));
-				vl->append(val_mgr->GetBool((i == 0)));
-				vl->append(val_mgr->GetCount(p->msg_pos));
-
-				ConnectionEvent(gnutella_partial_binary_msg, vl);
+				ConnectionEvent(gnutella_partial_binary_msg, {
+					BuildConnVal(),
+					new StringVal(p->msg),
+					val_mgr->GetBool((i == 0)),
+					val_mgr->GetCount(p->msg_pos),
+				});
 				}
 
 			else if ( ! p->msg_sent && p->payload_left )
@@ -129,10 +121,7 @@ int Gnutella_Analyzer::IsHTTP(string header)
 
 	if ( gnutella_http_notify )
 		{
-		val_list* vl = new val_list;
-
-		vl->append(BuildConnVal());
-		ConnectionEvent(gnutella_http_notify, vl);
+		ConnectionEvent(gnutella_http_notify, {BuildConnVal()});
 		}
 
 	analyzer::Analyzer* a = analyzer_mgr->InstantiateAnalyzer("HTTP", Conn());
@@ -192,13 +181,11 @@ void Gnutella_Analyzer::DeliverLines(int len, const u_char* data, bool orig)
 			{
 			if ( gnutella_text_msg )
 				{
-				val_list* vl = new val_list;
-
-				vl->append(BuildConnVal());
-				vl->append(val_mgr->GetBool(orig));
-				vl->append(new StringVal(ms->headers.data()));
-
-				ConnectionEvent(gnutella_text_msg, vl);
+				ConnectionEvent(gnutella_text_msg, {
+					BuildConnVal(),
+					val_mgr->GetBool(orig),
+					new StringVal(ms->headers.data()),
+				});
 				}
 
 			ms->headers = "";
@@ -206,12 +193,9 @@ void Gnutella_Analyzer::DeliverLines(int len, const u_char* data, bool orig)
 
 			if ( Established () && gnutella_establish )
 				{
-				val_list* vl = new val_list;
-
 				sent_establish = 1;
-				vl->append(BuildConnVal());
 
-				ConnectionEvent(gnutella_establish, vl);
+				ConnectionEvent(gnutella_establish, {BuildConnVal()});
 				}
 			}
 		}
@@ -237,21 +221,18 @@ void Gnutella_Analyzer::SendEvents(GnutellaMsgState* p, bool is_orig)
 
 	if ( gnutella_binary_msg )
 		{
-		val_list* vl = new val_list;
-
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(is_orig));
-		vl->append(val_mgr->GetCount(p->msg_type));
-		vl->append(val_mgr->GetCount(p->msg_ttl));
-		vl->append(val_mgr->GetCount(p->msg_hops));
-		vl->append(val_mgr->GetCount(p->msg_len));
-		vl->append(new StringVal(p->payload));
-		vl->append(val_mgr->GetCount(p->payload_len));
-		vl->append(val_mgr->GetBool(
-		    (p->payload_len < min(p->msg_len, (unsigned int)GNUTELLA_MAX_PAYLOAD))));
-		vl->append(val_mgr->GetBool((p->payload_left == 0)));
-
-		ConnectionEvent(gnutella_binary_msg, vl);
+		ConnectionEvent(gnutella_binary_msg, {
+			BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+			val_mgr->GetCount(p->msg_type),
+			val_mgr->GetCount(p->msg_ttl),
+			val_mgr->GetCount(p->msg_hops),
+			val_mgr->GetCount(p->msg_len),
+			new StringVal(p->payload),
+			val_mgr->GetCount(p->payload_len),
+			val_mgr->GetBool((p->payload_len < min(p->msg_len, (unsigned int)GNUTELLA_MAX_PAYLOAD))),
+			val_mgr->GetBool((p->payload_left == 0)),
+		});
 		}
 	}
 

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -646,7 +646,7 @@ void HTTP_Message::Done(const int interrupted, const char* detail)
 
 	if ( http_message_done )
 		{
-		GetAnalyzer()->ConnectionEvent(http_message_done, {
+		GetAnalyzer()->ConnectionEventFast(http_message_done, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 			BuildMessageStat(interrupted, detail),
@@ -679,7 +679,7 @@ void HTTP_Message::BeginEntity(mime::MIME_Entity* entity)
 
 	if ( http_begin_entity )
 		{
-		analyzer->ConnectionEvent(http_begin_entity, {
+		analyzer->ConnectionEventFast(http_begin_entity, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 		});
@@ -696,7 +696,7 @@ void HTTP_Message::EndEntity(mime::MIME_Entity* entity)
 
 	if ( http_end_entity )
 		{
-		analyzer->ConnectionEvent(http_end_entity, {
+		analyzer->ConnectionEventFast(http_end_entity, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 		});
@@ -737,7 +737,7 @@ void HTTP_Message::SubmitAllHeaders(mime::MIME_HeaderList& hlist)
 	{
 	if ( http_all_headers )
 		{
-		analyzer->ConnectionEvent(http_all_headers, {
+		analyzer->ConnectionEventFast(http_all_headers, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 			BuildHeaderTable(hlist),
@@ -751,7 +751,7 @@ void HTTP_Message::SubmitAllHeaders(mime::MIME_HeaderList& hlist)
 		ty->Ref();
 		subty->Ref();
 
-		analyzer->ConnectionEvent(http_content_type, {
+		analyzer->ConnectionEventFast(http_content_type, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 			ty,
@@ -1183,7 +1183,7 @@ void HTTP_Analyzer::GenStats()
 		r->Assign(3, new Val(reply_version, TYPE_DOUBLE));
 
 		// DEBUG_MSG("%.6f http_stats\n", network_time);
-		ConnectionEvent(http_stats, {BuildConnVal(), r});
+		ConnectionEventFast(http_stats, {BuildConnVal(), r});
 		}
 	}
 
@@ -1381,7 +1381,7 @@ void HTTP_Analyzer::HTTP_Event(const char* category, StringVal* detail)
 	if ( http_event )
 		{
 		// DEBUG_MSG("%.6f http_event\n", network_time);
-		ConnectionEvent(http_event, {
+		ConnectionEventFast(http_event, {
 			BuildConnVal(),
 			new StringVal(category),
 			detail,
@@ -1424,7 +1424,7 @@ void HTTP_Analyzer::HTTP_Request()
 		Ref(request_method);
 
 		// DEBUG_MSG("%.6f http_request\n", network_time);
-		ConnectionEvent(http_request, {
+		ConnectionEventFast(http_request, {
 			BuildConnVal(),
 			request_method,
 			TruncateURI(request_URI->AsStringVal()),
@@ -1438,7 +1438,7 @@ void HTTP_Analyzer::HTTP_Reply()
 	{
 	if ( http_reply )
 		{
-		ConnectionEvent(http_reply, {
+		ConnectionEventFast(http_reply, {
 			BuildConnVal(),
 			new StringVal(fmt("%.1f", reply_version)),
 			val_mgr->GetCount(reply_code),
@@ -1517,7 +1517,7 @@ void HTTP_Analyzer::ReplyMade(const int interrupted, const char* msg)
 
 		if ( http_connection_upgrade )
 			{
-			ConnectionEvent(http_connection_upgrade, {
+			ConnectionEventFast(http_connection_upgrade, {
 				BuildConnVal(),
 				new StringVal(upgrade_protocol),
 			});
@@ -1693,7 +1693,7 @@ void HTTP_Analyzer::HTTP_Header(int is_orig, mime::MIME_Header* h)
 		if ( DEBUG_http )
 			DEBUG_MSG("%.6f http_header\n", network_time);
 
-		ConnectionEvent(http_header, {
+		ConnectionEventFast(http_header, {
 			BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 			mime::new_string_val(h->get_name())->ToUpper(),
@@ -1827,7 +1827,7 @@ void HTTP_Analyzer::HTTP_EntityData(int is_orig, BroString* entity_data)
 	{
 	if ( http_entity_data )
 		{
-		ConnectionEvent(http_entity_data, {
+		ConnectionEventFast(http_entity_data, {
 			BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 			val_mgr->GetCount(entity_data->Len()),

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -646,11 +646,11 @@ void HTTP_Message::Done(const int interrupted, const char* detail)
 
 	if ( http_message_done )
 		{
-		val_list* vl = new val_list;
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetBool(is_orig));
-		vl->append(BuildMessageStat(interrupted, detail));
-		GetAnalyzer()->ConnectionEvent(http_message_done, vl);
+		GetAnalyzer()->ConnectionEvent(http_message_done, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+			BuildMessageStat(interrupted, detail),
+		});
 		}
 
 	MyHTTP_Analyzer()->HTTP_MessageDone(is_orig, this);
@@ -679,10 +679,10 @@ void HTTP_Message::BeginEntity(mime::MIME_Entity* entity)
 
 	if ( http_begin_entity )
 		{
-		val_list* vl = new val_list();
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetBool(is_orig));
-		analyzer->ConnectionEvent(http_begin_entity, vl);
+		analyzer->ConnectionEvent(http_begin_entity, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+		});
 		}
 	}
 
@@ -696,10 +696,10 @@ void HTTP_Message::EndEntity(mime::MIME_Entity* entity)
 
 	if ( http_end_entity )
 		{
-		val_list* vl = new val_list();
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetBool(is_orig));
-		analyzer->ConnectionEvent(http_end_entity, vl);
+		analyzer->ConnectionEvent(http_end_entity, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+		});
 		}
 
 	current_entity = (HTTP_Entity*) entity->Parent();
@@ -737,11 +737,11 @@ void HTTP_Message::SubmitAllHeaders(mime::MIME_HeaderList& hlist)
 	{
 	if ( http_all_headers )
 		{
-		val_list* vl = new val_list();
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetBool(is_orig));
-		vl->append(BuildHeaderTable(hlist));
-		analyzer->ConnectionEvent(http_all_headers, vl);
+		analyzer->ConnectionEvent(http_all_headers, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+			BuildHeaderTable(hlist),
+		});
 		}
 
 	if ( http_content_type )
@@ -751,12 +751,12 @@ void HTTP_Message::SubmitAllHeaders(mime::MIME_HeaderList& hlist)
 		ty->Ref();
 		subty->Ref();
 
-		val_list* vl = new val_list();
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetBool(is_orig));
-		vl->append(ty);
-		vl->append(subty);
-		analyzer->ConnectionEvent(http_content_type, vl);
+		analyzer->ConnectionEvent(http_content_type, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+			ty,
+			subty,
+		});
 		}
 	}
 
@@ -1182,12 +1182,8 @@ void HTTP_Analyzer::GenStats()
 		r->Assign(2, new Val(request_version, TYPE_DOUBLE));
 		r->Assign(3, new Val(reply_version, TYPE_DOUBLE));
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(r);
-
 		// DEBUG_MSG("%.6f http_stats\n", network_time);
-		ConnectionEvent(http_stats, vl);
+		ConnectionEvent(http_stats, {BuildConnVal(), r});
 		}
 	}
 
@@ -1384,13 +1380,12 @@ void HTTP_Analyzer::HTTP_Event(const char* category, StringVal* detail)
 	{
 	if ( http_event )
 		{
-		val_list* vl = new val_list();
-		vl->append(BuildConnVal());
-		vl->append(new StringVal(category));
-		vl->append(detail);
-
 		// DEBUG_MSG("%.6f http_event\n", network_time);
-		ConnectionEvent(http_event, vl);
+		ConnectionEvent(http_event, {
+			BuildConnVal(),
+			new StringVal(category),
+			detail,
+		});
 		}
 	else
 		delete detail;
@@ -1426,17 +1421,16 @@ void HTTP_Analyzer::HTTP_Request()
 
 	if ( http_request )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-
 		Ref(request_method);
-		vl->append(request_method);
-		vl->append(TruncateURI(request_URI->AsStringVal()));
-		vl->append(TruncateURI(unescaped_URI->AsStringVal()));
 
-		vl->append(new StringVal(fmt("%.1f", request_version)));
 		// DEBUG_MSG("%.6f http_request\n", network_time);
-		ConnectionEvent(http_request, vl);
+		ConnectionEvent(http_request, {
+			BuildConnVal(),
+			request_method,
+			TruncateURI(request_URI->AsStringVal()),
+			TruncateURI(unescaped_URI->AsStringVal()),
+			new StringVal(fmt("%.1f", request_version)),
+		});
 		}
 	}
 
@@ -1444,15 +1438,14 @@ void HTTP_Analyzer::HTTP_Reply()
 	{
 	if ( http_reply )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(new StringVal(fmt("%.1f", reply_version)));
-		vl->append(val_mgr->GetCount(reply_code));
-		if ( reply_reason_phrase )
-			vl->append(reply_reason_phrase->Ref());
-		else
-			vl->append(new StringVal("<empty>"));
-		ConnectionEvent(http_reply, vl);
+		ConnectionEvent(http_reply, {
+			BuildConnVal(),
+			new StringVal(fmt("%.1f", reply_version)),
+			val_mgr->GetCount(reply_code),
+			reply_reason_phrase ?
+				reply_reason_phrase->Ref() :
+				new StringVal("<empty>"),
+		});
 		}
 	else
 		{
@@ -1524,10 +1517,10 @@ void HTTP_Analyzer::ReplyMade(const int interrupted, const char* msg)
 
 		if ( http_connection_upgrade )
 			{
-			val_list* vl = new val_list();
-			vl->append(BuildConnVal());
-			vl->append(new StringVal(upgrade_protocol));
-			ConnectionEvent(http_connection_upgrade, vl);
+			ConnectionEvent(http_connection_upgrade, {
+				BuildConnVal(),
+				new StringVal(upgrade_protocol),
+			});
 			}
 		}
 
@@ -1697,14 +1690,15 @@ void HTTP_Analyzer::HTTP_Header(int is_orig, mime::MIME_Header* h)
 		Conn()->Match(rule, (const u_char*) hd_value.data, hd_value.length,
 				is_orig, false, true, false);
 
-		val_list* vl = new val_list();
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(is_orig));
-		vl->append(mime::new_string_val(h->get_name())->ToUpper());
-		vl->append(mime::new_string_val(h->get_value()));
 		if ( DEBUG_http )
 			DEBUG_MSG("%.6f http_header\n", network_time);
-		ConnectionEvent(http_header, vl);
+
+		ConnectionEvent(http_header, {
+			BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+			mime::new_string_val(h->get_name())->ToUpper(),
+			mime::new_string_val(h->get_value()),
+		});
 		}
 	}
 
@@ -1833,12 +1827,12 @@ void HTTP_Analyzer::HTTP_EntityData(int is_orig, BroString* entity_data)
 	{
 	if ( http_entity_data )
 		{
-		val_list* vl = new val_list();
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(is_orig));
-		vl->append(val_mgr->GetCount(entity_data->Len()));
-		vl->append(new StringVal(entity_data));
-		ConnectionEvent(http_entity_data, vl);
+		ConnectionEvent(http_entity_data, {
+			BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+			val_mgr->GetCount(entity_data->Len()),
+			new StringVal(entity_data),
+		});
 		}
 	else
 		delete entity_data;

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -199,20 +199,21 @@ void ICMP_Analyzer::ICMP_Sent(const struct icmp* icmpp, int len, int caplen,
     {
 	if ( icmp_sent )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(BuildICMPVal(icmpp, len, icmpv6, ip_hdr));
-		ConnectionEvent(icmp_sent, vl);
+		ConnectionEvent(icmp_sent, {
+			BuildConnVal(),
+			BuildICMPVal(icmpp, len, icmpv6, ip_hdr),
+		});
 		}
 
 	if ( icmp_sent_payload )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(BuildICMPVal(icmpp, len, icmpv6, ip_hdr));
 		BroString* payload = new BroString(data, min(len, caplen), 0);
-		vl->append(new StringVal(payload));
-		ConnectionEvent(icmp_sent_payload, vl);
+
+		ConnectionEvent(icmp_sent_payload, {
+			BuildConnVal(),
+			BuildICMPVal(icmpp, len, icmpv6, ip_hdr),
+			new StringVal(payload),
+		});
 		}
 	}
 
@@ -511,14 +512,13 @@ void ICMP_Analyzer::Echo(double t, const struct icmp* icmpp, int len,
 
 	BroString* payload = new BroString(data, caplen, 0);
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(BuildICMPVal(icmpp, len, ip_hdr->NextProto() != IPPROTO_ICMP, ip_hdr));
-	vl->append(val_mgr->GetCount(iid));
-	vl->append(val_mgr->GetCount(iseq));
-	vl->append(new StringVal(payload));
-
-	ConnectionEvent(f, vl);
+	ConnectionEvent(f, {
+		BuildConnVal(),
+		BuildICMPVal(icmpp, len, ip_hdr->NextProto() != IPPROTO_ICMP, ip_hdr),
+		val_mgr->GetCount(iid),
+		val_mgr->GetCount(iseq),
+		new StringVal(payload),
+	});
 	}
 
 
@@ -534,24 +534,23 @@ void ICMP_Analyzer::RouterAdvert(double t, const struct icmp* icmpp, int len,
 	if ( caplen >= (int)sizeof(reachable) + (int)sizeof(retrans) )
 		memcpy(&retrans, data + sizeof(reachable), sizeof(retrans));
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(BuildICMPVal(icmpp, len, 1, ip_hdr));
-	vl->append(val_mgr->GetCount(icmpp->icmp_num_addrs)); // Cur Hop Limit
-	vl->append(val_mgr->GetBool(icmpp->icmp_wpa & 0x80)); // Managed
-	vl->append(val_mgr->GetBool(icmpp->icmp_wpa & 0x40)); // Other
-	vl->append(val_mgr->GetBool(icmpp->icmp_wpa & 0x20)); // Home Agent
-	vl->append(val_mgr->GetCount((icmpp->icmp_wpa & 0x18)>>3)); // Pref
-	vl->append(val_mgr->GetBool(icmpp->icmp_wpa & 0x04)); // Proxy
-	vl->append(val_mgr->GetCount(icmpp->icmp_wpa & 0x02)); // Reserved
-	vl->append(new IntervalVal((double)ntohs(icmpp->icmp_lifetime), Seconds));
-	vl->append(new IntervalVal((double)ntohl(reachable), Milliseconds));
-	vl->append(new IntervalVal((double)ntohl(retrans), Milliseconds));
-
 	int opt_offset = sizeof(reachable) + sizeof(retrans);
-	vl->append(BuildNDOptionsVal(caplen - opt_offset, data + opt_offset));
 
-	ConnectionEvent(f, vl);
+	ConnectionEvent(f, {
+		BuildConnVal(),
+		BuildICMPVal(icmpp, len, 1, ip_hdr),
+		val_mgr->GetCount(icmpp->icmp_num_addrs), // Cur Hop Limit
+		val_mgr->GetBool(icmpp->icmp_wpa & 0x80), // Managed
+		val_mgr->GetBool(icmpp->icmp_wpa & 0x40), // Other
+		val_mgr->GetBool(icmpp->icmp_wpa & 0x20), // Home Agent
+		val_mgr->GetCount((icmpp->icmp_wpa & 0x18)>>3), // Pref
+		val_mgr->GetBool(icmpp->icmp_wpa & 0x04), // Proxy
+		val_mgr->GetCount(icmpp->icmp_wpa & 0x02), // Reserved
+		new IntervalVal((double)ntohs(icmpp->icmp_lifetime), Seconds),
+		new IntervalVal((double)ntohl(reachable), Milliseconds),
+		new IntervalVal((double)ntohl(retrans), Milliseconds),
+		BuildNDOptionsVal(caplen - opt_offset, data + opt_offset),
+	});
 	}
 
 
@@ -564,18 +563,17 @@ void ICMP_Analyzer::NeighborAdvert(double t, const struct icmp* icmpp, int len,
 	if ( caplen >= (int)sizeof(in6_addr) )
 		tgtaddr = IPAddr(*((const in6_addr*)data));
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(BuildICMPVal(icmpp, len, 1, ip_hdr));
-	vl->append(val_mgr->GetBool(icmpp->icmp_num_addrs & 0x80)); // Router
-	vl->append(val_mgr->GetBool(icmpp->icmp_num_addrs & 0x40)); // Solicited
-	vl->append(val_mgr->GetBool(icmpp->icmp_num_addrs & 0x20)); // Override
-	vl->append(new AddrVal(tgtaddr));
-
 	int opt_offset = sizeof(in6_addr);
-	vl->append(BuildNDOptionsVal(caplen - opt_offset, data + opt_offset));
 
-	ConnectionEvent(f, vl);
+	ConnectionEvent(f, {
+		BuildConnVal(),
+		BuildICMPVal(icmpp, len, 1, ip_hdr),
+		val_mgr->GetBool(icmpp->icmp_num_addrs & 0x80), // Router
+		val_mgr->GetBool(icmpp->icmp_num_addrs & 0x40), // Solicited
+		val_mgr->GetBool(icmpp->icmp_num_addrs & 0x20), // Override
+		new AddrVal(tgtaddr),
+		BuildNDOptionsVal(caplen - opt_offset, data + opt_offset),
+	});
 	}
 
 
@@ -588,15 +586,14 @@ void ICMP_Analyzer::NeighborSolicit(double t, const struct icmp* icmpp, int len,
 	if ( caplen >= (int)sizeof(in6_addr) )
 		tgtaddr = IPAddr(*((const in6_addr*)data));
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(BuildICMPVal(icmpp, len, 1, ip_hdr));
-	vl->append(new AddrVal(tgtaddr));
-
 	int opt_offset = sizeof(in6_addr);
-	vl->append(BuildNDOptionsVal(caplen - opt_offset, data + opt_offset));
 
-	ConnectionEvent(f, vl);
+	ConnectionEvent(f, {
+		BuildConnVal(),
+		BuildICMPVal(icmpp, len, 1, ip_hdr),
+		new AddrVal(tgtaddr),
+		BuildNDOptionsVal(caplen - opt_offset, data + opt_offset),
+	});
 	}
 
 
@@ -612,16 +609,15 @@ void ICMP_Analyzer::Redirect(double t, const struct icmp* icmpp, int len,
 	if ( caplen >= 2 * (int)sizeof(in6_addr) )
 		dstaddr = IPAddr(*((const in6_addr*)(data + sizeof(in6_addr))));
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(BuildICMPVal(icmpp, len, 1, ip_hdr));
-	vl->append(new AddrVal(tgtaddr));
-	vl->append(new AddrVal(dstaddr));
-
 	int opt_offset = 2 * sizeof(in6_addr);
-	vl->append(BuildNDOptionsVal(caplen - opt_offset, data + opt_offset));
 
-	ConnectionEvent(f, vl);
+	ConnectionEvent(f, {
+		BuildConnVal(),
+		BuildICMPVal(icmpp, len, 1, ip_hdr),
+		new AddrVal(tgtaddr),
+		new AddrVal(dstaddr),
+		BuildNDOptionsVal(caplen - opt_offset, data + opt_offset),
+	});
 	}
 
 
@@ -630,12 +626,11 @@ void ICMP_Analyzer::RouterSolicit(double t, const struct icmp* icmpp, int len,
 	{
 	EventHandlerPtr f = icmp_router_solicitation;
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(BuildICMPVal(icmpp, len, 1, ip_hdr));
-	vl->append(BuildNDOptionsVal(caplen, data));
-
-	ConnectionEvent(f, vl);
+	ConnectionEvent(f, {
+		BuildConnVal(),
+		BuildICMPVal(icmpp, len, 1, ip_hdr),
+		BuildNDOptionsVal(caplen, data),
+	});
 	}
 
 
@@ -657,12 +652,12 @@ void ICMP_Analyzer::Context4(double t, const struct icmp* icmpp,
 
 	if ( f )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(BuildICMPVal(icmpp, len, 0, ip_hdr));
-		vl->append(val_mgr->GetCount(icmpp->icmp_code));
-		vl->append(ExtractICMP4Context(caplen, data));
-		ConnectionEvent(f, vl);
+		ConnectionEvent(f, {
+			BuildConnVal(),
+			BuildICMPVal(icmpp, len, 0, ip_hdr),
+			val_mgr->GetCount(icmpp->icmp_code),
+			ExtractICMP4Context(caplen, data),
+		});
 		}
 	}
 
@@ -697,12 +692,12 @@ void ICMP_Analyzer::Context6(double t, const struct icmp* icmpp,
 
 	if ( f )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(BuildICMPVal(icmpp, len, 1, ip_hdr));
-		vl->append(val_mgr->GetCount(icmpp->icmp_code));
-		vl->append(ExtractICMP6Context(caplen, data));
-		ConnectionEvent(f, vl);
+		ConnectionEvent(f, {
+			BuildConnVal(),
+			BuildICMPVal(icmpp, len, 1, ip_hdr),
+			val_mgr->GetCount(icmpp->icmp_code),
+			ExtractICMP6Context(caplen, data),
+		});
 		}
 	}
 

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -199,7 +199,7 @@ void ICMP_Analyzer::ICMP_Sent(const struct icmp* icmpp, int len, int caplen,
     {
 	if ( icmp_sent )
 		{
-		ConnectionEvent(icmp_sent, {
+		ConnectionEventFast(icmp_sent, {
 			BuildConnVal(),
 			BuildICMPVal(icmpp, len, icmpv6, ip_hdr),
 		});
@@ -209,7 +209,7 @@ void ICMP_Analyzer::ICMP_Sent(const struct icmp* icmpp, int len, int caplen,
 		{
 		BroString* payload = new BroString(data, min(len, caplen), 0);
 
-		ConnectionEvent(icmp_sent_payload, {
+		ConnectionEventFast(icmp_sent_payload, {
 			BuildConnVal(),
 			BuildICMPVal(icmpp, len, icmpv6, ip_hdr),
 			new StringVal(payload),
@@ -512,7 +512,7 @@ void ICMP_Analyzer::Echo(double t, const struct icmp* icmpp, int len,
 
 	BroString* payload = new BroString(data, caplen, 0);
 
-	ConnectionEvent(f, {
+	ConnectionEventFast(f, {
 		BuildConnVal(),
 		BuildICMPVal(icmpp, len, ip_hdr->NextProto() != IPPROTO_ICMP, ip_hdr),
 		val_mgr->GetCount(iid),
@@ -526,6 +526,10 @@ void ICMP_Analyzer::RouterAdvert(double t, const struct icmp* icmpp, int len,
 			 int caplen, const u_char*& data, const IP_Hdr* ip_hdr)
 	{
 	EventHandlerPtr f = icmp_router_advertisement;
+
+	if ( ! f )
+		return;
+
 	uint32 reachable = 0, retrans = 0;
 
 	if ( caplen >= (int)sizeof(reachable) )
@@ -536,7 +540,7 @@ void ICMP_Analyzer::RouterAdvert(double t, const struct icmp* icmpp, int len,
 
 	int opt_offset = sizeof(reachable) + sizeof(retrans);
 
-	ConnectionEvent(f, {
+	ConnectionEventFast(f, {
 		BuildConnVal(),
 		BuildICMPVal(icmpp, len, 1, ip_hdr),
 		val_mgr->GetCount(icmpp->icmp_num_addrs), // Cur Hop Limit
@@ -558,6 +562,10 @@ void ICMP_Analyzer::NeighborAdvert(double t, const struct icmp* icmpp, int len,
 			 int caplen, const u_char*& data, const IP_Hdr* ip_hdr)
 	{
 	EventHandlerPtr f = icmp_neighbor_advertisement;
+
+	if ( ! f )
+		return;
+
 	IPAddr tgtaddr;
 
 	if ( caplen >= (int)sizeof(in6_addr) )
@@ -565,7 +573,7 @@ void ICMP_Analyzer::NeighborAdvert(double t, const struct icmp* icmpp, int len,
 
 	int opt_offset = sizeof(in6_addr);
 
-	ConnectionEvent(f, {
+	ConnectionEventFast(f, {
 		BuildConnVal(),
 		BuildICMPVal(icmpp, len, 1, ip_hdr),
 		val_mgr->GetBool(icmpp->icmp_num_addrs & 0x80), // Router
@@ -581,6 +589,10 @@ void ICMP_Analyzer::NeighborSolicit(double t, const struct icmp* icmpp, int len,
 			 int caplen, const u_char*& data, const IP_Hdr* ip_hdr)
 	{
 	EventHandlerPtr f = icmp_neighbor_solicitation;
+
+	if ( ! f )
+		return;
+
 	IPAddr tgtaddr;
 
 	if ( caplen >= (int)sizeof(in6_addr) )
@@ -588,7 +600,7 @@ void ICMP_Analyzer::NeighborSolicit(double t, const struct icmp* icmpp, int len,
 
 	int opt_offset = sizeof(in6_addr);
 
-	ConnectionEvent(f, {
+	ConnectionEventFast(f, {
 		BuildConnVal(),
 		BuildICMPVal(icmpp, len, 1, ip_hdr),
 		new AddrVal(tgtaddr),
@@ -601,6 +613,10 @@ void ICMP_Analyzer::Redirect(double t, const struct icmp* icmpp, int len,
 			 int caplen, const u_char*& data, const IP_Hdr* ip_hdr)
 	{
 	EventHandlerPtr f = icmp_redirect;
+
+	if ( ! f )
+		return;
+
 	IPAddr tgtaddr, dstaddr;
 
 	if ( caplen >= (int)sizeof(in6_addr) )
@@ -611,7 +627,7 @@ void ICMP_Analyzer::Redirect(double t, const struct icmp* icmpp, int len,
 
 	int opt_offset = 2 * sizeof(in6_addr);
 
-	ConnectionEvent(f, {
+	ConnectionEventFast(f, {
 		BuildConnVal(),
 		BuildICMPVal(icmpp, len, 1, ip_hdr),
 		new AddrVal(tgtaddr),
@@ -626,7 +642,10 @@ void ICMP_Analyzer::RouterSolicit(double t, const struct icmp* icmpp, int len,
 	{
 	EventHandlerPtr f = icmp_router_solicitation;
 
-	ConnectionEvent(f, {
+	if ( ! f )
+		return;
+
+	ConnectionEventFast(f, {
 		BuildConnVal(),
 		BuildICMPVal(icmpp, len, 1, ip_hdr),
 		BuildNDOptionsVal(caplen, data),
@@ -652,7 +671,7 @@ void ICMP_Analyzer::Context4(double t, const struct icmp* icmpp,
 
 	if ( f )
 		{
-		ConnectionEvent(f, {
+		ConnectionEventFast(f, {
 			BuildConnVal(),
 			BuildICMPVal(icmpp, len, 0, ip_hdr),
 			val_mgr->GetCount(icmpp->icmp_code),
@@ -692,7 +711,7 @@ void ICMP_Analyzer::Context6(double t, const struct icmp* icmpp,
 
 	if ( f )
 		{
-		ConnectionEvent(f, {
+		ConnectionEventFast(f, {
 			BuildConnVal(),
 			BuildICMPVal(icmpp, len, 1, ip_hdr),
 			val_mgr->GetCount(icmpp->icmp_code),

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -83,7 +83,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 			Weird("ident_request_addendum", s.CheckString());
 			}
 
-		ConnectionEvent(ident_request, {
+		ConnectionEventFast(ident_request, {
 			BuildConnVal(),
 			val_mgr->GetPort(local_port, TRANSPORT_TCP),
 			val_mgr->GetPort(remote_port, TRANSPORT_TCP),
@@ -143,12 +143,13 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 
 		if ( is_error )
 			{
-			ConnectionEvent(ident_error, {
-				BuildConnVal(),
-				val_mgr->GetPort(local_port, TRANSPORT_TCP),
-				val_mgr->GetPort(remote_port, TRANSPORT_TCP),
-				new StringVal(end_of_line - line, line),
-			});
+			if ( ident_error )
+				ConnectionEventFast(ident_error, {
+					BuildConnVal(),
+					val_mgr->GetPort(local_port, TRANSPORT_TCP),
+					val_mgr->GetPort(remote_port, TRANSPORT_TCP),
+					new StringVal(end_of_line - line, line),
+				});
 			}
 
 		else
@@ -176,7 +177,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 
 			line = skip_whitespace(colon + 1, end_of_line);
 
-			ConnectionEvent(ident_reply, {
+			ConnectionEventFast(ident_reply, {
 				BuildConnVal(),
 				val_mgr->GetPort(local_port, TRANSPORT_TCP),
 				val_mgr->GetPort(remote_port, TRANSPORT_TCP),

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -83,12 +83,11 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 			Weird("ident_request_addendum", s.CheckString());
 			}
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetPort(local_port, TRANSPORT_TCP));
-		vl->append(val_mgr->GetPort(remote_port, TRANSPORT_TCP));
-
-		ConnectionEvent(ident_request, vl);
+		ConnectionEvent(ident_request, {
+			BuildConnVal(),
+			val_mgr->GetPort(local_port, TRANSPORT_TCP),
+			val_mgr->GetPort(remote_port, TRANSPORT_TCP),
+		});
 
 		did_deliver = 1;
 		}
@@ -144,13 +143,12 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 
 		if ( is_error )
 			{
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetPort(local_port, TRANSPORT_TCP));
-			vl->append(val_mgr->GetPort(remote_port, TRANSPORT_TCP));
-			vl->append(new StringVal(end_of_line - line, line));
-
-			ConnectionEvent(ident_error, vl);
+			ConnectionEvent(ident_error, {
+				BuildConnVal(),
+				val_mgr->GetPort(local_port, TRANSPORT_TCP),
+				val_mgr->GetPort(remote_port, TRANSPORT_TCP),
+				new StringVal(end_of_line - line, line),
+			});
 			}
 
 		else
@@ -178,14 +176,13 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 
 			line = skip_whitespace(colon + 1, end_of_line);
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetPort(local_port, TRANSPORT_TCP));
-			vl->append(val_mgr->GetPort(remote_port, TRANSPORT_TCP));
-			vl->append(new StringVal(end_of_line - line, line));
-			vl->append(new StringVal(sys_type_s));
-
-			ConnectionEvent(ident_reply, vl);
+			ConnectionEvent(ident_reply, {
+				BuildConnVal(),
+				val_mgr->GetPort(local_port, TRANSPORT_TCP),
+				val_mgr->GetPort(remote_port, TRANSPORT_TCP),
+				new StringVal(end_of_line - line, line),
+				new StringVal(sys_type_s),
+			});
 			}
 		}
 	}

--- a/src/analyzer/protocol/imap/imap-analyzer.pac
+++ b/src/analyzer/protocol/imap/imap-analyzer.pac
@@ -43,7 +43,9 @@ refine connection IMAP_Conn += {
 			if ( commands == "ok" )
 				{
 				bro_analyzer()->StartTLS();
-				BifEvent::generate_imap_starttls(bro_analyzer(), bro_analyzer()->Conn());
+
+				if ( imap_starttls )
+					BifEvent::generate_imap_starttls(bro_analyzer(), bro_analyzer()->Conn());
 				}
 			else
 				reporter->Weird(bro_analyzer()->Conn(), "IMAP: server refused StartTLS");
@@ -54,6 +56,9 @@ refine connection IMAP_Conn += {
 
 	function proc_server_capability(capabilities: Capability[]): bool
 		%{
+		if ( ! imap_capabilities )
+			return true;
+
 		VectorVal* capv = new VectorVal(internal_type("string_vec")->AsVectorType());
 		for ( unsigned int i = 0; i< capabilities->size(); i++ )
 			{

--- a/src/analyzer/protocol/interconn/InterConn.cc
+++ b/src/analyzer/protocol/interconn/InterConn.cc
@@ -241,16 +241,18 @@ void InterConn_Analyzer::StatTimer(double t, int is_expire)
 
 void InterConn_Analyzer::StatEvent()
 	{
-	Conn()->ConnectionEvent(interconn_stats, this, {
-		Conn()->BuildConnVal(),
-		orig_endp->BuildStats(),
-		resp_endp->BuildStats(),
-	});
+	if ( interconn_stats )
+		Conn()->ConnectionEventFast(interconn_stats, this, {
+			Conn()->BuildConnVal(),
+			orig_endp->BuildStats(),
+			resp_endp->BuildStats(),
+		});
 	}
 
 void InterConn_Analyzer::RemoveEvent()
 	{
-	Conn()->ConnectionEvent(interconn_remove_conn, this, {Conn()->BuildConnVal()});
+	if ( interconn_remove_conn )
+		Conn()->ConnectionEventFast(interconn_remove_conn, this, {Conn()->BuildConnVal()});
 	}
 
 InterConnTimer::InterConnTimer(double t, InterConn_Analyzer* a)

--- a/src/analyzer/protocol/interconn/InterConn.cc
+++ b/src/analyzer/protocol/interconn/InterConn.cc
@@ -241,20 +241,16 @@ void InterConn_Analyzer::StatTimer(double t, int is_expire)
 
 void InterConn_Analyzer::StatEvent()
 	{
-	val_list* vl = new val_list;
-	vl->append(Conn()->BuildConnVal());
-	vl->append(orig_endp->BuildStats());
-	vl->append(resp_endp->BuildStats());
-
-	Conn()->ConnectionEvent(interconn_stats, this, vl);
+	Conn()->ConnectionEvent(interconn_stats, this, {
+		Conn()->BuildConnVal(),
+		orig_endp->BuildStats(),
+		resp_endp->BuildStats(),
+	});
 	}
 
 void InterConn_Analyzer::RemoveEvent()
 	{
-	val_list* vl = new val_list;
-	vl->append(Conn()->BuildConnVal());
-
-	Conn()->ConnectionEvent(interconn_remove_conn, this, vl);
+	Conn()->ConnectionEvent(interconn_remove_conn, this, {Conn()->BuildConnVal()});
 	}
 
 InterConnTimer::InterConnTimer(double t, InterConn_Analyzer* a)

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -233,14 +233,13 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				// else ###
 				}
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(val_mgr->GetInt(users));
-			vl->append(val_mgr->GetInt(services));
-			vl->append(val_mgr->GetInt(servers));
-
-			ConnectionEvent(irc_network_info, vl);
+			ConnectionEvent(irc_network_info, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				val_mgr->GetInt(users),
+				val_mgr->GetInt(services),
+				val_mgr->GetInt(servers),
+			});
 			}
 			break;
 
@@ -271,13 +270,8 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( parts.size() > 0 && parts[0][0] == ':' )
 				parts[0] = parts[0].substr(1);
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(type.c_str()));
-			vl->append(new StringVal(channel.c_str()));
-
 			TableVal* set = new TableVal(string_set);
+
 			for ( unsigned int i = 0; i < parts.size(); ++i )
 				{
 				if ( parts[i][0] == '@' )
@@ -286,9 +280,14 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				set->Assign(idx, 0);
 				Unref(idx);
 				}
-			vl->append(set);
 
-			ConnectionEvent(irc_names_info, vl);
+			ConnectionEvent(irc_names_info, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(type.c_str()),
+				new StringVal(channel.c_str()),
+				set,
+			});
 			}
 			break;
 
@@ -316,14 +315,13 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				// else ###
 				}
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(val_mgr->GetInt(users));
-			vl->append(val_mgr->GetInt(services));
-			vl->append(val_mgr->GetInt(servers));
-
-			ConnectionEvent(irc_server_info, vl);
+			ConnectionEvent(irc_server_info, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				val_mgr->GetInt(users),
+				val_mgr->GetInt(services),
+				val_mgr->GetInt(servers),
+			});
 			}
 			break;
 
@@ -339,12 +337,11 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				if ( parts[i] == ":channels" )
 					channels = atoi(parts[i - 1].c_str());
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(val_mgr->GetInt(channels));
-
-			ConnectionEvent(irc_channel_info, vl);
+			ConnectionEvent(irc_channel_info, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				val_mgr->GetInt(channels),
+			});
 			}
 			break;
 
@@ -372,12 +369,12 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				break;
 				}
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(eop - prefix, prefix));
-			vl->append(new StringVal(++msg));
-			ConnectionEvent(irc_global_users, vl);
+			ConnectionEvent(irc_global_users, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(eop - prefix, prefix),
+				new StringVal(++msg),
+			});
 			break;
 			}
 
@@ -397,12 +394,12 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				return;
 				}
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(parts[0].c_str()));
-			vl->append(new StringVal(parts[1].c_str()));
-			vl->append(new StringVal(parts[2].c_str()));
+			val_list vl(6);
+			vl.append(BuildConnVal());
+			vl.append(val_mgr->GetBool(orig));
+			vl.append(new StringVal(parts[0].c_str()));
+			vl.append(new StringVal(parts[1].c_str()));
+			vl.append(new StringVal(parts[2].c_str()));
 
 			parts.erase(parts.begin(), parts.begin() + 4);
 
@@ -413,9 +410,9 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( real_name[0] == ':' )
 				real_name = real_name.substr(1);
 
-			vl->append(new StringVal(real_name.c_str()));
+			vl.append(new StringVal(real_name.c_str()));
 
-			ConnectionEvent(irc_whois_user_line, vl);
+			ConnectionEvent(irc_whois_user_line, std::move(vl));
 			}
 			break;
 
@@ -436,12 +433,11 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				return;
 				}
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(parts[0].c_str()));
-
-			ConnectionEvent(irc_whois_operator_line, vl);
+			ConnectionEvent(irc_whois_operator_line, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(parts[0].c_str()),
+			});
 			}
 			break;
 
@@ -467,11 +463,8 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( parts.size() > 0 && parts[0][0] == ':' )
 				parts[0] = parts[0].substr(1);
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(nick.c_str()));
 			TableVal* set = new TableVal(string_set);
+
 			for ( unsigned int i = 0; i < parts.size(); ++i )
 				{
 				Val* idx = new StringVal(parts[i].c_str());
@@ -479,9 +472,12 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				Unref(idx);
 				}
 
-			vl->append(set);
-
-			ConnectionEvent(irc_whois_channel_line, vl);
+			ConnectionEvent(irc_whois_channel_line, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(nick.c_str()),
+				set,
+			});
 			}
 			break;
 
@@ -502,19 +498,17 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( pos < params.size() )
 				{
 				string topic = params.substr(pos + 1);
-				val_list* vl = new val_list;
-
-				vl->append(BuildConnVal());
-				vl->append(val_mgr->GetBool(orig));
-				vl->append(new StringVal(parts[1].c_str()));
-
 				const char* t = topic.c_str();
+
 				if ( *t == ':' )
 					++t;
 
-				vl->append(new StringVal(t));
-
-				ConnectionEvent(irc_channel_topic, vl);
+				ConnectionEvent(irc_channel_topic, {
+					BuildConnVal(),
+					val_mgr->GetBool(orig),
+					new StringVal(parts[1].c_str()),
+					new StringVal(t),
+				});
 				}
 			else
 				{
@@ -537,24 +531,25 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				return;
 				}
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(parts[0].c_str()));
-			vl->append(new StringVal(parts[1].c_str()));
 			if ( parts[2][0] == '~' )
 				parts[2] = parts[2].substr(1);
-			vl->append(new StringVal(parts[2].c_str()));
-			vl->append(new StringVal(parts[3].c_str()));
-			vl->append(new StringVal(parts[4].c_str()));
-			vl->append(new StringVal(parts[5].c_str()));
-			vl->append(new StringVal(parts[6].c_str()));
+
 			if ( parts[7][0] == ':' )
 				parts[7] = parts[7].substr(1);
-			vl->append(val_mgr->GetInt(atoi(parts[7].c_str())));
-			vl->append(new StringVal(parts[8].c_str()));
 
-			ConnectionEvent(irc_who_line, vl);
+			ConnectionEvent(irc_who_line, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(parts[0].c_str()),
+				new StringVal(parts[1].c_str()),
+				new StringVal(parts[2].c_str()),
+				new StringVal(parts[3].c_str()),
+				new StringVal(parts[4].c_str()),
+				new StringVal(parts[5].c_str()),
+				new StringVal(parts[6].c_str()),
+				val_mgr->GetInt(atoi(parts[7].c_str())),
+				new StringVal(parts[8].c_str()),
+			});
 			}
 			break;
 
@@ -565,10 +560,10 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		case 436:
 			if ( irc_invalid_nick )
 				{
-				val_list* vl = new val_list;
-				vl->append(BuildConnVal());
-				vl->append(val_mgr->GetBool(orig));
-				ConnectionEvent(irc_invalid_nick, vl);
+				ConnectionEvent(irc_invalid_nick, {
+					BuildConnVal(),
+					val_mgr->GetBool(orig),
+				});
 				}
 			break;
 
@@ -577,11 +572,11 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		case 491:  // user is not operator
 			if ( irc_oper_response )
 				{
-				val_list* vl = new val_list;
-				vl->append(BuildConnVal());
-				vl->append(val_mgr->GetBool(orig));
-				vl->append(val_mgr->GetBool(code == 381));
-				ConnectionEvent(irc_oper_response, vl);
+				ConnectionEvent(irc_oper_response, {
+					BuildConnVal(),
+					val_mgr->GetBool(orig),
+					val_mgr->GetBool(code == 381),
+				});
 				}
 			break;
 
@@ -592,14 +587,13 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		// All other server replies.
 		default:
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(prefix.c_str()));
-			vl->append(val_mgr->GetCount(code));
-			vl->append(new StringVal(params.c_str()));
-
-			ConnectionEvent(irc_reply, vl);
+			ConnectionEvent(irc_reply, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(prefix.c_str()),
+				val_mgr->GetCount(code),
+				new StringVal(params.c_str()),
+			});
 			break;
 		}
 		return;
@@ -662,33 +656,31 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				raw_ip = (10 * raw_ip) + atoi(s.c_str());
 				}
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(prefix.c_str()));
-			vl->append(new StringVal(target.c_str()));
-			vl->append(new StringVal(parts[1].c_str()));
-			vl->append(new StringVal(parts[2].c_str()));
-			vl->append(new AddrVal(htonl(raw_ip)));
-			vl->append(val_mgr->GetCount(atoi(parts[4].c_str())));
-			if ( parts.size() >= 6 )
-				vl->append(val_mgr->GetCount(atoi(parts[5].c_str())));
-			else
-				vl->append(val_mgr->GetCount(0));
 
-			ConnectionEvent(irc_dcc_message, vl);
+			ConnectionEvent(irc_dcc_message, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(prefix.c_str()),
+				new StringVal(target.c_str()),
+				new StringVal(parts[1].c_str()),
+				new StringVal(parts[2].c_str()),
+				new AddrVal(htonl(raw_ip)),
+				val_mgr->GetCount(atoi(parts[4].c_str())),
+				parts.size() >= 6 ?
+					val_mgr->GetCount(atoi(parts[5].c_str())) :
+					val_mgr->GetCount(0),
+			});
 			}
 
 		else
 			{
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(prefix.c_str()));
-			vl->append(new StringVal(target.c_str()));
-			vl->append(new StringVal(message.c_str()));
-
-			ConnectionEvent(irc_privmsg_message, vl);
+			ConnectionEvent(irc_privmsg_message, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(prefix.c_str()),
+				new StringVal(target.c_str()),
+				new StringVal(message.c_str()),
+			});
 			}
 		}
 
@@ -707,14 +699,13 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( message[0] == ':' )
 			message = message.substr(1);
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(prefix.c_str()));
-		vl->append(new StringVal(target.c_str()));
-		vl->append(new StringVal(message.c_str()));
-
-		ConnectionEvent(irc_notice_message, vl);
+		ConnectionEvent(irc_notice_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(prefix.c_str()),
+			new StringVal(target.c_str()),
+			new StringVal(message.c_str()),
+		});
 		}
 
 	else if ( irc_squery_message && command == "SQUERY" )
@@ -732,35 +723,34 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( message[0] == ':' )
 			message = message.substr(1);
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(prefix.c_str()));
-		vl->append(new StringVal(target.c_str()));
-		vl->append(new StringVal(message.c_str()));
-
-		ConnectionEvent(irc_squery_message, vl);
+		ConnectionEvent(irc_squery_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(prefix.c_str()),
+			new StringVal(target.c_str()),
+			new StringVal(message.c_str()),
+		});
 		}
 
 	else if ( irc_user_message && command == "USER" )
 		{
 		// extract username and real name
 		vector<string> parts = SplitWords(params, ' ');
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
+		val_list vl(6);
+		vl.append(BuildConnVal());
+		vl.append(val_mgr->GetBool(orig));
 
 		if ( parts.size() > 0 )
-			vl->append(new StringVal(parts[0].c_str()));
-		else vl->append(val_mgr->GetEmptyString());
+			vl.append(new StringVal(parts[0].c_str()));
+		else vl.append(val_mgr->GetEmptyString());
 
 		if ( parts.size() > 1 )
-			vl->append(new StringVal(parts[1].c_str()));
-		else vl->append(val_mgr->GetEmptyString());
+			vl.append(new StringVal(parts[1].c_str()));
+		else vl.append(val_mgr->GetEmptyString());
 
 		if ( parts.size() > 2 )
-			vl->append(new StringVal(parts[2].c_str()));
-		else vl->append(val_mgr->GetEmptyString());
+			vl.append(new StringVal(parts[2].c_str()));
+		else vl.append(val_mgr->GetEmptyString());
 
 		string realname;
 		for ( unsigned int i = 3; i < parts.size(); i++ )
@@ -771,9 +761,9 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		const char* name = realname.c_str();
-		vl->append(new StringVal(*name == ':' ? name + 1 : name));
+		vl.append(new StringVal(*name == ':' ? name + 1 : name));
 
-		ConnectionEvent(irc_user_message, vl);
+		ConnectionEvent(irc_user_message, std::move(vl));
 		}
 
 	else if ( irc_oper_message && command == "OPER" )
@@ -782,13 +772,12 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		vector<string> parts = SplitWords(params, ' ');
 		if ( parts.size() == 2 )
 			{
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(parts[0].c_str()));
-			vl->append(new StringVal(parts[1].c_str()));
-
-			ConnectionEvent(irc_oper_message, vl);
+			ConnectionEvent(irc_oper_message, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(parts[0].c_str()),
+				new StringVal(parts[1].c_str()),
+			});
 			}
 
 		else
@@ -805,12 +794,12 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			return;
 			}
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(prefix.c_str()));
-		vl->append(new StringVal(parts[0].c_str()));
-		vl->append(new StringVal(parts[1].c_str()));
+		val_list vl(6);
+		vl.append(BuildConnVal());
+		vl.append(val_mgr->GetBool(orig));
+		vl.append(new StringVal(prefix.c_str()));
+		vl.append(new StringVal(parts[0].c_str()));
+		vl.append(new StringVal(parts[1].c_str()));
 		if ( parts.size() > 2 )
 			{
 			string comment = parts[2];
@@ -820,12 +809,12 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( comment[0] == ':' )
 				comment = comment.substr(1);
 
-			vl->append(new StringVal(comment.c_str()));
+			vl.append(new StringVal(comment.c_str()));
 			}
 		else
-			vl->append(val_mgr->GetEmptyString());
+			vl.append(val_mgr->GetEmptyString());
 
-		ConnectionEvent(irc_kick_message, vl);
+		ConnectionEvent(irc_kick_message, std::move(vl));
 		}
 
 	else if ( irc_join_message && command == "JOIN" )
@@ -849,11 +838,8 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				nickname = prefix.substr(0, pos);
 			}
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-
 		TableVal* list = new TableVal(irc_join_list);
+
 		vector<string> channels = SplitWords(parts[0], ',');
 		vector<string> passwords;
 
@@ -876,9 +862,11 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			Unref(info);
 			}
 
-		vl->append(list);
-
-		ConnectionEvent(irc_join_message, vl);
+		ConnectionEvent(irc_join_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			list,
+		});
 		}
 
 	else if ( irc_join_message && command == "NJOIN" )
@@ -895,12 +883,8 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			parts[1] = parts[1].substr(1);
 
 		vector<string> users = SplitWords(parts[1], ',');
-
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-
 		TableVal* list = new TableVal(irc_join_list);
+
 		string empty_string = "";
 
 		for ( unsigned int i = 0; i < users.size(); ++i )
@@ -939,9 +923,11 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			Unref(info);
 			}
 
-		vl->append(list);
-
-		ConnectionEvent(irc_join_message, vl);
+		ConnectionEvent(irc_join_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			list,
+		});
 		}
 
 	else if ( irc_part_message && command == "PART" )
@@ -977,14 +963,13 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			Unref(idx);
 			}
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(nick.c_str()));
-		vl->append(set);
-		vl->append(new StringVal(message.c_str()));
-
-		ConnectionEvent(irc_part_message, vl);
+		ConnectionEvent(irc_part_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(nick.c_str()),
+			set,
+			new StringVal(message.c_str()),
+		});
 		}
 
 	else if ( irc_quit_message && command == "QUIT" )
@@ -1001,13 +986,12 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				nickname = prefix.substr(0, pos);
 			}
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(nickname.c_str()));
-		vl->append(new StringVal(message.c_str()));
-
-		ConnectionEvent(irc_quit_message, vl);
+		ConnectionEvent(irc_quit_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(nickname.c_str()),
+			new StringVal(message.c_str()),
+		});
 		}
 
 	else if ( irc_nick_message && command == "NICK" )
@@ -1016,13 +1000,12 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( nick[0] == ':' )
 			nick = nick.substr(1);
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(prefix.c_str()));
-		vl->append(new StringVal(nick.c_str()));
-
-		ConnectionEvent(irc_nick_message, vl);
+		ConnectionEvent(irc_nick_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(prefix.c_str()),
+			new StringVal(nick.c_str())
+		});
 		}
 
 	else if ( irc_who_message && command == "WHO" )
@@ -1042,16 +1025,14 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( parts.size() > 0 && parts[0].size() > 0 && parts[0][0] == ':' )
 			parts[0] = parts[0].substr(1);
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		if ( parts.size() > 0 )
-			vl->append(new StringVal(parts[0].c_str()));
-		else
-			vl->append(val_mgr->GetEmptyString());
-		vl->append(val_mgr->GetBool(oper));
-
-		ConnectionEvent(irc_who_message, vl);
+		ConnectionEvent(irc_who_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			parts.size() > 0 ?
+				new StringVal(parts[0].c_str()) :
+				val_mgr->GetEmptyString(),
+			val_mgr->GetBool(oper),
+		});
 		}
 
 	else if ( irc_whois_message && command == "WHOIS" )
@@ -1074,26 +1055,25 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		else
 			users = parts[0];
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(server.c_str()));
-		vl->append(new StringVal(users.c_str()));
-
-		ConnectionEvent(irc_whois_message, vl);
+		ConnectionEvent(irc_whois_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(server.c_str()),
+			new StringVal(users.c_str()),
+		});
 		}
 
 	else if ( irc_error_message && command == "ERROR" )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(prefix.c_str()));
 		if ( params[0] == ':' )
 			params = params.substr(1);
-		vl->append(new StringVal(params.c_str()));
 
-		ConnectionEvent(irc_error_message, vl);
+		ConnectionEvent(irc_error_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(prefix.c_str()),
+			new StringVal(params.c_str()),
+		});
 		}
 
 	else if ( irc_invite_message && command == "INVITE" )
@@ -1104,14 +1084,13 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( parts[1].size() > 0 && parts[1][0] == ':' )
 				parts[1] = parts[1].substr(1);
 
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(prefix.c_str()));
-			vl->append(new StringVal(parts[0].c_str()));
-			vl->append(new StringVal(parts[1].c_str()));
-
-			ConnectionEvent(irc_invite_message, vl);
+			ConnectionEvent(irc_invite_message, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(prefix.c_str()),
+				new StringVal(parts[0].c_str()),
+				new StringVal(parts[1].c_str()),
+			});
 			}
 		else
 			Weird("irc_invalid_invite_message_format");
@@ -1121,13 +1100,12 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		{
 		if ( params.size() > 0 )
 			{
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(prefix.c_str()));
-			vl->append(new StringVal(params.c_str()));
-
-			ConnectionEvent(irc_mode_message, vl);
+			ConnectionEvent(irc_mode_message, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(prefix.c_str()),
+				new StringVal(params.c_str()),
+			});
 			}
 
 		else
@@ -1136,11 +1114,11 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 	else if ( irc_password_message && command == "PASS" )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(params.c_str()));
-		ConnectionEvent(irc_password_message, vl);
+		ConnectionEvent(irc_password_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(params.c_str()),
+		});
 		}
 
 	else if ( irc_squit_message && command == "SQUIT" )
@@ -1158,14 +1136,13 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				message = message.substr(1);
 			}
 
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(orig));
-		vl->append(new StringVal(prefix.c_str()));
-		vl->append(new StringVal(server.c_str()));
-		vl->append(new StringVal(message.c_str()));
-
-		ConnectionEvent(irc_squit_message, vl);
+		ConnectionEvent(irc_squit_message, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig),
+			new StringVal(prefix.c_str()),
+			new StringVal(server.c_str()),
+			new StringVal(message.c_str()),
+		});
 		}
 
 
@@ -1173,14 +1150,13 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		{
 		if ( irc_request )
 			{
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(prefix.c_str()));
-			vl->append(new StringVal(command.c_str()));
-			vl->append(new StringVal(params.c_str()));
-
-			ConnectionEvent(irc_request, vl);
+			ConnectionEvent(irc_request, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(prefix.c_str()),
+				new StringVal(command.c_str()),
+				new StringVal(params.c_str()),
+			});
 			}
 		}
 
@@ -1188,14 +1164,13 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		{
 		if ( irc_message )
 			{
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(orig));
-			vl->append(new StringVal(prefix.c_str()));
-			vl->append(new StringVal(command.c_str()));
-			vl->append(new StringVal(params.c_str()));
-
-			ConnectionEvent(irc_message, vl);
+			ConnectionEvent(irc_message, {
+				BuildConnVal(),
+				val_mgr->GetBool(orig),
+				new StringVal(prefix.c_str()),
+				new StringVal(command.c_str()),
+				new StringVal(params.c_str()),
+			});
 			}
 		}
 
@@ -1224,10 +1199,7 @@ void IRC_Analyzer::StartTLS()
 	if ( ssl )
 		AddChildAnalyzer(ssl);
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-
-	ConnectionEvent(irc_starttls, vl);
+	ConnectionEvent(irc_starttls, {BuildConnVal()});
 	}
 
 vector<string> IRC_Analyzer::SplitWords(const string input, const char split)

--- a/src/analyzer/protocol/login/Login.cc
+++ b/src/analyzer/protocol/login/Login.cc
@@ -289,9 +289,7 @@ void Login_Analyzer::AuthenticationDialog(bool orig, char* line)
 		{
 		if ( authentication_skipped )
 			{
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			ConnectionEvent(authentication_skipped, vl);
+			ConnectionEvent(authentication_skipped, {BuildConnVal()});
 			}
 
 		state = LOGIN_STATE_SKIP;
@@ -334,32 +332,26 @@ void Login_Analyzer::SetEnv(bool orig, char* name, char* val)
 
 		else if ( login_terminal && streq(name, "TERM") )
 			{
-			val_list* vl = new val_list;
-
-			vl->append(BuildConnVal());
-			vl->append(new StringVal(val));
-
-			ConnectionEvent(login_terminal, vl);
+			ConnectionEvent(login_terminal, {
+				BuildConnVal(),
+				new StringVal(val),
+			});
 			}
 
 		else if ( login_display && streq(name, "DISPLAY") )
 			{
-			val_list* vl = new val_list;
-
-			vl->append(BuildConnVal());
-			vl->append(new StringVal(val));
-
-			ConnectionEvent(login_display, vl);
+			ConnectionEvent(login_display, {
+				BuildConnVal(),
+				new StringVal(val),
+			});
 			}
 
 		else if ( login_prompt && streq(name, "TTYPROMPT") )
 			{
-			val_list* vl = new val_list;
-
-			vl->append(BuildConnVal());
-			vl->append(new StringVal(val));
-
-			ConnectionEvent(login_prompt, vl);
+			ConnectionEvent(login_prompt, {
+				BuildConnVal(),
+				new StringVal(val),
+			});
 			}
 		}
 
@@ -433,15 +425,13 @@ void Login_Analyzer::LoginEvent(EventHandlerPtr f, const char* line,
 	Val* password = HaveTypeahead() ?
 				PopUserTextVal() : new StringVal("<none>");
 
-	val_list* vl = new val_list;
-
-	vl->append(BuildConnVal());
-	vl->append(username->Ref());
-	vl->append(client_name ? client_name->Ref() : val_mgr->GetEmptyString());
-	vl->append(password);
-	vl->append(new StringVal(line));
-
-	ConnectionEvent(f, vl);
+	ConnectionEvent(f, {
+		BuildConnVal(),
+		username->Ref(),
+		client_name ? client_name->Ref() : val_mgr->GetEmptyString(),
+		password,
+		new StringVal(line),
+	});
 	}
 
 const char* Login_Analyzer::GetUsername(const char* line) const
@@ -454,12 +444,10 @@ const char* Login_Analyzer::GetUsername(const char* line) const
 
 void Login_Analyzer::LineEvent(EventHandlerPtr f, const char* line)
 	{
-	val_list* vl = new val_list;
-
-	vl->append(BuildConnVal());
-	vl->append(new StringVal(line));
-
-	ConnectionEvent(f, vl);
+	ConnectionEvent(f, {
+		BuildConnVal(),
+		new StringVal(line),
+	});
 	}
 
 
@@ -469,12 +457,11 @@ void Login_Analyzer::Confused(const char* msg, const char* line)
 
 	if ( login_confused )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(new StringVal(msg));
-		vl->append(new StringVal(line));
-
-		ConnectionEvent(login_confused, vl);
+		ConnectionEvent(login_confused, {
+			BuildConnVal(),
+			new StringVal(msg),
+			new StringVal(line),
+		});
 		}
 
 	if ( login_confused_text )
@@ -496,10 +483,10 @@ void Login_Analyzer::ConfusionText(const char* line)
 	{
 	if ( login_confused_text )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(new StringVal(line));
-		ConnectionEvent(login_confused_text, vl);
+		ConnectionEvent(login_confused_text, {
+			BuildConnVal(),
+			new StringVal(line),
+		});
 		}
 	}
 

--- a/src/analyzer/protocol/login/Login.cc
+++ b/src/analyzer/protocol/login/Login.cc
@@ -289,7 +289,7 @@ void Login_Analyzer::AuthenticationDialog(bool orig, char* line)
 		{
 		if ( authentication_skipped )
 			{
-			ConnectionEvent(authentication_skipped, {BuildConnVal()});
+			ConnectionEventFast(authentication_skipped, {BuildConnVal()});
 			}
 
 		state = LOGIN_STATE_SKIP;
@@ -332,7 +332,7 @@ void Login_Analyzer::SetEnv(bool orig, char* name, char* val)
 
 		else if ( login_terminal && streq(name, "TERM") )
 			{
-			ConnectionEvent(login_terminal, {
+			ConnectionEventFast(login_terminal, {
 				BuildConnVal(),
 				new StringVal(val),
 			});
@@ -340,7 +340,7 @@ void Login_Analyzer::SetEnv(bool orig, char* name, char* val)
 
 		else if ( login_display && streq(name, "DISPLAY") )
 			{
-			ConnectionEvent(login_display, {
+			ConnectionEventFast(login_display, {
 				BuildConnVal(),
 				new StringVal(val),
 			});
@@ -348,7 +348,7 @@ void Login_Analyzer::SetEnv(bool orig, char* name, char* val)
 
 		else if ( login_prompt && streq(name, "TTYPROMPT") )
 			{
-			ConnectionEvent(login_prompt, {
+			ConnectionEventFast(login_prompt, {
 				BuildConnVal(),
 				new StringVal(val),
 			});
@@ -425,7 +425,7 @@ void Login_Analyzer::LoginEvent(EventHandlerPtr f, const char* line,
 	Val* password = HaveTypeahead() ?
 				PopUserTextVal() : new StringVal("<none>");
 
-	ConnectionEvent(f, {
+	ConnectionEventFast(f, {
 		BuildConnVal(),
 		username->Ref(),
 		client_name ? client_name->Ref() : val_mgr->GetEmptyString(),
@@ -444,7 +444,10 @@ const char* Login_Analyzer::GetUsername(const char* line) const
 
 void Login_Analyzer::LineEvent(EventHandlerPtr f, const char* line)
 	{
-	ConnectionEvent(f, {
+	if ( ! f )
+		return;
+
+	ConnectionEventFast(f, {
 		BuildConnVal(),
 		new StringVal(line),
 	});
@@ -457,7 +460,7 @@ void Login_Analyzer::Confused(const char* msg, const char* line)
 
 	if ( login_confused )
 		{
-		ConnectionEvent(login_confused, {
+		ConnectionEventFast(login_confused, {
 			BuildConnVal(),
 			new StringVal(msg),
 			new StringVal(line),
@@ -483,7 +486,7 @@ void Login_Analyzer::ConfusionText(const char* line)
 	{
 	if ( login_confused_text )
 		{
-		ConnectionEvent(login_confused_text, {
+		ConnectionEventFast(login_confused_text, {
 			BuildConnVal(),
 			new StringVal(line),
 		});

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -461,7 +461,7 @@ void NVT_Analyzer::SetTerminal(const u_char* terminal, int len)
 	{
 	if ( login_terminal )
 		{
-		ConnectionEvent(login_terminal, {
+		ConnectionEventFast(login_terminal, {
 			BuildConnVal(),
 			new StringVal(new BroString(terminal, len, 0)),
 		});

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -461,11 +461,10 @@ void NVT_Analyzer::SetTerminal(const u_char* terminal, int len)
 	{
 	if ( login_terminal )
 		{
-		val_list* vl = new val_list;
-		vl->append(BuildConnVal());
-		vl->append(new StringVal(new BroString(terminal, len, 0)));
-
-		ConnectionEvent(login_terminal, vl);
+		ConnectionEvent(login_terminal, {
+			BuildConnVal(),
+			new StringVal(new BroString(terminal, len, 0)),
+		});
 		}
 	}
 

--- a/src/analyzer/protocol/login/RSH.cc
+++ b/src/analyzer/protocol/login/RSH.cc
@@ -156,31 +156,38 @@ void Rsh_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	{
 	Login_Analyzer::DeliverStream(len, data, orig);
 
+	if ( orig )
+		{
+		if ( ! rsh_request )
+			return;
+		}
+	else
+		{
+		if ( ! rsh_reply )
+			return;
+		}
+
+	val_list vl(4 + orig);
 	const char* line = (const char*) data;
-	val_list* vl = new val_list;
-
 	line = skip_whitespace(line);
-	vl->append(BuildConnVal());
-	vl->append(client_name ? client_name->Ref() : new StringVal("<none>"));
-	vl->append(username ? username->Ref() : new StringVal("<none>"));
-	vl->append(new StringVal(line));
+	vl.append(BuildConnVal());
+	vl.append(client_name ? client_name->Ref() : new StringVal("<none>"));
+	vl.append(username ? username->Ref() : new StringVal("<none>"));
+	vl.append(new StringVal(line));
 
-	if ( orig && rsh_request )
+	if ( orig )
 		{
 		if ( contents_orig->RshSaveState() == RSH_SERVER_USER_NAME )
 			// First input
-			vl->append(val_mgr->GetTrue());
+			vl.append(val_mgr->GetTrue());
 		else
-			vl->append(val_mgr->GetFalse());
+			vl.append(val_mgr->GetFalse());
 
-		ConnectionEvent(rsh_request, vl);
+		ConnectionEvent(rsh_request, std::move(vl));
 		}
 
-	else if ( rsh_reply )
-		ConnectionEvent(rsh_reply, vl);
-
 	else
-		delete_vals(vl);
+		ConnectionEvent(rsh_reply, std::move(vl));
 	}
 
 void Rsh_Analyzer::ClientUserName(const char* s)

--- a/src/analyzer/protocol/login/RSH.cc
+++ b/src/analyzer/protocol/login/RSH.cc
@@ -183,11 +183,11 @@ void Rsh_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		else
 			vl.append(val_mgr->GetFalse());
 
-		ConnectionEvent(rsh_request, std::move(vl));
+		ConnectionEventFast(rsh_request, std::move(vl));
 		}
 
 	else
-		ConnectionEvent(rsh_reply, std::move(vl));
+		ConnectionEventFast(rsh_reply, std::move(vl));
 	}
 
 void Rsh_Analyzer::ClientUserName(const char* s)

--- a/src/analyzer/protocol/login/Rlogin.cc
+++ b/src/analyzer/protocol/login/Rlogin.cc
@@ -244,7 +244,7 @@ void Rlogin_Analyzer::TerminalType(const char* s)
 	{
 	if ( login_terminal )
 		{
-		ConnectionEvent(login_terminal, {
+		ConnectionEventFast(login_terminal, {
 			BuildConnVal(),
 			new StringVal(s),
 		});

--- a/src/analyzer/protocol/login/Rlogin.cc
+++ b/src/analyzer/protocol/login/Rlogin.cc
@@ -244,11 +244,9 @@ void Rlogin_Analyzer::TerminalType(const char* s)
 	{
 	if ( login_terminal )
 		{
-		val_list* vl = new val_list;
-
-		vl->append(BuildConnVal());
-		vl->append(new StringVal(s));
-
-		ConnectionEvent(login_terminal, vl);
+		ConnectionEvent(login_terminal, {
+			BuildConnVal(),
+			new StringVal(s),
+		});
 		}
 	}

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -1358,11 +1358,11 @@ void MIME_Mail::Done()
 		hash_final(md5_hash, digest);
 		md5_hash = nullptr;
 
-		val_list* vl = new val_list;
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetCount(content_hash_length));
-		vl->append(new StringVal(new BroString(1, digest, 16)));
-		analyzer->ConnectionEvent(mime_content_hash, vl);
+		analyzer->ConnectionEvent(mime_content_hash, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetCount(content_hash_length),
+			new StringVal(new BroString(1, digest, 16)),
+		});
 		}
 
 	MIME_Message::Done();
@@ -1386,11 +1386,7 @@ void MIME_Mail::BeginEntity(MIME_Entity* /* entity */)
 	cur_entity_id.clear();
 
 	if ( mime_begin_entity )
-		{
-		val_list* vl = new val_list;
-		vl->append(analyzer->BuildConnVal());
-		analyzer->ConnectionEvent(mime_begin_entity, vl);
-		}
+		analyzer->ConnectionEvent(mime_begin_entity, {analyzer->BuildConnVal()});
 
 	buffer_start = data_start = 0;
 	ASSERT(entity_content.size() == 0);
@@ -1402,12 +1398,12 @@ void MIME_Mail::EndEntity(MIME_Entity* /* entity */)
 		{
 		BroString* s = concatenate(entity_content);
 
-		val_list* vl = new val_list();
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetCount(s->Len()));
-		vl->append(new StringVal(s));
 
-		analyzer->ConnectionEvent(mime_entity_data, vl);
+		analyzer->ConnectionEvent(mime_entity_data, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetCount(s->Len()),
+			new StringVal(s),
+		});
 
 		if ( ! mime_all_data )
 			delete_strings(entity_content);
@@ -1416,11 +1412,7 @@ void MIME_Mail::EndEntity(MIME_Entity* /* entity */)
 		}
 
 	if ( mime_end_entity )
-		{
-		val_list* vl = new val_list;
-		vl->append(analyzer->BuildConnVal());
-		analyzer->ConnectionEvent(mime_end_entity, vl);
-		}
+		analyzer->ConnectionEvent(mime_end_entity, {analyzer->BuildConnVal()});
 
 	file_mgr->EndOfFile(analyzer->GetAnalyzerTag(), analyzer->Conn());
 	cur_entity_id.clear();
@@ -1430,10 +1422,10 @@ void MIME_Mail::SubmitHeader(MIME_Header* h)
 	{
 	if ( mime_one_header )
 		{
-		val_list* vl = new val_list();
-		vl->append(analyzer->BuildConnVal());
-		vl->append(BuildHeaderVal(h));
-		analyzer->ConnectionEvent(mime_one_header, vl);
+		analyzer->ConnectionEvent(mime_one_header, {
+			analyzer->BuildConnVal(),
+			BuildHeaderVal(h),
+		});
 		}
 	}
 
@@ -1441,10 +1433,10 @@ void MIME_Mail::SubmitAllHeaders(MIME_HeaderList& hlist)
 	{
 	if ( mime_all_headers )
 		{
-		val_list* vl = new val_list();
-		vl->append(analyzer->BuildConnVal());
-		vl->append(BuildHeaderTable(hlist));
-		analyzer->ConnectionEvent(mime_all_headers, vl);
+		analyzer->ConnectionEvent(mime_all_headers, {
+			analyzer->BuildConnVal(),
+			BuildHeaderTable(hlist),
+		});
 		}
 	}
 
@@ -1478,11 +1470,11 @@ void MIME_Mail::SubmitData(int len, const char* buf)
 		const char* data = (char*) data_buffer->Bytes() + data_start;
 		int data_len = (buf + len) - data;
 
-		val_list* vl = new val_list();
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetCount(data_len));
-		vl->append(new StringVal(data_len, data));
-		analyzer->ConnectionEvent(mime_segment_data, vl);
+		analyzer->ConnectionEvent(mime_segment_data, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetCount(data_len),
+			new StringVal(data_len, data),
+		});
 		}
 
 	cur_entity_id = file_mgr->DataIn(reinterpret_cast<const u_char*>(buf), len,
@@ -1525,12 +1517,11 @@ void MIME_Mail::SubmitAllData()
 		BroString* s = concatenate(all_content);
 		delete_strings(all_content);
 
-		val_list* vl = new val_list();
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetCount(s->Len()));
-		vl->append(new StringVal(s));
-
-		analyzer->ConnectionEvent(mime_all_data, vl);
+		analyzer->ConnectionEvent(mime_all_data, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetCount(s->Len()),
+			new StringVal(s),
+		});
 		}
 	}
 
@@ -1555,10 +1546,10 @@ void MIME_Mail::SubmitEvent(int event_type, const char* detail)
 
 	if ( mime_event )
 		{
-		val_list* vl = new val_list();
-		vl->append(analyzer->BuildConnVal());
-		vl->append(new StringVal(category));
-		vl->append(new StringVal(detail));
-		analyzer->ConnectionEvent(mime_event, vl);
+		analyzer->ConnectionEvent(mime_event, {
+			analyzer->BuildConnVal(),
+			new StringVal(category),
+			new StringVal(detail),
+		});
 		}
 	}

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -1358,7 +1358,7 @@ void MIME_Mail::Done()
 		hash_final(md5_hash, digest);
 		md5_hash = nullptr;
 
-		analyzer->ConnectionEvent(mime_content_hash, {
+		analyzer->ConnectionEventFast(mime_content_hash, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetCount(content_hash_length),
 			new StringVal(new BroString(1, digest, 16)),
@@ -1386,7 +1386,7 @@ void MIME_Mail::BeginEntity(MIME_Entity* /* entity */)
 	cur_entity_id.clear();
 
 	if ( mime_begin_entity )
-		analyzer->ConnectionEvent(mime_begin_entity, {analyzer->BuildConnVal()});
+		analyzer->ConnectionEventFast(mime_begin_entity, {analyzer->BuildConnVal()});
 
 	buffer_start = data_start = 0;
 	ASSERT(entity_content.size() == 0);
@@ -1398,8 +1398,7 @@ void MIME_Mail::EndEntity(MIME_Entity* /* entity */)
 		{
 		BroString* s = concatenate(entity_content);
 
-
-		analyzer->ConnectionEvent(mime_entity_data, {
+		analyzer->ConnectionEventFast(mime_entity_data, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetCount(s->Len()),
 			new StringVal(s),
@@ -1412,7 +1411,7 @@ void MIME_Mail::EndEntity(MIME_Entity* /* entity */)
 		}
 
 	if ( mime_end_entity )
-		analyzer->ConnectionEvent(mime_end_entity, {analyzer->BuildConnVal()});
+		analyzer->ConnectionEventFast(mime_end_entity, {analyzer->BuildConnVal()});
 
 	file_mgr->EndOfFile(analyzer->GetAnalyzerTag(), analyzer->Conn());
 	cur_entity_id.clear();
@@ -1422,7 +1421,7 @@ void MIME_Mail::SubmitHeader(MIME_Header* h)
 	{
 	if ( mime_one_header )
 		{
-		analyzer->ConnectionEvent(mime_one_header, {
+		analyzer->ConnectionEventFast(mime_one_header, {
 			analyzer->BuildConnVal(),
 			BuildHeaderVal(h),
 		});
@@ -1433,7 +1432,7 @@ void MIME_Mail::SubmitAllHeaders(MIME_HeaderList& hlist)
 	{
 	if ( mime_all_headers )
 		{
-		analyzer->ConnectionEvent(mime_all_headers, {
+		analyzer->ConnectionEventFast(mime_all_headers, {
 			analyzer->BuildConnVal(),
 			BuildHeaderTable(hlist),
 		});
@@ -1470,7 +1469,7 @@ void MIME_Mail::SubmitData(int len, const char* buf)
 		const char* data = (char*) data_buffer->Bytes() + data_start;
 		int data_len = (buf + len) - data;
 
-		analyzer->ConnectionEvent(mime_segment_data, {
+		analyzer->ConnectionEventFast(mime_segment_data, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetCount(data_len),
 			new StringVal(data_len, data),
@@ -1517,7 +1516,7 @@ void MIME_Mail::SubmitAllData()
 		BroString* s = concatenate(all_content);
 		delete_strings(all_content);
 
-		analyzer->ConnectionEvent(mime_all_data, {
+		analyzer->ConnectionEventFast(mime_all_data, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetCount(s->Len()),
 			new StringVal(s),
@@ -1546,7 +1545,7 @@ void MIME_Mail::SubmitEvent(int event_type, const char* detail)
 
 	if ( mime_event )
 		{
-		analyzer->ConnectionEvent(mime_event, {
+		analyzer->ConnectionEventFast(mime_event, {
 			analyzer->BuildConnVal(),
 			new StringVal(category),
 			new StringVal(detail),

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -63,7 +63,7 @@ void NCP_Session::DeliverFrame(const binpac::NCP::ncp_frame* frame)
 		{
 		if ( frame->is_orig() )
 			{
-			analyzer->ConnectionEvent(f, {
+			analyzer->ConnectionEventFast(f, {
 				analyzer->BuildConnVal(),
 				val_mgr->GetCount(frame->frame_type()),
 				val_mgr->GetCount(frame->body_length()),
@@ -72,7 +72,7 @@ void NCP_Session::DeliverFrame(const binpac::NCP::ncp_frame* frame)
 			}
 		else
 			{
-			analyzer->ConnectionEvent(f, {
+			analyzer->ConnectionEventFast(f, {
 				analyzer->BuildConnVal(),
 				val_mgr->GetCount(frame->frame_type()),
 				val_mgr->GetCount(frame->body_length()),

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -61,21 +61,27 @@ void NCP_Session::DeliverFrame(const binpac::NCP::ncp_frame* frame)
 	EventHandlerPtr f = frame->is_orig() ? ncp_request : ncp_reply;
 	if ( f )
 		{
-		val_list* vl = new val_list;
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetCount(frame->frame_type()));
-		vl->append(val_mgr->GetCount(frame->body_length()));
-
 		if ( frame->is_orig() )
-			vl->append(val_mgr->GetCount(req_func));
+			{
+			analyzer->ConnectionEvent(f, {
+				analyzer->BuildConnVal(),
+				val_mgr->GetCount(frame->frame_type()),
+				val_mgr->GetCount(frame->body_length()),
+				val_mgr->GetCount(req_func),
+			});
+			}
 		else
 			{
-			vl->append(val_mgr->GetCount(req_frame_type));
-			vl->append(val_mgr->GetCount(req_func));
-			vl->append(val_mgr->GetCount(frame->reply()->completion_code()));
+			analyzer->ConnectionEvent(f, {
+				analyzer->BuildConnVal(),
+				val_mgr->GetCount(frame->frame_type()),
+				val_mgr->GetCount(frame->body_length()),
+				val_mgr->GetCount(req_frame_type),
+				val_mgr->GetCount(req_func),
+				val_mgr->GetCount(frame->reply()->completion_code()),
+			});
 			}
 
-		analyzer->ConnectionEvent(f, vl);
 		}
 	}
 

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -58,12 +58,12 @@ int NetbiosSSN_Interpreter::ParseMessage(unsigned int type, unsigned int flags,
 	{
 	if ( netbios_session_message )
 		{
-		val_list* vl = new val_list;
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetBool(is_query));
-		vl->append(val_mgr->GetCount(type));
-		vl->append(val_mgr->GetCount(len));
-		analyzer->ConnectionEvent(netbios_session_message, vl);
+		analyzer->ConnectionEvent(netbios_session_message, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetBool(is_query),
+			val_mgr->GetCount(type),
+			val_mgr->GetCount(len),
+		});
 		}
 
 	switch ( type ) {
@@ -328,13 +328,19 @@ void NetbiosSSN_Interpreter::Event(EventHandlerPtr event, const u_char* data,
 	if ( ! event )
 		return;
 
-	val_list* vl = new val_list;
-	vl->append(analyzer->BuildConnVal());
 	if ( is_orig >= 0 )
-		vl->append(val_mgr->GetBool(is_orig));
-	vl->append(new StringVal(new BroString(data, len, 0)));
-
-	analyzer->ConnectionEvent(event, vl);
+		{
+		analyzer->ConnectionEvent(event, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+			new StringVal(new BroString(data, len, 0)),
+		});
+		}
+	else
+		analyzer->ConnectionEvent(event, {
+			analyzer->BuildConnVal(),
+			new StringVal(new BroString(data, len, 0)),
+		});
 	}
 
 

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -58,7 +58,7 @@ int NetbiosSSN_Interpreter::ParseMessage(unsigned int type, unsigned int flags,
 	{
 	if ( netbios_session_message )
 		{
-		analyzer->ConnectionEvent(netbios_session_message, {
+		analyzer->ConnectionEventFast(netbios_session_message, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetBool(is_query),
 			val_mgr->GetCount(type),
@@ -330,14 +330,14 @@ void NetbiosSSN_Interpreter::Event(EventHandlerPtr event, const u_char* data,
 
 	if ( is_orig >= 0 )
 		{
-		analyzer->ConnectionEvent(event, {
+		analyzer->ConnectionEventFast(event, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 			new StringVal(new BroString(data, len, 0)),
 		});
 		}
 	else
-		analyzer->ConnectionEvent(event, {
+		analyzer->ConnectionEventFast(event, {
 			analyzer->BuildConnVal(),
 			new StringVal(new BroString(data, len, 0)),
 		});

--- a/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
+++ b/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
@@ -94,6 +94,9 @@ refine connection NTLM_Conn += {
 
 	function proc_ntlm_negotiate(val: NTLM_Negotiate): bool
 		%{
+		if ( ! ntlm_negotiate )
+			return true;
+
 		RecordVal* result = new RecordVal(BifType::Record::NTLM::Negotiate);
 		result->Assign(0, build_negotiate_flag_record(${val.flags}));
 
@@ -115,6 +118,9 @@ refine connection NTLM_Conn += {
 
 	function proc_ntlm_challenge(val: NTLM_Challenge): bool
 		%{
+		if ( ! ntlm_challenge )
+			return true;
+
 		RecordVal* result = new RecordVal(BifType::Record::NTLM::Challenge);
 		result->Assign(0, build_negotiate_flag_record(${val.flags}));
 
@@ -136,6 +142,9 @@ refine connection NTLM_Conn += {
 
 	function proc_ntlm_authenticate(val: NTLM_Authenticate): bool
 		%{
+		if ( ! ntlm_authenticate )
+			return true;
+
 		RecordVal* result = new RecordVal(BifType::Record::NTLM::Authenticate);
 		result->Assign(0, build_negotiate_flag_record(${val.flags}));
 

--- a/src/analyzer/protocol/ntp/NTP.cc
+++ b/src/analyzer/protocol/ntp/NTP.cc
@@ -78,12 +78,11 @@ void NTP_Analyzer::Message(const u_char* data, int len)
 	msg->Assign(9, new Val(LongFloat(ntp_data->rec), TYPE_TIME));
 	msg->Assign(10, new Val(LongFloat(ntp_data->xmt), TYPE_TIME));
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-	vl->append(msg);
-	vl->append(new StringVal(new BroString(data, len, 0)));
-
-	ConnectionEvent(ntp_message, vl);
+	ConnectionEvent(ntp_message, {
+		BuildConnVal(),
+		msg,
+		new StringVal(new BroString(data, len, 0)),
+	});
 	}
 
 double NTP_Analyzer::ShortFloat(struct s_fixedpt fp)

--- a/src/analyzer/protocol/ntp/NTP.cc
+++ b/src/analyzer/protocol/ntp/NTP.cc
@@ -62,6 +62,9 @@ void NTP_Analyzer::Message(const u_char* data, int len)
 	len -= sizeof *ntp_data;
 	data += sizeof *ntp_data;
 
+	if ( ! ntp_message )
+		return;
+
 	RecordVal* msg = new RecordVal(ntp_msg);
 
 	unsigned int code = ntp_data->status & 0x7;
@@ -78,7 +81,7 @@ void NTP_Analyzer::Message(const u_char* data, int len)
 	msg->Assign(9, new Val(LongFloat(ntp_data->rec), TYPE_TIME));
 	msg->Assign(10, new Val(LongFloat(ntp_data->xmt), TYPE_TIME));
 
-	ConnectionEvent(ntp_message, {
+	ConnectionEventFast(ntp_message, {
 		BuildConnVal(),
 		msg,
 		new StringVal(new BroString(data, len, 0)),

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -833,7 +833,8 @@ void POP3_Analyzer::StartTLS()
 	if ( ssl )
 		AddChildAnalyzer(ssl);
 
-	ConnectionEvent(pop3_starttls, {BuildConnVal()});
+	if ( pop3_starttls )
+		ConnectionEventFast(pop3_starttls, {BuildConnVal()});
 	}
 
 void POP3_Analyzer::AuthSuccessfull()
@@ -932,5 +933,5 @@ void POP3_Analyzer::POP3Event(EventHandlerPtr event, bool is_orig,
 	if ( arg2 )
 		vl.append(new StringVal(arg2));
 
-	ConnectionEvent(event, std::move(vl));
+	ConnectionEventFast(event, std::move(vl));
 	}

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -833,10 +833,7 @@ void POP3_Analyzer::StartTLS()
 	if ( ssl )
 		AddChildAnalyzer(ssl);
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-
-	ConnectionEvent(pop3_starttls, vl);
+	ConnectionEvent(pop3_starttls, {BuildConnVal()});
 	}
 
 void POP3_Analyzer::AuthSuccessfull()
@@ -926,14 +923,14 @@ void POP3_Analyzer::POP3Event(EventHandlerPtr event, bool is_orig,
 	if ( ! event )
 		return;
 
-	val_list* vl = new val_list;
+	val_list vl(2 + (bool)arg1 + (bool)arg2);
 
-	vl->append(BuildConnVal());
-	vl->append(val_mgr->GetBool(is_orig));
+	vl.append(BuildConnVal());
+	vl.append(val_mgr->GetBool(is_orig));
 	if ( arg1 )
-		vl->append(new StringVal(arg1));
+		vl.append(new StringVal(arg1));
 	if ( arg2 )
-		vl->append(new StringVal(arg2));
+		vl.append(new StringVal(arg2));
 
-	ConnectionEvent(event, vl);
+	ConnectionEvent(event, std::move(vl));
 	}

--- a/src/analyzer/protocol/rfb/rfb-analyzer.pac
+++ b/src/analyzer/protocol/rfb/rfb-analyzer.pac
@@ -1,7 +1,8 @@
 refine flow RFB_Flow += {
 	function proc_rfb_message(msg: RFB_PDU): bool
 		%{
-		BifEvent::generate_rfb_event(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn());
+		if ( rfb_event )
+			BifEvent::generate_rfb_event(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn());
 		return true;
 		%}
 
@@ -9,44 +10,51 @@ refine flow RFB_Flow += {
 		%{
 		if (client)
 			{
-			BifEvent::generate_rfb_client_version(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), bytestring_to_val(major), bytestring_to_val(minor));
+			if ( rfb_client_version )
+				BifEvent::generate_rfb_client_version(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), bytestring_to_val(major), bytestring_to_val(minor));
 
 			connection()->bro_analyzer()->ProtocolConfirmation();
 			}
 			else
 			{
-			BifEvent::generate_rfb_server_version(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), bytestring_to_val(major), bytestring_to_val(minor));
+			if ( rfb_server_version )
+				BifEvent::generate_rfb_server_version(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), bytestring_to_val(major), bytestring_to_val(minor));
 			}
 		return true;
 		%}
 
 	function proc_rfb_share_flag(shared: bool) : bool
 		%{
-		BifEvent::generate_rfb_share_flag(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), shared);
+		if ( rfb_share_flag )
+			BifEvent::generate_rfb_share_flag(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), shared);
 		return true;
 		%}
 
 	function proc_security_types(msg: RFBSecurityTypes) : bool
 		%{
-		BifEvent::generate_rfb_authentication_type(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), ${msg.sectype});
+		if ( rfb_authentication_type )
+			BifEvent::generate_rfb_authentication_type(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), ${msg.sectype});
 		return true;
 		%}
 
 	function proc_security_types37(msg: RFBAuthTypeSelected) : bool
 		%{
-		BifEvent::generate_rfb_authentication_type(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), ${msg.type});
+		if ( rfb_authentication_type )
+			BifEvent::generate_rfb_authentication_type(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), ${msg.type});
 		return true;
 		%}
 
 	function proc_handle_server_params(msg:RFBServerInit) : bool
 		%{
-		BifEvent::generate_rfb_server_parameters(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), bytestring_to_val(${msg.name}), ${msg.width}, ${msg.height});
+		if ( rfb_server_parameters )
+			BifEvent::generate_rfb_server_parameters(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), bytestring_to_val(${msg.name}), ${msg.width}, ${msg.height});
 		return true;
 		%}
 
 	function proc_handle_security_result(result : uint32) : bool
 		%{
-		BifEvent::generate_rfb_auth_result(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), result);
+		if ( rfb_auth_result )
+			BifEvent::generate_rfb_auth_result(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), result);
 		return true;
 		%}
 };

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -95,7 +95,7 @@ int MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status
 		{
 		auto vl = event_common_vl(c, rpc_status, mount_status,
 					   start_time, last_time, reply_len, 0);
-		analyzer->ConnectionEvent(mount_reply_status, std::move(vl));
+		analyzer->ConnectionEventFast(mount_reply_status, std::move(vl));
 		}
 
 	if ( ! rpc_success )
@@ -173,7 +173,7 @@ int MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status
 		if ( reply )
 			vl.append(reply);
 
-		analyzer->ConnectionEvent(event, std::move(vl));
+		analyzer->ConnectionEventFast(event, std::move(vl));
 		}
 	else
 		Unref(reply);

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -93,9 +93,9 @@ int MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status
 
 	if ( mount_reply_status )
 		{
-		val_list* vl = event_common_vl(c, rpc_status, mount_status,
-					   start_time, last_time, reply_len);
-		analyzer->ConnectionEvent(mount_reply_status, vl);
+		auto vl = event_common_vl(c, rpc_status, mount_status,
+					   start_time, last_time, reply_len, 0);
+		analyzer->ConnectionEvent(mount_reply_status, std::move(vl));
 		}
 
 	if ( ! rpc_success )
@@ -162,34 +162,34 @@ int MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status
 	// optional and all are set to 0 ...
 	if ( event )
 		{
-		val_list* vl = event_common_vl(c, rpc_status, mount_status,
-					start_time, last_time, reply_len);
-
 		Val *request = c->TakeRequestVal();
 
+		auto vl = event_common_vl(c, rpc_status, mount_status,
+					start_time, last_time, reply_len, (bool)request + (bool)reply);
+
 		if ( request )
-			vl->append(request);
+			vl.append(request);
 
 		if ( reply )
-			vl->append(reply);
+			vl.append(reply);
 
-		analyzer->ConnectionEvent(event, vl);
+		analyzer->ConnectionEvent(event, std::move(vl));
 		}
 	else
 		Unref(reply);
 	return 1;
 	}
 
-val_list* MOUNT_Interp::event_common_vl(RPC_CallInfo *c, 
+val_list MOUNT_Interp::event_common_vl(RPC_CallInfo *c, 
 		      BifEnum::rpc_status rpc_status,
 				      BifEnum::MOUNT3::status_t mount_status,
 				      double rep_start_time,
-				      double rep_last_time, int reply_len)
+				      double rep_last_time, int reply_len, int extra_elements)
 	{
 	// Returns a new val_list that already has a conn_val, and mount3_info.
 	// These are the first parameters for each mount_* event ...
-	val_list *vl = new val_list;
-	vl->append(analyzer->BuildConnVal());
+	val_list vl(2 + extra_elements);
+	vl.append(analyzer->BuildConnVal());
 	VectorVal* auxgids = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 	for (size_t i = 0; i < c->AuxGIDs().size(); ++i)
@@ -212,7 +212,7 @@ val_list* MOUNT_Interp::event_common_vl(RPC_CallInfo *c,
 	info->Assign(11, new StringVal(c->MachineName()));
 	info->Assign(12, auxgids);
 
-	vl->append(info);
+	vl.append(info);
 	return vl;
 	}
 

--- a/src/analyzer/protocol/rpc/MOUNT.h
+++ b/src/analyzer/protocol/rpc/MOUNT.h
@@ -22,10 +22,10 @@ protected:
 	// Returns a new val_list that already has a conn_val, rpc_status and
 	// mount_status. These are the first parameters for each mount_* event
 	// ...
-	val_list* event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_status,
+	val_list event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_status,
 				BifEnum::MOUNT3::status_t mount_status,
 				double rep_start_time, double rep_last_time,
-				int reply_len);
+				int reply_len, int extra_elements);
 
 	// These methods parse the appropriate MOUNTv3 "type" out of buf. If
 	// there are any errors (i.e., buffer to short, etc), buf will be set

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -147,9 +147,9 @@ int NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 
 	if ( nfs_reply_status )
 		{
-		val_list* vl = event_common_vl(c, rpc_status, nfs_status,
-					       start_time, last_time, reply_len);
-		analyzer->ConnectionEvent(nfs_reply_status, vl);
+		auto vl = event_common_vl(c, rpc_status, nfs_status,
+					       start_time, last_time, reply_len, 0);
+		analyzer->ConnectionEvent(nfs_reply_status, std::move(vl));
 		}
 
 	if ( ! rpc_success )
@@ -274,18 +274,18 @@ int NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 	// optional and all are set to 0 ...
 	if ( event )
 		{
-		val_list* vl = event_common_vl(c, rpc_status, nfs_status,
-					start_time, last_time, reply_len);
-
 		Val *request = c->TakeRequestVal();
 
+		auto vl = event_common_vl(c, rpc_status, nfs_status,
+					start_time, last_time, reply_len, (bool)request + (bool)reply);
+
 		if ( request )
-			vl->append(request);
+			vl.append(request);
 
 		if ( reply )
-			vl->append(reply);
+			vl.append(reply);
 
-		analyzer->ConnectionEvent(event, vl);
+		analyzer->ConnectionEvent(event, std::move(vl));
 		}
 	else
 		Unref(reply);
@@ -317,15 +317,15 @@ StringVal* NFS_Interp::nfs3_file_data(const u_char*& buf, int& n, uint64_t offse
 	return 0;
 	}
 
-val_list* NFS_Interp::event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_status,
+val_list NFS_Interp::event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_status,
 				      BifEnum::NFS3::status_t nfs_status,
 				      double rep_start_time,
-				      double rep_last_time, int reply_len)
+				      double rep_last_time, int reply_len, int extra_elements)
 	{
 	// Returns a new val_list that already has a conn_val, and nfs3_info.
 	// These are the first parameters for each nfs_* event ...
-	val_list *vl = new val_list;
-	vl->append(analyzer->BuildConnVal());
+	val_list vl(2 + extra_elements);
+	vl.append(analyzer->BuildConnVal());
 	VectorVal* auxgids = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 	for ( size_t i = 0; i < c->AuxGIDs().size(); ++i )
@@ -346,7 +346,7 @@ val_list* NFS_Interp::event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_s
 	info->Assign(11, new StringVal(c->MachineName()));
 	info->Assign(12, auxgids);
 
-	vl->append(info);
+	vl.append(info);
 	return vl;
 	}
 

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -149,7 +149,7 @@ int NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 		{
 		auto vl = event_common_vl(c, rpc_status, nfs_status,
 					       start_time, last_time, reply_len, 0);
-		analyzer->ConnectionEvent(nfs_reply_status, std::move(vl));
+		analyzer->ConnectionEventFast(nfs_reply_status, std::move(vl));
 		}
 
 	if ( ! rpc_success )
@@ -285,7 +285,7 @@ int NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 		if ( reply )
 			vl.append(reply);
 
-		analyzer->ConnectionEvent(event, std::move(vl));
+		analyzer->ConnectionEventFast(event, std::move(vl));
 		}
 	else
 		Unref(reply);

--- a/src/analyzer/protocol/rpc/NFS.h
+++ b/src/analyzer/protocol/rpc/NFS.h
@@ -22,10 +22,10 @@ protected:
 	// Returns a new val_list that already has a conn_val, rpc_status and
 	// nfs_status. These are the first parameters for each nfs_* event
 	// ...
-	val_list* event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_status,
+	val_list event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_status,
 				BifEnum::NFS3::status_t nfs_status,
 				double rep_start_time, double rep_last_time,
-				int reply_len);
+				int reply_len, int extra_elements);
 
 	// These methods parse the appropriate NFSv3 "type" out of buf. If
 	// there are any errors (i.e., buffer to short, etc), buf will be set

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -261,10 +261,10 @@ uint32 PortmapperInterp::CheckPort(uint32 port)
 		{
 		if ( pm_bad_port )
 			{
-			val_list* vl = new val_list;
-			vl->append(analyzer->BuildConnVal());
-			vl->append(val_mgr->GetCount(port));
-			analyzer->ConnectionEvent(pm_bad_port, vl);
+			analyzer->ConnectionEvent(pm_bad_port, {
+				analyzer->BuildConnVal(),
+				val_mgr->GetCount(port),
+			});
 			}
 
 		port = 0;
@@ -282,25 +282,25 @@ void PortmapperInterp::Event(EventHandlerPtr f, Val* request, BifEnum::rpc_statu
 		return;
 		}
 
-	val_list* vl = new val_list;
+	val_list vl;
 
-	vl->append(analyzer->BuildConnVal());
+	vl.append(analyzer->BuildConnVal());
 
 	if ( status == BifEnum::RPC_SUCCESS )
 		{
 		if ( request )
-			vl->append(request);
+			vl.append(request);
 		if ( reply )
-			vl->append(reply);
+			vl.append(reply);
 		}
 	else
 		{
-		vl->append(BifType::Enum::rpc_status->GetVal(status));
+		vl.append(BifType::Enum::rpc_status->GetVal(status));
 		if ( request )
-			vl->append(request);
+			vl.append(request);
 		}
 
-	analyzer->ConnectionEvent(f, vl);
+	analyzer->ConnectionEvent(f, std::move(vl));
 	}
 
 Portmapper_Analyzer::Portmapper_Analyzer(Connection* conn)

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -261,7 +261,7 @@ uint32 PortmapperInterp::CheckPort(uint32 port)
 		{
 		if ( pm_bad_port )
 			{
-			analyzer->ConnectionEvent(pm_bad_port, {
+			analyzer->ConnectionEventFast(pm_bad_port, {
 				analyzer->BuildConnVal(),
 				val_mgr->GetCount(port),
 			});
@@ -300,7 +300,7 @@ void PortmapperInterp::Event(EventHandlerPtr f, Val* request, BifEnum::rpc_statu
 			vl.append(request);
 		}
 
-	analyzer->ConnectionEvent(f, std::move(vl));
+	analyzer->ConnectionEventFast(f, std::move(vl));
 	}
 
 Portmapper_Analyzer::Portmapper_Analyzer(Connection* conn)

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -330,7 +330,7 @@ void RPC_Interpreter::Event_RPC_Dialogue(RPC_CallInfo* c, BifEnum::rpc_status st
 	{
 	if ( rpc_dialogue )
 		{
-		analyzer->ConnectionEvent(rpc_dialogue, {
+		analyzer->ConnectionEventFast(rpc_dialogue, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetCount(c->Program()),
 			val_mgr->GetCount(c->Version()),
@@ -347,7 +347,7 @@ void RPC_Interpreter::Event_RPC_Call(RPC_CallInfo* c)
 	{
 	if ( rpc_call )
 		{
-		analyzer->ConnectionEvent(rpc_call, {
+		analyzer->ConnectionEventFast(rpc_call, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetCount(c->XID()),
 			val_mgr->GetCount(c->Program()),
@@ -362,7 +362,7 @@ void RPC_Interpreter::Event_RPC_Reply(uint32_t xid, BifEnum::rpc_status status, 
 	{
 	if ( rpc_reply )
 		{
-		analyzer->ConnectionEvent(rpc_reply, {
+		analyzer->ConnectionEventFast(rpc_reply, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetCount(xid),
 			BifType::Enum::rpc_status->GetVal(status),

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -330,16 +330,16 @@ void RPC_Interpreter::Event_RPC_Dialogue(RPC_CallInfo* c, BifEnum::rpc_status st
 	{
 	if ( rpc_dialogue )
 		{
-		val_list* vl = new val_list;
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetCount(c->Program()));
-		vl->append(val_mgr->GetCount(c->Version()));
-		vl->append(val_mgr->GetCount(c->Proc()));
-		vl->append(BifType::Enum::rpc_status->GetVal(status));
-		vl->append(new Val(c->StartTime(), TYPE_TIME));
-		vl->append(val_mgr->GetCount(c->CallLen()));
-		vl->append(val_mgr->GetCount(reply_len));
-		analyzer->ConnectionEvent(rpc_dialogue, vl);
+		analyzer->ConnectionEvent(rpc_dialogue, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetCount(c->Program()),
+			val_mgr->GetCount(c->Version()),
+			val_mgr->GetCount(c->Proc()),
+			BifType::Enum::rpc_status->GetVal(status),
+			new Val(c->StartTime(), TYPE_TIME),
+			val_mgr->GetCount(c->CallLen()),
+			val_mgr->GetCount(reply_len),
+		});
 		}
 	}
 
@@ -347,14 +347,14 @@ void RPC_Interpreter::Event_RPC_Call(RPC_CallInfo* c)
 	{
 	if ( rpc_call )
 		{
-		val_list* vl = new val_list;
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetCount(c->XID()));
-		vl->append(val_mgr->GetCount(c->Program()));
-		vl->append(val_mgr->GetCount(c->Version()));
-		vl->append(val_mgr->GetCount(c->Proc()));
-		vl->append(val_mgr->GetCount(c->CallLen()));
-		analyzer->ConnectionEvent(rpc_call, vl);
+		analyzer->ConnectionEvent(rpc_call, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetCount(c->XID()),
+			val_mgr->GetCount(c->Program()),
+			val_mgr->GetCount(c->Version()),
+			val_mgr->GetCount(c->Proc()),
+			val_mgr->GetCount(c->CallLen()),
+		});
 		}
 	}
 
@@ -362,12 +362,12 @@ void RPC_Interpreter::Event_RPC_Reply(uint32_t xid, BifEnum::rpc_status status, 
 	{
 	if ( rpc_reply )
 		{
-		val_list* vl = new val_list;
-		vl->append(analyzer->BuildConnVal());
-		vl->append(val_mgr->GetCount(xid));
-		vl->append(BifType::Enum::rpc_status->GetVal(status));
-		vl->append(val_mgr->GetCount(reply_len));
-		analyzer->ConnectionEvent(rpc_reply, vl);
+		analyzer->ConnectionEvent(rpc_reply, {
+			analyzer->BuildConnVal(),
+			val_mgr->GetCount(xid),
+			BifType::Enum::rpc_status->GetVal(status),
+			val_mgr->GetCount(reply_len),
+		});
 		}
 	}
 

--- a/src/analyzer/protocol/smb/smb1-com-nt-create-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-nt-create-andx.pac
@@ -6,8 +6,10 @@ refine connection SMB_Conn += {
 		     BifConst::SMB::pipe_filenames->AsTable()->Lookup(filename->CheckString()) )
 			{
 			set_tree_is_pipe(${header.tid});
-			BifEvent::generate_smb_pipe_connect_heuristic(bro_analyzer(),
-			                                              bro_analyzer()->Conn());
+
+			if ( smb_pipe_connect_heuristic )
+				BifEvent::generate_smb_pipe_connect_heuristic(bro_analyzer(),
+				                                              bro_analyzer()->Conn());
 			}
 
 		if ( smb1_nt_create_andx_request )

--- a/src/analyzer/protocol/smb/smb1-protocol.pac
+++ b/src/analyzer/protocol/smb/smb1-protocol.pac
@@ -66,9 +66,10 @@ refine connection SMB_Conn += {
 			}
 		else
 			{
-			BifEvent::generate_smb1_error(bro_analyzer(),
-			                              bro_analyzer()->Conn(),
-			                              BuildHeaderVal(h), is_orig);
+			if ( smb1_error )
+				BifEvent::generate_smb1_error(bro_analyzer(),
+				                              bro_analyzer()->Conn(),
+				                              BuildHeaderVal(h), is_orig);
 			}
 		return true;
 		%}

--- a/src/analyzer/protocol/smb/smb2-com-create.pac
+++ b/src/analyzer/protocol/smb/smb2-com-create.pac
@@ -7,8 +7,10 @@ refine connection SMB_Conn += {
 		     BifConst::SMB::pipe_filenames->AsTable()->Lookup(filename->CheckString()) )
 			{
 			set_tree_is_pipe(${h.tree_id});
-			BifEvent::generate_smb_pipe_connect_heuristic(bro_analyzer(),
-			                                              bro_analyzer()->Conn());
+
+			if ( smb_pipe_connect_heuristic )
+				BifEvent::generate_smb_pipe_connect_heuristic(bro_analyzer(),
+				                                              bro_analyzer()->Conn());
 			}
 
 		if ( smb2_create_request )

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -220,7 +220,7 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 
 			if ( smtp_data && ! skip_data )
 				{
-				ConnectionEvent(smtp_data, {
+				ConnectionEventFast(smtp_data, {
 					BuildConnVal(),
 					val_mgr->GetBool(orig),
 					new StringVal(data_len, line),
@@ -350,7 +350,7 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 						break;
 				}
 
-				ConnectionEvent(smtp_reply, {
+				ConnectionEventFast(smtp_reply, {
 					BuildConnVal(),
 					val_mgr->GetBool(orig),
 					val_mgr->GetCount(reply_code),
@@ -410,7 +410,8 @@ void SMTP_Analyzer::StartTLS()
 	if ( ssl )
 		AddChildAnalyzer(ssl);
 
-	ConnectionEvent(smtp_starttls, {BuildConnVal()});
+	if ( smtp_starttls )
+		ConnectionEventFast(smtp_starttls, {BuildConnVal()});
 	}
 
 
@@ -852,12 +853,14 @@ void SMTP_Analyzer::RequestEvent(int cmd_len, const char* cmd,
 				int arg_len, const char* arg)
 	{
 	ProtocolConfirmation();
-	ConnectionEvent(smtp_request, {
-		BuildConnVal(),
-		val_mgr->GetBool(orig_is_sender),
-		(new StringVal(cmd_len, cmd))->ToUpper(),
-		new StringVal(arg_len, arg),
-	});
+
+	if ( smtp_request )
+		ConnectionEventFast(smtp_request, {
+			BuildConnVal(),
+			val_mgr->GetBool(orig_is_sender),
+			(new StringVal(cmd_len, cmd))->ToUpper(),
+			new StringVal(arg_len, arg),
+		});
 	}
 
 void SMTP_Analyzer::Unexpected(const int is_sender, const char* msg,
@@ -872,7 +875,7 @@ void SMTP_Analyzer::Unexpected(const int is_sender, const char* msg,
 		if ( ! orig_is_sender )
 			is_orig = ! is_orig;
 
-		ConnectionEvent(smtp_unexpected, {
+		ConnectionEventFast(smtp_unexpected, {
 			BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 			new StringVal(msg),

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -220,11 +220,11 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 
 			if ( smtp_data && ! skip_data )
 				{
-				val_list* vl = new val_list;
-				vl->append(BuildConnVal());
-				vl->append(val_mgr->GetBool(orig));
-				vl->append(new StringVal(data_len, line));
-				ConnectionEvent(smtp_data, vl);
+				ConnectionEvent(smtp_data, {
+					BuildConnVal(),
+					val_mgr->GetBool(orig),
+					new StringVal(data_len, line),
+				});
 				}
 			}
 
@@ -350,15 +350,14 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 						break;
 				}
 
-				val_list* vl = new val_list;
-				vl->append(BuildConnVal());
-				vl->append(val_mgr->GetBool(orig));
-				vl->append(val_mgr->GetCount(reply_code));
-				vl->append(new StringVal(cmd));
-				vl->append(new StringVal(end_of_line - line, line));
-				vl->append(val_mgr->GetBool((pending_reply > 0)));
-
-				ConnectionEvent(smtp_reply, vl);
+				ConnectionEvent(smtp_reply, {
+					BuildConnVal(),
+					val_mgr->GetBool(orig),
+					val_mgr->GetCount(reply_code),
+					new StringVal(cmd),
+					new StringVal(end_of_line - line, line),
+					val_mgr->GetBool((pending_reply > 0)),
+				});
 				}
 			}
 
@@ -411,10 +410,7 @@ void SMTP_Analyzer::StartTLS()
 	if ( ssl )
 		AddChildAnalyzer(ssl);
 
-	val_list* vl = new val_list;
-	vl->append(BuildConnVal());
-
-	ConnectionEvent(smtp_starttls, vl);
+	ConnectionEvent(smtp_starttls, {BuildConnVal()});
 	}
 
 
@@ -856,14 +852,12 @@ void SMTP_Analyzer::RequestEvent(int cmd_len, const char* cmd,
 				int arg_len, const char* arg)
 	{
 	ProtocolConfirmation();
-	val_list* vl = new val_list;
-
-	vl->append(BuildConnVal());
-	vl->append(val_mgr->GetBool(orig_is_sender));
-	vl->append((new StringVal(cmd_len, cmd))->ToUpper());
-	vl->append(new StringVal(arg_len, arg));
-
-	ConnectionEvent(smtp_request, vl);
+	ConnectionEvent(smtp_request, {
+		BuildConnVal(),
+		val_mgr->GetBool(orig_is_sender),
+		(new StringVal(cmd_len, cmd))->ToUpper(),
+		new StringVal(arg_len, arg),
+	});
 	}
 
 void SMTP_Analyzer::Unexpected(const int is_sender, const char* msg,
@@ -874,17 +868,16 @@ void SMTP_Analyzer::Unexpected(const int is_sender, const char* msg,
 
 	if ( smtp_unexpected )
 		{
-		val_list* vl = new val_list;
 		int is_orig = is_sender;
 		if ( ! orig_is_sender )
 			is_orig = ! is_orig;
 
-		vl->append(BuildConnVal());
-		vl->append(val_mgr->GetBool(is_orig));
-		vl->append(new StringVal(msg));
-		vl->append(new StringVal(detail_len, detail));
-
-		ConnectionEvent(smtp_unexpected, vl);
+		ConnectionEvent(smtp_unexpected, {
+			BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+			new StringVal(msg),
+			new StringVal(detail_len, detail),
+		});
 		}
 	}
 

--- a/src/analyzer/protocol/ssl/ssl-analyzer.pac
+++ b/src/analyzer/protocol/ssl/ssl-analyzer.pac
@@ -17,8 +17,8 @@ refine connection SSL_Conn += {
 
 	function proc_v2_client_master_key(rec: SSLRecord, cipher_kind: int) : bool
 		%{
-		BifEvent::generate_ssl_established(bro_analyzer(),
-				bro_analyzer()->Conn());
+		if ( ssl_established )
+			BifEvent::generate_ssl_established(bro_analyzer(), bro_analyzer()->Conn());
 
 		return true;
 		%}

--- a/src/analyzer/protocol/ssl/ssl-dtls-analyzer.pac
+++ b/src/analyzer/protocol/ssl/ssl-dtls-analyzer.pac
@@ -31,8 +31,9 @@ refine connection SSL_Conn += {
 
 	function proc_alert(rec: SSLRecord, level : int, desc : int) : bool
 		%{
-		BifEvent::generate_ssl_alert(bro_analyzer(), bro_analyzer()->Conn(),
-						${rec.is_orig}, level, desc);
+		if ( ssl_alert )
+			BifEvent::generate_ssl_alert(bro_analyzer(), bro_analyzer()->Conn(),
+							${rec.is_orig}, level, desc);
 		return true;
 		%}
 	function proc_unknown_record(rec: SSLRecord) : bool
@@ -50,8 +51,8 @@ refine connection SSL_Conn += {
 		      established_ == false )
 			{
 			established_ = true;
-			BifEvent::generate_ssl_established(bro_analyzer(),
-							bro_analyzer()->Conn());
+			if ( ssl_established )
+				BifEvent::generate_ssl_established(bro_analyzer(), bro_analyzer()->Conn());
 			}
 
 		if ( ssl_encrypted_data )
@@ -72,9 +73,10 @@ refine connection SSL_Conn += {
 
 	function proc_heartbeat(rec : SSLRecord, type: uint8, payload_length: uint16, data: bytestring) : bool
 		%{
-		BifEvent::generate_ssl_heartbeat(bro_analyzer(),
-			bro_analyzer()->Conn(), ${rec.is_orig}, ${rec.length}, type, payload_length,
-			new StringVal(data.length(), (const char*) data.data()));
+		if ( ssl_heartbeat )
+			BifEvent::generate_ssl_heartbeat(bro_analyzer(),
+				bro_analyzer()->Conn(), ${rec.is_orig}, ${rec.length}, type, payload_length,
+				new StringVal(data.length(), (const char*) data.data()));
 		return true;
 		%}
 
@@ -93,8 +95,9 @@ refine connection SSL_Conn += {
 
 	function proc_ccs(rec: SSLRecord) : bool
 		%{
-		BifEvent::generate_ssl_change_cipher_spec(bro_analyzer(),
-			bro_analyzer()->Conn(), ${rec.is_orig});
+		if ( ssl_change_cipher_spec )
+			BifEvent::generate_ssl_change_cipher_spec(bro_analyzer(),
+				bro_analyzer()->Conn(), ${rec.is_orig});
 
 		return true;
 		%}

--- a/src/analyzer/protocol/ssl/tls-handshake-analyzer.pac
+++ b/src/analyzer/protocol/ssl/tls-handshake-analyzer.pac
@@ -72,6 +72,9 @@ refine connection Handshake_Conn += {
 
 	function proc_ec_point_formats(rec: HandshakeRecord, point_format_list: uint8[]) : bool
 		%{
+		if ( ! ssl_extension_ec_point_formats )
+			return true;
+
 		VectorVal* points = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 		if ( point_format_list )
@@ -88,6 +91,9 @@ refine connection Handshake_Conn += {
 
 	function proc_elliptic_curves(rec: HandshakeRecord, list: uint16[]) : bool
 		%{
+		if ( ! ssl_extension_elliptic_curves )
+			return true;
+
 		VectorVal* curves = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 		if ( list )
@@ -104,6 +110,9 @@ refine connection Handshake_Conn += {
 
 	function proc_client_key_share(rec: HandshakeRecord, keyshare: KeyShareEntry[]) : bool
 		%{
+		if ( ! ssl_extension_key_share )
+			return true;
+
 		VectorVal* nglist = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 		if ( keyshare )
@@ -113,11 +122,15 @@ refine connection Handshake_Conn += {
 			}
 
 		BifEvent::generate_ssl_extension_key_share(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, nglist);
+
 		return true;
 		%}
 
 	function proc_server_key_share(rec: HandshakeRecord, keyshare: KeyShareEntry) : bool
 		%{
+		if ( ! ssl_extension_key_share )
+			return true;
+
 		VectorVal* nglist = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 		nglist->Assign(0u, val_mgr->GetCount(keyshare->namedgroup()));
@@ -127,6 +140,9 @@ refine connection Handshake_Conn += {
 
 	function proc_signature_algorithm(rec: HandshakeRecord, supported_signature_algorithms: SignatureAndHashAlgorithm[]) : bool
 		%{
+		if ( ! ssl_extension_signature_algorithm )
+			return true;
+
 		VectorVal* slist = new VectorVal(internal_type("signature_and_hashalgorithm_vec")->AsVectorType());
 
 		if ( supported_signature_algorithms )
@@ -147,6 +163,9 @@ refine connection Handshake_Conn += {
 
 	function proc_apnl(rec: HandshakeRecord, protocols: ProtocolName[]) : bool
 		%{
+		if ( ! ssl_extension_application_layer_protocol_negotiation )
+			return true;
+
 		VectorVal* plist = new VectorVal(internal_type("string_vec")->AsVectorType());
 
 		if ( protocols )
@@ -183,14 +202,20 @@ refine connection Handshake_Conn += {
 				}
 			}
 
-		BifEvent::generate_ssl_extension_server_name(bro_analyzer(), bro_analyzer()->Conn(),
-		   ${rec.is_orig}, servers);
+		if ( ssl_extension_server_name )
+			BifEvent::generate_ssl_extension_server_name(bro_analyzer(), bro_analyzer()->Conn(),
+		   	   ${rec.is_orig}, servers);
+		else
+			Unref(servers);
 
 		return true;
 		%}
 
 	function proc_supported_versions(rec: HandshakeRecord, versions_list: uint16[]) : bool
 		%{
+		if ( ! ssl_extension_supported_versions )
+			return true;
+
 		VectorVal* versions = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 		if ( versions_list )
@@ -207,6 +232,9 @@ refine connection Handshake_Conn += {
 
 	function proc_one_supported_version(rec: HandshakeRecord, version: uint16) : bool
 		%{
+		if ( ! ssl_extension_supported_versions )
+			return true;
+
 		VectorVal* versions = new VectorVal(internal_type("index_vec")->AsVectorType());
 		versions->Assign(0u, val_mgr->GetCount(version));
 
@@ -218,6 +246,9 @@ refine connection Handshake_Conn += {
 
 	function proc_psk_key_exchange_modes(rec: HandshakeRecord, mode_list: uint8[]) : bool
 		%{
+		if ( ! ssl_extension_psk_key_exchange_modes )
+			return true;
+
 		VectorVal* modes = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 		if ( mode_list )
@@ -272,10 +303,11 @@ refine connection Handshake_Conn += {
 			                 response.length(), bro_analyzer()->GetAnalyzerTag(),
 			                 bro_analyzer()->Conn(), false, file_id, "application/ocsp-response");
 
-			BifEvent::generate_ssl_stapled_ocsp(bro_analyzer(),
-							    bro_analyzer()->Conn(), ${rec.is_orig},
-							    new StringVal(response.length(),
-							    (const char*) response.data()));
+			if ( ssl_stapled_ocsp )
+				BifEvent::generate_ssl_stapled_ocsp(bro_analyzer(),
+				        bro_analyzer()->Conn(),
+				        ${rec.is_orig},
+				        new StringVal(response.length(), (const char*) response.data()));
 
 			file_mgr->EndOfFile(file_id);
 			}
@@ -288,26 +320,32 @@ refine connection Handshake_Conn += {
 		if ( ${kex.curve_type} != NAMED_CURVE )
 			return true;
 
-		BifEvent::generate_ssl_server_curve(bro_analyzer(),
-			bro_analyzer()->Conn(), ${kex.params.curve});
-		BifEvent::generate_ssl_ecdh_server_params(bro_analyzer(),
-			bro_analyzer()->Conn(), ${kex.params.curve}, new StringVal(${kex.params.point}.length(), (const char*)${kex.params.point}.data()));
+		if ( ssl_server_curve )
+			BifEvent::generate_ssl_server_curve(bro_analyzer(),
+				bro_analyzer()->Conn(), ${kex.params.curve});
 
-		RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
-		if ( ${kex.signed_params.uses_signature_and_hashalgorithm} )
+		if ( ssl_ecdh_server_params )
+			BifEvent::generate_ssl_ecdh_server_params(bro_analyzer(),
+				bro_analyzer()->Conn(), ${kex.params.curve}, new StringVal(${kex.params.point}.length(), (const char*)${kex.params.point}.data()));
+
+		if ( ssl_server_signature )
 			{
-			ha->Assign(0, val_mgr->GetCount(${kex.signed_params.algorithm.HashAlgorithm}));
-			ha->Assign(1, val_mgr->GetCount(${kex.signed_params.algorithm.SignatureAlgorithm}));
-			}
+			RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
+			if ( ${kex.signed_params.uses_signature_and_hashalgorithm} )
+				{
+				ha->Assign(0, val_mgr->GetCount(${kex.signed_params.algorithm.HashAlgorithm}));
+				ha->Assign(1, val_mgr->GetCount(${kex.signed_params.algorithm.SignatureAlgorithm}));
+				}
 			else
-			{
-			// set to impossible value
-			ha->Assign(0, val_mgr->GetCount(256));
-			ha->Assign(1, val_mgr->GetCount(256));
-			}
+				{
+				// set to impossible value
+				ha->Assign(0, val_mgr->GetCount(256));
+				ha->Assign(1, val_mgr->GetCount(256));
+				}
 
-		BifEvent::generate_ssl_server_signature(bro_analyzer(),
-			bro_analyzer()->Conn(), ha, new StringVal(${kex.signed_params.signature}.length(), (const char*)(${kex.signed_params.signature}).data()));
+			BifEvent::generate_ssl_server_signature(bro_analyzer(),
+				bro_analyzer()->Conn(), ha, new StringVal(${kex.signed_params.signature}.length(), (const char*)(${kex.signed_params.signature}).data()));
+			}
 
 		return true;
 		%}
@@ -317,34 +355,46 @@ refine connection Handshake_Conn += {
 		if ( ${kex.curve_type} != NAMED_CURVE )
 			return true;
 
-		BifEvent::generate_ssl_server_curve(bro_analyzer(),
-			bro_analyzer()->Conn(), ${kex.params.curve});
-		BifEvent::generate_ssl_ecdh_server_params(bro_analyzer(),
-			bro_analyzer()->Conn(), ${kex.params.curve}, new StringVal(${kex.params.point}.length(), (const char*)${kex.params.point}.data()));
+		if ( ssl_server_curve )
+			BifEvent::generate_ssl_server_curve(bro_analyzer(),
+				bro_analyzer()->Conn(), ${kex.params.curve});
+
+		if ( ssl_ecdh_server_params )
+			BifEvent::generate_ssl_ecdh_server_params(bro_analyzer(),
+				bro_analyzer()->Conn(), ${kex.params.curve}, new StringVal(${kex.params.point}.length(), (const char*)${kex.params.point}.data()));
 
 		return true;
 		%}
 
 	function proc_rsa_client_key_exchange(rec: HandshakeRecord, rsa_pms: bytestring) : bool
 		%{
-		BifEvent::generate_ssl_rsa_client_pms(bro_analyzer(), bro_analyzer()->Conn(), new StringVal(rsa_pms.length(), (const char*)rsa_pms.data()));
+		if ( ssl_rsa_client_pms )
+			BifEvent::generate_ssl_rsa_client_pms(bro_analyzer(), bro_analyzer()->Conn(), new StringVal(rsa_pms.length(), (const char*)rsa_pms.data()));
+
 		return true;
 		%}
 
 	function proc_dh_client_key_exchange(rec: HandshakeRecord, Yc: bytestring) : bool
 		%{
-		BifEvent::generate_ssl_dh_client_params(bro_analyzer(), bro_analyzer()->Conn(), new StringVal(Yc.length(), (const char*)Yc.data()));
+		if ( ssl_dh_client_params )
+			BifEvent::generate_ssl_dh_client_params(bro_analyzer(), bro_analyzer()->Conn(), new StringVal(Yc.length(), (const char*)Yc.data()));
+
 		return true;
 		%}
 
 	function proc_ecdh_client_key_exchange(rec: HandshakeRecord, point: bytestring) : bool
 		%{
-		BifEvent::generate_ssl_ecdh_client_params(bro_analyzer(), bro_analyzer()->Conn(), new StringVal(point.length(), (const char*)point.data()));
+		if ( ssl_ecdh_client_params )
+			BifEvent::generate_ssl_ecdh_client_params(bro_analyzer(), bro_analyzer()->Conn(), new StringVal(point.length(), (const char*)point.data()));
+
 		return true;
 		%}
 
 	function proc_signedcertificatetimestamp(rec: HandshakeRecord, version: uint8, logid: const_bytestring, timestamp: uint64, digitally_signed_algorithms: SignatureAndHashAlgorithm, digitally_signed_signature: const_bytestring) : bool
 		%{
+		if ( ! ssl_extension_signed_certificate_timestamp )
+			return true;
+
 		RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
 		ha->Assign(0, val_mgr->GetCount(digitally_signed_algorithms->HashAlgorithm()));
 		ha->Assign(1, val_mgr->GetCount(digitally_signed_algorithms->SignatureAlgorithm()));
@@ -363,50 +413,56 @@ refine connection Handshake_Conn += {
 
 	function proc_dhe_server_key_exchange(rec: HandshakeRecord, p: bytestring, g: bytestring, Ys: bytestring, signed_params: ServerKeyExchangeSignature) : bool
 		%{
-		BifEvent::generate_ssl_dh_server_params(bro_analyzer(),
-			bro_analyzer()->Conn(),
-		  new StringVal(p.length(), (const char*) p.data()),
-		  new StringVal(g.length(), (const char*) g.data()),
-		  new StringVal(Ys.length(), (const char*) Ys.data())
-		  );
+		if ( ssl_ecdh_server_params )
+			BifEvent::generate_ssl_dh_server_params(bro_analyzer(),
+			  bro_analyzer()->Conn(),
+			  new StringVal(p.length(), (const char*) p.data()),
+			  new StringVal(g.length(), (const char*) g.data()),
+			  new StringVal(Ys.length(), (const char*) Ys.data())
+			  );
 
-		RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
-		if ( ${signed_params.uses_signature_and_hashalgorithm} )
+		if ( ssl_server_signature )
 			{
-			ha->Assign(0, val_mgr->GetCount(${signed_params.algorithm.HashAlgorithm}));
-			ha->Assign(1, val_mgr->GetCount(${signed_params.algorithm.SignatureAlgorithm}));
-			}
-			else
-			{
-			// set to impossible value
-			ha->Assign(0, val_mgr->GetCount(256));
-			ha->Assign(1, val_mgr->GetCount(256));
-			}
+			RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
+			if ( ${signed_params.uses_signature_and_hashalgorithm} )
+				{
+				ha->Assign(0, val_mgr->GetCount(${signed_params.algorithm.HashAlgorithm}));
+				ha->Assign(1, val_mgr->GetCount(${signed_params.algorithm.SignatureAlgorithm}));
+				}
+				else
+				{
+				// set to impossible value
+				ha->Assign(0, val_mgr->GetCount(256));
+				ha->Assign(1, val_mgr->GetCount(256));
+				}
 
-		BifEvent::generate_ssl_server_signature(bro_analyzer(),
-			bro_analyzer()->Conn(), ha,
-		  new StringVal(${signed_params.signature}.length(), (const char*)(${signed_params.signature}).data())
-		  );
+			BifEvent::generate_ssl_server_signature(bro_analyzer(),
+			  bro_analyzer()->Conn(), ha,
+			  new StringVal(${signed_params.signature}.length(), (const char*)(${signed_params.signature}).data())
+			  );
+			}
 
 		return true;
 		%}
 
 	function proc_dh_anon_server_key_exchange(rec: HandshakeRecord, p: bytestring, g: bytestring, Ys: bytestring) : bool
 		%{
-		BifEvent::generate_ssl_dh_server_params(bro_analyzer(),
-			bro_analyzer()->Conn(),
-		  new StringVal(p.length(), (const char*) p.data()),
-		  new StringVal(g.length(), (const char*) g.data()),
-		  new StringVal(Ys.length(), (const char*) Ys.data())
-		  );
+		if ( ssl_dh_server_params )
+			BifEvent::generate_ssl_dh_server_params(bro_analyzer(),
+			  bro_analyzer()->Conn(),
+			  new StringVal(p.length(), (const char*) p.data()),
+			  new StringVal(g.length(), (const char*) g.data()),
+			  new StringVal(Ys.length(), (const char*) Ys.data())
+			  );
 
 		return true;
 		%}
 
 	function proc_handshake(is_orig: bool, msg_type: uint8, length: uint24) : bool
 		%{
-		BifEvent::generate_ssl_handshake_message(bro_analyzer(),
-			bro_analyzer()->Conn(), is_orig, msg_type, to_int()(length));
+		if ( ssl_handshake_message )
+			BifEvent::generate_ssl_handshake_message(bro_analyzer(),
+				bro_analyzer()->Conn(), is_orig, msg_type, to_int()(length));
 
 		return true;
 		%}

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -139,25 +139,20 @@ void SteppingStoneEndpoint::Event(EventHandlerPtr f, int id1, int id2)
 	if ( ! f )
 		return;
 
-	val_list* vl = new val_list;
-
-	vl->append(val_mgr->GetInt(id1));
-
 	if ( id2 >= 0 )
-		vl->append(val_mgr->GetInt(id2));
+		endp->TCP()->ConnectionEvent(f, {val_mgr->GetInt(id1), val_mgr->GetInt(id2)});
+	else
+		endp->TCP()->ConnectionEvent(f, {val_mgr->GetInt(id1)});
 
-	endp->TCP()->ConnectionEvent(f, vl);
 	}
 
 void SteppingStoneEndpoint::CreateEndpEvent(int is_orig)
 	{
-	val_list* vl = new val_list;
-
-	vl->append(endp->TCP()->BuildConnVal());
-	vl->append(val_mgr->GetInt(stp_id));
-	vl->append(val_mgr->GetBool(is_orig));
-
-	endp->TCP()->ConnectionEvent(stp_create_endp, vl);
+	endp->TCP()->ConnectionEvent(stp_create_endp, {
+		endp->TCP()->BuildConnVal(),
+		val_mgr->GetInt(stp_id),
+		val_mgr->GetBool(is_orig),
+	});
 	}
 
 SteppingStone_Analyzer::SteppingStone_Analyzer(Connection* c)

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -140,15 +140,18 @@ void SteppingStoneEndpoint::Event(EventHandlerPtr f, int id1, int id2)
 		return;
 
 	if ( id2 >= 0 )
-		endp->TCP()->ConnectionEvent(f, {val_mgr->GetInt(id1), val_mgr->GetInt(id2)});
+		endp->TCP()->ConnectionEventFast(f, {val_mgr->GetInt(id1), val_mgr->GetInt(id2)});
 	else
-		endp->TCP()->ConnectionEvent(f, {val_mgr->GetInt(id1)});
+		endp->TCP()->ConnectionEventFast(f, {val_mgr->GetInt(id1)});
 
 	}
 
 void SteppingStoneEndpoint::CreateEndpEvent(int is_orig)
 	{
-	endp->TCP()->ConnectionEvent(stp_create_endp, {
+	if ( ! stp_create_endp )
+		return;
+
+	endp->TCP()->ConnectionEventFast(stp_create_endp, {
 		endp->TCP()->BuildConnVal(),
 		val_mgr->GetInt(stp_id),
 		val_mgr->GetBool(is_orig),

--- a/src/analyzer/protocol/syslog/syslog-analyzer.pac
+++ b/src/analyzer/protocol/syslog/syslog-analyzer.pac
@@ -11,6 +11,9 @@ flow Syslog_Flow
 
 	function process_syslog_message(m: Syslog_Message): bool
 		%{
+		if ( ! syslog_message )
+			return true;
+
 		if ( ${m.has_pri} )
 			BifEvent::generate_syslog_message(
 			    connection()->bro_analyzer(),

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -299,7 +299,7 @@ static void passive_fingerprint(TCP_Analyzer* tcp, bool is_orig,
 
 			if ( OS_val )
 				{ // found new OS version
-				tcp->ConnectionEvent(OS_version_found, {
+				tcp->ConnectionEventFast(OS_version_found, {
 					tcp->BuildConnVal(),
 					src_addr_val->Ref(),
 					OS_val,
@@ -965,7 +965,7 @@ void TCP_Analyzer::GeneratePacketEvent(
 					const u_char* data, int len, int caplen,
 					int is_orig, TCP_Flags flags)
 	{
-	ConnectionEvent(tcp_packet, {
+	ConnectionEventFast(tcp_packet, {
 		BuildConnVal(),
 		val_mgr->GetBool(is_orig),
 		new StringVal(flags.AsString()),
@@ -1280,7 +1280,7 @@ void TCP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 
 		if ( connection_SYN_packet )
 			{
-			ConnectionEvent(connection_SYN_packet, {
+			ConnectionEventFast(connection_SYN_packet, {
 				BuildConnVal(),
 				SYN_vals->Ref(),
 			});
@@ -1500,7 +1500,7 @@ int TCP_Analyzer::TCPOptionEvent(unsigned int opt,
 	{
 	if ( tcp_option )
 		{
-		analyzer->ConnectionEvent(tcp_option, {
+		analyzer->ConnectionEventFast(tcp_option, {
 			analyzer->BuildConnVal(),
 			val_mgr->GetBool(is_orig),
 			val_mgr->GetCount(opt),
@@ -1821,7 +1821,7 @@ void TCP_Analyzer::EndpointEOF(TCP_Reassembler* endp)
 	{
 	if ( connection_EOF )
 		{
-		ConnectionEvent(connection_EOF, {
+		ConnectionEventFast(connection_EOF, {
 			BuildConnVal(),
 			val_mgr->GetBool(endp->IsOrig()),
 		});
@@ -2103,7 +2103,7 @@ int TCPStats_Endpoint::DataSent(double /* t */, uint64 seq, int len, int caplen,
 
 		if ( tcp_rexmit )
 			{
-			endp->TCP()->ConnectionEvent(tcp_rexmit, {
+			endp->TCP()->ConnectionEventFast(tcp_rexmit, {
 				endp->TCP()->BuildConnVal(),
 				val_mgr->GetBool(endp->IsOrig()),
 				val_mgr->GetCount(seq),
@@ -2158,11 +2158,12 @@ void TCPStats_Analyzer::Done()
 	{
 	TCP_ApplicationAnalyzer::Done();
 
-	ConnectionEvent(conn_stats, {
-		BuildConnVal(),
-		orig_stats->BuildStats(),
-		resp_stats->BuildStats(),
-	});
+	if ( conn_stats )
+		ConnectionEventFast(conn_stats, {
+			BuildConnVal(),
+			orig_stats->BuildStats(),
+			resp_stats->BuildStats(),
+		});
 	}
 
 void TCPStats_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig, uint64 seq, const IP_Hdr* ip, int caplen)

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.cc
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.cc
@@ -237,7 +237,7 @@ int TCP_Endpoint::DataSent(double t, uint64 seq, int len, int caplen,
 
 			if ( contents_file_write_failure )
 				{
-				tcp_analyzer->ConnectionEvent(contents_file_write_failure, {
+				tcp_analyzer->ConnectionEventFast(contents_file_write_failure, {
 					Conn()->BuildConnVal(),
 					val_mgr->GetBool(IsOrig()),
 					new StringVal(buf),

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.cc
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.cc
@@ -237,11 +237,11 @@ int TCP_Endpoint::DataSent(double t, uint64 seq, int len, int caplen,
 
 			if ( contents_file_write_failure )
 				{
-				val_list* vl = new val_list();
-				vl->append(Conn()->BuildConnVal());
-				vl->append(val_mgr->GetBool(IsOrig()));
-				vl->append(new StringVal(buf));
-				tcp_analyzer->ConnectionEvent(contents_file_write_failure, vl);
+				tcp_analyzer->ConnectionEvent(contents_file_write_failure, {
+					Conn()->BuildConnVal(),
+					val_mgr->GetBool(IsOrig()),
+					new StringVal(buf),
+				});
 				}
 			}
 		}

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -136,12 +136,12 @@ void TCP_Reassembler::Gap(uint64 seq, uint64 len)
 
 	if ( report_gap(endp, endp->peer) )
 		{
-		val_list* vl = new val_list;
-		vl->append(dst_analyzer->BuildConnVal());
-		vl->append(val_mgr->GetBool(IsOrig()));
-		vl->append(val_mgr->GetCount(seq));
-		vl->append(val_mgr->GetCount(len));
-		dst_analyzer->ConnectionEvent(content_gap, vl);
+		dst_analyzer->ConnectionEvent(content_gap, {
+			dst_analyzer->BuildConnVal(),
+			val_mgr->GetBool(IsOrig()),
+			val_mgr->GetCount(seq),
+			val_mgr->GetCount(len),
+		});
 		}
 
 	if ( type == Direct )
@@ -335,11 +335,11 @@ void TCP_Reassembler::RecordBlock(DataBlock* b, BroFile* f)
 
 	if ( contents_file_write_failure )
 		{
-		val_list* vl = new val_list();
-		vl->append(Endpoint()->Conn()->BuildConnVal());
-		vl->append(val_mgr->GetBool(IsOrig()));
-		vl->append(new StringVal("TCP reassembler content write failure"));
-		tcp_analyzer->ConnectionEvent(contents_file_write_failure, vl);
+		tcp_analyzer->ConnectionEvent(contents_file_write_failure, {
+			Endpoint()->Conn()->BuildConnVal(),
+			val_mgr->GetBool(IsOrig()),
+			new StringVal("TCP reassembler content write failure"),
+		});
 		}
 	}
 
@@ -352,11 +352,11 @@ void TCP_Reassembler::RecordGap(uint64 start_seq, uint64 upper_seq, BroFile* f)
 
 	if ( contents_file_write_failure )
 		{
-		val_list* vl = new val_list();
-		vl->append(Endpoint()->Conn()->BuildConnVal());
-		vl->append(val_mgr->GetBool(IsOrig()));
-		vl->append(new StringVal("TCP reassembler gap write failure"));
-		tcp_analyzer->ConnectionEvent(contents_file_write_failure, vl);
+		tcp_analyzer->ConnectionEvent(contents_file_write_failure, {
+			Endpoint()->Conn()->BuildConnVal(),
+			val_mgr->GetBool(IsOrig()),
+			new StringVal("TCP reassembler gap write failure"),
+		});
 		}
 	}
 
@@ -425,12 +425,12 @@ void TCP_Reassembler::Overlap(const u_char* b1, const u_char* b2, uint64 n)
 		BroString* b1_s = new BroString((const u_char*) b1, n, 0);
 		BroString* b2_s = new BroString((const u_char*) b2, n, 0);
 
-		val_list* vl = new val_list(3);
-		vl->append(tcp_analyzer->BuildConnVal());
-		vl->append(new StringVal(b1_s));
-		vl->append(new StringVal(b2_s));
-		vl->append(new StringVal(flags.AsString()));
-		tcp_analyzer->ConnectionEvent(rexmit_inconsistency, vl);
+		tcp_analyzer->ConnectionEvent(rexmit_inconsistency, {
+			tcp_analyzer->BuildConnVal(),
+			new StringVal(b1_s),
+			new StringVal(b2_s),
+			new StringVal(flags.AsString()),
+		});
 		}
 	}
 
@@ -596,13 +596,12 @@ void TCP_Reassembler::DeliverBlock(uint64 seq, int len, const u_char* data)
 
 	if ( deliver_tcp_contents )
 		{
-		val_list* vl = new val_list();
-		vl->append(tcp_analyzer->BuildConnVal());
-		vl->append(val_mgr->GetBool(IsOrig()));
-		vl->append(val_mgr->GetCount(seq));
-		vl->append(new StringVal(len, (const char*) data));
-
-		tcp_analyzer->ConnectionEvent(tcp_contents, vl);
+		tcp_analyzer->ConnectionEvent(tcp_contents, {
+			tcp_analyzer->BuildConnVal(),
+			val_mgr->GetBool(IsOrig()),
+			val_mgr->GetCount(seq),
+			new StringVal(len, (const char*) data),
+		});
 		}
 
 	// Q. Can we say this because it is already checked in DataSent()?

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -136,7 +136,7 @@ void TCP_Reassembler::Gap(uint64 seq, uint64 len)
 
 	if ( report_gap(endp, endp->peer) )
 		{
-		dst_analyzer->ConnectionEvent(content_gap, {
+		dst_analyzer->ConnectionEventFast(content_gap, {
 			dst_analyzer->BuildConnVal(),
 			val_mgr->GetBool(IsOrig()),
 			val_mgr->GetCount(seq),
@@ -335,7 +335,7 @@ void TCP_Reassembler::RecordBlock(DataBlock* b, BroFile* f)
 
 	if ( contents_file_write_failure )
 		{
-		tcp_analyzer->ConnectionEvent(contents_file_write_failure, {
+		tcp_analyzer->ConnectionEventFast(contents_file_write_failure, {
 			Endpoint()->Conn()->BuildConnVal(),
 			val_mgr->GetBool(IsOrig()),
 			new StringVal("TCP reassembler content write failure"),
@@ -352,7 +352,7 @@ void TCP_Reassembler::RecordGap(uint64 start_seq, uint64 upper_seq, BroFile* f)
 
 	if ( contents_file_write_failure )
 		{
-		tcp_analyzer->ConnectionEvent(contents_file_write_failure, {
+		tcp_analyzer->ConnectionEventFast(contents_file_write_failure, {
 			Endpoint()->Conn()->BuildConnVal(),
 			val_mgr->GetBool(IsOrig()),
 			new StringVal("TCP reassembler gap write failure"),
@@ -425,7 +425,7 @@ void TCP_Reassembler::Overlap(const u_char* b1, const u_char* b2, uint64 n)
 		BroString* b1_s = new BroString((const u_char*) b1, n, 0);
 		BroString* b2_s = new BroString((const u_char*) b2, n, 0);
 
-		tcp_analyzer->ConnectionEvent(rexmit_inconsistency, {
+		tcp_analyzer->ConnectionEventFast(rexmit_inconsistency, {
 			tcp_analyzer->BuildConnVal(),
 			new StringVal(b1_s),
 			new StringVal(b2_s),
@@ -596,7 +596,7 @@ void TCP_Reassembler::DeliverBlock(uint64 seq, int len, const u_char* data)
 
 	if ( deliver_tcp_contents )
 		{
-		tcp_analyzer->ConnectionEvent(tcp_contents, {
+		tcp_analyzer->ConnectionEventFast(tcp_contents, {
 			tcp_analyzer->BuildConnVal(),
 			val_mgr->GetBool(IsOrig()),
 			val_mgr->GetCount(seq),

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -157,11 +157,11 @@ void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 
 		if ( do_udp_contents )
 			{
-			val_list* vl = new val_list;
-			vl->append(BuildConnVal());
-			vl->append(val_mgr->GetBool(is_orig));
-			vl->append(new StringVal(len, (const char*) data));
-			ConnectionEvent(udp_contents, vl);
+			ConnectionEvent(udp_contents, {
+				BuildConnVal(),
+				val_mgr->GetBool(is_orig),
+				new StringVal(len, (const char*) data),
+			});
 			}
 
 		Unref(port_val);

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -157,7 +157,7 @@ void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 
 		if ( do_udp_contents )
 			{
-			ConnectionEvent(udp_contents, {
+			ConnectionEventFast(udp_contents, {
 				BuildConnVal(),
 				val_mgr->GetBool(is_orig),
 				new StringVal(len, (const char*) data),

--- a/src/analyzer/protocol/xmpp/xmpp-analyzer.pac
+++ b/src/analyzer/protocol/xmpp/xmpp-analyzer.pac
@@ -32,7 +32,8 @@ refine connection XMPP_Conn += {
 		if ( !is_orig && ( token == "proceed" || token_no_ns == "proceed" ) && client_starttls )
 			{
 			bro_analyzer()->StartTLS();
-			BifEvent::generate_xmpp_starttls(bro_analyzer(), bro_analyzer()->Conn());
+			if ( xmpp_starttls )
+				BifEvent::generate_xmpp_starttls(bro_analyzer(), bro_analyzer()->Conn());
 			}
 		else if ( !is_orig && token == "proceed" )
 			reporter->Weird(bro_analyzer()->Conn(), "XMPP: proceed without starttls");

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -1016,7 +1016,7 @@ void Manager::ProcessEvent(const broker::topic& topic, broker::bro::Event ev)
 		}
 
 	if ( static_cast<size_t>(vl.length()) == args.size() )
-		mgr.QueueEvent(handler, std::move(vl), SOURCE_BROKER);
+		mgr.QueueEventFast(handler, std::move(vl), SOURCE_BROKER);
 	else
 		{
 		loop_over_list(vl, i)
@@ -1247,6 +1247,9 @@ void Manager::ProcessStatus(broker::status stat)
 		break;
 	}
 
+	if ( ! event )
+		return;
+
 	auto ei = internal_type("Broker::EndpointInfo")->AsRecordType();
 	auto endpoint_info = new RecordVal(ei);
 
@@ -1275,7 +1278,7 @@ void Manager::ProcessStatus(broker::status stat)
 	auto str = stat.message();
 	auto msg = new StringVal(str ? *str : "");
 
-	mgr.QueueEvent(event, {endpoint_info, msg});
+	mgr.QueueEventFast(event, {endpoint_info, msg});
 	}
 
 void Manager::ProcessError(broker::error err)
@@ -1352,7 +1355,7 @@ void Manager::ProcessError(broker::error err)
 		msg = fmt("[%s] %s", caf::to_string(err.category()).c_str(), caf::to_string(err.context()).c_str());
 		}
 
-	mgr.QueueEvent(Broker::error, {
+	mgr.QueueEventFast(Broker::error, {
 		BifType::Enum::Broker::ErrorCode->GetVal(ec),
 		new StringVal(msg),
 	});

--- a/src/broker/messaging.bif
+++ b/src/broker/messaging.bif
@@ -183,9 +183,7 @@ function Cluster::publish_rr%(pool: Pool, key: string, ...%): bool
 	if ( ! topic_func )
 		topic_func = global_scope()->Lookup("Cluster::rr_topic")->ID_Val()->AsFunc();
 
-	val_list vl(2);
-	vl.append(pool->Ref());
-	vl.append(key->Ref());
+	val_list vl{pool->Ref(), key->Ref()};
 	auto topic = topic_func->Call(&vl);
 
 	if ( ! topic->AsString()->Len() )
@@ -226,9 +224,7 @@ function Cluster::publish_hrw%(pool: Pool, key: any, ...%): bool
 	if ( ! topic_func )
 		topic_func = global_scope()->Lookup("Cluster::hrw_topic")->ID_Val()->AsFunc();
 
-	val_list vl(2);
-	vl.append(pool->Ref());
-	vl.append(key->Ref());
+	val_list vl{pool->Ref(), key->Ref()};
 	auto topic = topic_func->Call(&vl);
 
 	if ( ! topic->AsString()->Len() )

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -154,11 +154,11 @@ void File::RaiseFileOverNewConnection(Connection* conn, bool is_orig)
 	{
 	if ( conn && FileEventAvailable(file_over_new_connection) )
 		{
-		val_list* vl = new val_list();
-		vl->append(val->Ref());
-		vl->append(conn->BuildConnVal());
-		vl->append(val_mgr->GetBool(is_orig));
-		FileEvent(file_over_new_connection, vl);
+		FileEvent(file_over_new_connection, {
+			val->Ref(),
+			conn->BuildConnVal(),
+			val_mgr->GetBool(is_orig),
+		});
 		}
 	}
 
@@ -303,13 +303,11 @@ bool File::SetMime(const string& mime_type)
 	if ( ! FileEventAvailable(file_sniff) )
 		return false;
 
-	val_list* vl = new val_list();
-	vl->append(val->Ref());
 	RecordVal* meta = new RecordVal(fa_metadata_type);
-	vl->append(meta);
 	meta->Assign(meta_mime_type_idx, new StringVal(mime_type));
 	meta->Assign(meta_inferred_idx, val_mgr->GetBool(0));
-	FileEvent(file_sniff, vl);
+
+	FileEvent(file_sniff, {val->Ref(), meta});
 	return true;
 	}
 
@@ -338,10 +336,7 @@ void File::InferMetadata()
 	len = min(len, LookupFieldDefaultCount(bof_buffer_size_idx));
 	file_mgr->DetectMIME(data, len, &matches);
 
-	val_list* vl = new val_list();
-	vl->append(val->Ref());
 	RecordVal* meta = new RecordVal(fa_metadata_type);
-	vl->append(meta);
 
 	if ( ! matches.empty() )
 		{
@@ -351,7 +346,7 @@ void File::InferMetadata()
 		             file_analysis::GenMIMEMatchesVal(matches));
 		}
 
-	FileEvent(file_sniff, vl);
+	FileEvent(file_sniff, {val->Ref(), meta});
 	return;
 	}
 
@@ -463,11 +458,11 @@ void File::DeliverChunk(const u_char* data, uint64 len, uint64 offset)
 
 			if ( FileEventAvailable(file_reassembly_overflow) )
 				{
-				val_list* vl = new val_list();
-				vl->append(val->Ref());
-				vl->append(val_mgr->GetCount(current_offset));
-				vl->append(val_mgr->GetCount(gap_bytes));
-				FileEvent(file_reassembly_overflow, vl);
+				FileEvent(file_reassembly_overflow, {
+					val->Ref(),
+					val_mgr->GetCount(current_offset),
+					val_mgr->GetCount(gap_bytes),
+				});
 				}
 			}
 
@@ -608,11 +603,11 @@ void File::Gap(uint64 offset, uint64 len)
 
 	if ( FileEventAvailable(file_gap) )
 		{
-		val_list* vl = new val_list();
-		vl->append(val->Ref());
-		vl->append(val_mgr->GetCount(offset));
-		vl->append(val_mgr->GetCount(len));
-		FileEvent(file_gap, vl);
+		FileEvent(file_gap, {
+			val->Ref(),
+			val_mgr->GetCount(offset),
+			val_mgr->GetCount(len),
+		});
 		}
 
 	analyzers.DrainModifications();
@@ -631,14 +626,18 @@ void File::FileEvent(EventHandlerPtr h)
 	if ( ! FileEventAvailable(h) )
 		return;
 
-	val_list* vl = new val_list();
-	vl->append(val->Ref());
-	FileEvent(h, vl);
+	FileEvent(h, {val->Ref()});
 	}
 
 void File::FileEvent(EventHandlerPtr h, val_list* vl)
 	{
-	mgr.QueueEvent(h, vl);
+	FileEvent(h, std::move(*vl));
+	delete vl;
+	}
+
+void File::FileEvent(EventHandlerPtr h, val_list vl)
+	{
+	mgr.QueueEvent(h, std::move(vl));
 
 	if ( h == file_new || h == file_over_new_connection ||
 	     h == file_sniff ||

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -637,7 +637,7 @@ void File::FileEvent(EventHandlerPtr h, val_list* vl)
 
 void File::FileEvent(EventHandlerPtr h, val_list vl)
 	{
-	mgr.QueueEvent(h, std::move(vl));
+	mgr.QueueEventFast(h, std::move(vl));
 
 	if ( h == file_new || h == file_over_new_connection ||
 	     h == file_sniff ||

--- a/src/file_analysis/File.h
+++ b/src/file_analysis/File.h
@@ -172,6 +172,12 @@ public:
 	 */
 	void FileEvent(EventHandlerPtr h, val_list* vl);
 
+	/**
+	 * Raises an event related to the file's life-cycle.
+	 * @param h pointer to an event handler.
+	 * @param vl list of argument values to pass to event call.
+	 */
+	void FileEvent(EventHandlerPtr h, val_list vl);
 
 	/**
 	 * Sets the MIME type for a file to a specific value.

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -443,12 +443,11 @@ string Manager::GetFileID(analyzer::Tag tag, Connection* c, bool is_orig)
 	EnumVal* tagval = tag.AsEnumVal();
 	Ref(tagval);
 
-	val_list* vl = new val_list();
-	vl->append(tagval);
-	vl->append(c->BuildConnVal());
-	vl->append(val_mgr->GetBool(is_orig));
-
-	mgr.QueueEvent(get_file_handle, vl);
+	mgr.QueueEvent(get_file_handle, {
+		tagval,
+		c->BuildConnVal(),
+		val_mgr->GetBool(is_orig),
+	});
 	mgr.Drain(); // need file handle immediately so we don't have to buffer data
 	return current_file_id;
 	}

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -443,7 +443,7 @@ string Manager::GetFileID(analyzer::Tag tag, Connection* c, bool is_orig)
 	EnumVal* tagval = tag.AsEnumVal();
 	Ref(tagval);
 
-	mgr.QueueEvent(get_file_handle, {
+	mgr.QueueEventFast(get_file_handle, {
 		tagval,
 		c->BuildConnVal(),
 		val_mgr->GetBool(is_orig),

--- a/src/file_analysis/analyzer/data_event/DataEvent.cc
+++ b/src/file_analysis/analyzer/data_event/DataEvent.cc
@@ -41,12 +41,11 @@ bool DataEvent::DeliverChunk(const u_char* data, uint64 len, uint64 offset)
 	{
 	if ( ! chunk_event ) return true;
 
-	val_list* args = new val_list;
-	args->append(GetFile()->GetVal()->Ref());
-	args->append(new StringVal(new BroString(data, len, 0)));
-	args->append(val_mgr->GetCount(offset));
-
-	mgr.QueueEvent(chunk_event, args);
+	mgr.QueueEvent(chunk_event, {
+		GetFile()->GetVal()->Ref(),
+		new StringVal(new BroString(data, len, 0)),
+		val_mgr->GetCount(offset),
+	});
 
 	return true;
 	}
@@ -55,11 +54,10 @@ bool DataEvent::DeliverStream(const u_char* data, uint64 len)
 	{
 	if ( ! stream_event ) return true;
 
-	val_list* args = new val_list;
-	args->append(GetFile()->GetVal()->Ref());
-	args->append(new StringVal(new BroString(data, len, 0)));
-
-	mgr.QueueEvent(stream_event, args);
+	mgr.QueueEvent(stream_event, {
+		GetFile()->GetVal()->Ref(),
+		new StringVal(new BroString(data, len, 0)),
+	});
 
 	return true;
 	}

--- a/src/file_analysis/analyzer/data_event/DataEvent.cc
+++ b/src/file_analysis/analyzer/data_event/DataEvent.cc
@@ -41,7 +41,7 @@ bool DataEvent::DeliverChunk(const u_char* data, uint64 len, uint64 offset)
 	{
 	if ( ! chunk_event ) return true;
 
-	mgr.QueueEvent(chunk_event, {
+	mgr.QueueEventFast(chunk_event, {
 		GetFile()->GetVal()->Ref(),
 		new StringVal(new BroString(data, len, 0)),
 		val_mgr->GetCount(offset),
@@ -54,7 +54,7 @@ bool DataEvent::DeliverStream(const u_char* data, uint64 len)
 	{
 	if ( ! stream_event ) return true;
 
-	mgr.QueueEvent(stream_event, {
+	mgr.QueueEventFast(stream_event, {
 		GetFile()->GetVal()->Ref(),
 		new StringVal(new BroString(data, len, 0)),
 	});

--- a/src/file_analysis/analyzer/entropy/Entropy.cc
+++ b/src/file_analysis/analyzer/entropy/Entropy.cc
@@ -53,6 +53,9 @@ void Entropy::Finalize()
 	if ( ! fed )
 		return;
 
+	if ( ! file_entropy )
+		return;
+
 	double montepi, scc, ent, mean, chisq;
 	montepi = scc = ent = mean = chisq = 0.0;
 	entropy->Get(&ent, &chisq, &mean, &montepi, &scc);
@@ -64,7 +67,7 @@ void Entropy::Finalize()
 	ent_result->Assign(3, new Val(montepi, TYPE_DOUBLE));
 	ent_result->Assign(4, new Val(scc,     TYPE_DOUBLE));
 
-	mgr.QueueEvent(file_entropy, {
+	mgr.QueueEventFast(file_entropy, {
 		GetFile()->GetVal()->Ref(),
 		ent_result,
 	});

--- a/src/file_analysis/analyzer/entropy/Entropy.cc
+++ b/src/file_analysis/analyzer/entropy/Entropy.cc
@@ -53,9 +53,6 @@ void Entropy::Finalize()
 	if ( ! fed )
 		return;
 
-	val_list* vl = new val_list();
-	vl->append(GetFile()->GetVal()->Ref());
-
 	double montepi, scc, ent, mean, chisq;
 	montepi = scc = ent = mean = chisq = 0.0;
 	entropy->Get(&ent, &chisq, &mean, &montepi, &scc);
@@ -67,6 +64,8 @@ void Entropy::Finalize()
 	ent_result->Assign(3, new Val(montepi, TYPE_DOUBLE));
 	ent_result->Assign(4, new Val(scc,     TYPE_DOUBLE));
 
-	vl->append(ent_result);
-	mgr.QueueEvent(file_entropy, vl);
+	mgr.QueueEvent(file_entropy, {
+		GetFile()->GetVal()->Ref(),
+		ent_result,
+	});
 	}

--- a/src/file_analysis/analyzer/extract/Extract.cc
+++ b/src/file_analysis/analyzer/extract/Extract.cc
@@ -90,12 +90,12 @@ bool Extract::DeliverStream(const u_char* data, uint64 len)
 	if ( limit_exceeded && file_extraction_limit )
 		{
 		File* f = GetFile();
-		val_list* vl = new val_list();
-		vl->append(f->GetVal()->Ref());
-		vl->append(Args()->Ref());
-		vl->append(val_mgr->GetCount(limit));
-		vl->append(val_mgr->GetCount(len));
-		f->FileEvent(file_extraction_limit, vl);
+		f->FileEvent(file_extraction_limit, {
+			f->GetVal()->Ref(),
+			Args()->Ref(),
+			val_mgr->GetCount(limit),
+			val_mgr->GetCount(len),
+		});
 
 		// Limit may have been modified by a BIF, re-check it.
 		limit_exceeded = check_limit_exceeded(limit, depth, len, &towrite);

--- a/src/file_analysis/analyzer/hash/Hash.cc
+++ b/src/file_analysis/analyzer/hash/Hash.cc
@@ -48,10 +48,9 @@ void Hash::Finalize()
 	if ( ! hash->IsValid() || ! fed )
 		return;
 
-	val_list* vl = new val_list();
-	vl->append(GetFile()->GetVal()->Ref());
-	vl->append(new StringVal(kind));
-	vl->append(hash->Get());
-
-	mgr.QueueEvent(file_hash, vl);
+	mgr.QueueEvent(file_hash, {
+		GetFile()->GetVal()->Ref(),
+		new StringVal(kind),
+		hash->Get(),
+	});
 	}

--- a/src/file_analysis/analyzer/hash/Hash.cc
+++ b/src/file_analysis/analyzer/hash/Hash.cc
@@ -48,7 +48,10 @@ void Hash::Finalize()
 	if ( ! hash->IsValid() || ! fed )
 		return;
 
-	mgr.QueueEvent(file_hash, {
+	if ( ! file_hash )
+		return;
+
+	mgr.QueueEventFast(file_hash, {
 		GetFile()->GetVal()->Ref(),
 		new StringVal(kind),
 		hash->Get(),

--- a/src/file_analysis/analyzer/unified2/unified2-analyzer.pac
+++ b/src/file_analysis/analyzer/unified2/unified2-analyzer.pac
@@ -81,7 +81,7 @@ refine flow Flow += {
 			ids_event->Assign(11, to_port(${ev.dst_p}, ${ev.protocol}));
 			ids_event->Assign(17, val_mgr->GetCount(${ev.packet_action}));
 
-			mgr.QueueEvent(::unified2_event, {
+			mgr.QueueEventFast(::unified2_event, {
 					connection()->bro_analyzer()->GetFile()->GetVal()->Ref(),
 					ids_event,
 					},
@@ -113,7 +113,7 @@ refine flow Flow += {
 			ids_event->Assign(15, val_mgr->GetCount(${ev.mpls_label}));
 			ids_event->Assign(16, val_mgr->GetCount(${ev.vlan_id}));
 
-			mgr.QueueEvent(::unified2_event, {
+			mgr.QueueEventFast(::unified2_event, {
 					connection()->bro_analyzer()->GetFile()->GetVal()->Ref(),
 					ids_event,
 					},
@@ -135,7 +135,7 @@ refine flow Flow += {
 			packet->Assign(4, val_mgr->GetCount(${pkt.link_type}));
 			packet->Assign(5, bytestring_to_val(${pkt.packet_data}));
 
-			mgr.QueueEvent(::unified2_packet, {
+			mgr.QueueEventFast(::unified2_packet, {
 					connection()->bro_analyzer()->GetFile()->GetVal()->Ref(),
 					packet,
 					},

--- a/src/file_analysis/analyzer/unified2/unified2-analyzer.pac
+++ b/src/file_analysis/analyzer/unified2/unified2-analyzer.pac
@@ -81,10 +81,11 @@ refine flow Flow += {
 			ids_event->Assign(11, to_port(${ev.dst_p}, ${ev.protocol}));
 			ids_event->Assign(17, val_mgr->GetCount(${ev.packet_action}));
 
-			val_list* vl = new val_list();
-			vl->append(connection()->bro_analyzer()->GetFile()->GetVal()->Ref());
-			vl->append(ids_event);
-			mgr.QueueEvent(::unified2_event, vl, SOURCE_LOCAL);
+			mgr.QueueEvent(::unified2_event, {
+					connection()->bro_analyzer()->GetFile()->GetVal()->Ref(),
+					ids_event,
+					},
+				SOURCE_LOCAL);
 			}
 		return true;
 		%}
@@ -112,10 +113,11 @@ refine flow Flow += {
 			ids_event->Assign(15, val_mgr->GetCount(${ev.mpls_label}));
 			ids_event->Assign(16, val_mgr->GetCount(${ev.vlan_id}));
 
-			val_list* vl = new val_list();
-			vl->append(connection()->bro_analyzer()->GetFile()->GetVal()->Ref());
-			vl->append(ids_event);
-			mgr.QueueEvent(::unified2_event, vl, SOURCE_LOCAL);
+			mgr.QueueEvent(::unified2_event, {
+					connection()->bro_analyzer()->GetFile()->GetVal()->Ref(),
+					ids_event,
+					},
+				SOURCE_LOCAL);
 			}
 
 		return true;
@@ -133,10 +135,11 @@ refine flow Flow += {
 			packet->Assign(4, val_mgr->GetCount(${pkt.link_type}));
 			packet->Assign(5, bytestring_to_val(${pkt.packet_data}));
 
-			val_list* vl = new val_list();
-			vl->append(connection()->bro_analyzer()->GetFile()->GetVal()->Ref());
-			vl->append(packet);
-			mgr.QueueEvent(::unified2_packet, vl, SOURCE_LOCAL);
+			mgr.QueueEvent(::unified2_packet, {
+					connection()->bro_analyzer()->GetFile()->GetVal()->Ref(),
+					packet,
+					},
+				SOURCE_LOCAL);
 			}
 
 		return true;

--- a/src/file_analysis/analyzer/x509/OCSP.cc
+++ b/src/file_analysis/analyzer/x509/OCSP.cc
@@ -417,10 +417,6 @@ void file_analysis::OCSP::ParseRequest(OCSP_REQUEST* req)
 	char buf[OCSP_STRING_BUF_SIZE]; // we need a buffer for some of the openssl functions
 	memset(buf, 0, sizeof(buf));
 
-	// build up our response as we go along...
-	val_list* vl = new val_list();
-	vl->append(GetFile()->GetVal()->Ref());
-
 	uint64 version = 0;
 
 #if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
@@ -431,23 +427,24 @@ void file_analysis::OCSP::ParseRequest(OCSP_REQUEST* req)
 	// TODO: try to parse out general name ?
 #endif
 
-	vl->append(val_mgr->GetCount(version));
+	mgr.QueueEvent(ocsp_request, {
+		GetFile()->GetVal()->Ref(),
+		val_mgr->GetCount(version),
+	});
 
 	BIO *bio = BIO_new(BIO_s_mem());
-
-	mgr.QueueEvent(ocsp_request, vl);
 
 	int req_count = OCSP_request_onereq_count(req);
 	for ( int i=0; i<req_count; i++ )
 		{
-		val_list* rvl = new val_list();
-		rvl->append(GetFile()->GetVal()->Ref());
+		val_list rvl(5);
+		rvl.append(GetFile()->GetVal()->Ref());
 
 		OCSP_ONEREQ *one_req = OCSP_request_onereq_get0(req, i);
 		OCSP_CERTID *cert_id = OCSP_onereq_get0_id(one_req);
 
-		ocsp_add_cert_id(cert_id, rvl, bio);
-		mgr.QueueEvent(ocsp_request_certificate, rvl);
+		ocsp_add_cert_id(cert_id, &rvl, bio);
+		mgr.QueueEvent(ocsp_request_certificate, std::move(rvl));
 		}
 
 	BIO_free(bio);
@@ -470,14 +467,13 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val)
  	char buf[OCSP_STRING_BUF_SIZE];
 	memset(buf, 0, sizeof(buf));
 
-	val_list* vl = new val_list();
-	vl->append(GetFile()->GetVal()->Ref());
-
 	const char *status_str = OCSP_response_status_str(OCSP_response_status(resp));
 	StringVal* status_val = new StringVal(strlen(status_str), status_str);
-	vl->append(status_val->Ref());
-	mgr.QueueEvent(ocsp_response_status, vl);
-	vl = nullptr;
+
+	mgr.QueueEvent(ocsp_response_status, {
+		GetFile()->GetVal()->Ref(),
+		status_val->Ref(),
+	});
 
 	//if (!resp_bytes)
 	//	{
@@ -490,6 +486,8 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val)
 	//int len = BIO_read(bio, buf, sizeof(buf));
 	//BIO_reset(bio);
 
+	val_list vl(8);
+
 	// get the basic response
 	basic_resp = OCSP_response_get1_basic(resp);
 	if ( !basic_resp )
@@ -501,28 +499,27 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val)
 		goto clean_up;
 #endif
 
-	vl = new val_list();
-	vl->append(GetFile()->GetVal()->Ref());
-	vl->append(resp_val->Ref());
-	vl->append(status_val);
+	vl.append(GetFile()->GetVal()->Ref());
+	vl.append(resp_val->Ref());
+	vl.append(status_val);
 
 #if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
-	vl->append(val_mgr->GetCount((uint64)ASN1_INTEGER_get(resp_data->version)));
+	vl.append(val_mgr->GetCount((uint64)ASN1_INTEGER_get(resp_data->version)));
 #else
-	vl->append(parse_basic_resp_data_version(basic_resp));
+	vl.append(parse_basic_resp_data_version(basic_resp));
 #endif
 
 	// responderID
 	if ( OCSP_RESPID_bio(basic_resp, bio) )
 		{
 		len = BIO_read(bio, buf, sizeof(buf));
-		vl->append(new StringVal(len, buf));
+		vl.append(new StringVal(len, buf));
 		BIO_reset(bio);
 		}
 	else
 		{
 		reporter->Weird("OpenSSL failed to get OCSP responder id");
-		vl->append(val_mgr->GetEmptyString());
+		vl.append(val_mgr->GetEmptyString());
 		}
 
 	// producedAt
@@ -532,7 +529,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val)
 	produced_at = OCSP_resp_get0_produced_at(basic_resp);
 #endif
 
-	vl->append(new Val(GetTimeFromAsn1(produced_at, GetFile(), reporter), TYPE_TIME));
+	vl.append(new Val(GetTimeFromAsn1(produced_at, GetFile(), reporter), TYPE_TIME));
 
 	// responses
 
@@ -545,8 +542,8 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val)
 		if ( !single_resp )
 			continue;
 
-		val_list* rvl = new val_list();
-		rvl->append(GetFile()->GetVal()->Ref());
+		val_list rvl(10);
+		rvl.append(GetFile()->GetVal()->Ref());
 
 		// cert id
 		const OCSP_CERTID* cert_id = nullptr;
@@ -557,7 +554,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val)
 		cert_id = OCSP_SINGLERESP_get0_id(single_resp);
 #endif
 
-		ocsp_add_cert_id(cert_id, rvl, bio);
+		ocsp_add_cert_id(cert_id, &rvl, bio);
 		BIO_reset(bio);
 
 		// certStatus
@@ -574,38 +571,38 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val)
 			reporter->Weird("OpenSSL failed to find status of OCSP response");
 
 		const char* cert_status_str = OCSP_cert_status_str(status);
-		rvl->append(new StringVal(strlen(cert_status_str), cert_status_str));
+		rvl.append(new StringVal(strlen(cert_status_str), cert_status_str));
 
 		// revocation time and reason if revoked
 		if ( status == V_OCSP_CERTSTATUS_REVOKED )
 			{
-			rvl->append(new Val(GetTimeFromAsn1(revoke_time, GetFile(), reporter), TYPE_TIME));
+			rvl.append(new Val(GetTimeFromAsn1(revoke_time, GetFile(), reporter), TYPE_TIME));
 
 			if ( reason != OCSP_REVOKED_STATUS_NOSTATUS )
 				{
 				const char* revoke_reason = OCSP_crl_reason_str(reason);
-				rvl->append(new StringVal(strlen(revoke_reason), revoke_reason));
+				rvl.append(new StringVal(strlen(revoke_reason), revoke_reason));
 				}
 			else
-				rvl->append(new StringVal(0, ""));
+				rvl.append(new StringVal(0, ""));
 			}
 		else
 			{
-			rvl->append(new Val(0.0, TYPE_TIME));
-			rvl->append(new StringVal(0, ""));
+			rvl.append(new Val(0.0, TYPE_TIME));
+			rvl.append(new StringVal(0, ""));
 			}
 
 		if ( this_update )
-			rvl->append(new Val(GetTimeFromAsn1(this_update, GetFile(), reporter), TYPE_TIME));
+			rvl.append(new Val(GetTimeFromAsn1(this_update, GetFile(), reporter), TYPE_TIME));
 		else
-			rvl->append(new Val(0.0, TYPE_TIME));
+			rvl.append(new Val(0.0, TYPE_TIME));
 
 		if ( next_update )
-			rvl->append(new Val(GetTimeFromAsn1(next_update, GetFile(), reporter), TYPE_TIME));
+			rvl.append(new Val(GetTimeFromAsn1(next_update, GetFile(), reporter), TYPE_TIME));
 		else
-			rvl->append(new Val(0.0, TYPE_TIME));
+			rvl.append(new Val(0.0, TYPE_TIME));
 
-		mgr.QueueEvent(ocsp_response_certificate, rvl);
+		mgr.QueueEvent(ocsp_response_certificate, std::move(rvl));
 
 		num_ext = OCSP_SINGLERESP_get_ext_count(single_resp);
 		for ( int k = 0; k < num_ext; ++k )
@@ -621,10 +618,10 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val)
 #if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	i2a_ASN1_OBJECT(bio, basic_resp->signatureAlgorithm->algorithm);
 	len = BIO_read(bio, buf, sizeof(buf));
-	vl->append(new StringVal(len, buf));
+	vl.append(new StringVal(len, buf));
 	BIO_reset(bio);
 #else
-	vl->append(parse_basic_resp_sig_alg(basic_resp, bio, buf, sizeof(buf)));
+	vl.append(parse_basic_resp_sig_alg(basic_resp, bio, buf, sizeof(buf)));
 #endif
 
 	//i2a_ASN1_OBJECT(bio, basic_resp->signature);
@@ -633,7 +630,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val)
 	//BIO_reset(bio);
 
 	certs_vector = new VectorVal(internal_type("x509_opaque_vector")->AsVectorType());
-	vl->append(certs_vector);
+	vl.append(certs_vector);
 
 #if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	certs = basic_resp->certs;
@@ -654,7 +651,8 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPVal *resp_val)
 				reporter->Weird("OpenSSL returned null certificate");
 			}
 	  }
-	mgr.QueueEvent(ocsp_response_bytes, vl);
+
+	mgr.QueueEvent(ocsp_response_bytes, std::move(vl));
 
 	// ok, now that we are done with the actual certificate - let's parse extensions :)
 	num_ext = OCSP_BASICRESP_get_ext_count(basic_resp);

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -221,16 +221,20 @@ void file_analysis::X509::ParseBasicConstraints(X509_EXTENSION* ex)
 
 	if ( constr )
 		{
-		RecordVal* pBasicConstraint = new RecordVal(BifType::Record::X509::BasicConstraints);
-		pBasicConstraint->Assign(0, val_mgr->GetBool(constr->ca ? 1 : 0));
+		if ( x509_ext_basic_constraints )
+			{
+			RecordVal* pBasicConstraint = new RecordVal(BifType::Record::X509::BasicConstraints);
+			pBasicConstraint->Assign(0, val_mgr->GetBool(constr->ca ? 1 : 0));
 
-		if ( constr->pathlen )
-			pBasicConstraint->Assign(1, val_mgr->GetCount((int32_t) ASN1_INTEGER_get(constr->pathlen)));
+			if ( constr->pathlen )
+				pBasicConstraint->Assign(1, val_mgr->GetCount((int32_t) ASN1_INTEGER_get(constr->pathlen)));
 
-		mgr.QueueEvent(x509_ext_basic_constraints, {
-			GetFile()->GetVal()->Ref(),
-			pBasicConstraint,
-		});
+			mgr.QueueEventFast(x509_ext_basic_constraints, {
+				GetFile()->GetVal()->Ref(),
+				pBasicConstraint,
+			});
+			}
+
 		BASIC_CONSTRAINTS_free(constr);
 		}
 

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -57,11 +57,11 @@ bool file_analysis::X509::EndOfFile()
 	RecordVal* cert_record = ParseCertificate(cert_val, GetFile());
 
 	// and send the record on to scriptland
-	val_list* vl = new val_list();
-	vl->append(GetFile()->GetVal()->Ref());
-	vl->append(cert_val->Ref());
-	vl->append(cert_record->Ref()); // we Ref it here, because we want to keep a copy around for now...
-	mgr.QueueEvent(x509_certificate, vl);
+	mgr.QueueEvent(x509_certificate, {
+		GetFile()->GetVal()->Ref(),
+		cert_val->Ref(),
+		cert_record->Ref(), // we Ref it here, because we want to keep a copy around for now...
+	});
 
 	// after parsing the certificate - parse the extensions...
 
@@ -227,11 +227,10 @@ void file_analysis::X509::ParseBasicConstraints(X509_EXTENSION* ex)
 		if ( constr->pathlen )
 			pBasicConstraint->Assign(1, val_mgr->GetCount((int32_t) ASN1_INTEGER_get(constr->pathlen)));
 
-		val_list* vl = new val_list();
-		vl->append(GetFile()->GetVal()->Ref());
-		vl->append(pBasicConstraint);
-
-		mgr.QueueEvent(x509_ext_basic_constraints, vl);
+		mgr.QueueEvent(x509_ext_basic_constraints, {
+			GetFile()->GetVal()->Ref(),
+			pBasicConstraint,
+		});
 		BASIC_CONSTRAINTS_free(constr);
 		}
 
@@ -367,10 +366,10 @@ void file_analysis::X509::ParseSAN(X509_EXTENSION* ext)
 
 		sanExt->Assign(4, val_mgr->GetBool(otherfields));
 
-		val_list* vl = new val_list();
-		vl->append(GetFile()->GetVal()->Ref());
-		vl->append(sanExt);
-		mgr.QueueEvent(x509_ext_subject_alternative_name, vl);
+		mgr.QueueEvent(x509_ext_subject_alternative_name, {
+			GetFile()->GetVal()->Ref(),
+			sanExt,
+		});
 	GENERAL_NAMES_free(altname);
 	}
 

--- a/src/file_analysis/analyzer/x509/X509Common.cc
+++ b/src/file_analysis/analyzer/x509/X509Common.cc
@@ -277,13 +277,18 @@ void file_analysis::X509Common::ParseExtension(X509_EXTENSION* ex, EventHandlerP
 	// parsed. And if we have it, we send the specialized event on top of the
 	// generic event that we just had. I know, that is... kind of not nice,
 	// but I am not sure if there is a better way to do it...
-	val_list* vl = new val_list();
-	vl->append(GetFile()->GetVal()->Ref());
-	vl->append(pX509Ext);
-	if ( h == ocsp_extension )
-		vl->append(val_mgr->GetBool(global ? 1 : 0));
 
-	mgr.QueueEvent(h, vl);
+	if ( h == ocsp_extension )
+		mgr.QueueEvent(h, {
+			GetFile()->GetVal()->Ref(),
+			pX509Ext,
+			val_mgr->GetBool(global ? 1 : 0),
+		});
+	else
+		mgr.QueueEvent(h, {
+			GetFile()->GetVal()->Ref(),
+			pX509Ext,
+		});
 
 	// let individual analyzers parse more.
 	ParseExtensionsSpecific(ex, global, ext_asn, oid);

--- a/src/file_analysis/analyzer/x509/x509-extension.pac
+++ b/src/file_analysis/analyzer/x509/x509-extension.pac
@@ -35,6 +35,9 @@ refine connection MockConnection += {
 
 	function proc_signedcertificatetimestamp(rec: HandshakeRecord, version: uint8, logid: const_bytestring, timestamp: uint64, digitally_signed_algorithms: SignatureAndHashAlgorithm, digitally_signed_signature: const_bytestring) : bool
 		%{
+		if ( ! x509_ocsp_ext_signed_certificate_timestamp )
+			return true;
+
 		BifEvent::generate_x509_ocsp_ext_signed_certificate_timestamp((analyzer::Analyzer *) bro_analyzer(),
 			bro_analyzer()->GetFile()->GetVal()->Ref(),
 			version,

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -715,7 +715,7 @@ bool Manager::Write(EnumVal* id, RecordVal* columns)
 
 	// Raise the log event.
 	if ( stream->event )
-		mgr.QueueEvent(stream->event, {columns->Ref()}, SOURCE_LOCAL);
+		mgr.QueueEventFast(stream->event, {columns->Ref()}, SOURCE_LOCAL);
 
 	// Send to each of our filters.
 	for ( list<Filter*>::iterator i = stream->filters.begin();

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -715,11 +715,7 @@ bool Manager::Write(EnumVal* id, RecordVal* columns)
 
 	// Raise the log event.
 	if ( stream->event )
-		{
-		val_list* vl = new val_list(1);
-		vl->append(columns->Ref());
-		mgr.QueueEvent(stream->event, vl, SOURCE_LOCAL);
-		}
+		mgr.QueueEvent(stream->event, {columns->Ref()}, SOURCE_LOCAL);
 
 	// Send to each of our filters.
 	for ( list<Filter*>::iterator i = stream->filters.begin();
@@ -732,8 +728,7 @@ bool Manager::Write(EnumVal* id, RecordVal* columns)
 			{
 			// See whether the predicates indicates that we want
 			// to log this record.
-			val_list vl(1);
-			vl.append(columns->Ref());
+			val_list vl{columns->Ref()};
 
 			int result = 1;
 
@@ -750,16 +745,11 @@ bool Manager::Write(EnumVal* id, RecordVal* columns)
 
 		if ( filter->path_func )
 			{
-			val_list vl(3);
-			vl.append(id->Ref());
-
 			Val* path_arg;
 			if ( filter->path_val )
 				path_arg = filter->path_val->Ref();
 			else
 				path_arg = val_mgr->GetEmptyString();
-
-			vl.append(path_arg);
 
 			Val* rec_arg;
 			BroType* rt = filter->path_func->FType()->Args()->FieldType("rec");
@@ -770,7 +760,11 @@ bool Manager::Write(EnumVal* id, RecordVal* columns)
 				// Can be TYPE_ANY here.
 				rec_arg = columns->Ref();
 
-			vl.append(rec_arg);
+			val_list vl{
+				id->Ref(),
+				path_arg,
+				rec_arg,
+			};
 
 			Val* v = 0;
 
@@ -1087,8 +1081,7 @@ threading::Value** Manager::RecordToFilterVals(Stream* stream, Filter* filter,
 	RecordVal* ext_rec = nullptr;
 	if ( filter->num_ext_fields > 0 )
 		{
-		val_list vl(1);
-		vl.append(filter->path_val->Ref());
+		val_list vl{filter->path_val->Ref()};
 		Val* res = filter->ext_func->Call(&vl);
 		if ( res )
 			ext_rec = res->AsRecordVal();
@@ -1593,8 +1586,7 @@ bool Manager::FinishedRotation(WriterFrontend* writer, const char* new_name, con
 	assert(func);
 
 	// Call the postprocessor function.
-	val_list vl(1);
-	vl.append(info);
+	val_list vl{info};
 
 	int result = 0;
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -340,7 +340,7 @@ void terminate_bro()
 
 	EventHandlerPtr bro_done = internal_handler("bro_done");
 	if ( bro_done )
-		mgr.QueueEvent(bro_done, val_list{});
+		mgr.QueueEventFast(bro_done, val_list{});
 
 	timer_mgr->Expire();
 	mgr.Drain();
@@ -1138,7 +1138,7 @@ int main(int argc, char** argv)
 	EventHandlerPtr bro_init = internal_handler("bro_init");
 
 	if ( bro_init )
-		mgr.QueueEvent(bro_init, val_list{});
+		mgr.QueueEventFast(bro_init, val_list{});
 
 	EventRegistry::string_list* dead_handlers =
 		event_registry->UnusedHandlers();
@@ -1184,16 +1184,19 @@ int main(int argc, char** argv)
 	if ( override_ignore_checksums )
 		ignore_checksums = 1;
 
-	// Queue events reporting loaded scripts.
-	for ( std::list<ScannedFile>::iterator i = files_scanned.begin(); i != files_scanned.end(); i++ )
+	if ( bro_script_loaded )
 		{
-		if ( i->skipped )
-			continue;
+		// Queue events reporting loaded scripts.
+		for ( std::list<ScannedFile>::iterator i = files_scanned.begin(); i != files_scanned.end(); i++ )
+			{
+			if ( i->skipped )
+				continue;
 
-		mgr.QueueEvent(bro_script_loaded, {
-			new StringVal(i->name.c_str()),
-			val_mgr->GetCount(i->include_level),
-		});
+			mgr.QueueEventFast(bro_script_loaded, {
+				new StringVal(i->name.c_str()),
+				val_mgr->GetCount(i->include_level),
+			});
+			}
 		}
 
 	reporter->ReportViaEvents(true);

--- a/src/main.cc
+++ b/src/main.cc
@@ -284,12 +284,11 @@ void done_with_network()
 
 	if ( net_done )
 		{
-		val_list* args = new val_list;
-		args->append(new Val(timer_mgr->Time(), TYPE_TIME));
 		mgr.Drain();
-
 		// Don't propagate this event to remote clients.
-		mgr.Dispatch(new Event(net_done, args), true);
+		mgr.Dispatch(new Event(net_done,
+		                       {new Val(timer_mgr->Time(), TYPE_TIME)}),
+		             true);
 		}
 
 	// Save state before expiring the remaining events/timers.
@@ -341,7 +340,7 @@ void terminate_bro()
 
 	EventHandlerPtr bro_done = internal_handler("bro_done");
 	if ( bro_done )
-		mgr.QueueEvent(bro_done, new val_list);
+		mgr.QueueEvent(bro_done, val_list{});
 
 	timer_mgr->Expire();
 	mgr.Drain();
@@ -1137,8 +1136,9 @@ int main(int argc, char** argv)
 		net_update_time(current_time());
 
 	EventHandlerPtr bro_init = internal_handler("bro_init");
-	if ( bro_init )	//### this should be a function
-		mgr.QueueEvent(bro_init, new val_list);
+
+	if ( bro_init )
+		mgr.QueueEvent(bro_init, val_list{});
 
 	EventRegistry::string_list* dead_handlers =
 		event_registry->UnusedHandlers();
@@ -1190,10 +1190,10 @@ int main(int argc, char** argv)
 		if ( i->skipped )
 			continue;
 
-		val_list* vl = new val_list;
-		vl->append(new StringVal(i->name.c_str()));
-		vl->append(val_mgr->GetCount(i->include_level));
-		mgr.QueueEvent(bro_script_loaded, vl);
+		mgr.QueueEvent(bro_script_loaded, {
+			new StringVal(i->name.c_str()),
+			val_mgr->GetCount(i->include_level),
+		});
 		}
 
 	reporter->ReportViaEvents(true);

--- a/src/option.bif
+++ b/src/option.bif
@@ -15,10 +15,12 @@ static bool call_option_handlers_and_set_value(StringVal* name, ID* i, Val* val,
 		{
 		for ( auto handler_function : i->GetOptionHandlers() )
 			{
-			val_list vl(2);
+			bool add_loc = handler_function->FType()->AsFuncType()->ArgTypes()->Types()->length() == 3;
+			val_list vl(2 + add_loc);
 			vl.append(name->Ref());
 			vl.append(val);
-			if ( handler_function->FType()->AsFuncType()->ArgTypes()->Types()->length() == 3 )
+
+			if ( add_loc )
 				vl.append(location->Ref());
 
 			val = handler_function->Call(&vl); // consumed by next call.


### PR DESCRIPTION
`topic/jsiwek/plist-and-event-cleanup` is in `zeek` and `bifcl` repos.   See commit message for details, but the bulk of this is motivated toward getting rid of some of the extra or unnecessary heap allocation being done in most places that generate/queue events and their argument Vals.

Final measurements on a test pcap were giving ~2.5% better timing and ~12% reduction in max mem. allocated (but this was only a small test case that ends up allocating on the order of 150mb total, I'd expect cases where the bulk of memory is used for storing state in script-land, there's less benefit to optimizing how much memory gets used for storing the current-batch-of-queued-events, but still).