### PR TITLE
expose some TCP analyzer utility functions for use by derived classes

### DIFF
--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -1019,9 +1019,9 @@ void TCP_Analyzer::CheckPIA_FirstPacket(int is_orig, const IP_Hdr* ip)
 		}
 	}
 
-static uint64 get_relative_seq(const TCP_Endpoint* endpoint,
-			       uint32 cur_base, uint32 last, uint32 wraps,
-			       bool* underflow = 0)
+uint64 TCP_Analyzer::get_relative_seq(const TCP_Endpoint* endpoint,
+				       uint32 cur_base, uint32 last,
+				       uint32 wraps, bool* underflow)
 	{
 	int32 delta = seq_delta(cur_base, last);
 
@@ -1052,7 +1052,7 @@ static uint64 get_relative_seq(const TCP_Endpoint* endpoint,
 	return endpoint->ToRelativeSeqSpace(cur_base, wraps);
 	}
 
-static int get_segment_len(int payload_len, TCP_Flags flags)
+int TCP_Analyzer::get_segment_len(int payload_len, TCP_Flags flags)
 	{
 	int seg_len = payload_len;
 

--- a/src/analyzer/protocol/tcp/TCP.h
+++ b/src/analyzer/protocol/tcp/TCP.h
@@ -174,6 +174,14 @@ protected:
 				const u_char* option, TCP_Analyzer* analyzer,
 				  bool is_orig, void* cookie);
 
+	// A couple of handle utility functions that we make available
+	// to any derived analyzers.
+	static uint64 get_relative_seq(const TCP_Endpoint* endpoint,
+				       uint32 cur_base, uint32 last,
+				       uint32 wraps, bool* underflow = 0);
+
+	static int get_segment_len(int payload_len, TCP_Flags flags);
+
 private:
 	TCP_Endpoint* orig;
 	TCP_Endpoint* resp;


### PR DESCRIPTION
In working on a plugin for some TCP analysis, I found I had to duplicate code from the `TCP_Analyzer` class because it wasn't exposed to subclasses.  Seems safe to export these (at least as `protected`), and would help with avoiding code duplication in the future.