### PR TITLE
Fixes to DNS lookups

### DIFF
--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -1407,12 +1407,15 @@ void DNS_Mgr::DoProcess()
 		if ( req->time + DNS_TIMEOUT > current_time() )
 			break;
 
-		if ( req->IsAddrReq() )
-			CheckAsyncAddrRequest(req->host, true);
-		else if ( req->is_txt )
-			CheckAsyncTextRequest(req->name.c_str(), true);
-		else
-			CheckAsyncHostRequest(req->name.c_str(), true);
+		if ( ! req->processed )
+			{
+			if ( req->IsAddrReq() )
+				CheckAsyncAddrRequest(req->host, true);
+			else if ( req->is_txt )
+				CheckAsyncTextRequest(req->name.c_str(), true);
+			else
+				CheckAsyncHostRequest(req->name.c_str(), true);
+			}
 
 		asyncs_timeouts.pop();
 		delete req;

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -1418,9 +1418,6 @@ void DNS_Mgr::DoProcess()
 		delete req;
 		}
 
-	if ( asyncs_addrs.size() == 0 && asyncs_names.size() == 0 && asyncs_texts.size() == 0 )
-		return;
-
 	if ( AnswerAvailable(0) <= 0 )
 		return;
 

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -289,10 +289,13 @@ ListVal* DNS_Mapping::Addrs()
 
 TableVal* DNS_Mapping::AddrsSet() {
 	ListVal* l = Addrs();
-	if ( l )
-		return l->ConvertToSet();
-	else
+
+	if ( ! l )
 		return empty_addr_set();
+
+	auto rval = l->ConvertToSet();
+	Unref(l);
+	return rval;
 	}
 
 StringVal* DNS_Mapping::Host()

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -1369,7 +1369,7 @@ void DNS_Mgr::CheckAsyncHostRequest(const char* host, bool timeout)
 
 void DNS_Mgr::Flush()
 	{
-	DoProcess(false);
+	DoProcess();
 
 	HostMap::iterator it;
 	for ( it = host_mappings.begin(); it != host_mappings.end(); ++it )
@@ -1391,11 +1391,11 @@ void DNS_Mgr::Flush()
 
 void DNS_Mgr::Process()
 	{
-	DoProcess(false);
+	DoProcess();
 	next_timestamp = -1.0;
 	}
 
-void DNS_Mgr::DoProcess(bool flush)
+void DNS_Mgr::DoProcess()
 	{
 	if ( ! nb_dns )
 		return;
@@ -1404,7 +1404,7 @@ void DNS_Mgr::DoProcess(bool flush)
 		{
 		AsyncRequest* req = asyncs_timeouts.top();
 
-		if ( req->time + DNS_TIMEOUT > current_time() || flush )
+		if ( req->time + DNS_TIMEOUT > current_time() )
 			break;
 
 		if ( req->IsAddrReq() )

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -236,6 +236,7 @@ protected:
 	unsigned long num_requests;
 	unsigned long successful;
 	unsigned long failed;
+	double next_timestamp;
 };
 
 extern DNS_Mgr* dns_mgr;

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -172,12 +172,13 @@ protected:
 
 	struct AsyncRequest {
 		double time;
+		bool is_txt;
+		bool processed;
 		IPAddr host;
 		string name;
-		bool is_txt;
 		CallbackList callbacks;
 
-		AsyncRequest() : time(0.0), is_txt(false) { }
+		AsyncRequest() : time(0.0), is_txt(false), processed(false) { }
 
 		bool IsAddrReq() const	{ return name.length() == 0; }
 
@@ -190,6 +191,7 @@ protected:
 				delete *i;
 				}
 			callbacks.clear();
+			processed = true;
 			}
 
 		void Resolved(TableVal* addrs)
@@ -201,6 +203,7 @@ protected:
 				delete *i;
 				}
 			callbacks.clear();
+			processed = true;
 			}
 
 		void Timeout()
@@ -212,6 +215,7 @@ protected:
 				delete *i;
 				}
 			callbacks.clear();
+			processed = true;
 			}
 
 	};

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -132,7 +132,7 @@ protected:
 	void CheckAsyncTextRequest(const char* host, bool timeout);
 
 	// Process outstanding requests.
-	void DoProcess(bool flush);
+	void DoProcess();
 
 	// IOSource interface.
 	void GetFds(iosource::FD_Set* read, iosource::FD_Set* write,

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -228,7 +228,14 @@ protected:
 	typedef list<AsyncRequest*> QueuedList;
 	QueuedList asyncs_queued;
 
-	typedef priority_queue<AsyncRequest*> TimeoutQueue;
+    struct AsyncRequestCompare {
+		bool operator()(const AsyncRequest* a, const AsyncRequest* b)
+			{
+			return a->time > b->time;
+			}
+    };
+
+	typedef priority_queue<AsyncRequest*, std::vector<AsyncRequest*>, AsyncRequestCompare> TimeoutQueue;
 	TimeoutQueue asyncs_timeouts;
 
 	int asyncs_pending;


### PR DESCRIPTION
See individual commit messages for more details.  I think most are straightforward to understand.  The one I'd put most care into reviewing is https://github.com/zeek/zeek/commit/6db576195c4417bac663a05a12bd4b712c47ff2a since that changes how the DNS_Mgr integrates into the I/O loop (and that can be a fragile thing to alter).

My understanding is that the DNS_Mgr is an "always idle" IOSource, meaning it never is eligible to be processed unless theres activity on its file descriptor and the main loop only polls that so often.  The other main IOSource that will be polled is the Broker one.   Before this change, both the Broker and DNS_Mgr IOSource report the last `network_time` if they're eligible to be processed when polled, so which wins?  We iterate in this order:

https://github.com/zeek/zeek/blob/1a77c1b287bab7d95f4c59fb630bc37de850cd00/src/iosource/Manager.cc#L153-L154

And compare timestamps like this:

https://github.com/zeek/zeek/blob/1a77c1b287bab7d95f4c59fb630bc37de850cd00/src/iosource/Manager.cc#L165-L168

So whichever IOSource got registered first would win.  Registration happens here:

https://github.com/zeek/zeek/blob/1a77c1b287bab7d95f4c59fb630bc37de850cd00/src/main.cc#L880-L890

So Broker could potentially starve out DNS lookups.  The fix I did has DNS_Mgr remember the last timestamp at which it could have been processed and report that in subsequent I/O loops to prevent starvation.