### PR TITLE
Force the Broker IOSource to idle periodically

### DIFF
--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -382,6 +382,7 @@ private:
 	bool reading_pcaps;
 	bool after_zeek_init;
 	int peer_count;
+	int times_processed_without_idle;
 
 	Func* log_topic_func;
 	VectorType* vector_of_data_type;


### PR DESCRIPTION
Previously, if there was always input in each Process() call, then
the Broker IOSource would never go idle and could completely starve
out a packet IOSource since it would always report readiness with
a timestamp value of the last known network_time (which prevents
selecting a packet IOSource for processing, due to incoming packets
likely having timestamps that are later).

Fixes #346 