### PR TITLE
Integrate paraglob with Zeek.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "doc"]
 	path = doc
 	url = https://github.com/zeek/zeek-docs
+[submodule "aux/paraglob"]
+	path = aux/paraglob
+	url = https://github.com/zeek/paraglob

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,10 @@ include_directories(BEFORE ${CAF_INCLUDE_DIR_CORE})
 include_directories(BEFORE ${CAF_INCLUDE_DIR_IO})
 include_directories(BEFORE ${CAF_INCLUDE_DIR_OPENSSL})
 
+add_subdirectory(aux/paraglob)
+set(brodeps ${brodeps} paraglob)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/aux/paraglob)
+
 add_subdirectory(src)
 add_subdirectory(scripts)
 add_subdirectory(man)

--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -794,3 +794,21 @@ void CardinalityVal::Add(const Val* val)
 	delete key;
 	}
 
+ParaglobVal::ParaglobVal(paraglob::Paraglob* p)
+: OpaqueVal(paraglob_type)
+	{
+	this->internal_paraglob = p;
+	}
+
+VectorVal* ParaglobVal::get(StringVal* &pattern)
+	{
+	VectorVal* rval = new VectorVal(internal_type("string_vec")->AsVectorType());
+	std::string string_pattern (pattern->CheckString(), pattern->Len());
+	std::vector<std::string> matches = this->internal_paraglob->get(string_pattern);
+
+	for (unsigned int i = 0; i < matches.size(); i++) {
+		rval->Assign(i, new StringVal(matches.at(i).c_str()));
+	}
+
+	return rval;
+	}

--- a/src/OpaqueVal.h
+++ b/src/OpaqueVal.h
@@ -8,6 +8,7 @@
 #include "RandTest.h"
 #include "Val.h"
 #include "digest.h"
+#include "src/paraglob.h"
 
 namespace probabilistic {
 	class BloomFilter;
@@ -173,6 +174,15 @@ private:
 	probabilistic::CardinalityCounter* c;
 
 	DECLARE_SERIAL(CardinalityVal);
+};
+
+class ParaglobVal : public OpaqueVal {
+public:
+	explicit ParaglobVal(paraglob::Paraglob* p);
+	VectorVal* get(StringVal* &pattern);
+
+private:
+	paraglob::Paraglob* internal_paraglob;
 };
 
 #endif

--- a/src/Type.h
+++ b/src/Type.h
@@ -639,6 +639,7 @@ extern OpaqueType* topk_type;
 extern OpaqueType* bloomfilter_type;
 extern OpaqueType* x509_opaque_type;
 extern OpaqueType* ocsp_resp_opaque_type;
+extern OpaqueType* paraglob_type;
 
 // Returns the Bro basic (non-parameterized) type with the given type.
 // The reference count of the type is not increased.

--- a/src/bro.bif
+++ b/src/bro.bif
@@ -782,6 +782,42 @@ function sha256_hash_finish%(handle: opaque of sha256%): string
 	return static_cast<HashVal*>(handle)->Get();
 	%}
 
+## Initializes and returns a new paraglob.
+##
+## v: Vector of patterns to initialize the paraglob with.
+##
+## Returns: A new, compiled, paraglob with the patterns in *v*
+function paraglob_init%(v: any%) : opaque of paraglob
+	%{
+	if ( v->Type()->Tag() != TYPE_VECTOR ||
+	     v->Type()->YieldType()->Tag() != TYPE_STRING )
+		{
+		builtin_error("paraglob requires a vector for initialization.");
+		return nullptr;
+		}
+
+	std::vector<std::string> patterns;
+	VectorVal* vv = v->AsVectorVal();
+	for ( unsigned int i = 0; i < vv->Size(); ++i )
+		{
+		const BroString* s = vv->Lookup(i)->AsString();
+		patterns.push_back(std::string(s->CheckString(), s->Len()));
+		}
+
+	return new ParaglobVal(new paraglob::Paraglob(patterns));
+	%}
+
+## Gets all the strings inside the handle associated with an input pattern.
+##
+## handle: A compiled paraglob.
+## pattern: A glob style pattern.
+##
+## Returns: A vector of strings matching the input pattern
+function paraglob_get%(handle: opaque of paraglob, pattern: string%): string_vec
+	%{
+	return static_cast<ParaglobVal*>(handle)->get(pattern);
+	%}
+
 ## Returns 32-bit digest of arbitrary input values using FNV-1a hash algorithm.
 ## See `<https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function>`_.
 ##
@@ -3064,7 +3100,7 @@ function strptime%(fmt: string, d: string%) : time
 	const time_t timeval = time_t();
 	struct tm t;
 
-	if ( ! localtime_r(&timeval, &t) || 
+	if ( ! localtime_r(&timeval, &t) ||
 	     ! strptime(d->CheckString(), fmt->CheckString(), &t) )
 		{
 		reporter->Warning("strptime conversion failed: fmt:%s d:%s", fmt->CheckString(), d->CheckString());

--- a/src/main.cc
+++ b/src/main.cc
@@ -122,6 +122,7 @@ OpaqueType* topk_type = 0;
 OpaqueType* bloomfilter_type = 0;
 OpaqueType* x509_opaque_type = 0;
 OpaqueType* ocsp_resp_opaque_type = 0;
+OpaqueType* paraglob_type = 0;
 
 // Keep copy of command line
 int bro_argc;
@@ -810,6 +811,7 @@ int main(int argc, char** argv)
 	bloomfilter_type = new OpaqueType("bloomfilter");
 	x509_opaque_type = new OpaqueType("x509");
 	ocsp_resp_opaque_type = new OpaqueType("ocsp_resp");
+	paraglob_type = new OpaqueType("paraglob");
 
 	// The leak-checker tends to produce some false
 	// positives (memory which had already been

--- a/testing/btest/Baseline/language.paraglob/out
+++ b/testing/btest/Baseline/language.paraglob/out
@@ -1,0 +1,4 @@
+[*, *og, d?g, d[!wl]g]
+[once]
+[*.gov*, *malware*]
+[*.gov*, *malware*]

--- a/testing/btest/language/paraglob.zeek
+++ b/testing/btest/language/paraglob.zeek
@@ -1,0 +1,28 @@
+# @TEST-EXEC: bro -b %INPUT >out
+# @TEST-EXEC: btest-diff out
+
+event zeek_init ()
+{
+  local v1 = vector("*", "d?g", "*og", "d?", "d[!wl]g");
+  local v2 = vector("once", "!o*", "once");
+  local v3 = vector("https://*.google.com/*", "*malware*", "*.gov*");
+
+  local p1 = paraglob_init(v1);
+  local p2: opaque of paraglob = paraglob_init(v2);
+  local p3 = paraglob_init(v3);
+
+  print paraglob_get(p1, "dog");
+  print paraglob_get(p2, "once");
+  print paraglob_get(p3, "www.strange-malware-domain.gov");
+
+  # This looks like a lot, but really should complete quickly.
+  # Paraglob should stop addition of duplicate patterns.
+  local i = 1000000;
+  while (i > 0) {
+    i = i - 1;
+    v3 += v3[1];
+  }
+
+  local large_glob: opaque of paraglob = paraglob_init(v3);
+  print paraglob_get(large_glob, "www.strange-malware-domain.gov");
+}


### PR DESCRIPTION
Resolves #268.

Paraglob is a data structure for quick string matching against a large set of [glob](https://en.wikipedia.org/wiki/Glob_(programming)) style patterns. The algorithm was originally designed and implemented by @rsmmr. Paraglob prefers longer construction times in order to provide fast as operations when it has been constructed. This leads to a rather minimal api inside of Zeek scripts.

The original implementation was slowed by an internal set data-structure with O(N) operations. This moves to a faster `std::vector` only implementation allowing for constant time operations outside of string and pattern matching with an aho-corasick data structure called [Multifast](http://multifast.sourceforge.net/index.php) used with permission of the author Kamiar Kanani.

Internally, paraglob is an `OpaqueType` and its syntax closely follows other similar constructs inside Zeek. A paraglob can only be instantiated once from a vector of patterns and then only supports get operations which return a vector of all patterns matching an input string. The syntax is as follows:

```
  local v = vector("*", "d?g", "*og", "d?", "d[!wl]g");

  local p = paraglob_init(v);

  print paraglob_get(p1, "dog");  
```
out:
```
[*, *og, d?g, d[!wl]g]
```
While performance is machine specific, for a set of 100,000 patterns paraglob can perform some 200,000 queries a second on my ThinkPad with a 2.7GHz i7. The imagined use case for paraglob is that given some class of bad urls or other inputs that you want to categorize, you can quickly match them against a potentially very large set of patterns.

I'll make another pull request shortly for documentation. Look forward to any critiques or additions that people would like. 

One notable point is that while it is technically possible to add additional strings to a paraglob, doing so requires that you re-compile the aho-corasick structure from scratch anyway, so I've hidden the option to add additional patterns after a paraglob has been created. This prevents 'bad' usage where someone might assume that adding to paraglob is similar to adding to a vector or set and do it in a loop where they would experience very poor performance. Adding the option to manually add and then choose when to compile are entirely possible though and I'm open to discussion on rather or not that should be done.