### PR TITLE
Add input file name to additional ASCII reader warning messages

### DIFF
--- a/src/input/readers/ascii/Ascii.cc
+++ b/src/input/readers/ascii/Ascii.cc
@@ -243,8 +243,8 @@ bool Ascii::ReadHeader(bool useCached)
 			map<string, uint32_t>::iterator fit2 = ifields.find(field->secondary_name);
 			if ( fit2 == ifields.end() )
 				{
-				FailWarn(fail_on_file_problem, Fmt("Could not find requested port type field %s in input data file.",
-								 field->secondary_name), true);
+				FailWarn(fail_on_file_problem, Fmt("Could not find requested port type field %s in input data file %s.",
+									field->secondary_name, fname.c_str()), true);
 
 				return false;
 				}
@@ -387,8 +387,8 @@ bool Ascii::DoUpdate()
 
 			if ( (*fit).position > pos || (*fit).secondary_position > pos )
 				{
-				FailWarn(fail_on_invalid_lines, Fmt("Not enough fields in line %s. Found %d fields, want positions %d and %d",
-					  line.c_str(), pos, (*fit).position, (*fit).secondary_position));
+				FailWarn(fail_on_invalid_lines, Fmt("Not enough fields in line '%s' of %s. Found %d fields, want positions %d and %d",
+									line.c_str(), fname.c_str(), pos, (*fit).position, (*fit).secondary_position));
 
 				if ( fail_on_invalid_lines )
 					{
@@ -410,7 +410,7 @@ bool Ascii::DoUpdate()
 
 			if ( val == 0 )
 				{
-				Warning(Fmt("Could not convert line '%s' to Val. Ignoring line.", line.c_str()));
+				Warning(Fmt("Could not convert line '%s' of %s to Val. Ignoring line.", line.c_str(), fname.c_str()));
 				error = true;
 				break;
 				}

--- a/testing/btest/Baseline/scripts.base.frameworks.input.invalidnumbers/.stderrwithoutfirstline
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.invalidnumbers/.stderrwithoutfirstline
@@ -1,8 +1,8 @@
 warning: ../input.log/Input::READER_ASCII: Number '12129223372036854775800' out of supported range.
-warning: ../input.log/Input::READER_ASCII: Could not convert line '12129223372036854775800	121218446744073709551612' to Val. Ignoring line.
+warning: ../input.log/Input::READER_ASCII: Could not convert line '12129223372036854775800	121218446744073709551612' of ../input.log to Val. Ignoring line.
 warning: ../input.log/Input::READER_ASCII: Number '9223372036854775801TEXTHERE' contained non-numeric trailing characters. Ignored trailing characters 'TEXTHERE'
 warning: ../input.log/Input::READER_ASCII: Number '1Justtext' contained non-numeric trailing characters. Ignored trailing characters 'Justtext'
 warning: ../input.log/Input::READER_ASCII: String 'Justtext' contained no parseable number
-warning: ../input.log/Input::READER_ASCII: Could not convert line 'Justtext	1' to Val. Ignoring line.
+warning: ../input.log/Input::READER_ASCII: Could not convert line 'Justtext	1' of ../input.log to Val. Ignoring line.
 received termination signal
 >>>

--- a/testing/btest/Baseline/scripts.base.frameworks.input.invalidset/.stderrwithoutfirstline
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.invalidset/.stderrwithoutfirstline
@@ -1,8 +1,8 @@
 warning: ../input.log/Input::READER_ASCII: Invalid value for subnet: 127.0.0.1
 warning: ../input.log/Input::READER_ASCII: Error while reading set or vector
-warning: ../input.log/Input::READER_ASCII: Could not convert line 'name	127.0.0.1' to Val. Ignoring line.
+warning: ../input.log/Input::READER_ASCII: Could not convert line 'name	127.0.0.1' of ../input.log to Val. Ignoring line.
 warning: ../input.log/Input::READER_ASCII: Invalid value for subnet: 127.0.0.1
 warning: ../input.log/Input::READER_ASCII: Error while reading set or vector
-warning: ../input.log/Input::READER_ASCII: Could not convert line 'name	127.0.0.1' to Val. Ignoring line.
+warning: ../input.log/Input::READER_ASCII: Could not convert line 'name	127.0.0.1' of ../input.log to Val. Ignoring line.
 received termination signal
 >>>

--- a/testing/btest/Baseline/scripts.base.frameworks.input.invalidset/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.invalidset/out
@@ -1,12 +1,12 @@
 TableErrorEvent, Invalid value for subnet: 127.0.0.1, Reporter::WARNING
 TableErrorEvent, Error while reading set or vector, Reporter::WARNING
-TableErrorEvent, Could not convert line 'name\x09127.0.0.1' to Val. Ignoring line., Reporter::WARNING
+TableErrorEvent, Could not convert line 'name\x09127.0.0.1' of ../input.log to Val. Ignoring line., Reporter::WARNING
 Event, [s={
 
 }]
 EventErrorEvent, Invalid value for subnet: 127.0.0.1, Reporter::WARNING
 EventErrorEvent, Error while reading set or vector, Reporter::WARNING
-EventErrorEvent, Could not convert line 'name\x09127.0.0.1' to Val. Ignoring line., Reporter::WARNING
+EventErrorEvent, Could not convert line 'name\x09127.0.0.1' of ../input.log to Val. Ignoring line., Reporter::WARNING
 {
 [name] = [s={
 

--- a/testing/btest/Baseline/scripts.base.frameworks.input.invalidtext/.stderrwithoutfirstline
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.invalidtext/.stderrwithoutfirstline
@@ -1,6 +1,6 @@
 warning: ../input.log/Input::READER_ASCII: String 'l' contained no parseable number
-warning: ../input.log/Input::READER_ASCII: Could not convert line '	l' to Val. Ignoring line.
+warning: ../input.log/Input::READER_ASCII: Could not convert line '	l' of ../input.log to Val. Ignoring line.
 warning: ../input.log/Input::READER_ASCII: String 'l' contained no parseable number
-warning: ../input.log/Input::READER_ASCII: Could not convert line '	l' to Val. Ignoring line.
+warning: ../input.log/Input::READER_ASCII: Could not convert line '	l' of ../input.log to Val. Ignoring line.
 received termination signal
 >>>

--- a/testing/btest/Baseline/scripts.base.frameworks.input.invalidtext/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.invalidtext/out
@@ -1,8 +1,8 @@
 TableErrorEvent, String 'l' contained no parseable number, Reporter::WARNING
-TableErrorEvent, Could not convert line '\x09l' to Val. Ignoring line., Reporter::WARNING
+TableErrorEvent, Could not convert line '\x09l' of ../input.log to Val. Ignoring line., Reporter::WARNING
+EventErrorEvent, String 'l' contained no parseable number, Reporter::WARNING
+EventErrorEvent, Could not convert line '\x09l' of ../input.log to Val. Ignoring line., Reporter::WARNING
+Event, [c=5]
 {
 [] = [c=5]
 }
-EventErrorEvent, String 'l' contained no parseable number, Reporter::WARNING
-EventErrorEvent, Could not convert line '\x09l' to Val. Ignoring line., Reporter::WARNING
-Event, [c=5]


### PR DESCRIPTION
The ASCII reader had a few messages that did not indicate in which
file it notices a problem. With the input framework it simplifies
troubleshooting when that file is spelled out, because you may have
multiple such files on your system.

Includes test baseline updates.