### PR TITLE
RDP: Add weird if specification violated for max channels allowed.

### DIFF
--- a/scripts/base/protocols/rdp/main.zeek
+++ b/scripts/base/protocols/rdp/main.zeek
@@ -204,6 +204,10 @@ event rdp_client_network_data(c: connection, channels: ClientChannelList)
 		c$rdp$client_channels[i] = gsub(channels[i]$name, /\x00+$/, "");
 		}
 
+	if ( |channels| > 31 ) {
+		Reporter::conn_weird("RDP_channels_requested_exceeds_max", c, fmt("%s", |channels|));
+		}
+
 	}
 
 event rdp_gcc_server_create_response(c: connection, result: count) &priority=5


### PR DESCRIPTION
Per discussion in #384 add a weird if the number of channels exceeds the max allowed per the spec.

Note that this doesn't detect CVE-2019-0708.