### PR TITLE
GH-387: update Broker topic names to use "zeek/" prefix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -216,6 +216,39 @@ Changed Functionality
   in scripts has also been updated to replace Sphinx cross-referencing roles
   and directives like ":bro:see:" with ":zeek:zee:".
 
+- Any Broker topic names used in scripts shipped with Zeek that
+  previously were prefixed with "bro/" are now prefixed with "zeek/"
+  instead.
+
+  In the case where external applications were using a "bro/" topic
+  to send data into a Bro process, a Zeek process still subscribes
+  to those topics in addition to the equivalently named "zeek/" topic.
+
+  In the case where external applications were using a "bro/" topic
+  to subscribe to remote messages or query data stores, there's no
+  backwards compatibility and external applications must be changed
+  to use the new "zeek/" topic.  The thought is this change will have
+  low impact since most data published under "bro/" topic names is
+  intended for use only as a detail of implementing cluster-enabled
+  versions of various scripts.
+
+  A list of the most relevant/common topic names that could potentially
+  be used in external applications to consume/query remote data that
+  one may need to change:
+
+  - store names
+    - bro/known/services
+    - bro/known/hosts
+    - bro/known/certs
+
+  - cluster nodes
+    - bro/cluster/<node type>
+    - bro/cluster/node/<name>
+    - bro/cluster/nodeid/<id>
+
+  - logging
+    - bro/logs/<stream>
+
 Removed Functionality
 ---------------------
 

--- a/scripts/base/frameworks/broker/main.zeek
+++ b/scripts/base/frameworks/broker/main.zeek
@@ -113,7 +113,7 @@ export {
 
 	## The default topic prefix where logs will be published.  The log's stream
 	## id is appended when writing to a particular stream.
-	const default_log_topic_prefix = "bro/logs/" &redef;
+	const default_log_topic_prefix = "zeek/logs/" &redef;
 
 	## The default implementation for :zeek:see:`Broker::log_topic`.
 	function default_log_topic(id: Log::ID, path: string): string

--- a/scripts/base/frameworks/cluster/main.zeek
+++ b/scripts/base/frameworks/cluster/main.zeek
@@ -17,31 +17,31 @@ export {
 
 	## The topic name used for exchanging messages that are relevant to
 	## logger nodes in a cluster.  Used with broker-enabled cluster communication.
-	const logger_topic = "bro/cluster/logger" &redef;
+	const logger_topic = "zeek/cluster/logger" &redef;
 
 	## The topic name used for exchanging messages that are relevant to
 	## manager nodes in a cluster.  Used with broker-enabled cluster communication.
-	const manager_topic = "bro/cluster/manager" &redef;
+	const manager_topic = "zeek/cluster/manager" &redef;
 
 	## The topic name used for exchanging messages that are relevant to
 	## proxy nodes in a cluster.  Used with broker-enabled cluster communication.
-	const proxy_topic = "bro/cluster/proxy" &redef;
+	const proxy_topic = "zeek/cluster/proxy" &redef;
 
 	## The topic name used for exchanging messages that are relevant to
 	## worker nodes in a cluster.  Used with broker-enabled cluster communication.
-	const worker_topic = "bro/cluster/worker" &redef;
+	const worker_topic = "zeek/cluster/worker" &redef;
 
 	## The topic name used for exchanging messages that are relevant to
 	## time machine nodes in a cluster.  Used with broker-enabled cluster communication.
-	const time_machine_topic = "bro/cluster/time_machine" &redef;
+	const time_machine_topic = "zeek/cluster/time_machine" &redef;
 
 	## The topic prefix used for exchanging messages that are relevant to
 	## a named node in a cluster.  Used with broker-enabled cluster communication.
-	const node_topic_prefix = "bro/cluster/node/" &redef;
+	const node_topic_prefix = "zeek/cluster/node/" &redef;
 
 	## The topic prefix used for exchanging messages that are relevant to
 	## a unique node in a cluster.  Used with broker-enabled cluster communication.
-	const nodeid_topic_prefix = "bro/cluster/nodeid/" &redef;
+	const nodeid_topic_prefix = "zeek/cluster/nodeid/" &redef;
 
 	## Name of the node on which master data stores will be created if no other
 	## has already been specified by the user in :zeek:see:`Cluster::stores`.

--- a/scripts/base/frameworks/cluster/pools.zeek
+++ b/scripts/base/frameworks/cluster/pools.zeek
@@ -60,17 +60,17 @@ export {
 
 	## The specification for :zeek:see:`Cluster::proxy_pool`.
 	global proxy_pool_spec: PoolSpec =
-		PoolSpec($topic = "bro/cluster/pool/proxy",
+		PoolSpec($topic = "zeek/cluster/pool/proxy",
 				 $node_type = Cluster::PROXY) &redef;
 
 	## The specification for :zeek:see:`Cluster::worker_pool`.
 	global worker_pool_spec: PoolSpec =
-		PoolSpec($topic = "bro/cluster/pool/worker",
+		PoolSpec($topic = "zeek/cluster/pool/worker",
 				 $node_type = Cluster::WORKER) &redef;
 
 	## The specification for :zeek:see:`Cluster::logger_pool`.
 	global logger_pool_spec: PoolSpec =
-		PoolSpec($topic = "bro/cluster/pool/logger",
+		PoolSpec($topic = "zeek/cluster/pool/logger",
 				 $node_type = Cluster::LOGGER) &redef;
 
 	## A pool containing all the proxy nodes of a cluster.

--- a/scripts/policy/protocols/conn/known-hosts.zeek
+++ b/scripts/policy/protocols/conn/known-hosts.zeek
@@ -36,7 +36,7 @@ export {
 	global host_store: Cluster::StoreInfo;
 
 	## The Broker topic name to use for :zeek:see:`Known::host_store`.
-	const host_store_name = "bro/known/hosts" &redef;
+	const host_store_name = "zeek/known/hosts" &redef;
 
 	## The expiry interval of new entries in :zeek:see:`Known::host_store`.
 	## This also changes the interval at which hosts get logged.

--- a/scripts/policy/protocols/conn/known-services.zeek
+++ b/scripts/policy/protocols/conn/known-services.zeek
@@ -48,7 +48,7 @@ export {
 	global service_store: Cluster::StoreInfo;
 
 	## The Broker topic name to use for :zeek:see:`Known::service_store`.
-	const service_store_name = "bro/known/services" &redef;
+	const service_store_name = "zeek/known/services" &redef;
 
 	## The expiry interval of new entries in :zeek:see:`Known::service_store`.
 	## This also changes the interval at which services get logged.

--- a/scripts/policy/protocols/ssl/known-certs.zeek
+++ b/scripts/policy/protocols/ssl/known-certs.zeek
@@ -48,7 +48,7 @@ export {
 	global cert_store: Cluster::StoreInfo;
 
 	## The Broker topic name to use for :zeek:see:`Known::cert_store`.
-	const cert_store_name = "bro/known/certs" &redef;
+	const cert_store_name = "zeek/known/certs" &redef;
 
 	## The expiry interval of new entries in :zeek:see:`Known::cert_store`.
 	## This also changes the interval at which certs get logged.

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -772,6 +772,15 @@ bool Manager::Subscribe(const string& topic_prefix)
 	{
 	DBG_LOG(DBG_BROKER, "Subscribing to topic prefix %s", topic_prefix.c_str());
 	bstate->subscriber.add_topic(topic_prefix, ! after_zeek_init);
+
+	// For backward compatibility, we also may receive messages on
+	// "bro/" topic prefixes in addition to "zeek/".
+	if ( strncmp(topic_prefix.data(), "zeek/", 5) == 0 )
+		{
+		std::string alt_topic = "bro/" + topic_prefix.substr(5);
+		bstate->subscriber.add_topic(std::move(alt_topic), ! after_zeek_init);
+		}
+
 	return true;
 	}
 

--- a/testing/btest/Baseline/plugins.hooks/output
+++ b/testing/btest/Baseline/plugins.hooks/output
@@ -161,9 +161,9 @@
 0.000000   MetaHookPost  CallFunction(Cluster::is_enabled, <frame>, ()) -> <no result>
 0.000000   MetaHookPost  CallFunction(Cluster::is_enabled, <null>, ()) -> <no result>
 0.000000   MetaHookPost  CallFunction(Cluster::local_node_type, <null>, ()) -> <no result>
-0.000000   MetaHookPost  CallFunction(Cluster::register_pool, <frame>, ([topic=bro<...>/logger, node_type=Cluster::LOGGER, max_nodes=<uninitialized>, exclusive=F])) -> <no result>
-0.000000   MetaHookPost  CallFunction(Cluster::register_pool, <frame>, ([topic=bro<...>/proxy, node_type=Cluster::PROXY, max_nodes=<uninitialized>, exclusive=F])) -> <no result>
-0.000000   MetaHookPost  CallFunction(Cluster::register_pool, <frame>, ([topic=bro<...>/worker, node_type=Cluster::WORKER, max_nodes=<uninitialized>, exclusive=F])) -> <no result>
+0.000000   MetaHookPost  CallFunction(Cluster::register_pool, <frame>, ([topic=zeek<...>/logger, node_type=Cluster::LOGGER, max_nodes=<uninitialized>, exclusive=F])) -> <no result>
+0.000000   MetaHookPost  CallFunction(Cluster::register_pool, <frame>, ([topic=zeek<...>/proxy, node_type=Cluster::PROXY, max_nodes=<uninitialized>, exclusive=F])) -> <no result>
+0.000000   MetaHookPost  CallFunction(Cluster::register_pool, <frame>, ([topic=zeek<...>/worker, node_type=Cluster::WORKER, max_nodes=<uninitialized>, exclusive=F])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Files::register_analyzer_add_callback, <frame>, (Files::ANALYZER_EXTRACT, FileExtract::on_add{ if (!FileExtract::args?$extract_filename) FileExtract::args$extract_filename = cat(extract-, FileExtract::f$last_active, -, FileExtract::f$source, -, FileExtract::f$id)FileExtract::f$info$extracted = FileExtract::args$extract_filenameFileExtract::args$extract_filename = build_path_compressed(FileExtract::prefix, FileExtract::args$extract_filename)FileExtract::f$info$extracted_cutoff = Fmkdir(FileExtract::prefix)})) -> <no result>
 0.000000   MetaHookPost  CallFunction(Files::register_for_mime_type, <frame>, (Files::ANALYZER_MD5, application/pkix-cert)) -> <no result>
 0.000000   MetaHookPost  CallFunction(Files::register_for_mime_type, <frame>, (Files::ANALYZER_MD5, application/x-x509-ca-cert)) -> <no result>
@@ -277,7 +277,7 @@
 0.000000   MetaHookPost  CallFunction(Log::__create_stream, <frame>, (Weird::LOG, [columns=Weird::Info, ev=Weird::log_weird, path=weird])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::__create_stream, <frame>, (X509::LOG, [columns=X509::Info, ev=X509::log_x509, path=x509])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::__create_stream, <frame>, (mysql::LOG, [columns=MySQL::Info, ev=MySQL::log_mysql, path=mysql])) -> <no result>
-0.000000   MetaHookPost  CallFunction(Log::__write, <frame>, (PacketFilter::LOG, [ts=1555986109.036092, node=bro, filter=ip or not ip, init=T, success=T])) -> <no result>
+0.000000   MetaHookPost  CallFunction(Log::__write, <frame>, (PacketFilter::LOG, [ts=1559169206.982011, node=bro, filter=ip or not ip, init=T, success=T])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::add_default_filter, <frame>, (Broker::LOG)) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::add_default_filter, <frame>, (Cluster::LOG)) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::add_default_filter, <frame>, (Config::LOG)) -> <no result>
@@ -462,7 +462,7 @@
 0.000000   MetaHookPost  CallFunction(Log::create_stream, <frame>, (Weird::LOG, [columns=Weird::Info, ev=Weird::log_weird, path=weird])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::create_stream, <frame>, (X509::LOG, [columns=X509::Info, ev=X509::log_x509, path=x509])) -> <no result>
 0.000000   MetaHookPost  CallFunction(Log::create_stream, <frame>, (mysql::LOG, [columns=MySQL::Info, ev=MySQL::log_mysql, path=mysql])) -> <no result>
-0.000000   MetaHookPost  CallFunction(Log::write, <frame>, (PacketFilter::LOG, [ts=1555986109.036092, node=bro, filter=ip or not ip, init=T, success=T])) -> <no result>
+0.000000   MetaHookPost  CallFunction(Log::write, <frame>, (PacketFilter::LOG, [ts=1559169206.982011, node=bro, filter=ip or not ip, init=T, success=T])) -> <no result>
 0.000000   MetaHookPost  CallFunction(NetControl::check_plugins, <frame>, ()) -> <no result>
 0.000000   MetaHookPost  CallFunction(NetControl::init, <null>, ()) -> <no result>
 0.000000   MetaHookPost  CallFunction(Notice::want_pp, <frame>, ()) -> <no result>
@@ -1064,9 +1064,9 @@
 0.000000   MetaHookPre   CallFunction(Cluster::is_enabled, <frame>, ())
 0.000000   MetaHookPre   CallFunction(Cluster::is_enabled, <null>, ())
 0.000000   MetaHookPre   CallFunction(Cluster::local_node_type, <null>, ())
-0.000000   MetaHookPre   CallFunction(Cluster::register_pool, <frame>, ([topic=bro<...>/logger, node_type=Cluster::LOGGER, max_nodes=<uninitialized>, exclusive=F]))
-0.000000   MetaHookPre   CallFunction(Cluster::register_pool, <frame>, ([topic=bro<...>/proxy, node_type=Cluster::PROXY, max_nodes=<uninitialized>, exclusive=F]))
-0.000000   MetaHookPre   CallFunction(Cluster::register_pool, <frame>, ([topic=bro<...>/worker, node_type=Cluster::WORKER, max_nodes=<uninitialized>, exclusive=F]))
+0.000000   MetaHookPre   CallFunction(Cluster::register_pool, <frame>, ([topic=zeek<...>/logger, node_type=Cluster::LOGGER, max_nodes=<uninitialized>, exclusive=F]))
+0.000000   MetaHookPre   CallFunction(Cluster::register_pool, <frame>, ([topic=zeek<...>/proxy, node_type=Cluster::PROXY, max_nodes=<uninitialized>, exclusive=F]))
+0.000000   MetaHookPre   CallFunction(Cluster::register_pool, <frame>, ([topic=zeek<...>/worker, node_type=Cluster::WORKER, max_nodes=<uninitialized>, exclusive=F]))
 0.000000   MetaHookPre   CallFunction(Files::register_analyzer_add_callback, <frame>, (Files::ANALYZER_EXTRACT, FileExtract::on_add{ if (!FileExtract::args?$extract_filename) FileExtract::args$extract_filename = cat(extract-, FileExtract::f$last_active, -, FileExtract::f$source, -, FileExtract::f$id)FileExtract::f$info$extracted = FileExtract::args$extract_filenameFileExtract::args$extract_filename = build_path_compressed(FileExtract::prefix, FileExtract::args$extract_filename)FileExtract::f$info$extracted_cutoff = Fmkdir(FileExtract::prefix)}))
 0.000000   MetaHookPre   CallFunction(Files::register_for_mime_type, <frame>, (Files::ANALYZER_MD5, application/pkix-cert))
 0.000000   MetaHookPre   CallFunction(Files::register_for_mime_type, <frame>, (Files::ANALYZER_MD5, application/x-x509-ca-cert))
@@ -1180,7 +1180,7 @@
 0.000000   MetaHookPre   CallFunction(Log::__create_stream, <frame>, (Weird::LOG, [columns=Weird::Info, ev=Weird::log_weird, path=weird]))
 0.000000   MetaHookPre   CallFunction(Log::__create_stream, <frame>, (X509::LOG, [columns=X509::Info, ev=X509::log_x509, path=x509]))
 0.000000   MetaHookPre   CallFunction(Log::__create_stream, <frame>, (mysql::LOG, [columns=MySQL::Info, ev=MySQL::log_mysql, path=mysql]))
-0.000000   MetaHookPre   CallFunction(Log::__write, <frame>, (PacketFilter::LOG, [ts=1555986109.036092, node=bro, filter=ip or not ip, init=T, success=T]))
+0.000000   MetaHookPre   CallFunction(Log::__write, <frame>, (PacketFilter::LOG, [ts=1559169206.982011, node=bro, filter=ip or not ip, init=T, success=T]))
 0.000000   MetaHookPre   CallFunction(Log::add_default_filter, <frame>, (Broker::LOG))
 0.000000   MetaHookPre   CallFunction(Log::add_default_filter, <frame>, (Cluster::LOG))
 0.000000   MetaHookPre   CallFunction(Log::add_default_filter, <frame>, (Config::LOG))
@@ -1365,7 +1365,7 @@
 0.000000   MetaHookPre   CallFunction(Log::create_stream, <frame>, (Weird::LOG, [columns=Weird::Info, ev=Weird::log_weird, path=weird]))
 0.000000   MetaHookPre   CallFunction(Log::create_stream, <frame>, (X509::LOG, [columns=X509::Info, ev=X509::log_x509, path=x509]))
 0.000000   MetaHookPre   CallFunction(Log::create_stream, <frame>, (mysql::LOG, [columns=MySQL::Info, ev=MySQL::log_mysql, path=mysql]))
-0.000000   MetaHookPre   CallFunction(Log::write, <frame>, (PacketFilter::LOG, [ts=1555986109.036092, node=bro, filter=ip or not ip, init=T, success=T]))
+0.000000   MetaHookPre   CallFunction(Log::write, <frame>, (PacketFilter::LOG, [ts=1559169206.982011, node=bro, filter=ip or not ip, init=T, success=T]))
 0.000000   MetaHookPre   CallFunction(NetControl::check_plugins, <frame>, ())
 0.000000   MetaHookPre   CallFunction(NetControl::init, <null>, ())
 0.000000   MetaHookPre   CallFunction(Notice::want_pp, <frame>, ())
@@ -1966,9 +1966,9 @@
 0.000000 | HookCallFunction Analyzer::register_for_ports(Analyzer::ANALYZER_XMPP, {5222<...>/tcp})
 0.000000 | HookCallFunction Cluster::is_enabled()
 0.000000 | HookCallFunction Cluster::local_node_type()
-0.000000 | HookCallFunction Cluster::register_pool([topic=bro<...>/logger, node_type=Cluster::LOGGER, max_nodes=<uninitialized>, exclusive=F])
-0.000000 | HookCallFunction Cluster::register_pool([topic=bro<...>/proxy, node_type=Cluster::PROXY, max_nodes=<uninitialized>, exclusive=F])
-0.000000 | HookCallFunction Cluster::register_pool([topic=bro<...>/worker, node_type=Cluster::WORKER, max_nodes=<uninitialized>, exclusive=F])
+0.000000 | HookCallFunction Cluster::register_pool([topic=zeek<...>/logger, node_type=Cluster::LOGGER, max_nodes=<uninitialized>, exclusive=F])
+0.000000 | HookCallFunction Cluster::register_pool([topic=zeek<...>/proxy, node_type=Cluster::PROXY, max_nodes=<uninitialized>, exclusive=F])
+0.000000 | HookCallFunction Cluster::register_pool([topic=zeek<...>/worker, node_type=Cluster::WORKER, max_nodes=<uninitialized>, exclusive=F])
 0.000000 | HookCallFunction Files::register_analyzer_add_callback(Files::ANALYZER_EXTRACT, FileExtract::on_add{ if (!FileExtract::args?$extract_filename) FileExtract::args$extract_filename = cat(extract-, FileExtract::f$last_active, -, FileExtract::f$source, -, FileExtract::f$id)FileExtract::f$info$extracted = FileExtract::args$extract_filenameFileExtract::args$extract_filename = build_path_compressed(FileExtract::prefix, FileExtract::args$extract_filename)FileExtract::f$info$extracted_cutoff = Fmkdir(FileExtract::prefix)})
 0.000000 | HookCallFunction Files::register_for_mime_type(Files::ANALYZER_MD5, application/pkix-cert)
 0.000000 | HookCallFunction Files::register_for_mime_type(Files::ANALYZER_MD5, application/x-x509-ca-cert)
@@ -2082,7 +2082,7 @@
 0.000000 | HookCallFunction Log::__create_stream(Weird::LOG, [columns=Weird::Info, ev=Weird::log_weird, path=weird])
 0.000000 | HookCallFunction Log::__create_stream(X509::LOG, [columns=X509::Info, ev=X509::log_x509, path=x509])
 0.000000 | HookCallFunction Log::__create_stream(mysql::LOG, [columns=MySQL::Info, ev=MySQL::log_mysql, path=mysql])
-0.000000 | HookCallFunction Log::__write(PacketFilter::LOG, [ts=1555986109.036092, node=bro, filter=ip or not ip, init=T, success=T])
+0.000000 | HookCallFunction Log::__write(PacketFilter::LOG, [ts=1559169206.982011, node=bro, filter=ip or not ip, init=T, success=T])
 0.000000 | HookCallFunction Log::add_default_filter(Broker::LOG)
 0.000000 | HookCallFunction Log::add_default_filter(Cluster::LOG)
 0.000000 | HookCallFunction Log::add_default_filter(Config::LOG)
@@ -2267,7 +2267,7 @@
 0.000000 | HookCallFunction Log::create_stream(Weird::LOG, [columns=Weird::Info, ev=Weird::log_weird, path=weird])
 0.000000 | HookCallFunction Log::create_stream(X509::LOG, [columns=X509::Info, ev=X509::log_x509, path=x509])
 0.000000 | HookCallFunction Log::create_stream(mysql::LOG, [columns=MySQL::Info, ev=MySQL::log_mysql, path=mysql])
-0.000000 | HookCallFunction Log::write(PacketFilter::LOG, [ts=1555986109.036092, node=bro, filter=ip or not ip, init=T, success=T])
+0.000000 | HookCallFunction Log::write(PacketFilter::LOG, [ts=1559169206.982011, node=bro, filter=ip or not ip, init=T, success=T])
 0.000000 | HookCallFunction NetControl::check_plugins()
 0.000000 | HookCallFunction NetControl::init()
 0.000000 | HookCallFunction Notice::want_pp()
@@ -2702,7 +2702,7 @@
 0.000000 | HookLoadFile  base<...>/x509
 0.000000 | HookLoadFile  base<...>/xmpp
 0.000000 | HookLogInit   packet_filter 1/1 {ts (time), node (string), filter (string), init (bool), success (bool)}
-0.000000 | HookLogWrite  packet_filter [ts=1555986109.036092, node=bro, filter=ip or not ip, init=T, success=T]
+0.000000 | HookLogWrite  packet_filter [ts=1559169206.982011, node=bro, filter=ip or not ip, init=T, success=T]
 0.000000 | HookQueueEvent NetControl::init()
 0.000000 | HookQueueEvent filter_change_tracking()
 0.000000 | HookQueueEvent zeek_init()

--- a/testing/btest/Baseline/scripts.base.frameworks.cluster.custom_pool_exclusivity/manager-1..stdout
+++ b/testing/btest/Baseline/scripts.base.frameworks.cluster.custom_pool_exclusivity/manager-1..stdout
@@ -1,101 +1,101 @@
 1st stuff
-hrw, 0, bro/cluster/node/proxy-1
-hrw (custom pool), 0, bro/cluster/node/proxy-2
-hrw, 1, bro/cluster/node/proxy-1
-hrw (custom pool), 1, bro/cluster/node/proxy-2
-hrw, 2, bro/cluster/node/proxy-1
-hrw (custom pool), 2, bro/cluster/node/proxy-2
-hrw, 3, bro/cluster/node/proxy-1
-hrw (custom pool), 3, bro/cluster/node/proxy-2
-hrw, 13, bro/cluster/node/proxy-1
-hrw (custom pool), 13, bro/cluster/node/proxy-2
-hrw, 37, bro/cluster/node/proxy-1
-hrw (custom pool), 37, bro/cluster/node/proxy-2
-hrw, 42, bro/cluster/node/proxy-1
-hrw (custom pool), 42, bro/cluster/node/proxy-2
-hrw, 101, bro/cluster/node/proxy-1
-hrw (custom pool), 101, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-hrw, 0, bro/cluster/node/proxy-1
-hrw (custom pool), 0, bro/cluster/node/proxy-2
-hrw, 1, bro/cluster/node/proxy-1
-hrw (custom pool), 1, bro/cluster/node/proxy-2
-hrw, 2, bro/cluster/node/proxy-1
-hrw (custom pool), 2, bro/cluster/node/proxy-2
-hrw, 3, bro/cluster/node/proxy-1
-hrw (custom pool), 3, bro/cluster/node/proxy-2
-hrw, 13, bro/cluster/node/proxy-1
-hrw (custom pool), 13, bro/cluster/node/proxy-2
-hrw, 37, bro/cluster/node/proxy-1
-hrw (custom pool), 37, bro/cluster/node/proxy-2
-hrw, 42, bro/cluster/node/proxy-1
-hrw (custom pool), 42, bro/cluster/node/proxy-2
-hrw, 101, bro/cluster/node/proxy-1
-hrw (custom pool), 101, bro/cluster/node/proxy-2
+hrw, 0, zeek/cluster/node/proxy-1
+hrw (custom pool), 0, zeek/cluster/node/proxy-2
+hrw, 1, zeek/cluster/node/proxy-1
+hrw (custom pool), 1, zeek/cluster/node/proxy-2
+hrw, 2, zeek/cluster/node/proxy-1
+hrw (custom pool), 2, zeek/cluster/node/proxy-2
+hrw, 3, zeek/cluster/node/proxy-1
+hrw (custom pool), 3, zeek/cluster/node/proxy-2
+hrw, 13, zeek/cluster/node/proxy-1
+hrw (custom pool), 13, zeek/cluster/node/proxy-2
+hrw, 37, zeek/cluster/node/proxy-1
+hrw (custom pool), 37, zeek/cluster/node/proxy-2
+hrw, 42, zeek/cluster/node/proxy-1
+hrw (custom pool), 42, zeek/cluster/node/proxy-2
+hrw, 101, zeek/cluster/node/proxy-1
+hrw (custom pool), 101, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+hrw, 0, zeek/cluster/node/proxy-1
+hrw (custom pool), 0, zeek/cluster/node/proxy-2
+hrw, 1, zeek/cluster/node/proxy-1
+hrw (custom pool), 1, zeek/cluster/node/proxy-2
+hrw, 2, zeek/cluster/node/proxy-1
+hrw (custom pool), 2, zeek/cluster/node/proxy-2
+hrw, 3, zeek/cluster/node/proxy-1
+hrw (custom pool), 3, zeek/cluster/node/proxy-2
+hrw, 13, zeek/cluster/node/proxy-1
+hrw (custom pool), 13, zeek/cluster/node/proxy-2
+hrw, 37, zeek/cluster/node/proxy-1
+hrw (custom pool), 37, zeek/cluster/node/proxy-2
+hrw, 42, zeek/cluster/node/proxy-1
+hrw (custom pool), 42, zeek/cluster/node/proxy-2
+hrw, 101, zeek/cluster/node/proxy-1
+hrw (custom pool), 101, zeek/cluster/node/proxy-2
 2nd stuff
 hrw, 0, 
-hrw (custom pool), 0, bro/cluster/node/proxy-2
+hrw (custom pool), 0, zeek/cluster/node/proxy-2
 hrw, 1, 
-hrw (custom pool), 1, bro/cluster/node/proxy-2
+hrw (custom pool), 1, zeek/cluster/node/proxy-2
 hrw, 2, 
-hrw (custom pool), 2, bro/cluster/node/proxy-2
+hrw (custom pool), 2, zeek/cluster/node/proxy-2
 hrw, 3, 
-hrw (custom pool), 3, bro/cluster/node/proxy-2
+hrw (custom pool), 3, zeek/cluster/node/proxy-2
 hrw, 13, 
-hrw (custom pool), 13, bro/cluster/node/proxy-2
+hrw (custom pool), 13, zeek/cluster/node/proxy-2
 hrw, 37, 
-hrw (custom pool), 37, bro/cluster/node/proxy-2
+hrw (custom pool), 37, zeek/cluster/node/proxy-2
 hrw, 42, 
-hrw (custom pool), 42, bro/cluster/node/proxy-2
+hrw (custom pool), 42, zeek/cluster/node/proxy-2
 hrw, 101, 
-hrw (custom pool), 101, bro/cluster/node/proxy-2
+hrw (custom pool), 101, zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 hrw, 0, 
-hrw (custom pool), 0, bro/cluster/node/proxy-2
+hrw (custom pool), 0, zeek/cluster/node/proxy-2
 hrw, 1, 
-hrw (custom pool), 1, bro/cluster/node/proxy-2
+hrw (custom pool), 1, zeek/cluster/node/proxy-2
 hrw, 2, 
-hrw (custom pool), 2, bro/cluster/node/proxy-2
+hrw (custom pool), 2, zeek/cluster/node/proxy-2
 hrw, 3, 
-hrw (custom pool), 3, bro/cluster/node/proxy-2
+hrw (custom pool), 3, zeek/cluster/node/proxy-2
 hrw, 13, 
-hrw (custom pool), 13, bro/cluster/node/proxy-2
+hrw (custom pool), 13, zeek/cluster/node/proxy-2
 hrw, 37, 
-hrw (custom pool), 37, bro/cluster/node/proxy-2
+hrw (custom pool), 37, zeek/cluster/node/proxy-2
 hrw, 42, 
-hrw (custom pool), 42, bro/cluster/node/proxy-2
+hrw (custom pool), 42, zeek/cluster/node/proxy-2
 hrw, 101, 
-hrw (custom pool), 101, bro/cluster/node/proxy-2
+hrw (custom pool), 101, zeek/cluster/node/proxy-2
 no stuff
 hrw, 0, 
 hrw (custom pool), 0, 

--- a/testing/btest/Baseline/scripts.base.frameworks.cluster.custom_pool_limits/manager-1..stdout
+++ b/testing/btest/Baseline/scripts.base.frameworks.cluster.custom_pool_limits/manager-1..stdout
@@ -1,101 +1,101 @@
 1st stuff
-hrw, 0, bro/cluster/node/proxy-1
-hrw (custom pool), 0, bro/cluster/node/proxy-1
-hrw, 1, bro/cluster/node/proxy-1
-hrw (custom pool), 1, bro/cluster/node/proxy-1
-hrw, 2, bro/cluster/node/proxy-1
-hrw (custom pool), 2, bro/cluster/node/proxy-1
-hrw, 3, bro/cluster/node/proxy-1
-hrw (custom pool), 3, bro/cluster/node/proxy-1
-hrw, 13, bro/cluster/node/proxy-1
-hrw (custom pool), 13, bro/cluster/node/proxy-2
-hrw, 37, bro/cluster/node/proxy-1
-hrw (custom pool), 37, bro/cluster/node/proxy-2
-hrw, 42, bro/cluster/node/proxy-1
-hrw (custom pool), 42, bro/cluster/node/proxy-2
-hrw, 101, bro/cluster/node/proxy-1
-hrw (custom pool), 101, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-1
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-1
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-1
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-1
-rr, bro/cluster/node/proxy-1
-rr (custom pool), bro/cluster/node/proxy-2
-hrw, 0, bro/cluster/node/proxy-1
-hrw (custom pool), 0, bro/cluster/node/proxy-1
-hrw, 1, bro/cluster/node/proxy-1
-hrw (custom pool), 1, bro/cluster/node/proxy-1
-hrw, 2, bro/cluster/node/proxy-1
-hrw (custom pool), 2, bro/cluster/node/proxy-1
-hrw, 3, bro/cluster/node/proxy-1
-hrw (custom pool), 3, bro/cluster/node/proxy-1
-hrw, 13, bro/cluster/node/proxy-1
-hrw (custom pool), 13, bro/cluster/node/proxy-2
-hrw, 37, bro/cluster/node/proxy-1
-hrw (custom pool), 37, bro/cluster/node/proxy-2
-hrw, 42, bro/cluster/node/proxy-1
-hrw (custom pool), 42, bro/cluster/node/proxy-2
-hrw, 101, bro/cluster/node/proxy-1
-hrw (custom pool), 101, bro/cluster/node/proxy-2
+hrw, 0, zeek/cluster/node/proxy-1
+hrw (custom pool), 0, zeek/cluster/node/proxy-1
+hrw, 1, zeek/cluster/node/proxy-1
+hrw (custom pool), 1, zeek/cluster/node/proxy-1
+hrw, 2, zeek/cluster/node/proxy-1
+hrw (custom pool), 2, zeek/cluster/node/proxy-1
+hrw, 3, zeek/cluster/node/proxy-1
+hrw (custom pool), 3, zeek/cluster/node/proxy-1
+hrw, 13, zeek/cluster/node/proxy-1
+hrw (custom pool), 13, zeek/cluster/node/proxy-2
+hrw, 37, zeek/cluster/node/proxy-1
+hrw (custom pool), 37, zeek/cluster/node/proxy-2
+hrw, 42, zeek/cluster/node/proxy-1
+hrw (custom pool), 42, zeek/cluster/node/proxy-2
+hrw, 101, zeek/cluster/node/proxy-1
+hrw (custom pool), 101, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-1
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-1
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-1
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-1
+rr, zeek/cluster/node/proxy-1
+rr (custom pool), zeek/cluster/node/proxy-2
+hrw, 0, zeek/cluster/node/proxy-1
+hrw (custom pool), 0, zeek/cluster/node/proxy-1
+hrw, 1, zeek/cluster/node/proxy-1
+hrw (custom pool), 1, zeek/cluster/node/proxy-1
+hrw, 2, zeek/cluster/node/proxy-1
+hrw (custom pool), 2, zeek/cluster/node/proxy-1
+hrw, 3, zeek/cluster/node/proxy-1
+hrw (custom pool), 3, zeek/cluster/node/proxy-1
+hrw, 13, zeek/cluster/node/proxy-1
+hrw (custom pool), 13, zeek/cluster/node/proxy-2
+hrw, 37, zeek/cluster/node/proxy-1
+hrw (custom pool), 37, zeek/cluster/node/proxy-2
+hrw, 42, zeek/cluster/node/proxy-1
+hrw (custom pool), 42, zeek/cluster/node/proxy-2
+hrw, 101, zeek/cluster/node/proxy-1
+hrw (custom pool), 101, zeek/cluster/node/proxy-2
 2nd stuff
 hrw, 0, 
-hrw (custom pool), 0, bro/cluster/node/proxy-2
+hrw (custom pool), 0, zeek/cluster/node/proxy-2
 hrw, 1, 
-hrw (custom pool), 1, bro/cluster/node/proxy-2
+hrw (custom pool), 1, zeek/cluster/node/proxy-2
 hrw, 2, 
-hrw (custom pool), 2, bro/cluster/node/proxy-2
+hrw (custom pool), 2, zeek/cluster/node/proxy-2
 hrw, 3, 
-hrw (custom pool), 3, bro/cluster/node/proxy-2
+hrw (custom pool), 3, zeek/cluster/node/proxy-2
 hrw, 13, 
-hrw (custom pool), 13, bro/cluster/node/proxy-2
+hrw (custom pool), 13, zeek/cluster/node/proxy-2
 hrw, 37, 
-hrw (custom pool), 37, bro/cluster/node/proxy-2
+hrw (custom pool), 37, zeek/cluster/node/proxy-2
 hrw, 42, 
-hrw (custom pool), 42, bro/cluster/node/proxy-2
+hrw (custom pool), 42, zeek/cluster/node/proxy-2
 hrw, 101, 
-hrw (custom pool), 101, bro/cluster/node/proxy-2
+hrw (custom pool), 101, zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 rr, 
-rr (custom pool), bro/cluster/node/proxy-2
+rr (custom pool), zeek/cluster/node/proxy-2
 hrw, 0, 
-hrw (custom pool), 0, bro/cluster/node/proxy-2
+hrw (custom pool), 0, zeek/cluster/node/proxy-2
 hrw, 1, 
-hrw (custom pool), 1, bro/cluster/node/proxy-2
+hrw (custom pool), 1, zeek/cluster/node/proxy-2
 hrw, 2, 
-hrw (custom pool), 2, bro/cluster/node/proxy-2
+hrw (custom pool), 2, zeek/cluster/node/proxy-2
 hrw, 3, 
-hrw (custom pool), 3, bro/cluster/node/proxy-2
+hrw (custom pool), 3, zeek/cluster/node/proxy-2
 hrw, 13, 
-hrw (custom pool), 13, bro/cluster/node/proxy-2
+hrw (custom pool), 13, zeek/cluster/node/proxy-2
 hrw, 37, 
-hrw (custom pool), 37, bro/cluster/node/proxy-2
+hrw (custom pool), 37, zeek/cluster/node/proxy-2
 hrw, 42, 
-hrw (custom pool), 42, bro/cluster/node/proxy-2
+hrw (custom pool), 42, zeek/cluster/node/proxy-2
 hrw, 101, 
-hrw (custom pool), 101, bro/cluster/node/proxy-2
+hrw (custom pool), 101, zeek/cluster/node/proxy-2
 no stuff
 hrw, 0, 
 hrw (custom pool), 0, 

--- a/testing/btest/Baseline/scripts.base.frameworks.cluster.topic_distribution/manager-1..stdout
+++ b/testing/btest/Baseline/scripts.base.frameworks.cluster.topic_distribution/manager-1..stdout
@@ -1,53 +1,53 @@
 1st stuff
-hrw, 0, bro/cluster/node/proxy-1
-hrw, 1, bro/cluster/node/proxy-1
-hrw, 2, bro/cluster/node/proxy-1
-hrw, 3, bro/cluster/node/proxy-1
-hrw, 13, bro/cluster/node/proxy-2
-hrw, 37, bro/cluster/node/proxy-2
-hrw, 42, bro/cluster/node/proxy-2
-hrw, 101, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-1
-rr, bro/cluster/node/proxy-2
-hrw, 0, bro/cluster/node/proxy-1
-hrw, 1, bro/cluster/node/proxy-1
-hrw, 2, bro/cluster/node/proxy-1
-hrw, 3, bro/cluster/node/proxy-1
-hrw, 13, bro/cluster/node/proxy-2
-hrw, 37, bro/cluster/node/proxy-2
-hrw, 42, bro/cluster/node/proxy-2
-hrw, 101, bro/cluster/node/proxy-2
+hrw, 0, zeek/cluster/node/proxy-1
+hrw, 1, zeek/cluster/node/proxy-1
+hrw, 2, zeek/cluster/node/proxy-1
+hrw, 3, zeek/cluster/node/proxy-1
+hrw, 13, zeek/cluster/node/proxy-2
+hrw, 37, zeek/cluster/node/proxy-2
+hrw, 42, zeek/cluster/node/proxy-2
+hrw, 101, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-1
+rr, zeek/cluster/node/proxy-2
+hrw, 0, zeek/cluster/node/proxy-1
+hrw, 1, zeek/cluster/node/proxy-1
+hrw, 2, zeek/cluster/node/proxy-1
+hrw, 3, zeek/cluster/node/proxy-1
+hrw, 13, zeek/cluster/node/proxy-2
+hrw, 37, zeek/cluster/node/proxy-2
+hrw, 42, zeek/cluster/node/proxy-2
+hrw, 101, zeek/cluster/node/proxy-2
 2nd stuff
-hrw, 0, bro/cluster/node/proxy-2
-hrw, 1, bro/cluster/node/proxy-2
-hrw, 2, bro/cluster/node/proxy-2
-hrw, 3, bro/cluster/node/proxy-2
-hrw, 13, bro/cluster/node/proxy-2
-hrw, 37, bro/cluster/node/proxy-2
-hrw, 42, bro/cluster/node/proxy-2
-hrw, 101, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-2
-rr, bro/cluster/node/proxy-2
-hrw, 0, bro/cluster/node/proxy-2
-hrw, 1, bro/cluster/node/proxy-2
-hrw, 2, bro/cluster/node/proxy-2
-hrw, 3, bro/cluster/node/proxy-2
-hrw, 13, bro/cluster/node/proxy-2
-hrw, 37, bro/cluster/node/proxy-2
-hrw, 42, bro/cluster/node/proxy-2
-hrw, 101, bro/cluster/node/proxy-2
+hrw, 0, zeek/cluster/node/proxy-2
+hrw, 1, zeek/cluster/node/proxy-2
+hrw, 2, zeek/cluster/node/proxy-2
+hrw, 3, zeek/cluster/node/proxy-2
+hrw, 13, zeek/cluster/node/proxy-2
+hrw, 37, zeek/cluster/node/proxy-2
+hrw, 42, zeek/cluster/node/proxy-2
+hrw, 101, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-2
+rr, zeek/cluster/node/proxy-2
+hrw, 0, zeek/cluster/node/proxy-2
+hrw, 1, zeek/cluster/node/proxy-2
+hrw, 2, zeek/cluster/node/proxy-2
+hrw, 3, zeek/cluster/node/proxy-2
+hrw, 13, zeek/cluster/node/proxy-2
+hrw, 37, zeek/cluster/node/proxy-2
+hrw, 42, zeek/cluster/node/proxy-2
+hrw, 101, zeek/cluster/node/proxy-2
 no stuff
 hrw, 0, 
 hrw, 1, 

--- a/testing/btest/Baseline/scripts.base.frameworks.netcontrol.acld/send.netcontrol.log
+++ b/testing/btest/Baseline/scripts.base.frameworks.netcontrol.acld/send.netcontrol.log
@@ -6,20 +6,20 @@
 #open	2017-04-07-17-26-05
 #fields	ts	rule_id	category	cmd	state	action	target	entity_type	entity	mod	msg	priority	expire	location	plugin
 #types	time	string	enum	string	enum	string	enum	string	string	string	string	int	interval	string	string
-0.000000	-	NetControl::MESSAGE	-	-	-	-	-	-	-	activating plugin with priority 0	-	-	-	Acld-bro/event/netcontroltest
+0.000000	-	NetControl::MESSAGE	-	-	-	-	-	-	-	activating plugin with priority 0	-	-	-	Acld-zeek/event/netcontroltest
 0.000000	-	NetControl::MESSAGE	-	-	-	-	-	-	-	waiting for plugins to initialize	-	-	-	-
-1491585965.002956	-	NetControl::MESSAGE	-	-	-	-	-	-	-	activation finished	-	-	-	Acld-bro/event/netcontroltest
+1491585965.002956	-	NetControl::MESSAGE	-	-	-	-	-	-	-	activation finished	-	-	-	Acld-zeek/event/netcontroltest
 1491585965.002956	-	NetControl::MESSAGE	-	-	-	-	-	-	-	plugin initialization done	-	-	-	-
-1491585965.027155	2	NetControl::RULE	ADD	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	192.168.18.50/32/*->74.125.239.97/32/*	-	-	0	36000.000000	here	Acld-bro/event/netcontroltest
-1491585965.027155	3	NetControl::RULE	ADD	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	*/*->*/443	-	-	0	36000.000000	there	Acld-bro/event/netcontroltest
-1491585965.027155	4	NetControl::RULE	ADD	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	192.168.18.50/32	-	-	0	36000.000000	-	Acld-bro/event/netcontroltest
-1491585965.027706	2	NetControl::RULE	ADD	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	192.168.18.50/32/*->74.125.239.97/32/*	-	blockhosthost	0	36000.000000	here	Acld-bro/event/netcontroltest
-1491585965.027706	2	NetControl::RULE	REMOVE	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	192.168.18.50/32/*->74.125.239.97/32/*	-	-	0	36000.000000	here	Acld-bro/event/netcontroltest
-1491585965.027706	3	NetControl::RULE	ADD	NetControl::EXISTS	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	*/*->*/443	-	droptcpport	0	36000.000000	there	Acld-bro/event/netcontroltest
-1491585965.027706	3	NetControl::RULE	REMOVE	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	*/*->*/443	-	-	0	36000.000000	there	Acld-bro/event/netcontroltest
-1491585965.027706	4	NetControl::RULE	ADD	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	192.168.18.50/32	-	drop	0	36000.000000	-	Acld-bro/event/netcontroltest
-1491585965.027706	4	NetControl::RULE	REMOVE	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	192.168.18.50/32	-	-	0	36000.000000	-	Acld-bro/event/netcontroltest
-1491585965.027706	2	NetControl::ERROR	-	-	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	192.168.18.50/32/*->74.125.239.97/32/*	-	restorehosthost	0	36000.000000	here	Acld-bro/event/netcontroltest
-1491585965.027706	3	NetControl::RULE	REMOVE	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	*/*->*/443	-	restoretcpport	0	36000.000000	there	Acld-bro/event/netcontroltest
-1491585965.027706	4	NetControl::RULE	REMOVE	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	192.168.18.50/32	-	restore	0	36000.000000	-	Acld-bro/event/netcontroltest
+1491585965.027155	2	NetControl::RULE	ADD	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	192.168.18.50/32/*->74.125.239.97/32/*	-	-	0	36000.000000	here	Acld-zeek/event/netcontroltest
+1491585965.027155	3	NetControl::RULE	ADD	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	*/*->*/443	-	-	0	36000.000000	there	Acld-zeek/event/netcontroltest
+1491585965.027155	4	NetControl::RULE	ADD	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	192.168.18.50/32	-	-	0	36000.000000	-	Acld-zeek/event/netcontroltest
+1491585965.027706	2	NetControl::RULE	ADD	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	192.168.18.50/32/*->74.125.239.97/32/*	-	blockhosthost	0	36000.000000	here	Acld-zeek/event/netcontroltest
+1491585965.027706	2	NetControl::RULE	REMOVE	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	192.168.18.50/32/*->74.125.239.97/32/*	-	-	0	36000.000000	here	Acld-zeek/event/netcontroltest
+1491585965.027706	3	NetControl::RULE	ADD	NetControl::EXISTS	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	*/*->*/443	-	droptcpport	0	36000.000000	there	Acld-zeek/event/netcontroltest
+1491585965.027706	3	NetControl::RULE	REMOVE	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	*/*->*/443	-	-	0	36000.000000	there	Acld-zeek/event/netcontroltest
+1491585965.027706	4	NetControl::RULE	ADD	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	192.168.18.50/32	-	drop	0	36000.000000	-	Acld-zeek/event/netcontroltest
+1491585965.027706	4	NetControl::RULE	REMOVE	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	192.168.18.50/32	-	-	0	36000.000000	-	Acld-zeek/event/netcontroltest
+1491585965.027706	2	NetControl::ERROR	-	-	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	192.168.18.50/32/*->74.125.239.97/32/*	-	restorehosthost	0	36000.000000	here	Acld-zeek/event/netcontroltest
+1491585965.027706	3	NetControl::RULE	REMOVE	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::FLOW	*/*->*/443	-	restoretcpport	0	36000.000000	there	Acld-zeek/event/netcontroltest
+1491585965.027706	4	NetControl::RULE	REMOVE	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	192.168.18.50/32	-	restore	0	36000.000000	-	Acld-zeek/event/netcontroltest
 #close	2017-04-07-17-26-05

--- a/testing/btest/Baseline/scripts.base.frameworks.netcontrol.broker/send.netcontrol.log
+++ b/testing/btest/Baseline/scripts.base.frameworks.netcontrol.broker/send.netcontrol.log
@@ -6,15 +6,15 @@
 #open	2016-08-05-17-34-55
 #fields	ts	rule_id	category	cmd	state	action	target	entity_type	entity	mod	msg	priority	expire	location	plugin
 #types	time	string	enum	string	enum	string	enum	string	string	string	string	int	interval	string	string
-0.000000	-	NetControl::MESSAGE	-	-	-	-	-	-	-	activating plugin with priority 0	-	-	-	Broker-bro/event/netcontroltest
+0.000000	-	NetControl::MESSAGE	-	-	-	-	-	-	-	activating plugin with priority 0	-	-	-	Broker-zeek/event/netcontroltest
 0.000000	-	NetControl::MESSAGE	-	-	-	-	-	-	-	waiting for plugins to initialize	-	-	-	-
-1470418495.661396	-	NetControl::MESSAGE	-	-	-	-	-	-	-	activation finished	-	-	-	Broker-bro/event/netcontroltest
+1470418495.661396	-	NetControl::MESSAGE	-	-	-	-	-	-	-	activation finished	-	-	-	Broker-zeek/event/netcontroltest
 1470418495.661396	-	NetControl::MESSAGE	-	-	-	-	-	-	-	plugin initialization done	-	-	-	-
-1470418496.045332	2	NetControl::RULE	ADD	NetControl::REQUESTED	NetControl::DROP	NetControl::MONITOR	NetControl::FLOW	10.10.1.4/32/1470->74.53.140.153/32/25	-	-	0	36000.000000	-	Broker-bro/event/netcontroltest
-1470418496.045332	3	NetControl::RULE	ADD	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	10.10.1.4/32	-	-	0	36000.000000	-	Broker-bro/event/netcontroltest
-1470418496.045364	2	NetControl::RULE	ADD	NetControl::EXISTS	NetControl::DROP	NetControl::MONITOR	NetControl::FLOW	10.10.1.4/32/1470->74.53.140.153/32/25	-	-	0	36000.000000	-	Broker-bro/event/netcontroltest
-1470418496.045364	2	NetControl::RULE	EXPIRE	NetControl::TIMEOUT	NetControl::DROP	NetControl::MONITOR	NetControl::FLOW	10.10.1.4/32/1470->74.53.140.153/32/25	-	-	0	36000.000000	-	Broker-bro/event/netcontroltest
-1470418496.045364	3	NetControl::RULE	ADD	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	10.10.1.4/32	-	-	0	36000.000000	-	Broker-bro/event/netcontroltest
-1470418496.045364	3	NetControl::RULE	REMOVE	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	10.10.1.4/32	-	removing	0	36000.000000	-	Broker-bro/event/netcontroltest
-1470418496.045364	3	NetControl::RULE	REMOVE	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	10.10.1.4/32	-	-	0	36000.000000	-	Broker-bro/event/netcontroltest
+1470418496.045332	2	NetControl::RULE	ADD	NetControl::REQUESTED	NetControl::DROP	NetControl::MONITOR	NetControl::FLOW	10.10.1.4/32/1470->74.53.140.153/32/25	-	-	0	36000.000000	-	Broker-zeek/event/netcontroltest
+1470418496.045332	3	NetControl::RULE	ADD	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	10.10.1.4/32	-	-	0	36000.000000	-	Broker-zeek/event/netcontroltest
+1470418496.045364	2	NetControl::RULE	ADD	NetControl::EXISTS	NetControl::DROP	NetControl::MONITOR	NetControl::FLOW	10.10.1.4/32/1470->74.53.140.153/32/25	-	-	0	36000.000000	-	Broker-zeek/event/netcontroltest
+1470418496.045364	2	NetControl::RULE	EXPIRE	NetControl::TIMEOUT	NetControl::DROP	NetControl::MONITOR	NetControl::FLOW	10.10.1.4/32/1470->74.53.140.153/32/25	-	-	0	36000.000000	-	Broker-zeek/event/netcontroltest
+1470418496.045364	3	NetControl::RULE	ADD	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	10.10.1.4/32	-	-	0	36000.000000	-	Broker-zeek/event/netcontroltest
+1470418496.045364	3	NetControl::RULE	REMOVE	NetControl::REQUESTED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	10.10.1.4/32	-	removing	0	36000.000000	-	Broker-zeek/event/netcontroltest
+1470418496.045364	3	NetControl::RULE	REMOVE	NetControl::SUCCEEDED	NetControl::DROP	NetControl::FORWARD	NetControl::ADDRESS	10.10.1.4/32	-	-	0	36000.000000	-	Broker-zeek/event/netcontroltest
 #close	2016-08-05-17-34-56

--- a/testing/btest/broker/connect-on-retry.zeek
+++ b/testing/btest/broker/connect-on-retry.zeek
@@ -18,8 +18,8 @@ global ping: event(msg: string, c: count);
 
 event zeek_init()
     {
-    Broker::subscribe("bro/event/my_topic");
-    Broker::auto_publish("bro/event/my_topic", ping);
+    Broker::subscribe("zeek/event/my_topic");
+    Broker::auto_publish("zeek/event/my_topic", ping);
     Broker::peer("127.0.0.1", to_port(getenv("BROKER_PORT")));
     }
 
@@ -67,8 +67,8 @@ event delayed_listen()
 
 event zeek_init()
         {
-        Broker::subscribe("bro/event/my_topic");
-	Broker::auto_publish("bro/event/my_topic", pong);
+        Broker::subscribe("zeek/event/my_topic");
+        Broker::auto_publish("zeek/event/my_topic", pong);
 	schedule 5secs { delayed_listen() };
         }
 

--- a/testing/btest/broker/disconnect.zeek
+++ b/testing/btest/broker/disconnect.zeek
@@ -17,7 +17,7 @@
 redef exit_only_after_terminate = T;
 
 global peers = 0;
-const test_topic = "bro/test/my_topic";
+const test_topic = "zeek/test/my_topic";
 
 event my_event(i: count)
 	{
@@ -52,7 +52,7 @@ event Broker::peer_added(endpoint: Broker::EndpointInfo, msg: string)
 
 redef exit_only_after_terminate = T;
 
-const test_topic = "bro/test/my_topic";
+const test_topic = "zeek/test/my_topic";
 
 event my_event(i: count)
 	{

--- a/testing/btest/broker/error.zeek
+++ b/testing/btest/broker/error.zeek
@@ -29,8 +29,8 @@ event Broker::error(code: Broker::ErrorCode, msg: string)
 
 event zeek_init()
     {
-    Broker::subscribe("bro/event/my_topic");
-    
+    Broker::subscribe("zeek/event/my_topic");
+
     schedule 2secs { do_something() };
     schedule 4secs { do_terminate() };
     }

--- a/testing/btest/broker/remote_event.zeek
+++ b/testing/btest/broker/remote_event.zeek
@@ -17,7 +17,7 @@ global ping: event(msg: string, c: count);
 
 event zeek_init()
     {
-    Broker::subscribe("bro/event/my_topic");
+    Broker::subscribe("zeek/event/my_topic");
     Broker::peer("127.0.0.1", to_port(getenv("BROKER_PORT")));
     print "is_remote should be F, and is", is_remote_event();
     }
@@ -26,7 +26,7 @@ function send_event()
     {
     ++event_count;
     local e = Broker::make_event(ping, "my-message", event_count);
-    Broker::publish("bro/event/my_topic", e);
+    Broker::publish("zeek/event/my_topic", e);
     }
 
 event Broker::peer_added(endpoint: Broker::EndpointInfo, msg: string)
@@ -66,7 +66,7 @@ global pong: event(msg: string, c: count);
 
 event zeek_init()
         {
-        Broker::subscribe("bro/event/my_topic");
+        Broker::subscribe("zeek/event/my_topic");
         Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
         }
 
@@ -93,7 +93,7 @@ event ping(msg: string, n: count)
                 }
 
         local e = Broker::make_event(pong, msg, n);
-        Broker::publish("bro/event/my_topic", e);
+        Broker::publish("zeek/event/my_topic", e);
         }
 
 @TEST-END-FILE

--- a/testing/btest/broker/remote_event_any.zeek
+++ b/testing/btest/broker/remote_event_any.zeek
@@ -17,7 +17,7 @@ global ping: event(msg: string, c: any);
 
 event zeek_init()
     {
-    Broker::subscribe("bro/event/my_topic");
+    Broker::subscribe("zeek/event/my_topic");
     Broker::peer("127.0.0.1", to_port(getenv("BROKER_PORT")));
     print "is_remote should be F, and is", is_remote_event();
     }
@@ -26,7 +26,7 @@ function send_event()
     {
     ++event_count;
     local e = Broker::make_event(ping, "my-message", event_count);
-    Broker::publish("bro/event/my_topic", e);
+    Broker::publish("zeek/event/my_topic", e);
     }
 
 event Broker::peer_added(endpoint: Broker::EndpointInfo, msg: string)
@@ -69,7 +69,7 @@ global pong: event(msg: string, c: any);
 
 event zeek_init()
         {
-        Broker::subscribe("bro/event/my_topic");
+        Broker::subscribe("zeek/event/my_topic");
         Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
         }
 
@@ -98,10 +98,10 @@ event ping(msg: string, n: any)
                 }
 
 		if ( (n as count) % 2 == 0 )
-			Broker::publish("bro/event/my_topic", pong, msg, n as count);
+			Broker::publish("zeek/event/my_topic", pong, msg, n as count);
 		else
 			# internals should not wrap n into another Broker::Data record
-			Broker::publish("bro/event/my_topic", pong, msg, n);
+			Broker::publish("zeek/event/my_topic", pong, msg, n);
         }
 
 @TEST-END-FILE

--- a/testing/btest/broker/remote_event_auto.zeek
+++ b/testing/btest/broker/remote_event_auto.zeek
@@ -17,8 +17,8 @@ global ping: event(msg: string, c: count);
 
 event zeek_init()
     {
-    Broker::subscribe("bro/event/my_topic");
-    Broker::auto_publish("bro/event/my_topic", ping);
+    Broker::subscribe("zeek/event/my_topic");
+    Broker::auto_publish("zeek/event/my_topic", ping);
     Broker::peer("127.0.0.1", to_port(getenv("BROKER_PORT")));
     }
 
@@ -61,8 +61,8 @@ global pong: event(msg: string, c: count);
 
 event zeek_init()
         {
-        Broker::subscribe("bro/event/my_topic");
-	Broker::auto_publish("bro/event/my_topic", pong);
+        Broker::subscribe("zeek/event/my_topic");
+        Broker::auto_publish("zeek/event/my_topic", pong);
         Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
         }
 

--- a/testing/btest/broker/remote_event_ssl_auth.zeek
+++ b/testing/btest/broker/remote_event_ssl_auth.zeek
@@ -176,7 +176,7 @@ global ping: event(msg: string, c: count);
 
 event zeek_init()
     {
-    Broker::subscribe("bro/event/my_topic");
+    Broker::subscribe("zeek/event/my_topic");
     Broker::peer("127.0.0.1", to_port(getenv("BROKER_PORT")));
     }
 
@@ -184,7 +184,7 @@ function send_event()
     {
     ++event_count;
     local e = Broker::make_event(ping, "my-message", event_count);
-    Broker::publish("bro/event/my_topic", e);
+    Broker::publish("zeek/event/my_topic", e);
     }
 
 event Broker::peer_added(endpoint: Broker::EndpointInfo, msg: string)
@@ -227,7 +227,7 @@ global pong: event(msg: string, c: count);
 
 event zeek_init()
         {
-        Broker::subscribe("bro/event/my_topic");
+        Broker::subscribe("zeek/event/my_topic");
         Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
         }
 
@@ -253,7 +253,7 @@ event ping(msg: string, n: count)
                 }
 
         local e = Broker::make_event(pong, msg, n);
-        Broker::publish("bro/event/my_topic", e);
+        Broker::publish("zeek/event/my_topic", e);
         }
 
 @TEST-END-FILE

--- a/testing/btest/broker/remote_id.zeek
+++ b/testing/btest/broker/remote_id.zeek
@@ -24,7 +24,7 @@ event Broker::peer_lost(endpoint: Broker::EndpointInfo, msg: string)
 event Broker::peer_added(endpoint: Broker::EndpointInfo, msg: string)
 	{
 	print "peer added";
-	Broker::publish_id("bro/ids/test", "test_var");
+	Broker::publish_id("zeek/ids/test", "test_var");
 	}
 
 @TEST-END-FILE
@@ -47,7 +47,7 @@ event check_var()
 event zeek_init()
 	{
 	print "intial val", test_var;
-	Broker::subscribe("bro/ids");
+	Broker::subscribe("zeek/ids");
 	Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 

--- a/testing/btest/broker/remote_log.zeek
+++ b/testing/btest/broker/remote_log.zeek
@@ -44,7 +44,7 @@ event Broker::peer_lost(endpoint: Broker::EndpointInfo, msg: string)
 
 event zeek_init()
 	{
-	Broker::subscribe("bro/");
+	Broker::subscribe("zeek/");
 	Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 

--- a/testing/btest/broker/remote_log_late_join.zeek
+++ b/testing/btest/broker/remote_log_late_join.zeek
@@ -44,7 +44,7 @@ event Broker::peer_lost(endpoint: Broker::EndpointInfo, msg: string)
 
 event zeek_init()
 	{
-	Broker::subscribe("bro/");
+	Broker::subscribe("zeek/");
 	Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 

--- a/testing/btest/broker/remote_log_types.zeek
+++ b/testing/btest/broker/remote_log_types.zeek
@@ -60,7 +60,7 @@ event zeek_init() &priority=5
 
 event zeek_init()
 	{
-	Broker::subscribe("bro/");
+	Broker::subscribe("zeek/");
 	Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 
@@ -123,7 +123,7 @@ event Broker::peer_added(endpoint: Broker::EndpointInfo, msg: string)
 		]);
 
 	local e = Broker::make_event(quit_receiver);
-	Broker::publish("bro/", e);
+	Broker::publish("zeek/", e);
 	schedule 1sec { quit_sender() };
         }
 

--- a/testing/btest/broker/ssl_auth_failure.zeek
+++ b/testing/btest/broker/ssl_auth_failure.zeek
@@ -105,7 +105,7 @@ event do_terminate()
 
 event zeek_init()
     {
-    Broker::subscribe("bro/event/my_topic");
+    Broker::subscribe("zeek/event/my_topic");
     Broker::peer("127.0.0.1", to_port(getenv("BROKER_PORT")));
     schedule 5secs { do_terminate()   };
     }

--- a/testing/btest/broker/store/clone.zeek
+++ b/testing/btest/broker/store/clone.zeek
@@ -50,8 +50,8 @@ event inserted()
 
 event zeek_init()
 	{
-	Broker::auto_publish("bro/events", done);
-	Broker::subscribe("bro/");
+	Broker::auto_publish("zeek/events", done);
+	Broker::subscribe("zeek/");
 
 	h = Broker::create_master("test");
 	Broker::put(h, "one", "110");
@@ -131,8 +131,8 @@ event lookup(stage: count)
 
 event zeek_init()
 	{
-	Broker::auto_publish("bro/events", inserted);
-	Broker::subscribe("bro/");
+	Broker::auto_publish("zeek/events", inserted);
+	Broker::subscribe("zeek/");
 	Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 

--- a/testing/btest/broker/unpeer.zeek
+++ b/testing/btest/broker/unpeer.zeek
@@ -36,8 +36,8 @@ event unpeer(endpoint: Broker::EndpointInfo)
 
 event zeek_init()
     {
-    Broker::subscribe("bro/event/my_topic");
-    Broker::auto_publish("bro/event/my_topic", print_something);
+    Broker::subscribe("zeek/event/my_topic");
+    Broker::auto_publish("zeek/event/my_topic", print_something);
     Broker::peer("127.0.0.1", to_port(getenv("BROKER_PORT")));
     }
 
@@ -67,7 +67,7 @@ event print_something(i: int)
 
 event zeek_init()
     {
-    Broker::subscribe("bro/event/my_topic");
+    Broker::subscribe("zeek/event/my_topic");
     Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
     schedule 10secs { do_terminate() };
     }

--- a/testing/btest/scripts/base/frameworks/cluster/custom_pool_exclusivity.zeek
+++ b/testing/btest/scripts/base/frameworks/cluster/custom_pool_exclusivity.zeek
@@ -22,7 +22,7 @@ redef Cluster::nodes = {
 
 global my_pool_spec: Cluster::PoolSpec =
 		Cluster::PoolSpec(
-			$topic = "bro/cluster/pool/my_pool",
+			$topic = "zeek/cluster/pool/my_pool",
 			$node_type = Cluster::PROXY
 			);
 
@@ -30,7 +30,7 @@ global my_pool: Cluster::Pool;
 
 redef Cluster::proxy_pool_spec =
 		Cluster::PoolSpec(
-			$topic = "bro/cluster/pool/proxy",
+			$topic = "zeek/cluster/pool/proxy",
 			$node_type = Cluster::PROXY,
 			$exclusive = T,
 			$max_nodes = 1 

--- a/testing/btest/scripts/base/frameworks/cluster/custom_pool_limits.zeek
+++ b/testing/btest/scripts/base/frameworks/cluster/custom_pool_limits.zeek
@@ -22,7 +22,7 @@ redef Cluster::nodes = {
 
 global my_pool_spec: Cluster::PoolSpec =
 		Cluster::PoolSpec(
-			$topic = "bro/cluster/pool/my_pool",
+			$topic = "zeek/cluster/pool/my_pool",
 			$node_type = Cluster::PROXY
 			);
 
@@ -30,7 +30,7 @@ global my_pool: Cluster::Pool;
 
 redef Cluster::proxy_pool_spec =
 		Cluster::PoolSpec(
-			$topic = "bro/cluster/pool/proxy",
+			$topic = "zeek/cluster/pool/proxy",
 			$node_type = Cluster::PROXY,
 			$exclusive = F,
 			$max_nodes = 1 

--- a/testing/btest/scripts/base/frameworks/netcontrol/acld-hook.zeek
+++ b/testing/btest/scripts/base/frameworks/netcontrol/acld-hook.zeek
@@ -21,7 +21,7 @@ event zeek_init()
 
 event NetControl::init()
 	{
-	local netcontrol_acld = NetControl::create_acld(NetControl::AcldConfig($acld_host=127.0.0.1, $acld_port=to_port(getenv("BROKER_PORT")), $acld_topic="bro/event/netcontroltest"));
+	local netcontrol_acld = NetControl::create_acld(NetControl::AcldConfig($acld_host=127.0.0.1, $acld_port=to_port(getenv("BROKER_PORT")), $acld_topic="zeek/event/netcontroltest"));
 	NetControl::activate(netcontrol_acld, 0);
 	}
 
@@ -103,7 +103,7 @@ event die()
 
 event zeek_init()
 	{
-	Broker::subscribe("bro/event/netcontroltest");
+	Broker::subscribe("zeek/event/netcontroltest");
 	Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 
@@ -116,14 +116,14 @@ event NetControl::acld_add_rule(id: count, r: NetControl::Rule, ar: NetControl::
 	{
 	print "add_rule", id, r$entity, r$ty, ar;
 
-	Broker::publish("bro/event/netcontroltest", NetControl::acld_rule_added, id, r, ar$command);
+	Broker::publish("zeek/event/netcontroltest", NetControl::acld_rule_added, id, r, ar$command);
 	}
 
 event NetControl::acld_remove_rule(id: count, r: NetControl::Rule, ar: NetControl::AclRule)
 	{
 	print "remove_rule", id, r$entity, r$ty, ar;
 
-	Broker::publish("bro/event/netcontroltest", NetControl::acld_rule_removed, id, r, ar$command);
+	Broker::publish("zeek/event/netcontroltest", NetControl::acld_rule_removed, id, r, ar$command);
 
 	if ( r$cid == 4 )
 		{

--- a/testing/btest/scripts/base/frameworks/netcontrol/acld.zeek
+++ b/testing/btest/scripts/base/frameworks/netcontrol/acld.zeek
@@ -22,7 +22,7 @@ event zeek_init()
 
 event NetControl::init()
 	{
-	local netcontrol_acld = NetControl::create_acld(NetControl::AcldConfig($acld_host=127.0.0.1, $acld_port=to_port(getenv("BROKER_PORT")), $acld_topic="bro/event/netcontroltest"));
+	local netcontrol_acld = NetControl::create_acld(NetControl::AcldConfig($acld_host=127.0.0.1, $acld_port=to_port(getenv("BROKER_PORT")), $acld_topic="zeek/event/netcontroltest"));
 	NetControl::activate(netcontrol_acld, 0);
 	}
 
@@ -108,7 +108,7 @@ event die()
 
 event zeek_init()
 	{
-	Broker::subscribe("bro/event/netcontroltest");
+	Broker::subscribe("zeek/event/netcontroltest");
 	Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 
@@ -122,9 +122,9 @@ event NetControl::acld_add_rule(id: count, r: NetControl::Rule, ar: NetControl::
 	print "add_rule", id, r$entity, r$ty, ar;
 
 	if ( r$cid != 3 )
-		Broker::publish("bro/event/netcontroltest", NetControl::acld_rule_added, id, r, ar$command);
+		Broker::publish("zeek/event/netcontroltest", NetControl::acld_rule_added, id, r, ar$command);
 	else
-		Broker::publish("bro/event/netcontroltest", NetControl::acld_rule_exists, id, r, ar$command);
+		Broker::publish("zeek/event/netcontroltest", NetControl::acld_rule_exists, id, r, ar$command);
 	}
 
 event NetControl::acld_remove_rule(id: count, r: NetControl::Rule, ar: NetControl::AclRule)
@@ -132,9 +132,9 @@ event NetControl::acld_remove_rule(id: count, r: NetControl::Rule, ar: NetContro
 	print "remove_rule", id, r$entity, r$ty, ar;
 
 	if ( r$cid != 2 )
-		Broker::publish("bro/event/netcontroltest", NetControl::acld_rule_removed, id, r, ar$command);
+		Broker::publish("zeek/event/netcontroltest", NetControl::acld_rule_removed, id, r, ar$command);
 	else
-		Broker::publish("bro/event/netcontroltest", NetControl::acld_rule_error, id, r, ar$command);
+		Broker::publish("zeek/event/netcontroltest", NetControl::acld_rule_error, id, r, ar$command);
 
 	if ( r$cid == 4 )
 		{

--- a/testing/btest/scripts/base/frameworks/netcontrol/broker.zeek
+++ b/testing/btest/scripts/base/frameworks/netcontrol/broker.zeek
@@ -22,7 +22,7 @@ event zeek_init()
 
 event NetControl::init()
 	{
-	local netcontrol_broker = NetControl::create_broker(NetControl::BrokerConfig($host=127.0.0.1, $bport=to_port(getenv("BROKER_PORT")), $topic="bro/event/netcontroltest"), T);
+	local netcontrol_broker = NetControl::create_broker(NetControl::BrokerConfig($host=127.0.0.1, $bport=to_port(getenv("BROKER_PORT")), $topic="zeek/event/netcontroltest"), T);
 	NetControl::activate(netcontrol_broker, 0);
 	}
 
@@ -92,7 +92,7 @@ event die()
 
 event zeek_init()
 	{
-	Broker::subscribe("bro/event/netcontroltest");
+	Broker::subscribe("zeek/event/netcontroltest");
 	Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 
@@ -106,19 +106,19 @@ event NetControl::broker_add_rule(id: count, r: NetControl::Rule)
 	print "add_rule", id, r$entity, r$ty;
 
 	if ( r$cid == 3 )
-		Broker::publish("bro/event/netcontroltest", NetControl::broker_rule_added, id, r, "");
+		Broker::publish("zeek/event/netcontroltest", NetControl::broker_rule_added, id, r, "");
 	if ( r$cid == 2 )
-		Broker::publish("bro/event/netcontroltest", NetControl::broker_rule_exists, id, r, "");
+		Broker::publish("zeek/event/netcontroltest", NetControl::broker_rule_exists, id, r, "");
 
 	if ( r$cid == 2 )
-		Broker::publish("bro/event/netcontroltest", NetControl::broker_rule_timeout, id, r, NetControl::FlowInfo());
+		Broker::publish("zeek/event/netcontroltest", NetControl::broker_rule_timeout, id, r, NetControl::FlowInfo());
 	}
 
 event NetControl::broker_remove_rule(id: count, r: NetControl::Rule, reason: string)
 	{
 	print "remove_rule", id, r$entity, r$ty, reason;
 
-	Broker::publish("bro/event/netcontroltest", NetControl::broker_rule_removed, id, r, "");
+	Broker::publish("zeek/event/netcontroltest", NetControl::broker_rule_removed, id, r, "");
 
 	if ( r$cid == 3 )
 		{

--- a/testing/btest/scripts/base/frameworks/openflow/broker-basic.zeek
+++ b/testing/btest/scripts/base/frameworks/openflow/broker-basic.zeek
@@ -18,7 +18,7 @@ global of_controller: OpenFlow::Controller;
 event zeek_init()
 	{
 	suspend_processing();
-	of_controller = OpenFlow::broker_new("broker1", 127.0.0.1, to_port(getenv("BROKER_PORT")), "bro/openflow", 42);
+	of_controller = OpenFlow::broker_new("broker1", 127.0.0.1, to_port(getenv("BROKER_PORT")), "zeek/openflow", 42);
 	}
 
 event Broker::peer_added(endpoint: Broker::EndpointInfo, msg: string)
@@ -88,7 +88,7 @@ redef exit_only_after_terminate = T;
 
 event zeek_init()
 	{
-	Broker::subscribe("bro/openflow");
+	Broker::subscribe("zeek/openflow");
 	Broker::listen("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 
@@ -105,8 +105,8 @@ event Broker::peer_lost(endpoint: Broker::EndpointInfo, msg: string)
 event OpenFlow::broker_flow_mod(name: string, dpid: count, match: OpenFlow::ofp_match, flow_mod: OpenFlow::ofp_flow_mod)
 	{
 	print "got flow_mod", dpid, match, flow_mod;
-	Broker::publish("bro/openflow", OpenFlow::flow_mod_success, name, match, flow_mod, "");
-	Broker::publish("bro/openflow", OpenFlow::flow_mod_failure, name, match, flow_mod, "");
+	Broker::publish("zeek/openflow", OpenFlow::flow_mod_success, name, match, flow_mod, "");
+	Broker::publish("zeek/openflow", OpenFlow::flow_mod_failure, name, match, flow_mod, "");
 	}
 
 event OpenFlow::broker_flow_clear(name: string, dpid: count)


### PR DESCRIPTION
This branch is also in `zeek-docs` to merge w/ this.

Mostly hoping for a sanity check here regarding backwards compatibility concerns since it's a potentially breaking change and maybe a hard one to realize without a careful read of the release notes, but I expect few to be impacted.

Fixes #387 