### PR TITLE
Tweak to ASCII reader warning suppression

### DIFF
--- a/src/input/readers/ascii/Ascii.cc
+++ b/src/input/readers/ascii/Ascii.cc
@@ -305,11 +305,15 @@ bool Ascii::DoUpdate()
 				// no change
 				return true;
 
+			// Warn again in case of trouble if the file changes. The comparison to 0
+			// is to suppress an extra warning that we'd otherwise get on the initial
+			// inode assignment.
+			if ( ino != 0 )
+				suppress_warnings = false;
+
 			mtime = sb.st_mtime;
 			ino = sb.st_ino;
-			// file changed. reread.
-
-			// fallthrough
+			// File changed. Fall through to re-read.
 			}
 
 		case MODE_MANUAL:
@@ -470,8 +474,8 @@ bool Ascii::DoHeartbeat(double network_time, double current_time)
 
 		case MODE_REREAD:
 		case MODE_STREAM:
-			Update(); // call update and not DoUpdate, because update
-				  // checks disabled.
+			Update(); // Call Update, not DoUpdate, because Update
+				  // checks the "disabled" flag.
 			break;
 
 		default:

--- a/src/input/readers/config/Config.cc
+++ b/src/input/readers/config/Config.cc
@@ -151,11 +151,15 @@ bool Config::DoUpdate()
 				// no change
 				return true;
 
+			// Warn again in case of trouble if the file changes. The comparison to 0
+			// is to suppress an extra warning that we'd otherwise get on the initial
+			// inode assignment.
+			if ( ino != 0 )
+				suppress_warnings = false;
+
 			mtime = sb.st_mtime;
 			ino = sb.st_ino;
-			// file changed. reread.
-
-			// fallthrough
+			// File changed. Fall through to re-read.
 			}
 
 		case MODE_MANUAL:
@@ -309,8 +313,8 @@ bool Config::DoHeartbeat(double network_time, double current_time)
 
 		case MODE_REREAD:
 		case MODE_STREAM:
-			Update(); // call update and not DoUpdate, because update
-				  // checks disabled.
+			Update(); // Call Update, not DoUpdate, because Update
+				  // checks the "disabled" flag.
 			break;
 
 		default:


### PR DESCRIPTION
Warnings in the ASCII reader so far remained suppressed even when an
input file changed. It's helpful to learn about problems in the data
when putting in place new data files, so this isn't great. This change
maintains the existing warning suppression while processing a file,
but re-enables warnings after updates to a file.

Also includes minor comment clarifications, and maintains the
not-so-great code duplication between the ASCII and Config readers
until we refactor this properly.