### PR TITLE
GH-209: replace "remote_ip" field of radius.log with "tunnel_client"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -216,6 +216,11 @@ Changed Functionality
   in scripts has also been updated to replace Sphinx cross-referencing roles
   and directives like ":bro:see:" with ":zeek:zee:".
 
+- The "remote_ip" field of "addr" type was removed from radius.log and
+  replaced with a field named "tunnel_client" of "string" type.  The
+  reason for this is that the Tunnel-Client-Endpoint RADIUS attribute
+  this data is derived from may also be a FQDN, not just an IP address.
+
 Removed Functionality
 ---------------------
 

--- a/scripts/base/protocols/radius/main.zeek
+++ b/scripts/base/protocols/radius/main.zeek
@@ -24,9 +24,10 @@ export {
 		## and the network access server is not required to honor 
 		## the address.
 		framed_addr  : addr     &log &optional;
-		## Remote IP address, if present.  This is collected
-		## from the Tunnel-Client-Endpoint attribute.
-		remote_ip    : addr     &log &optional;
+		## Address (IPv4, IPv6, or FQDN) of the initiator end of the tunnel,
+		## if present.  This is collected from the Tunnel-Client-Endpoint
+		## attribute.
+		tunnel_client: string   &log &optional;
 		## Connect info, if present.
 		connect_info : string   &log &optional;
 		## Reply message from the server challenge. This is 
@@ -85,8 +86,8 @@ event radius_message(c: connection, result: RADIUS::Message) &priority=5
 					c$radius$mac = normalize_mac(result$attributes[31][0]);
 
 				# Tunnel-Client-EndPoint (useful for VPNs)
-				if ( ! c$radius?$remote_ip && 66 in result$attributes )
-					c$radius$remote_ip = to_addr(result$attributes[66][0]);
+				if ( ! c$radius?$tunnel_client && 66 in result$attributes )
+					c$radius$tunnel_client = result$attributes[66][0];
 
 				# Connect-Info
 				if ( ! c$radius?$connect_info && 77 in result$attributes )

--- a/testing/btest/Baseline/scripts.base.protocols.radius.auth/radius.log
+++ b/testing/btest/Baseline/scripts.base.protocols.radius.auth/radius.log
@@ -3,8 +3,8 @@
 #empty_field	(empty)
 #unset_field	-
 #path	radius
-#open	2017-02-20-04-53-55
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	username	mac	framed_addr	remote_ip	connect_info	reply_msg	result	ttl
-#types	time	string	addr	port	addr	port	string	string	addr	addr	string	string	string	interval
+#open	2019-06-05-18-03-41
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	username	mac	framed_addr	tunnel_client	connect_info	reply_msg	result	ttl
+#types	time	string	addr	port	addr	port	string	string	addr	string	string	string	string	interval
 1217631137.872968	CHhAvVGS1DHFjwGM9	10.0.0.1	1645	10.0.0.100	1812	John.McGuirk	00:14:22:e9:54:5e	255.255.255.254	-	-	Hello, %u	success	0.043882
-#close	2017-02-20-04-53-55
+#close	2019-06-05-18-03-41

--- a/testing/btest/Baseline/scripts.base.protocols.radius.radius-multiple-attempts/radius.log
+++ b/testing/btest/Baseline/scripts.base.protocols.radius.radius-multiple-attempts/radius.log
@@ -3,9 +3,9 @@
 #empty_field	(empty)
 #unset_field	-
 #path	radius
-#open	2017-02-20-04-56-31
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	username	mac	framed_addr	remote_ip	connect_info	reply_msg	result	ttl
-#types	time	string	addr	port	addr	port	string	string	addr	addr	string	string	string	interval
+#open	2019-06-05-18-04-34
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	username	mac	framed_addr	tunnel_client	connect_info	reply_msg	result	ttl
+#types	time	string	addr	port	addr	port	string	string	addr	string	string	string	string	interval
 1440447766.440305	CHhAvVGS1DHFjwGM9	127.0.0.1	53031	127.0.0.1	1812	steve	-	172.16.3.33	-	-	-	failed	1.005906
 1440447839.947454	ClEkJM2Vm5giqnMf4h	127.0.0.1	65443	127.0.0.1	1812	steve	-	172.16.3.33	-	-	-	success	0.000779
 1440447848.196115	C4J4Th3PJpwUYZZ6gc	127.0.0.1	57717	127.0.0.1	1812	steve	-	-	-	-	-	success	0.000275
@@ -13,4 +13,4 @@
 1440447880.931272	CUM0KZ3MLUfNB0cl11	127.0.0.1	52178	127.0.0.1	1812	steve	-	-	-	-	-	failed	1.001459
 1440447904.122012	CmES5u32sYpV7JYN	127.0.0.1	62956	127.0.0.1	1812	steve	-	-	-	-	-	unknown	-
 1440448190.335333	CP5puj4I8PtEU4qzYg	127.0.0.1	53127	127.0.0.1	1812	steve	-	-	-	-	-	success	0.000517
-#close	2017-02-20-04-56-31
+#close	2019-06-05-18-04-34


### PR DESCRIPTION
The type of the field also changed from "addr" to "string" because the
former cannot represent all possible values of the
Tunnel-Client-Endpoint attribute, which may include FQDNs, not just IP
addresses.

Fixes #209