### PR TITLE
add: rdp_native_encrytped_data event

### DIFF
--- a/src/analyzer/protocol/rdp/RDP.cc
+++ b/src/analyzer/protocol/rdp/RDP.cc
@@ -10,7 +10,7 @@ RDP_Analyzer::RDP_Analyzer(Connection* c)
 	: tcp::TCP_ApplicationAnalyzer("RDP", c)
 	{
 	interp = new binpac::RDP::RDP_Conn(this);
-	
+
 	had_gap = false;
 	pia = 0;
 	}
@@ -71,6 +71,11 @@ void RDP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 				}
 
 			ForwardStream(len, data, orig);
+			}
+		else
+			{
+			BifEvent::generate_rdp_native_encrypted_data(interp->bro_analyzer(),
+				interp->bro_analyzer()->Conn(), orig, len);
 			}
 		}
 	else // if not encrypted

--- a/src/analyzer/protocol/rdp/events.bif
+++ b/src/analyzer/protocol/rdp/events.bif
@@ -1,3 +1,12 @@
+## Generated for each packet after RDP native encryption begins
+##
+## c: The connection record for the underlying transport-layer session/flow.
+##
+## orig: True if the packet was sent by the originator of the connection.
+##
+## len: The length of the encrypted data.
+event rdp_native_encrypted_data%(c: connection, orig: bool, len: count%);
+
 ## Generated for X.224 client requests.
 ##
 ## c: The connection record for the underlying transport-layer session/flow.


### PR DESCRIPTION
This PR creates a new event for use in scriptland. The event is raised for each encrypted packet of an RDP connection using the native/ RDP encryption scheme. 

The event is meant to mimic `ssh_encrypted_packet()` and `ssl_encrypted_data()` but for native RDP encryption. RDP connections using ssl will still generate `ssl_encrypted_data()`.