### PR TITLE
Add ability to turn on Clang sanitizers during configure, fix a couple of null-dereference bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,12 @@ if(${ENABLE_DEBUG})
     set(VERSION_C_IDENT "${VERSION_C_IDENT}_debug")
 endif()
 
+if (SANITIZERS)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=${SANITIZERS} -fno-omit-frame-pointer")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${SANITIZERS} -fno-omit-frame-pointer")
+    set(CMAKE_LD_FLAGS "${CMAKE_LD_FLAGS} -fsanitize=${SANITIZERS} -fno-omit-frame-pointer")
+endif()
+
 ########################################################################
 ## Dependency Configuration
 

--- a/configure
+++ b/configure
@@ -58,6 +58,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --disable-perftools    don't try to build with Google Perftools
     --disable-python       don't try to build python bindings for Broker
     --disable-broker-tests don't try to build Broker unit tests
+    --sanitizers=SANITIZERS comma-separated list of Clang sanitizers to enable
 
   Required Packages in Non-Standard Locations:
     --with-openssl=PATH    path to OpenSSL install root
@@ -144,6 +145,7 @@ append_cache_entry INSTALL_ZEEKCTL      BOOL   true
 append_cache_entry CPACK_SOURCE_IGNORE_FILES STRING
 append_cache_entry ENABLE_MOBILE_IPV6   BOOL   false
 append_cache_entry DISABLE_PERFTOOLS    BOOL   false
+append_cache_entry SANITIZERS           STRING ""
 
 # parse arguments
 while [ $# -ne 0 ]; do
@@ -215,6 +217,9 @@ while [ $# -ne 0 ]; do
         --enable-perftools-debug)
             append_cache_entry ENABLE_PERFTOOLS     BOOL   true
             append_cache_entry ENABLE_PERFTOOLS_DEBUG BOOL   true
+            ;;
+        --sanitizers=*)
+            append_cache_entry SANITIZERS    STRING    $optarg
             ;;
         --enable-jemalloc)
             append_cache_entry ENABLE_JEMALLOC     BOOL   true

--- a/src/util.cc
+++ b/src/util.cc
@@ -1507,13 +1507,11 @@ double current_time(bool real)
 
 	double t = double(tv.tv_sec) + double(tv.tv_usec) / 1e6;
 
-	const iosource::Manager::PktSrcList& pkt_srcs(iosource_mgr->GetPktSrcs());
-
-	if ( ! pseudo_realtime || real || pkt_srcs.empty() )
+	if ( ! pseudo_realtime || real || ! iosource_mgr || iosource_mgr->GetPktSrcs().empty() )
 		return t;
 
 	// This obviously only works for a single source ...
-	iosource::PktSrc* src = pkt_srcs.front();
+	iosource::PktSrc* src = iosource_mgr->GetPktSrcs().front();
 
 	if ( net_is_processing_suspended() )
 		return src->CurrentPacketTimestamp();


### PR DESCRIPTION
I can't decide whether the `--sanitizer` flag is really necessary, since you could potentially just set the various `FLAGS` variables in your environment and have configure pick them up. I left that commit in for this PR for discussion.

The other two commits are a couple of null-dereference bugs found by Coverity and one found by UndefinedBehaviorSanitizer.