### PR TITLE
Rename bro to zeek in error messages and a few other places

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,8 +10,8 @@ set(bro_ALL_GENERATED_OUTPUTS  CACHE INTERNAL "automatically generated files" FO
 set(bro_AUTO_BIFS     CACHE INTERNAL "BIFs for automatic inclusion" FORCE)
 set(bro_REGISTER_BIFS CACHE INTERNAL "BIFs for automatic registering" FORCE)
 
-set(bro_BASE_BIF_SCRIPTS CACHE INTERNAL "Bro script stubs for BIFs in base distribution of Bro" FORCE)
-set(bro_PLUGIN_BIF_SCRIPTS CACHE INTERNAL "Bro script stubs for BIFs in Bro plugins" FORCE)
+set(bro_BASE_BIF_SCRIPTS CACHE INTERNAL "Zeek script stubs for BIFs in base distribution of Zeek" FORCE)
+set(bro_PLUGIN_BIF_SCRIPTS CACHE INTERNAL "Zeek script stubs for BIFs in Zeek plugins" FORCE)
 
 # If TRUE, use CMake's object libraries for sub-directories instead of
 # static libraries. This requires CMake >= 2.8.8.

--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -721,7 +721,7 @@ static char* get_prompt(bool reset_counter = false)
 	if ( reset_counter )
 		counter = 0;
 
-	safe_snprintf(prompt, sizeof(prompt), "(Bro [%d]) ", counter++);
+	safe_snprintf(prompt, sizeof(prompt), "(Zeek [%d]) ", counter++);
 
 	return prompt;
 	}

--- a/src/DebugCmdInfoConstants.cc
+++ b/src/DebugCmdInfoConstants.cc
@@ -35,7 +35,7 @@ void init_global_dbg_constants () {
 	"quit"
       };
 
-      info = new DebugCmdInfo (dcQuit, names, 1, false, "Exit Bro",
+      info = new DebugCmdInfo (dcQuit, names, 1, false, "Exit Zeek",
                                false);
       g_DebugCmdInfos.push_back(info);
    }

--- a/src/DebugCmdInfoConstants.in
+++ b/src/DebugCmdInfoConstants.in
@@ -13,7 +13,7 @@ help: Get help with debugger commands
 cmd: dcQuit
 names: quit
 resume: false
-help: Exit Bro
+help: Exit Zeek
 
 cmd: dcNext
 names: next

--- a/src/DebugLogger.cc
+++ b/src/DebugLogger.cc
@@ -72,7 +72,7 @@ void DebugLogger::ShowStreamsHelp()
 		fprintf(stderr,"  %s\n", streams[i].prefix);
 
 	fprintf(stderr, "\n");
-	fprintf(stderr, "  plugin-<plugin-name>   (replace '::' in name with '-'; e.g., '-B plugin-Bro-Netmap')\n");
+	fprintf(stderr, "  plugin-<plugin-name>   (replace '::' in name with '-'; e.g., '-B plugin-Zeek-Netmap')\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "Pseudo streams\n");
 	fprintf(stderr, "  verbose  Increase verbosity.\n");

--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -26,7 +26,7 @@ void init_hash_function()
 	{
 	// Make sure we have already called init_random_seed().
 	if ( ! (hmac_key_set && siphash_key_set) )
-		reporter->InternalError("Bro's hash functions aren't fully initialized");
+		reporter->InternalError("Zeek's hash functions aren't fully initialized");
 	}
 
 HashKey::HashKey(bro_int_t i)

--- a/src/Serializer.cc
+++ b/src/Serializer.cc
@@ -887,7 +887,7 @@ bool FileSerializer::ReadHeader(UnserialInfo* info)
 
 	if ( magic != htonl(MAGIC) )
 		{
-		Error(fmt("%s is not a bro state file", file));
+		Error(fmt("%s is not a Zeek state file", file));
 		CloseFile();
 		return false;
 		}

--- a/src/broker/comm.bif
+++ b/src/broker/comm.bif
@@ -1,5 +1,5 @@
 
-##! Functions and events regarding Bro's broker communication mechanisms.
+##! Functions and events regarding broker communication mechanisms.
 
 %%{
 #include "broker/Manager.h"

--- a/src/input/readers/sqlite/SQLite.cc
+++ b/src/input/readers/sqlite/SQLite.cc
@@ -71,7 +71,7 @@ bool SQLite::DoInit(const ReaderInfo& info, int arg_num_fields, const threading:
 	{
 	if ( sqlite3_threadsafe() == 0 )
 		{
-		Error("SQLite reports that it is not threadsafe. Bro needs a threadsafe version of SQLite. Aborting");
+		Error("SQLite reports that it is not threadsafe. Zeek needs a threadsafe version of SQLite. Aborting");
 		return false;
 		}
 

--- a/src/logging/writers/sqlite/SQLite.cc
+++ b/src/logging/writers/sqlite/SQLite.cc
@@ -116,7 +116,7 @@ bool SQLite::DoInit(const WriterInfo& info, int arg_num_fields,
 	{
 	if ( sqlite3_threadsafe() == 0 )
 		{
-		Error("SQLite reports that it is not threadsafe. Bro needs a threadsafe version of SQLite. Aborting");
+		Error("SQLite reports that it is not threadsafe. Zeek needs a threadsafe version of SQLite. Aborting");
 		return false;
 		}
 

--- a/src/zeekygen/Manager.cc
+++ b/src/zeekygen/Manager.cc
@@ -83,7 +83,7 @@ Manager::Manager(const string& arg_config, const string& bro_command)
 	// a PATH component that starts with a tilde (such as "~/bin").  A simple
 	// workaround is to just run bro with a relative or absolute path.
 	if ( path_to_bro.empty() || stat(path_to_bro.c_str(), &s) < 0 )
-		reporter->InternalError("Zeekygen can't get mtime of bro binary %s (try again by specifying the absolute or relative path to Bro): %s",
+		reporter->InternalError("Zeekygen can't get mtime of zeek binary %s (try again by specifying the absolute or relative path to Zeek): %s",
 		                        path_to_bro.c_str(), strerror(errno));
 
 	bro_mtime = s.st_mtime;


### PR DESCRIPTION
Branch "topic/dnthayer/rename-to-zeek" in the zeek, broker, btest, pysubnettree, and trace-summary repos contains more bro-to-zeek renaming.