### PR TITLE
Fix CIF integration and add logging options to intel.log

### DIFF
--- a/scripts/policy/integration/collective-intel/main.zeek
+++ b/scripts/policy/integration/collective-intel/main.zeek
@@ -3,13 +3,50 @@
 
 module Intel;
 
-## These are some fields to add extended compatibility between Zeek and the
-## Collective Intelligence Framework.
-redef record Intel::MetaData += {
-	## Maps to the Impact field in the Collective Intelligence Framework.
-	cif_impact:     string &optional;
-	## Maps to the Severity field in the Collective Intelligence Framework.
-	cif_severity:   string &optional;
-	## Maps to the Confidence field in the Collective Intelligence Framework.
-	cif_confidence: double &optional;
-};
+export {
+	redef record Intel::MetaData += {
+		cif_tags: string &optional;
+		cif_confidence: double &optional;
+		cif_source: string &optional;
+		cif_description: string &optional;
+		cif_firstseen: string &optional;
+		cif_lastseen: string &optional;
+	};
+
+	type CIF: record {
+		tags: string &optional &log;
+		confidence: double &optional &log;
+		source: string &optional &log;
+		description: string &optional &log;
+		firstseen: string &optional &log;
+		lastseen: string &optional &log;
+	};
+
+	redef record Info += {
+		cif: CIF &log &optional;
+	};
+
+}
+
+hook extend_match(info: Info, s: Seen, items: set[Item]) &priority=5
+	{
+	for ( item in items )
+		{
+		local tmp: CIF;
+
+		if ( item$meta?$cif_tags )
+			tmp$tags = item$meta$cif_tags;
+		if ( item$meta?$cif_confidence )
+			tmp$confidence = item$meta$cif_confidence;
+		if ( item$meta?$cif_source )
+			tmp$source = item$meta$cif_source;
+		if ( item$meta?$cif_description )
+			tmp$description = item$meta$cif_description
+		if ( item$meta?$cif_firstseen )
+			tmp$firstseen = item$meta$cif_firtseen;
+		if ( item$meta?$cif_lastseen )
+			tmp$lastseen = item$meta$cif_lastseen;
+
+		info$cif = tmp;
+	}
+}


### PR DESCRIPTION
Properly passes CIF meta data through to the intel.log.
Example line:
`{"ts":"2019-06-24T06:38:01.537913Z","uid":"COYf8W12DtDsFfSgzf","id.orig_h":"192.168.252.11","id.orig_p":64340,"id.resp_h":"192.168.254.254","id.resp_p":53,"seen.indicator":"example.com","seen.indicator_type":"Intel::DOMAIN","seen.where":"DNS::IN_REQUEST","seen.node":"heimdall-enp0s4-3","matched":["Intel::DOMAIN"],"sources":["scott\u0027s computer"],"cif.tags":"test","cif.confidence":10.0,"cif.description":"this is a test"}`
