### PR TITLE
GH-427: improve default ID values shown by Zeekygen

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -1096,7 +1096,7 @@ decl:
 	|	TOK_REDEF global_id opt_type init_class opt_init opt_attr ';'
 			{
 			add_global($2, $3, $4, $5, $6, VAR_REDEF);
-			zeekygen_mgr->Redef($2, ::filename);
+			zeekygen_mgr->Redef($2, ::filename, $4, $5);
 			}
 
 	|	TOK_REDEF TOK_ENUM global_id TOK_ADD_TO '{'

--- a/src/zeekygen/IdentifierInfo.h
+++ b/src/zeekygen/IdentifierInfo.h
@@ -39,6 +39,12 @@ public:
 	~IdentifierInfo() override;
 
 	/**
+	 * Returns the initial value of the identifier.
+	 */
+	Val* InitialVal() const
+		{ return initial_val; }
+
+	/**
 	 * Add a comment associated with the identifier.  If the identifier is a
 	 * record type and it's in the middle of parsing fields, the comment is
 	 * associated with the last field that was parsed.
@@ -59,9 +65,12 @@ public:
 	/**
 	 * Register a redefinition of the identifier.
 	 * @param from_script The script in which the redef occurred.
+	 * @param ic The initialization class used (e.g. =, +=, -=)
+	 * @param init_expr The initialzation expression used.
 	 * @param comments Comments associated with the redef statement.
 	 */
-	void AddRedef(const std::string& from_script,
+	void AddRedef(const std::string& from_script, init_class ic,
+	              Expr* init_expr,
 	              const std::vector<std::string>& comments);
 
 	/**
@@ -117,8 +126,19 @@ public:
 	 */
 	struct Redefinition {
 		std::string from_script; /**< Name of script doing the redef. */
-		std::string new_val_desc; /**< Description of new value bound to ID. */
+		init_class ic;
+		Expr* init_expr;
 		std::vector<std::string> comments; /**< Zeekygen comments on redef. */
+
+		Redefinition(std::string arg_script, init_class arg_ic,
+	                 Expr* arg_expr,
+		             std::vector<std::string> arg_comments);
+
+		Redefinition(const Redefinition& other);
+
+		Redefinition& operator=(const Redefinition& other);
+
+		~Redefinition();
 	};
 
 	/**
@@ -128,6 +148,13 @@ public:
 	 * @return A list of redefs that occurred in \a from_script.
 	 */
 	std::list<Redefinition> GetRedefs(const std::string& from_script) const;
+
+	/**
+	 * Get a list of information about redefinitions of the identifier.
+	 * @return A list of redefs that occurred for the identifier.
+	 */
+	const std::list<Redefinition*>& GetRedefs() const
+		{ return redefs; }
 
 private:
 
@@ -152,7 +179,7 @@ private:
 
 	std::vector<std::string> comments;
 	ID* id;
-	std::string initial_val_desc;
+	Val* initial_val;
 	redef_list redefs;
 	record_field_map fields;
 	RecordField* last_field_seen;

--- a/src/zeekygen/Manager.cc
+++ b/src/zeekygen/Manager.cc
@@ -352,7 +352,8 @@ void Manager::RecordField(const ID* id, const TypeDecl* field,
 	        field->id, id->Name(), script.c_str());
 	}
 
-void Manager::Redef(const ID* id, const string& path)
+void Manager::Redef(const ID* id, const string& path,
+                    init_class ic, Expr* init_expr)
 	{
 	if ( disabled )
 		return;
@@ -380,7 +381,7 @@ void Manager::Redef(const ID* id, const string& path)
 		return;
 		}
 
-	id_info->AddRedef(from_script, comment_buffer);
+	id_info->AddRedef(from_script, ic, init_expr, comment_buffer);
 	script_info->AddRedef(id_info);
 	comment_buffer.clear();
 	last_identifier_seen = id_info;

--- a/src/zeekygen/Manager.h
+++ b/src/zeekygen/Manager.h
@@ -136,8 +136,11 @@ public:
 	 * Register a redefinition of a particular identifier.
 	 * @param id The identifier being redef'd.
 	 * @param path Absolute path to a Bro script doing the redef.
+	 * @param ic The initialization class that was used (e.g. =, +=, -=).
+	 * @param init_expr The intiialization expression that was used.
 	 */
-	void Redef(const ID* id, const std::string& path);
+	void Redef(const ID* id, const std::string& path,
+			   init_class ic = INIT_NONE, Expr* init_expr = nullptr);
 
 	/**
 	 * Register Zeekygen script summary content.

--- a/testing/btest/Baseline/doc.zeekygen.vectors/autogen-reST-vectors.rst
+++ b/testing/btest/Baseline/doc.zeekygen.vectors/autogen-reST-vectors.rst
@@ -3,9 +3,10 @@
    :Type: :zeek:type:`vector` of :zeek:type:`string`
    :Default:
 
-   ::
+      ::
 
-      []
+         []
+
 
    Yield type is documented/cross-referenced for primitize types.
 
@@ -14,9 +15,10 @@
    :Type: :zeek:type:`vector` of :zeek:type:`TestRecord`
    :Default:
 
-   ::
+      ::
 
-      []
+         []
+
 
    Yield type is documented/cross-referenced for composite types.
 
@@ -25,9 +27,10 @@
    :Type: :zeek:type:`vector` of :zeek:type:`vector` of :zeek:type:`TestRecord`
    :Default:
 
-   ::
+      ::
 
-      []
+         []
+
 
    Just showing an even fancier yield type.
 


### PR DESCRIPTION
The default value of an ID is now truly the one used to initialize it,
unaltered by any subsequent redefs.

Redefs are now shown separately, along with the expression that
modifies the ID's value.

The `zeek-docs` repo needs an update on merging.

Fixes #427