### PR TITLE
Change notices to be processed on worker

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -338,6 +338,11 @@ Changed Functionality
   passed to any other functions for further processing. The remainder of the
   ``ocsp_response_bytes`` is unchanged.
 
+- For performance reasons, procesing on notices is now always performed on
+  the node on which the notice is raised. This is in difference to earlier
+  versions of Zeek, in which notices always were first sent to the manager
+  and processed there.
+
 Removed Functionality
 ---------------------
 

--- a/scripts/base/frameworks/notice/actions/pp-alarms.zeek
+++ b/scripts/base/frameworks/notice/actions/pp-alarms.zeek
@@ -10,7 +10,7 @@ module Notice;
 export {
 	## Activate pretty-printed alarm summaries.
 	const pretty_print_alarms = T &redef;
-	
+
 	## Address to send the pretty-printed reports to. Default if not set is
 	## :zeek:id:`Notice::mail_dest`.
 	##
@@ -20,10 +20,10 @@ export {
 	## the entry with an additional quote symbol (i.e., ">"). Many MUAs
 	## then highlight such lines differently.
 	global flag_nets: set[subnet] &redef;
-	
+
 	## Function that renders a single alarm. Can be overridden.
 	global pretty_print_alarm: function(out: file, n: Info) &redef;
-	
+
 	## Force generating mail file, even if reading from traces or no mail
 	## destination is defined. This is mainly for testing.
 	global force_email_summaries = F &redef;
@@ -39,7 +39,7 @@ function want_pp() : bool
 	{
 	if ( force_email_summaries )
 		return T;
-	
+
 	return (pretty_print_alarms && ! reading_traces()
 		&& (mail_dest != "" || mail_dest_pretty_printed != ""));
 	}
@@ -49,7 +49,7 @@ function pp_open()
 	{
 	if ( pp_alarms_open )
 		return;
-	
+
 	pp_alarms_open = T;
 	pp_alarms = open(pp_alarms_name);
 	}
@@ -59,29 +59,29 @@ function pp_send(rinfo: Log::RotationInfo)
 	{
 	if ( ! pp_alarms_open )
 		return;
-	
+
 	write_file(pp_alarms, "\n\n--\n[Automatically generated]\n\n");
 	close(pp_alarms);
 	pp_alarms_open = F;
-	
+
 	local from = strftime("%H:%M:%S", rinfo$open);
 	local to = strftime("%H:%M:%S", rinfo$close);
 	local subject = fmt("Alarm summary from %s-%s", from, to);
 	local dest = mail_dest_pretty_printed != "" ? mail_dest_pretty_printed
 		: mail_dest;
-	
+
 	if ( dest == "" )
 		# No mail destination configured, just leave the file alone. This is mainly for
 		# testing.
 		return;
-	
+
 	local headers = email_headers(subject, dest);
-	
+
 	local header_name = pp_alarms_name + ".tmp";
 	local header = open(header_name);
 	write_file(header, headers + "\n");
 	close(header);
-	
+
 	system(fmt("/bin/cat %s %s | %s -t -oi && /bin/rm -f %s %s",
 		   header_name, pp_alarms_name, sendmail, header_name, pp_alarms_name));
 	}
@@ -91,7 +91,7 @@ function pp_postprocessor(info: Log::RotationInfo): bool
 	{
 	if ( want_pp() )
 		pp_send(info);
-	
+
 	return T;
 	}
 
@@ -99,7 +99,7 @@ event zeek_init()
 	{
 	if ( ! want_pp() )
 		return;
-	
+
 	# This replaces the standard non-pretty-printing filter.
 	Log::add_filter(Notice::ALARM_LOG,
 			[$name="alarm-mail", $writer=Log::WRITER_NONE,
@@ -111,13 +111,13 @@ hook notice(n: Notice::Info) &priority=-5
 	{
 	if ( ! want_pp() )
 		return;
-	
+
 	if ( ACTION_ALARM !in n$actions )
 		return;
-	
+
 	if ( ! pp_alarms_open )
 		pp_open();
-	
+
 	pretty_print_alarm(pp_alarms, n);
 	}
 
@@ -128,17 +128,17 @@ function do_msg(out: file, n: Info, line1: string, line2: string, line3: string,
 	if ( n?$remote_location && n$remote_location?$country_code  )
 		country = fmt(" (remote location %s)", n$remote_location$country_code);
 @endif
-	
+
 	line1 = cat(line1, country);
-	
+
 	local resolved = "";
-	
+
 	if ( host1 != 0.0.0.0 )
 		resolved = fmt("%s   # %s = %s", resolved, host1, name1);
-	
+
 	if ( host2 != 0.0.0.0 )
 		resolved = fmt("%s  %s = %s", resolved, host2, name2);
-	
+
 	print out, line1;
 	print out, line2;
 	if ( line3 != "" )
@@ -152,7 +152,7 @@ function do_msg(out: file, n: Info, line1: string, line2: string, line3: string,
 function pretty_print_alarm(out: file, n: Info)
 	{
 	local pdescr = "";
-	
+
 @if ( Cluster::is_enabled() )
 	pdescr = "local";
 
@@ -163,16 +163,16 @@ function pretty_print_alarm(out: file, n: Info)
 
 	pdescr = fmt("<%s> ", pdescr);
 @endif
-	
+
 	local msg = fmt( "%s%s", pdescr, n$msg);
-	
+
 	local who = "";
 	local h1 = 0.0.0.0;
 	local h2 = 0.0.0.0;
-	
+
 	local orig_p = "";
 	local resp_p = "";
-	
+
 	if ( n?$id )
 		{
 		h1 = n$id$orig_h;
@@ -190,56 +190,56 @@ function pretty_print_alarm(out: file, n: Info)
 		h1 = n$src;
 		who = fmt("%s%s", h1, (n?$p ? fmt(":%s", n$p) : ""));
 		}
-	
+
 	if ( n?$uid )
 		who = fmt("%s (uid %s)", who, n$uid );
-	
+
 	local flag = (h1 in flag_nets || h2 in flag_nets);
-	
+
 	local line1 = fmt(">%s %D %s %s", (flag ? ">" : " "), network_time(), n$note, who);
 	local line2 = fmt("   %s", msg);
 	local line3 = n?$sub ? fmt("   %s", n$sub) : "";
-	
+
 	if ( h1 == 0.0.0.0 )
 		{
 		do_msg(out, n, line1, line2, line3, h1, "", h2, "");
 		return;
 		}
-	
+
 	if ( reading_traces() )
 		{
 		do_msg(out, n, line1, line2, line3, h1, "<skipped>", h2, "<skipped>");
 		return;
 		}
-	
+
 	when ( local h1name = lookup_addr(h1) )
 		{
-		if ( h2 == 0.0.0.0 ) 
+		if ( h2 == 0.0.0.0 )
 			{
 			do_msg(out, n, line1, line2, line3, h1, h1name, h2, "");
 			return;
 			}
-		
+
 		when ( local h2name = lookup_addr(h2) )
 			{
 			do_msg(out, n, line1, line2, line3, h1, h1name, h2, h2name);
 			return;
 			}
-		timeout 5secs 
+		timeout 5secs
 			{
 			do_msg(out, n, line1, line2, line3, h1, h1name, h2, "(dns timeout)");
 			return;
 			}
 		}
-	
+
 	timeout 5secs
 		{
-		if ( h2 == 0.0.0.0 ) 
+		if ( h2 == 0.0.0.0 )
 			{
 			do_msg(out, n, line1, line2, line3, h1,  "(dns timeout)", h2, "");
 			return;
 			}
-		
+
 		when ( local h2name_ = lookup_addr(h2) )
 			{
 			do_msg(out, n, line1, line2, line3, h1,  "(dns timeout)", h2, h2name_);

--- a/testing/btest/scripts/base/frameworks/notice/cluster.zeek
+++ b/testing/btest/scripts/base/frameworks/notice/cluster.zeek
@@ -33,9 +33,15 @@ event delayed_notice()
 		NOTICE([$note=Test_Notice, $msg="test notice!"]);
 	}
 
+event terminate_me()
+	{
+	terminate();
+	}
+
 event ready()
 	{
 	schedule 1secs { delayed_notice() };
+	schedule 2secs { terminate_me() };
 	}
 
 @if ( Cluster::local_node_type() == Cluster::MANAGER )
@@ -50,7 +56,7 @@ event Cluster::node_up(name: string, id: string)
 		Broker::publish(Cluster::worker_topic, ready);
 	}
 
-event Notice::log_notice(rec: Notice::Info)
+event Cluster::node_down(name: string, id: string)
 	{
 	terminate();
 	}


### PR DESCRIPTION
In the past they were processed on the manager - which requires big records to be sent around.

This has a potential of incompatibilities if someone relied on global state for notice processing.

More discussion of this in #214 