### PR TITLE
Fix creating a StringVal from std::string

### DIFF
--- a/src/Val.cc
+++ b/src/Val.cc
@@ -710,7 +710,7 @@ StringVal::StringVal(const char* s) : Val(TYPE_STRING)
 
 StringVal::StringVal(const string& s) : Val(TYPE_STRING)
 	{
-	val.string_val = new BroString(s.c_str());
+	val.string_val = new BroString(reinterpret_cast<const u_char*>(s.data()), s.length(), 1);
 	}
 
 StringVal* StringVal::ToUpper()

--- a/testing/btest/Baseline/language.paraglob/out
+++ b/testing/btest/Baseline/language.paraglob/out
@@ -5,5 +5,5 @@ F
 [once]
 []
 [*.gov*, *malware*]
-[z*ro]
+[z*ro, zero\x00zero]
 [*.gov*, *malware*]

--- a/testing/btest/language/paraglob.zeek
+++ b/testing/btest/language/paraglob.zeek
@@ -6,7 +6,7 @@ event zeek_init ()
 	local v1 = vector("*", "d?g", "*og", "d?", "d[!wl]g");
 	local v2 = vector("once", "!o*", "once");
 	local v3 = vector("https://*.google.com/*", "*malware*", "*.gov*");
-	local v4 = vector("z*ro");
+	local v4 = vector("z*ro", "zero\0zero");
 
 	local p1 = paraglob_init(v1);
 	local p2: opaque of paraglob = paraglob_init(v2);


### PR DESCRIPTION
Currently, creating a StringVal from a std::string did not work with data that contains \0 characters. This easy fix changes this - and should also lead to a small speed increase for code using this constructor.

This obviously means that more data might copied now in some cases that were previously cut off at the first 0-byte. Our test-suite did not reveal any such cases.