### PR TITLE
Add Windows Minidump file signature

### DIFF
--- a/scripts/base/frameworks/files/magic/general.sig
+++ b/scripts/base/frameworks/files/magic/general.sig
@@ -414,3 +414,9 @@ signature file-vim-tmp {
 	file-mime "application/x-vim-tmp", 100
 	file-magic /^b0VIM/
 }
+
+# Windows Minidump
+signature file-windows-minidump {
+    file-mime "application/x-windows-minidump", 50
+    file-magic /^MDMP/
+}


### PR DESCRIPTION
This signature is relevant for process dumps on Windows that could be extracted by various tools. The unencrypted transmission of the dump of a critical system process (for example, `lsass.exe`) via network would be detected by this rule.