### PR TITLE
Deprecate rfb_event

### DIFF
--- a/scripts/base/protocols/rfb/main.zeek
+++ b/scripts/base/protocols/rfb/main.zeek
@@ -106,11 +106,6 @@ function set_session(c: connection)
 		}
 	}
 
-event rfb_event(c: connection) &priority=5
-	{
-	set_session(c);
-	}
-
 event rfb_client_version(c: connection, major_version: string, minor_version: string) &priority=5
 	{
 	set_session(c);

--- a/src/analyzer/protocol/rfb/events.bif
+++ b/src/analyzer/protocol/rfb/events.bif
@@ -1,7 +1,7 @@
 ## Generated for RFB event
 ##
 ## c: The connection record for the underlying transport-layer session/flow.
-event rfb_event%(c: connection%);
+event rfb_event%(c: connection%) &deprecated="Remove in v3.1: This event never served a real purpose and will be removed. Please use the other rfb events instead.";
 
 ## Generated for RFB event authentication mechanism selection
 ##


### PR DESCRIPTION
This deprecates the seemingly quite pointless rfb_event. See #446 