### PR TITLE
Change Val cloning failure to assert rather than throw

### DIFF
--- a/src/Val.cc
+++ b/src/Val.cc
@@ -85,10 +85,7 @@ Val* Val::Clone(CloneState* state)
 		return i->second->Ref();
 
 	auto c = DoClone(state);
-
-	if ( ! c )
-		reporter->RuntimeError(GetLocationInfo(), "cannot clone value");
-
+	assert(c);
 	return c;
 	}
 


### PR DESCRIPTION
A failed clone would represent a programming / logic error since all
Vals (in any state) should be clone-able.

This also helps clean up several unhandled exception errors reported
by Coverity on esoteric code paths.

I recall the original cloning code used an assert, but the new opaque serialization introduced the run-time exception.  Don't think there was any real reason for that outside of helping track down methods that weren't yet implemented.