### PR TITLE
Fix potential thread safety issue with zeekenv util function

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1842,24 +1842,24 @@ void bro_strerror_r(int bro_errno, char* buf, size_t buflen)
 	strerror_r_helper(res, buf, buflen);
 	}
 
+static const std::map<const char*, const char*, CompareString> legacy_vars = {
+	{ "ZEEKPATH", "BROPATH" },
+	{ "ZEEK_PLUGIN_PATH", "BRO_PLUGIN_PATH" },
+	{ "ZEEK_PLUGIN_ACTIVATE", "BRO_PLUGIN_ACTIVATE" },
+	{ "ZEEK_PREFIXES", "BRO_PREFIXES" },
+	{ "ZEEK_DNS_FAKE", "BRO_DNS_FAKE" },
+	{ "ZEEK_SEED_FILE", "BRO_SEED_FILE" },
+	{ "ZEEK_LOG_SUFFIX", "BRO_LOG_SUFFIX" },
+	{ "ZEEK_PROFILER_FILE", "BRO_PROFILER_FILE" },
+	{ "ZEEK_DISABLE_ZEEKYGEN", "BRO_DISABLE_BROXYGEN" },
+	{ "ZEEK_DEFAULT_CONNECT_RETRY", "BRO_DEFAULT_CONNECT_RETRY" },
+	{ "ZEEK_BROKER_MAX_THREADS", "BRO_BROKER_MAX_THREADS" },
+	{ "ZEEK_DEFAULT_LISTEN_ADDRESS", "BRO_DEFAULT_LISTEN_ADDRESS" },
+	{ "ZEEK_DEFAULT_LISTEN_RETRY", "BRO_DEFAULT_LISTEN_RETRY" },
+};
+
 char* zeekenv(const char* name)
 	{
-	static std::map<const char*, const char*, CompareString> legacy_vars = {
-		{ "ZEEKPATH", "BROPATH" },
-		{ "ZEEK_PLUGIN_PATH", "BRO_PLUGIN_PATH" },
-		{ "ZEEK_PLUGIN_ACTIVATE", "BRO_PLUGIN_ACTIVATE" },
-		{ "ZEEK_PREFIXES", "BRO_PREFIXES" },
-		{ "ZEEK_DNS_FAKE", "BRO_DNS_FAKE" },
-		{ "ZEEK_SEED_FILE", "BRO_SEED_FILE" },
-		{ "ZEEK_LOG_SUFFIX", "BRO_LOG_SUFFIX" },
-		{ "ZEEK_PROFILER_FILE", "BRO_PROFILER_FILE" },
-		{ "ZEEK_DISABLE_ZEEKYGEN", "BRO_DISABLE_BROXYGEN" },
-		{ "ZEEK_DEFAULT_CONNECT_RETRY", "BRO_DEFAULT_CONNECT_RETRY" },
-		{ "ZEEK_BROKER_MAX_THREADS", "BRO_BROKER_MAX_THREADS" },
-		{ "ZEEK_DEFAULT_LISTEN_ADDRESS", "BRO_DEFAULT_LISTEN_ADDRESS" },
-		{ "ZEEK_DEFAULT_LISTEN_RETRY", "BRO_DEFAULT_LISTEN_RETRY" },
-	};
-
 	auto rval = getenv(name);
 
 	if ( rval )


### PR DESCRIPTION
Observed segfault accessing the local static std::map of zeekenv() from
a logging thread, but only in non-debug builds using Apple/Clang
compiler, not in a debug build or GCC.  Don't quite get this behavior
since static local variable initialization is supposed to be thread-safe
since C++11, but moving to a global static works and is "more efficient"
anyway since there's no longer any run-time overhead.

Here's a way to reproduce the segfault:

```
$ cat test.zeek
global data: table[subnet] of string;

event zeek_init()
    {
    data[192.168.0.1] = "router";
    }
$ zeek ./test.zeek
error in <no location> and ././test.zeek, line 1: index type doesn't match table (192.168.0.1 and list of subnet)
runtime error in ././test.zeek, line 5: table index assignment failed for invalid type 'string', value: router, expression: data[192.168.0.1], call stack: | #0 zeek_init() |
fatal error: errors occurred while initializing
Segmentation fault: 11
```