### PR TITLE
Remove unused BroObj::in_ser_cache member

### DIFF
--- a/src/Obj.h
+++ b/src/Obj.h
@@ -82,7 +82,6 @@ public:
 	BroObj()
 		{
 		ref_cnt = 1;
-		in_ser_cache = false;
 		notify_plugins = false;
 
 		// A bit of a hack.  We'd like to associate location
@@ -155,8 +154,6 @@ public:
 		SuppressErrors()	{ ++BroObj::suppress_errors; }
 		~SuppressErrors()	{ --BroObj::suppress_errors; }
 	};
-
-	bool in_ser_cache;
 
 protected:
 	Location* location;	// all that matters in real estate


### PR DESCRIPTION
Doesn't look like it was used even before removing the old serialization stuff, so really not sure why it's hanging around or what the intent was.