### PR TITLE
GH-475: Require --enable-perftools to link in tcmalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,15 +199,11 @@ set(HAVE_PERFTOOLS false)
 set(USE_PERFTOOLS_DEBUG false)
 set(USE_PERFTOOLS_TCMALLOC false)
 
-if (NOT DISABLE_PERFTOOLS)
+if ( ENABLE_PERFTOOLS )
    find_package(GooglePerftools)
-endif ()
 
-if (GOOGLEPERFTOOLS_FOUND OR TCMALLOC_FOUND)
-    set(HAVE_PERFTOOLS true)
-    # Non-Linux systems may not be well-supported by gperftools, so
-    # require explicit request from user to enable it in that case.
-    if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ENABLE_PERFTOOLS)
+    if ( GOOGLEPERFTOOLS_FOUND OR TCMALLOC_FOUND )
+        set(HAVE_PERFTOOLS true)
         set(USE_PERFTOOLS_TCMALLOC true)
 
         if (ENABLE_PERFTOOLS_DEBUG)
@@ -216,16 +212,10 @@ if (GOOGLEPERFTOOLS_FOUND OR TCMALLOC_FOUND)
             include_directories(BEFORE ${GooglePerftools_INCLUDE_DIR})
             list(APPEND OPTLIBS ${GooglePerftools_LIBRARIES_DEBUG})
         else ()
-            # Link in tcmalloc for better performance.
+            # Link in tcmalloc.
             list(APPEND OPTLIBS ${GooglePerftools_LIBRARIES})
         endif ()
     endif ()
-endif ()
-
-if (ENABLE_PERFTOOLS_DEBUG OR ENABLE_PERFTOOLS)
-    # Just a no op to prevent CMake from complaining about manually-specified
-    # ENABLE_PERFTOOLS_DEBUG or ENABLE_PERFTOOLS not being used if google
-    # perftools weren't found
 endif ()
 
 # Making sure any non-standard OpenSSL includes get searched earlier

--- a/NEWS
+++ b/NEWS
@@ -378,6 +378,12 @@ Changed Functionality
     Queue::pop methods do not return a value at all (one must check for
     a non-empty container before removing an element).
 
+- Google Perftools (tcmalloc) is no longer used by default on Linux
+  systems if it's found during the configuration process.
+  Use the --enable-perftools configuration flag to use tcmalloc.
+  The --disable-perftools flag is also no longer provided since
+  there's no longer any case in which tcmalloc will be used by default.
+
 Removed Functionality
 ---------------------
 

--- a/configure
+++ b/configure
@@ -47,15 +47,13 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --enable-debug         compile in debugging mode (like --build-type=Debug)
     --enable-coverage      compile with code coverage support (implies debugging mode)
     --enable-mobile-ipv6   analyze mobile IPv6 features defined by RFC 6275
-    --enable-perftools     force use of Google perftools on non-Linux systems
-                           (automatically on when perftools is present on Linux)
+    --enable-perftools     enable use of Google perftools (use tcmalloc)
     --enable-perftools-debug use Google's perftools for debugging
     --enable-jemalloc      link against jemalloc
     --enable-static-broker build Broker statically (ignored if --with-broker is specified)
     --enable-static-binpac build binpac statically (ignored if --with-binpac is specified)
     --disable-zeekctl      don't install ZeekControl
     --disable-auxtools     don't build or install auxiliary tools
-    --disable-perftools    don't try to build with Google Perftools
     --disable-python       don't try to build python bindings for Broker
     --disable-broker-tests don't try to build Broker unit tests
     --sanitizers=SANITIZERS comma-separated list of Clang sanitizers to enable
@@ -149,14 +147,12 @@ append_cache_entry ZEEK_SCRIPT_INSTALL_PATH STRING $prefix/share/zeek
 append_cache_entry ZEEK_ETC_INSTALL_DIR PATH   $prefix/etc
 append_cache_entry ENABLE_DEBUG         BOOL   false
 append_cache_entry ENABLE_PERFTOOLS     BOOL   false
-append_cache_entry ENABLE_PERFTOOLS_DEBUG BOOL false
 append_cache_entry ENABLE_JEMALLOC      BOOL   false
 append_cache_entry BUILD_SHARED_LIBS    BOOL   true
 append_cache_entry INSTALL_AUX_TOOLS    BOOL   true
 append_cache_entry INSTALL_ZEEKCTL      BOOL   true
 append_cache_entry CPACK_SOURCE_IGNORE_FILES STRING
 append_cache_entry ENABLE_MOBILE_IPV6   BOOL   false
-append_cache_entry DISABLE_PERFTOOLS    BOOL   false
 append_cache_entry SANITIZERS           STRING ""
 
 # parse arguments
@@ -247,9 +243,6 @@ while [ $# -ne 0 ]; do
             ;;
         --disable-auxtools)
             append_cache_entry INSTALL_AUX_TOOLS    BOOL   false
-            ;;
-        --disable-perftools)
-            append_cache_entry DISABLE_PERFTOOLS    BOOL   true
             ;;
         --disable-python)
             append_cache_entry DISABLE_PYTHON_BINDINGS     BOOL   true


### PR DESCRIPTION
Before, Linux systems would automatically use tcmalloc if found.

Remove --disable-perftools since there's no longer any case where
it's used by default.

Fixes #475 