### PR TITLE
 Add a protocol_confirmation_timeout before logging new services

### DIFF
--- a/testing/btest/Baseline/core.tunnels.teredo-known-services/known_services.log
+++ b/testing/btest/Baseline/core.tunnels.teredo-known-services/known_services.log
@@ -1,0 +1,10 @@
+#separator \x09
+#set_separator	,
+#empty_field	(empty)
+#unset_field	-
+#path	known_services
+#open	2019-07-25-12-52-46
+#fields	ts	host	port_num	port_proto	service
+#types	time	addr	port	enum	set[string]
+1258578181.260420	192.168.1.1	53	udp	DNS
+#close	2019-07-25-12-52-46

--- a/testing/btest/core/tunnels/teredo-known-services.test
+++ b/testing/btest/core/tunnels/teredo-known-services.test
@@ -1,5 +1,5 @@
 # @TEST-EXEC: zeek -r $TRACES/tunnels/false-teredo.pcap base/frameworks/dpd base/protocols/tunnels protocols/conn/known-services Tunnel::delay_teredo_confirmation=T "Site::local_nets+={192.168.1.0/24}"
-# @TEST-EXEC: test ! -e known_services.log
+# @TEST-EXEC: btest-diff known_services.log
 
 # The first case using Tunnel::delay_teredo_confirmation=T doesn't produce
 # a known services.log since valid Teredo encapsulations from both endpoints


### PR DESCRIPTION
I added a new option variable (tunable by users) for delaying the logging of known_services. 

To my understanding, on one hand it is desirable to log known services asap, on the other hand some information is available only later during a connection lifetime. I believe it is better to introduce a tunable time interval after protocol confirmation to let some fields in the connection record to be properly filled. 

This PR fixes the issue below: 
https://github.com/zeek/zeek/issues/455

I also updated the test core.tunnels.teredo-known-services. It seems to me the reason why there was no known_services.log before was because of the above issue. Not sure comments in the test script are updated.