### PR TITLE
Fix merge_types crash in vector-of-enum-values

### DIFF
--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1770,6 +1770,7 @@ BroType* merge_types(const BroType* t1, const BroType* t2)
 		}
 
 	switch ( tg1 ) {
+	case TYPE_ENUM:
 	case TYPE_TIME:
 	case TYPE_INTERVAL:
 	case TYPE_STRING:

--- a/testing/btest/language/vector-of-enum.zeek
+++ b/testing/btest/language/vector-of-enum.zeek
@@ -1,0 +1,8 @@
+# @TEST-EXEC: zeek %INPUT
+
+# This regression test checks a special case in the vector code.
+# Test succeeds if it doesn't crash Zeek.
+# (Error was "internal error in <stdin>, line 2: bad type in merge_types()")
+
+type color : enum {Red, White, Blue};
+global v = vector(Red, White, Blue);


### PR DESCRIPTION
Missing case for `TYPE_ENUM` in the switch statement in `merge_types()` causes core dump.

I initially found this while trying to initialize a vector of analyzer tags before discovering it was a problem with any vector-of-enums initialized this way:

```
local v = vector(
		Analyzer::ANALYZER_HTTP,
		Analyzer::ANALYZER_SSL,
		Analyzer::ANALYZER_SSH,
		Analyzer::ANALYZER_ICMP
	);
```


Interestingly, there's no problem if you define the type ahead of time. This works:
```
type analyzer_vec: vector of Analyzer::Tag;
	local v = analyzer_vec(
		Analyzer::ANALYZER_HTTP,
		Analyzer::ANALYZER_SSL,
		Analyzer::ANALYZER_SSH,
		Analyzer::ANALYZER_ICMP
	);
```
