### PR TITLE
Improve type inference for vector-of-enum constructor

### DIFF
--- a/testing/btest/Baseline/language.vector-of-enum-mismatch/out
+++ b/testing/btest/Baseline/language.vector-of-enum-mismatch/out
@@ -1,0 +1,2 @@
+error in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.vector-of-enum-mismatch/vector-of-enum-mismatch.zeek, line 7 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.vector-of-enum-mismatch/vector-of-enum-mismatch.zeek, line 8: incompatible enum types: 'color' and 'number' (enum and enum)
+error in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.vector-of-enum-mismatch/vector-of-enum-mismatch.zeek, line 9: inconsistent types in list

--- a/testing/btest/Baseline/language.vector-of-enum/out
+++ b/testing/btest/Baseline/language.vector-of-enum/out
@@ -1,0 +1,1 @@
+vector of enum, [Red, Green, Blue]

--- a/testing/btest/language/vector-of-enum-mismatch.zeek
+++ b/testing/btest/language/vector-of-enum-mismatch.zeek
@@ -1,0 +1,9 @@
+# @TEST-EXEC-FAIL: zeek -b %INPUT >out 2>&1
+# @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff out
+
+# Type inference for vector constructor comprised of disparate enum types
+# should raise an error message about the types being incompatible.
+
+type color: enum { Red, Green, Blue };
+type number: enum { One, Two, Three, Four};
+global v = vector(Red, Four, Blue);

--- a/testing/btest/language/vector-of-enum.zeek
+++ b/testing/btest/language/vector-of-enum.zeek
@@ -1,0 +1,9 @@
+# @TEST-EXEC: zeek -b %INPUT >out
+# @TEST-EXEC: btest-diff out
+
+# Type inference for vector constructor comprised of enums should work fine
+# (previously the internal merge_types code did not handle enums).
+
+type color: enum { Red, Green, Blue };
+global v = vector(Red, Green, Blue);
+print type_name(v), v;


### PR DESCRIPTION
This is an alternative fix for the underlying issue of https://github.com/zeek/zeek/pull/491