### PR TITLE
GH-485: fix cases where DHCP log omits MAC field

### DIFF
--- a/scripts/base/protocols/dhcp/main.zeek
+++ b/scripts/base/protocols/dhcp/main.zeek
@@ -79,6 +79,9 @@ export {
 		## Duration of the DHCP "session" representing the 
 		## time from the first message to the last.
 		duration:       interval    &log &default=0secs;
+
+		## The CHADDR field sent by the client.
+		client_chaddr:  string      &optional;
 	};
 
 	## The maximum amount of time that a transation ID will be watched
@@ -143,6 +146,12 @@ function join_data_expiration(t: table[count] of Info, idx: count): interval
 	     (now - info$ts) > max_txid_watch_time ||
 	     zeek_is_terminating() )
 		{
+		# If client didn't send client-identifier option and we didn't see
+		# a response from a server to use its chaddr field, then fill in mac
+		# from the client's chaddr field.
+		if ( ! info?$mac && info?$client_chaddr )
+			info$mac = info$client_chaddr;
+
 		Log::write(LOG, info);
 
 		# Go ahead and expire the data now that the log
@@ -219,6 +228,8 @@ event DHCP::aggregate_msgs(ts: time, id: conn_id, uid: string, is_orig: bool, ms
 		if ( options?$client_id &&
 		     options$client_id$hwtype == 1 ) # ETHERNET
 			log_info$mac = options$client_id$hwaddr;
+		else
+			log_info$client_chaddr = msg$chaddr;
 
 		if ( options?$addr_request )
 			log_info$requested_addr = options$addr_request;

--- a/testing/btest/Baseline/scripts.base.protocols.dhcp.dhcp-all-msg-types/dhcp.log
+++ b/testing/btest/Baseline/scripts.base.protocols.dhcp.dhcp-all-msg-types/dhcp.log
@@ -3,10 +3,10 @@
 #empty_field	(empty)
 #unset_field	-
 #path	dhcp
-#open	2018-03-01-15-19-24
+#open	2019-07-27-03-03-35
 #fields	ts	uids	client_addr	server_addr	mac	host_name	client_fqdn	domain	requested_addr	assigned_addr	lease_time	client_message	server_message	msg_types	duration
 #types	time	set[string]	addr	addr	string	string	string	string	addr	addr	interval	string	string	vector[string]	interval
-1370200447.422207	CHhAvVGS1DHFjwGM9	-	-	-	btest.is.cool	-	-	128.2.6.189	-	-	-	-	INFORM	0.000000
+1370200447.422207	CHhAvVGS1DHFjwGM9	-	-	90:b1:1c:99:49:29	btest.is.cool	-	-	128.2.6.189	-	-	-	-	INFORM	0.000000
 1370200442.323173	CtPZjS20MLrsMUOJi2,CHhAvVGS1DHFjwGM9,C4J4Th3PJpwUYZZ6gc,ClEkJM2Vm5giqnMf4h	128.2.6.97	128.2.6.152	90:b1:1c:99:49:29	btest.is.cool	-	cmu.edu	128.2.6.189	128.2.6.189	900.000000	-	requested address not available	DISCOVER,OFFER,REQUEST,NAK,REQUEST,ACK,DECLINE	3.058797
-1370200446.402928	CHhAvVGS1DHFjwGM9	-	-	-	-	-	-	-	-	-	-	-	RELEASE	0.000000
-#close	2018-03-01-15-19-24
+1370200446.402928	CHhAvVGS1DHFjwGM9	-	-	90:b1:1c:99:49:29	-	-	-	-	-	-	-	-	RELEASE	0.000000
+#close	2019-07-27-03-03-35


### PR DESCRIPTION
Need to regenerate docs during merge.

Fixes #485 