### PR TITLE
Remove redundant buffering in contentline

### DIFF
--- a/src/analyzer/protocol/tcp/ContentLine.cc
+++ b/src/analyzer/protocol/tcp/ContentLine.cc
@@ -92,19 +92,6 @@ void ContentLine_Analyzer::DeliverStream(int len, const u_char* data,
 			return;
 		}
 
-	if ( buf && len + offset >= buf_len )
-		{ // Make sure we have enough room to accommodate the new stuff.
-		int old_buf_len = buf_len;
-		buf_len = ((offset + len) * 3) / 2 + 1;
-
-		u_char* tmp = new u_char[buf_len];
-		for ( int i = 0; i < old_buf_len; ++i )
-			tmp[i] = buf[i];
-
-		delete [] buf;
-		buf = tmp;
-		}
-
 	DoDeliver(len, data);
 
 	seq += len;


### PR DESCRIPTION
The contentline analyzer has two code paths that buffer data:
 * right at the top of DeliverStream
 * later in DoDeliverOnce

However, contentline can be in plain delivery mode, and if so, the
buffer resize in DeliverStream does not need to be done just because
DeliverStream was passed an 8K data chunk.

This was causing contentline to resize its buffer to fit chunks of HTTP
response data.  Additionally, the buffer was sized to be 3/2 of the
chunk, so an 8K chunk would result in a 12K allocation.