### PR TITLE
Avoid buffering all http headers

### DIFF
--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -53,6 +53,7 @@ HTTP_Entity::HTTP_Entity(HTTP_Message *arg_message, MIME_Entity* parent_entity, 
 	offset = 0;
 	instance_length = -1; // unspecified
 	send_size = true;
+	want_all_headers = (bool)http_all_headers;
 	}
 
 void HTTP_Entity::EndOfData()

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -537,6 +537,7 @@ MIME_Entity::MIME_Entity(MIME_Message* output_message, MIME_Entity* parent_entit
 	message = output_message;
 	if ( parent )
 		content_encoding = parent->ContentTransferEncoding();
+	want_all_headers = (bool)mime_all_headers;
 	}
 
 void MIME_Entity::init()
@@ -744,8 +745,11 @@ void MIME_Entity::FinishHeader()
 		{
 		ParseMIMEHeader(h);
 		SubmitHeader(h);
-		headers.push_back(h);
-		}
+		if(want_all_headers)
+			headers.push_back(h);
+		else
+			delete h;
+		} 
 	else
 		delete h;
 	}

--- a/src/analyzer/protocol/mime/MIME.h
+++ b/src/analyzer/protocol/mime/MIME.h
@@ -173,6 +173,7 @@ protected:
 
 	MIME_Message* message;
 	bool delay_adding_implicit_CRLF;
+	bool want_all_headers;
 };
 
 // The reason I separate MIME_Message as an abstract class is to


### PR DESCRIPTION
Only buffer all http headers if the http_all_headers event is in use.