### PR TITLE
remove empty services and include udp active connections 

### DIFF
--- a/scripts/policy/protocols/conn/known-services.zeek
+++ b/scripts/policy/protocols/conn/known-services.zeek
@@ -210,7 +210,12 @@ event connection_state_remove(c: connection) &priority=-5
 	if ( c$known_services_done )
 		return;
 
-	if ( c$resp$state != TCP_ESTABLISHED )
+	# log tcp connection if established or udp if active
+	if ( c$resp$state != TCP_ESTABLISHED && c$resp$state != UDP_ACTIVE)
+		return;
+
+	# don't log empty service
+	if ( |c$service| == 0 )
 		return;
 
 	known_services_done(c);


### PR DESCRIPTION
I added checking for empty services in c$service and udp active connections when logging services in the connection_state_remove event.

I think we don't want to log pairs host/port_num for which no service was detected in c$service at the end of the connection.

Besides, as we check for tcp_established connections we should check for udp active connections as well and log only in this case. If we get here (in the event connection_state_remove) and we haven't log the service, it is because no protocol_confirmation was generated from the analyzer, maybe because something is wrong with the connection. So, better to check that either it is an estabilshed tcp connection or an active udp one.
However, I must admit that all present udp analyzers in my tests have generated the protocol confirmation and logged the services without getting here...