### PR TITLE
Add new LogAscii::gzip_file_extension option.

### DIFF
--- a/scripts/base/frameworks/logging/writers/ascii.zeek
+++ b/scripts/base/frameworks/logging/writers/ascii.zeek
@@ -39,6 +39,12 @@ export {
 	## This option is also available as a per-filter ``$config`` option.
 	const gzip_level = 0 &redef;
 
+	## Define the file extension used when compressing log files when
+	## they are created.
+	##
+	## This option is also available as a per-filter ``$config`` option.
+	const gzip_file_extension = "gz" &redef;
+
 	## Format of timestamps when writing out JSON. By default, the JSON
 	## formatter will use double values for timestamps which represent the
 	## number of seconds from the UNIX epoch.

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -71,6 +71,11 @@ void Ascii::InitConfigOptions()
 			(const char*) tsfmt.Bytes(),
 			tsfmt.Len()
 			);
+
+	gzip_file_extension.assign(
+		(const char*) BifConst::LogAscii::gzip_file_extension->Bytes(),
+		BifConst::LogAscii::gzip_file_extension->Len()
+		);
 	}
 
 bool Ascii::InitFilterOptions()
@@ -160,6 +165,9 @@ bool Ascii::InitFilterOptions()
 
 		else if ( strcmp(i->first, "json_timestamps") == 0 )
 			json_timestamps.assign(i->second);
+
+		else if ( strcmp(i->first, "gzip_file_extension") == 0 )
+			gzip_file_extension.assign(i->second);
 		}
 
 	if ( ! InitFormatter() )
@@ -252,8 +260,13 @@ bool Ascii::DoInit(const WriterInfo& info, int num_fields, const Field* const * 
 	if ( output_to_stdout )
 		path = "/dev/stdout";
 
-	fname = IsSpecial(path) ? path : path + "." + LogExt() +
-	                          (gzip_level > 0 ? ".gz" : "");
+	fname = IsSpecial(path) ? path : path + "." + LogExt();
+
+	if ( gzip_level > 0 )
+		{
+		fname += ".";
+		fname += gzip_file_extension.empty() ? "gz" : gzip_file_extension;
+		}
 
 	fd = open(fname.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
 
@@ -427,8 +440,13 @@ bool Ascii::DoRotate(const char* rotated_path, double open, double close, bool t
 
 	CloseFile(close);
 
-	string nname = string(rotated_path) + "." + LogExt() +
-	               (gzip_level > 0 ? ".gz" : "");
+	string nname = string(rotated_path) + "." + LogExt();
+
+	if ( gzip_level > 0 )
+		{
+		nname += ".";
+		nname += gzip_file_extension.empty() ? "gz" : gzip_file_extension;
+		}
 
 	if ( rename(fname.c_str(), nname.c_str()) != 0 )
 		{

--- a/src/logging/writers/ascii/Ascii.h
+++ b/src/logging/writers/ascii/Ascii.h
@@ -64,6 +64,7 @@ private:
 	string meta_prefix;
 
 	int gzip_level; // level > 0 enables gzip compression
+	string gzip_file_extension;
 	bool use_json;
 	bool enable_utf_8;
 	string json_timestamps;

--- a/src/logging/writers/ascii/ascii.bif
+++ b/src/logging/writers/ascii/ascii.bif
@@ -14,3 +14,4 @@ const use_json: bool;
 const enable_utf_8: bool;
 const json_timestamps: JSON::TimestampFormat;
 const gzip_level: count;
+const gzip_file_extension: string;

--- a/testing/btest/scripts/base/frameworks/logging/ascii-gz.zeek
+++ b/testing/btest/scripts/base/frameworks/logging/ascii-gz.zeek
@@ -1,12 +1,13 @@
 #
 # @TEST-EXEC: zeek -b %INPUT
-# @TEST-EXEC: gunzip ssh.log.gz
+# @TEST-EXEC: gunzip -S .gzip ssh.log.gzip
 # @TEST-EXEC: btest-diff ssh.log
 # @TEST-EXEC: btest-diff ssh-uncompressed.log
 #
 # Testing all possible types.
 
 redef LogAscii::gzip_level = 9;
+redef LogAscii::gzip_file_extension = "gzip";
 
 module SSH;
 


### PR DESCRIPTION
This can be used with the LogAscii::gzip_level option to set the file extension of log files when they are compressed at creation time.

For #360 

Needed by https://github.com/zeek/zeekctl/pull/16 to set the option.