### PR TITLE
Export intel events

### DIFF
--- a/scripts/base/frameworks/intel/input.zeek
+++ b/scripts/base/frameworks/intel/input.zeek
@@ -21,15 +21,36 @@ export {
 	## additionally.
 	const path_prefix = "" &redef;
 
-	event Intel::read_entry(desc: Input::EventDescription, tpe: Input::Event, item: Intel::Item)
-		{
-		Intel::insert(item);
-		}
+	## This event is raised each time the intel framework reads a new line
+	## from an intel file. It is used in the intel framework but can
+	## also be used in custom scripts for further checks.
+	##
+	## desc: The :zeek:type:`Input::EventDescription` record which generated the event.
+	##
+	## tpe: The type of input event.
+	##
+	## item: The intel item being read (of type :zeek:type:`Intel::Item`).
+	##
+	global read_entry: event(desc: Input::EventDescription, tpe: Input::Event, item: Intel::Item);
 
-	event Intel::read_error(desc: Input::EventDescription, message: string, level: Reporter::Level)
-		{
-		}
+	## This event is raised each time the input framework detects an error
+	## while reading the intel file. It can be used to implement further checks
+	## in custom scripts. Errors can be of different levels (information, warning, errors).
+	##
+	## desc: The :zeek:type:`Input::EventDescription` record which generated the error.
+	##
+	## message: An error message.
+	##
+	## level: The :zeek:type:`Reporter::Level` of the error.
+	##
+	global read_error: event(desc: Input::EventDescription, message: string, level: Reporter::Level);
 }
+
+event Intel::read_entry(desc: Input::EventDescription, tpe: Input::Event, item: Intel::Item)
+	{
+	Intel::insert(item);
+	}
+
 
 event zeek_init() &priority=5
 	{

--- a/scripts/base/frameworks/intel/input.zeek
+++ b/scripts/base/frameworks/intel/input.zeek
@@ -26,6 +26,9 @@ export {
 		Intel::insert(item);
 		}
 
+	event Intel::read_error(desc: Input::EventDescription, message: string, level: Reporter::Level)
+		{
+		}
 }
 
 event zeek_init() &priority=5
@@ -50,7 +53,8 @@ event zeek_init() &priority=5
 			                  $mode=Input::REREAD,
 			                  $name=cat("intel-", a_file),
 			                  $fields=Intel::Item,
-			                  $ev=Intel::read_entry]);
+			                  $ev=Intel::read_entry,
+					  $error_ev=Intel::read_error]);
 			}
 		}
 	}

--- a/scripts/base/frameworks/intel/input.zeek
+++ b/scripts/base/frameworks/intel/input.zeek
@@ -20,12 +20,13 @@ export {
 	## any path_prefix specified in the input framework will apply
 	## additionally.
 	const path_prefix = "" &redef;
-}
 
-event Intel::read_entry(desc: Input::EventDescription, tpe: Input::Event, item: Intel::Item)
-	{
-	Intel::insert(item);
-	}
+	event Intel::read_entry(desc: Input::EventDescription, tpe: Input::Event, item: Intel::Item)
+		{
+		Intel::insert(item);
+		}
+
+}
 
 event zeek_init() &priority=5
 	{


### PR DESCRIPTION
I think it would be useful for users to have the possibility to use the event Intel::read_entry in their own scripts and to have another event, which I called Intel::read_error, for managing the errors coming from from the input framework when reading intel files. The latter event is empty and only there to allow users to implement further checks (as I did).

Both changes should not much of an impact on the intel framework.