### PR TITLE
Deprecate the internal int/uint types

### DIFF
--- a/src/Anon.cc
+++ b/src/Anon.cc
@@ -12,16 +12,16 @@
 
 AnonymizeIPAddr* ip_anonymizer[NUM_ADDR_ANONYMIZATION_METHODS] = {0};
 
-static uint32 rand32()
+static uint32_t rand32()
 	{
 	return ((bro_random() & 0xffff) << 16) | (bro_random() & 0xffff);
 	}
 
 // From tcpdpriv.
-int bi_ffs(uint32 value)
+int bi_ffs(uint32_t value)
 	{
 	int add = 0;
-	static uint8 bvals[] = {
+	static uint8_t bvals[] = {
 		0, 4, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1
 	};
 
@@ -88,7 +88,7 @@ ipaddr32_t AnonymizeIPAddr_Seq::anonymize(ipaddr32_t /* input */)
 
 ipaddr32_t AnonymizeIPAddr_RandomMD5::anonymize(ipaddr32_t input)
 	{
-	uint8 digest[16];
+	uint8_t digest[16];
 	ipaddr32_t output = 0;
 
 	hmac_md5(sizeof(input), (u_char*)(&input), digest);
@@ -107,7 +107,7 @@ ipaddr32_t AnonymizeIPAddr_RandomMD5::anonymize(ipaddr32_t input)
 
 ipaddr32_t AnonymizeIPAddr_PrefixMD5::anonymize(ipaddr32_t input)
 	{
-	uint8 digest[16];
+	uint8_t digest[16];
 	ipaddr32_t prefix_mask = 0xffffffff;
 	input = ntohl(input);
 	ipaddr32_t output = input;
@@ -179,8 +179,8 @@ int AnonymizeIPAddr_A50::PreservePrefix(ipaddr32_t input, int num_bits)
 	else if ( num_bits > 0 )
 		{
 		assert((0xFFFFFFFFU >> 1) == 0x7FFFFFFFU);
-		uint32 suffix_mask = (0xFFFFFFFFU >> num_bits);
-		uint32 prefix_mask = ~suffix_mask;
+		uint32_t suffix_mask = (0xFFFFFFFFU >> num_bits);
+		uint32_t prefix_mask = ~suffix_mask;
 		n->output = (input & prefix_mask) | (rand32() & suffix_mask);
 		}
 

--- a/src/Anon.h
+++ b/src/Anon.h
@@ -37,7 +37,7 @@ enum ip_addr_anonymization_method_t {
 	NUM_ADDR_ANONYMIZATION_METHODS,
 };
 
-typedef uint32 ipaddr32_t;
+typedef uint32_t ipaddr32_t;
 
 // NOTE: all addresses in parameters of *public* functions are in
 // network order.

--- a/src/Base64.cc
+++ b/src/Base64.cc
@@ -153,7 +153,7 @@ int Base64Converter::Decode(int len, const char* data, int* pblen, char** pbuf)
 			if ( buf + num_octets > *pbuf + blen )
 				break;
 
-			uint32 bit32 =
+			uint32_t bit32 =
 				((base64_group[0] & 0x3f) << 18) |
 				((base64_group[1] & 0x3f) << 12) |
 				((base64_group[2] & 0x3f) << 6)  |

--- a/src/Brofiler.cc
+++ b/src/Brofiler.cc
@@ -37,7 +37,7 @@ bool Brofiler::ReadStats()
 		string location(strtok(0, delimiter.c_str()));
 		string desc(strtok(0, delimiter.c_str()));
 		pair<string, string> location_desc(location, desc);
-		uint64 count;
+		uint64_t count;
 		atoi_n(cnt.size(), cnt.c_str(), 0, 10, count);
 		usage_map[location_desc] = count;
 		}
@@ -104,7 +104,7 @@ bool Brofiler::WriteStats()
 			usage_map[location_desc] = (*it)->GetAccessCount();
 		}
 
-	map<pair<string, string>, uint64 >::const_iterator it;
+	map<pair<string, string>, uint64_t >::const_iterator it;
 	for ( it = usage_map.begin(); it != usage_map.end(); ++it )
 		{
 		fprintf(f, "%" PRIu64"%c%s%c%s\n", it->second, delim,

--- a/src/Brofiler.h
+++ b/src/Brofiler.h
@@ -59,7 +59,7 @@ private:
 	 * startup time and modified at shutdown time before writing back
 	 * to a file.
 	 */
-	map<pair<string, string>, uint64> usage_map;
+	map<pair<string, string>, uint64_t> usage_map;
 
 	/**
 	 * The character to use to delimit Brofiler output files.  Default is '\t'.

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -111,7 +111,7 @@ char* CompositeHash::SingleValHash(int type_check, char* kp0,
 
 	case TYPE_INTERNAL_ADDR:
 		{
-		uint32* kp = AlignAndPadType<uint32>(kp0);
+		uint32_t* kp = AlignAndPadType<uint32_t>(kp0);
 		v->AsAddr().CopyIPv6(kp);
 		kp1 = reinterpret_cast<char*>(kp+4);
 		}
@@ -119,7 +119,7 @@ char* CompositeHash::SingleValHash(int type_check, char* kp0,
 
 	case TYPE_INTERNAL_SUBNET:
 		{
-		uint32* kp = AlignAndPadType<uint32>(kp0);
+		uint32_t* kp = AlignAndPadType<uint32_t>(kp0);
 		v->AsSubNet().Prefix().CopyIPv6(kp);
 		kp[4] = v->AsSubNet().Length();
 		kp1 = reinterpret_cast<char*>(kp+5);
@@ -140,7 +140,7 @@ char* CompositeHash::SingleValHash(int type_check, char* kp0,
 		switch ( v->Type()->Tag() ) {
 		case TYPE_FUNC:
 			{
-			uint32* kp = AlignAndPadType<uint32>(kp0);
+			uint32_t* kp = AlignAndPadType<uint32_t>(kp0);
 			*kp = v->AsFunc()->GetUniqueFuncID();
 			kp1 = reinterpret_cast<char*>(kp+1);
 			break;
@@ -439,13 +439,13 @@ int CompositeHash::SingleTypeKeySize(BroType* bt, const Val* v,
 		break;
 
 	case TYPE_INTERNAL_ADDR:
-		sz = SizeAlign(sz, sizeof(uint32));
-		sz += sizeof(uint32) * 3;	// to make a total of 4 words
+		sz = SizeAlign(sz, sizeof(uint32_t));
+		sz += sizeof(uint32_t) * 3;	// to make a total of 4 words
 		break;
 
 	case TYPE_INTERNAL_SUBNET:
-		sz = SizeAlign(sz, sizeof(uint32));
-		sz += sizeof(uint32) * 4;	// to make a total of 5 words
+		sz = SizeAlign(sz, sizeof(uint32_t));
+		sz += sizeof(uint32_t) * 4;	// to make a total of 5 words
 		break;
 
 	case TYPE_INTERNAL_DOUBLE:
@@ -458,7 +458,7 @@ int CompositeHash::SingleTypeKeySize(BroType* bt, const Val* v,
 		switch ( bt->Tag() ) {
 		case TYPE_FUNC:
 			{
-			sz = SizeAlign(sz, sizeof(uint32));
+			sz = SizeAlign(sz, sizeof(uint32_t));
 			break;
 			}
 
@@ -770,7 +770,7 @@ const char* CompositeHash::RecoverOneVal(const HashKey* k, const char* kp0,
 
 	case TYPE_INTERNAL_ADDR:
 		{
-		const uint32* const kp = AlignType<uint32>(kp0);
+		const uint32_t* const kp = AlignType<uint32_t>(kp0);
 		kp1 = reinterpret_cast<const char*>(kp+4);
 
 		IPAddr addr(IPv6, kp, IPAddr::Network);
@@ -790,7 +790,7 @@ const char* CompositeHash::RecoverOneVal(const HashKey* k, const char* kp0,
 
 	case TYPE_INTERNAL_SUBNET:
 		{
-		const uint32* const kp = AlignType<uint32>(kp0);
+		const uint32_t* const kp = AlignType<uint32_t>(kp0);
 		kp1 = reinterpret_cast<const char*>(kp+5);
 		pval = new SubNetVal(kp, kp[4]);
 		}
@@ -802,7 +802,7 @@ const char* CompositeHash::RecoverOneVal(const HashKey* k, const char* kp0,
 		switch ( t->Tag() ) {
 		case TYPE_FUNC:
 			{
-			const uint32* const kp = AlignType<uint32>(kp0);
+			const uint32_t* const kp = AlignType<uint32_t>(kp0);
 			kp1 = reinterpret_cast<const char*>(kp+1);
 
 			Func* f = Func::GetFuncPtrByID(*kp);

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -50,12 +50,12 @@ void ConnectionTimer::Dispatch(double t, int is_expire)
 		reporter->InternalError("reference count inconsistency in ConnectionTimer::Dispatch");
 	}
 
-uint64 Connection::total_connections = 0;
-uint64 Connection::current_connections = 0;
-uint64 Connection::external_connections = 0;
+uint64_t Connection::total_connections = 0;
+uint64_t Connection::current_connections = 0;
+uint64_t Connection::external_connections = 0;
 
 Connection::Connection(NetSessions* s, HashKey* k, double t, const ConnID* id,
-                       uint32 flow, const Packet* pkt,
+                       uint32_t flow, const Packet* pkt,
 		       const EncapsulationStack* arg_encap)
 	{
 	sessions = s;
@@ -228,9 +228,9 @@ bool Connection::IsReuse(double t, const u_char* pkt)
 	return root_analyzer && root_analyzer->IsReuse(t, pkt);
 	}
 
-bool Connection::ScaledHistoryEntry(char code, uint32& counter,
-                                    uint32& scaling_threshold,
-                                    uint32 scaling_base)
+bool Connection::ScaledHistoryEntry(char code, uint32_t& counter,
+                                    uint32_t& scaling_threshold,
+                                    uint32_t scaling_base)
 	{
 	if ( ++counter == scaling_threshold )
 		{
@@ -254,7 +254,7 @@ bool Connection::ScaledHistoryEntry(char code, uint32& counter,
 	}
 
 void Connection::HistoryThresholdEvent(EventHandlerPtr e, bool is_orig,
-                                       uint32 threshold)
+                                       uint32_t threshold)
 	{
 	if ( ! e )
 		return;
@@ -568,7 +568,7 @@ void Connection::FlipRoles()
 	resp_addr = orig_addr;
 	orig_addr = tmp_addr;
 
-	uint32 tmp_port = resp_port;
+	uint32_t tmp_port = resp_port;
 	resp_port = orig_port;
 	orig_port = tmp_port;
 
@@ -582,7 +582,7 @@ void Connection::FlipRoles()
 	saw_first_resp_packet = saw_first_orig_packet;
 	saw_first_orig_packet = tmp_bool;
 
-	uint32 tmp_flow = resp_flow_label;
+	uint32_t tmp_flow = resp_flow_label;
 	resp_flow_label = orig_flow_label;
 	orig_flow_label = tmp_flow;
 
@@ -678,9 +678,9 @@ void Connection::SetRootAnalyzer(analyzer::TransportLayerAnalyzer* analyzer, ana
 	primary_PIA = pia;
 	}
 
-void Connection::CheckFlowLabel(bool is_orig, uint32 flow_label)
+void Connection::CheckFlowLabel(bool is_orig, uint32_t flow_label)
 	{
-	uint32& my_flow_label = is_orig ? orig_flow_label : resp_flow_label;
+	uint32_t& my_flow_label = is_orig ? orig_flow_label : resp_flow_label;
 
 	if ( my_flow_label != flow_label )
 		{
@@ -710,7 +710,7 @@ void Connection::CheckFlowLabel(bool is_orig, uint32 flow_label)
 		saw_first_resp_packet = 1;
 	}
 
-bool Connection::PermitWeird(const char* name, uint64 threshold, uint64 rate,
+bool Connection::PermitWeird(const char* name, uint64_t threshold, uint64_t rate,
                              double duration)
 	{
 	return ::PermitWeird(weird_state, name, threshold, rate, duration);

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -42,13 +42,13 @@ typedef void (Connection::*timer_func)(double t);
 struct ConnID {
 	IPAddr src_addr;
 	IPAddr dst_addr;
-	uint32 src_port;
-	uint32 dst_port;
+	uint32_t src_port;
+	uint32_t dst_port;
 	bool is_one_way;	// if true, don't canonicalize order
 };
 
-static inline int addr_port_canon_lt(const IPAddr& addr1, uint32 p1,
-					const IPAddr& addr2, uint32 p2)
+static inline int addr_port_canon_lt(const IPAddr& addr1, uint32_t p1,
+					const IPAddr& addr2, uint32_t p2)
 	{
 	return addr1 < addr2 || (addr1 == addr2 && p1 < p2);
 	}
@@ -58,7 +58,7 @@ namespace analyzer { class Analyzer; }
 class Connection : public BroObj {
 public:
 	Connection(NetSessions* s, HashKey* k, double t, const ConnID* id,
-	           uint32 flow, const Packet* pkt, const EncapsulationStack* arg_encap);
+	           uint32_t flow, const Packet* pkt, const EncapsulationStack* arg_encap);
 	~Connection() override;
 
 	// Invoked when an encapsulation is discovered. It records the
@@ -101,8 +101,8 @@ public:
 	const IPAddr& OrigAddr() const		{ return orig_addr; }
 	const IPAddr& RespAddr() const		{ return resp_addr; }
 
-	uint32 OrigPort() const			{ return orig_port; }
-	uint32 RespPort() const			{ return resp_port; }
+	uint32_t OrigPort() const			{ return orig_port; }
+	uint32_t RespPort() const			{ return resp_port; }
 
 	void FlipRoles();
 
@@ -228,15 +228,15 @@ public:
 	unsigned int MemoryAllocation() const;
 	unsigned int MemoryAllocationConnVal() const;
 
-	static uint64 TotalConnections()
+	static uint64_t TotalConnections()
 		{ return total_connections; }
-	static uint64 CurrentConnections()
+	static uint64_t CurrentConnections()
 		{ return current_connections; }
-	static uint64 CurrentExternalConnections()
+	static uint64_t CurrentExternalConnections()
 		{ return external_connections; }
 
 	// Returns true if the history was already seen, false otherwise.
-	int CheckHistory(uint32 mask, char code)
+	int CheckHistory(uint32_t mask, char code)
 		{
 		if ( (hist_seen & mask) == 0 )
 			{
@@ -252,12 +252,12 @@ public:
 	// code if it has crossed the next scaling threshold.  Scaling
 	// is done in terms of powers of the third argument.
 	// Returns true if the threshold was crossed, false otherwise.
-	bool ScaledHistoryEntry(char code, uint32& counter,
-	                        uint32& scaling_threshold,
-	                        uint32 scaling_base = 10);
+	bool ScaledHistoryEntry(char code, uint32_t& counter,
+	                        uint32_t& scaling_threshold,
+	                        uint32_t scaling_base = 10);
 
 	void HistoryThresholdEvent(EventHandlerPtr e, bool is_orig,
-	                           uint32 threshold);
+	                           uint32_t threshold);
 
 	void AddHistory(char code)	{ history += code; }
 
@@ -278,12 +278,12 @@ public:
 	const EncapsulationStack* GetEncapsulation() const
 		{ return encapsulation; }
 
-	void CheckFlowLabel(bool is_orig, uint32 flow_label);
+	void CheckFlowLabel(bool is_orig, uint32_t flow_label);
 
-	uint32 GetOrigFlowLabel() { return orig_flow_label; }
-	uint32 GetRespFlowLabel() { return resp_flow_label; }
+	uint32_t GetOrigFlowLabel() { return orig_flow_label; }
+	uint32_t GetRespFlowLabel() { return resp_flow_label; }
 
-	bool PermitWeird(const char* name, uint64 threshold, uint64 rate,
+	bool PermitWeird(const char* name, uint64_t threshold, uint64_t rate,
 	                 double duration);
 
 protected:
@@ -314,10 +314,10 @@ protected:
 
 	IPAddr orig_addr;
 	IPAddr resp_addr;
-	uint32 orig_port, resp_port;	// in network order
+	uint32_t orig_port, resp_port;	// in network order
 	TransportProto proto;
-	uint32 orig_flow_label, resp_flow_label;	// most recent IPv6 flow labels
-	uint32 vlan, inner_vlan;	// VLAN this connection traverses, if available
+	uint32_t orig_flow_label, resp_flow_label;	// most recent IPv6 flow labels
+	uint32_t vlan, inner_vlan;	// VLAN this connection traverses, if available
 	u_char orig_l2_addr[Packet::l2_addr_len];	// Link-layer originator address, if available
 	u_char resp_l2_addr[Packet::l2_addr_len];	// Link-layer responder address, if available
 	double start_time, last_time;
@@ -338,12 +338,12 @@ protected:
 	unsigned int saw_first_orig_packet:1, saw_first_resp_packet:1;
 
 	// Count number of connections.
-	static uint64 total_connections;
-	static uint64 current_connections;
-	static uint64 external_connections;
+	static uint64_t total_connections;
+	static uint64_t current_connections;
+	static uint64_t external_connections;
 
 	string history;
-	uint32 hist_seen;
+	uint32_t hist_seen;
 
 	analyzer::TransportLayerAnalyzer* root_analyzer;
 	analyzer::pia::PIA* primary_PIA;

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -89,7 +89,7 @@ int DNS_Mgr_Request::MakeRequest(nb_dns_info* nb_dns)
 		return nb_dns_host_request2(nb_dns, host, fam, qtype, (void*) this, err) >= 0;
 	else
 		{
-		const uint32* bytes;
+		const uint32_t* bytes;
 		int len = addr.GetBytes(&bytes);
 		return nb_dns_addr_request2(nb_dns, (char*) bytes,
 				len == 1 ? AF_INET : AF_INET6, (void*) this, err) >= 0;
@@ -98,8 +98,8 @@ int DNS_Mgr_Request::MakeRequest(nb_dns_info* nb_dns)
 
 class DNS_Mapping {
 public:
-	DNS_Mapping(const char* host, struct hostent* h, uint32 ttl);
-	DNS_Mapping(const IPAddr& addr, struct hostent* h, uint32 ttl);
+	DNS_Mapping(const char* host, struct hostent* h, uint32_t ttl);
+	DNS_Mapping(const IPAddr& addr, struct hostent* h, uint32_t ttl);
 	DNS_Mapping(FILE* f);
 
 	int NoMapping() const		{ return no_mapping; }
@@ -147,7 +147,7 @@ protected:
 
 	char* req_host;
 	IPAddr req_addr;
-	uint32 req_ttl;
+	uint32_t req_ttl;
 
 	int num_names;
 	char** names;
@@ -176,7 +176,7 @@ static TableVal* empty_addr_set()
 	return new TableVal(s);
 	}
 
-DNS_Mapping::DNS_Mapping(const char* host, struct hostent* h, uint32 ttl)
+DNS_Mapping::DNS_Mapping(const char* host, struct hostent* h, uint32_t ttl)
 	{
 	Init(h);
 	req_host = copy_string(host);
@@ -186,7 +186,7 @@ DNS_Mapping::DNS_Mapping(const char* host, struct hostent* h, uint32 ttl)
 		names[0] = copy_string(host);
 	}
 
-DNS_Mapping::DNS_Mapping(const IPAddr& addr, struct hostent* h, uint32 ttl)
+DNS_Mapping::DNS_Mapping(const IPAddr& addr, struct hostent* h, uint32_t ttl)
 	{
 	Init(h);
 	req_addr = addr;
@@ -337,10 +337,10 @@ void DNS_Mapping::Init(struct hostent* h)
 		addrs = new IPAddr[num_addrs];
 		for ( int i = 0; i < num_addrs; ++i )
 			if ( h->h_addrtype == AF_INET )
-				addrs[i] = IPAddr(IPv4, (uint32*)h->h_addr_list[i],
+				addrs[i] = IPAddr(IPv4, (uint32_t*)h->h_addr_list[i],
 				                  IPAddr::Network);
 			else if ( h->h_addrtype == AF_INET6 )
-				addrs[i] = IPAddr(IPv6, (uint32*)h->h_addr_list[i],
+				addrs[i] = IPAddr(IPv6, (uint32_t*)h->h_addr_list[i],
 				                  IPAddr::Network);
 		}
 	else
@@ -473,7 +473,7 @@ void DNS_Mgr::InitPostScript()
 
 static TableVal* fake_name_lookup_result(const char* name)
 	{
-	uint32 hash[4];
+	uint32_t hash[4];
 	internal_md5(reinterpret_cast<const u_char*>(name), strlen(name),
 	    reinterpret_cast<u_char*>(hash));
 	ListVal* hv = new ListVal(TYPE_ADDR);

--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -111,7 +111,7 @@ void ODesc::Add(int i)
 		}
 	}
 
-void ODesc::Add(uint32 u)
+void ODesc::Add(uint32_t u)
 	{
 	if ( IsBinary() )
 		AddBytes(&u, sizeof(u));
@@ -123,7 +123,7 @@ void ODesc::Add(uint32 u)
 		}
 	}
 
-void ODesc::Add(int64 i)
+void ODesc::Add(int64_t i)
 	{
 	if ( IsBinary() )
 		AddBytes(&i, sizeof(i));
@@ -135,7 +135,7 @@ void ODesc::Add(int64 i)
 		}
 	}
 
-void ODesc::Add(uint64 u)
+void ODesc::Add(uint64_t u)
 	{
 	if ( IsBinary() )
 		AddBytes(&u, sizeof(u));

--- a/src/Desc.h
+++ b/src/Desc.h
@@ -79,9 +79,9 @@ public:
 	void AddN(const char* s, int len)	{ AddBytes(s, len); }
 	void Add(const string& s)	{ AddBytes(s.data(), s.size()); }
 	void Add(int i);
-	void Add(uint32 u);
-	void Add(int64 i);
-	void Add(uint64 u);
+	void Add(uint32_t u);
+	void Add(int64_t i);
+	void Add(uint64_t u);
 	void Add(double d, bool no_exp=false);
 	void Add(const IPAddr& addr);
 	void Add(const IPPrefix& prefix);

--- a/src/Dict.h
+++ b/src/Dict.h
@@ -65,7 +65,7 @@ public:
 		}
 
 	// Total number of entries ever.
-	uint64 NumCumulativeInserts() const
+	uint64_t NumCumulativeInserts() const
 		{
 		return cumulative_entries;
 		}
@@ -163,7 +163,7 @@ private:
 	int num_buckets;
 	int num_entries;
 	int max_num_entries;
-	uint64 cumulative_entries;
+	uint64_t cumulative_entries;
 	double den_thresh;
 	int thresh_entries;
 

--- a/src/Event.cc
+++ b/src/Event.cc
@@ -10,8 +10,8 @@
 
 EventMgr mgr;
 
-uint64 num_events_queued = 0;
-uint64 num_events_dispatched = 0;
+uint64_t num_events_queued = 0;
+uint64_t num_events_dispatched = 0;
 
 Event::Event(EventHandlerPtr arg_handler, val_list arg_args,
 		SourceID arg_src, analyzer::ID arg_aid, TimerMgr* arg_mgr,

--- a/src/Event.h
+++ b/src/Event.h
@@ -49,8 +49,8 @@ protected:
 	Event* next_event;
 };
 
-extern uint64 num_events_queued;
-extern uint64 num_events_dispatched;
+extern uint64_t num_events_queued;
+extern uint64_t num_events_dispatched;
 
 class EventMgr : public BroObj {
 public:

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -1469,11 +1469,11 @@ DivideExpr::DivideExpr(Expr* arg_op1, Expr* arg_op2)
 
 Val* DivideExpr::AddrFold(Val* v1, Val* v2) const
 	{
-	uint32 mask;
+	uint32_t mask;
 	if ( v2->Type()->Tag() == TYPE_COUNT )
-		mask = static_cast<uint32>(v2->InternalUnsigned());
+		mask = static_cast<uint32_t>(v2->InternalUnsigned());
 	else
-		mask = static_cast<uint32>(v2->InternalInt());
+		mask = static_cast<uint32_t>(v2->InternalInt());
 
 	auto& a = v1->AsAddr();
 

--- a/src/Frag.cc
+++ b/src/Frag.cc
@@ -97,9 +97,9 @@ void FragReassembler::AddFragment(double t, const IP_Hdr* ip, const u_char* pkt)
 		// Linux MTU discovery for UDP can do this, for example.
 		s->Weird("fragment_with_DF", ip);
 
-	uint16 offset = ip->FragOffset();
-	uint32 len = ip->TotalLen();
-	uint16 hdr_len = ip->HdrLen();
+	uint16_t offset = ip->FragOffset();
+	uint32_t len = ip->TotalLen();
+	uint16_t hdr_len = ip->HdrLen();
 
 	if ( len < hdr_len )
 		{
@@ -107,7 +107,7 @@ void FragReassembler::AddFragment(double t, const IP_Hdr* ip, const u_char* pkt)
 		return;
 		}
 
-	uint64 upper_seq = offset + len - hdr_len;
+	uint64_t upper_seq = offset + len - hdr_len;
 
 	if ( ! offset )
 		// Make sure to use the first fragment header's next field.
@@ -178,7 +178,7 @@ void FragReassembler::Weird(const char* name) const
 		}
 	}
 
-void FragReassembler::Overlap(const u_char* b1, const u_char* b2, uint64 n)
+void FragReassembler::Overlap(const u_char* b1, const u_char* b2, uint64_t n)
 	{
 	if ( memcmp((const void*) b1, (const void*) b2, n) )
 		Weird("fragment_inconsistency");
@@ -231,7 +231,7 @@ void FragReassembler::BlockInserted(DataBlock* /* start_block */)
 		return;
 
 	// We have it all.  Compute the expected size of the fragment.
-	uint64 n = proto_hdr_len + frag_size;
+	uint64_t n = proto_hdr_len + frag_size;
 
 	// It's possible that we have blocks associated with this fragment
 	// that exceed this size, if we saw MF fragments (which don't lead

--- a/src/Frag.h
+++ b/src/Frag.h
@@ -34,15 +34,15 @@ public:
 
 protected:
 	void BlockInserted(DataBlock* start_block) override;
-	void Overlap(const u_char* b1, const u_char* b2, uint64 n) override;
+	void Overlap(const u_char* b1, const u_char* b2, uint64_t n) override;
 	void Weird(const char* name) const;
 
 	u_char* proto_hdr;
 	IP_Hdr* reassembled_pkt;
-	uint16 proto_hdr_len;
+	uint16_t proto_hdr_len;
 	NetSessions* s;
-	uint64 frag_size;	// size of fully reassembled fragment
-	uint16 next_proto; // first IPv6 fragment header's next proto field
+	uint64_t frag_size;	// size of fully reassembled fragment
+	uint16_t next_proto; // first IPv6 fragment header's next proto field
 	HashKey* key;
 
 	FragTimer* expire_timer;

--- a/src/Func.h
+++ b/src/Func.h
@@ -68,8 +68,8 @@ public:
 
 	virtual TraversalCode Traverse(TraversalCallback* cb) const;
 
-	uint32 GetUniqueFuncID() const { return unique_id; }
-	static Func* GetFuncPtrByID(uint32 id)
+	uint32_t GetUniqueFuncID() const { return unique_id; }
+	static Func* GetFuncPtrByID(uint32_t id)
 		{ return id >= unique_ids.size() ? 0 : unique_ids[id]; }
 
 protected:
@@ -86,7 +86,7 @@ protected:
 	Kind kind;
 	BroType* type;
 	string name;
-	uint32 unique_id;
+	uint32_t unique_id;
 	static vector<Func*> unique_ids;
 };
 

--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -47,7 +47,7 @@ HashKey::HashKey(bro_uint_t u)
 	is_our_dynamic = 0;
 	}
 
-HashKey::HashKey(uint32 u)
+HashKey::HashKey(uint32_t u)
 	{
 	key_u.u32 = u;
 	key = (void*) &key_u;
@@ -56,7 +56,7 @@ HashKey::HashKey(uint32 u)
 	is_our_dynamic = 0;
 	}
 
-HashKey::HashKey(const uint32 u[], int n)
+HashKey::HashKey(const uint32_t u[], int n)
 	{
 	size = n * sizeof(u[0]);
 	key = (void*) u;
@@ -173,7 +173,7 @@ hash_t HashKey::HashBytes(const void* bytes, int size)
 
 	// Fall back to HMAC/MD5 for longer data (which is usually rare).
 	assert(sizeof(hash_t) == 8);
-	hash_t digest[2]; // 2x hash_t (uint64) = 128 bits = 32 hex chars = sizeof md5
+	hash_t digest[2]; // 2x hash_t (uint64_t) = 128 bits = 32 hex chars = sizeof md5
 	hmac_md5(size, (const unsigned char*) bytes, (unsigned char*) digest);
 	return digest[0];
 	}

--- a/src/Hash.h
+++ b/src/Hash.h
@@ -9,7 +9,7 @@
 
 #define UHASH_KEY_SIZE 36
 
-typedef uint64 hash_t;
+typedef uint64_t hash_t;
 
 typedef enum {
 	HASH_KEY_INT,
@@ -22,8 +22,8 @@ class HashKey {
 public:
 	explicit HashKey(bro_int_t i);
 	explicit HashKey(bro_uint_t u);
-	explicit HashKey(uint32 u);
-	HashKey(const uint32 u[], int n);
+	explicit HashKey(uint32_t u);
+	HashKey(const uint32_t u[], int n);
 	explicit HashKey(double d);
 	explicit HashKey(const void* p);
 	explicit HashKey(const char* s);
@@ -74,7 +74,7 @@ protected:
 
 	union {
 		bro_int_t i;
-		uint32 u32;
+		uint32_t u32;
 		double d;
 		const void* p;
 	} key_u;

--- a/src/IP.cc
+++ b/src/IP.cc
@@ -53,13 +53,13 @@ static VectorVal* BuildOptionsVal(const u_char* data, int len)
 			// Pad1 option
 			rv->Assign(1, val_mgr->GetCount(0));
 			rv->Assign(2, val_mgr->GetEmptyString());
-			data += sizeof(uint8);
-			len -= sizeof(uint8);
+			data += sizeof(uint8_t);
+			len -= sizeof(uint8_t);
 			}
 		else
 			{
 			// PadN or other option
-			uint16 off = 2 * sizeof(uint8);
+			uint16_t off = 2 * sizeof(uint8_t);
 			rv->Assign(1, val_mgr->GetCount(opt->ip6o_len));
 			rv->Assign(2, new StringVal(
 			        new BroString(data + off, opt->ip6o_len, 1)));
@@ -102,7 +102,7 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		const struct ip6_hbh* hbh = (const struct ip6_hbh*)data;
 		rv->Assign(0, val_mgr->GetCount(hbh->ip6h_nxt));
 		rv->Assign(1, val_mgr->GetCount(hbh->ip6h_len));
-		uint16 off = 2 * sizeof(uint8);
+		uint16_t off = 2 * sizeof(uint8_t);
 		rv->Assign(2, BuildOptionsVal(data + off, Length() - off));
 
 		}
@@ -114,7 +114,7 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		const struct ip6_dest* dst = (const struct ip6_dest*)data;
 		rv->Assign(0, val_mgr->GetCount(dst->ip6d_nxt));
 		rv->Assign(1, val_mgr->GetCount(dst->ip6d_len));
-		uint16 off = 2 * sizeof(uint8);
+		uint16_t off = 2 * sizeof(uint8_t);
 		rv->Assign(2, BuildOptionsVal(data + off, Length() - off));
 		}
 		break;
@@ -127,7 +127,7 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		rv->Assign(1, val_mgr->GetCount(rt->ip6r_len));
 		rv->Assign(2, val_mgr->GetCount(rt->ip6r_type));
 		rv->Assign(3, val_mgr->GetCount(rt->ip6r_segleft));
-		uint16 off = 4 * sizeof(uint8);
+		uint16_t off = 4 * sizeof(uint8_t);
 		rv->Assign(4, new StringVal(new BroString(data + off, Length() - off, 1)));
 		}
 		break;
@@ -150,15 +150,15 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		rv = new RecordVal(hdrType(ip6_ah_type, "ip6_ah"));
 		rv->Assign(0, val_mgr->GetCount(((ip6_ext*)data)->ip6e_nxt));
 		rv->Assign(1, val_mgr->GetCount(((ip6_ext*)data)->ip6e_len));
-		rv->Assign(2, val_mgr->GetCount(ntohs(((uint16*)data)[1])));
-		rv->Assign(3, val_mgr->GetCount(ntohl(((uint32*)data)[1])));
+		rv->Assign(2, val_mgr->GetCount(ntohs(((uint16_t*)data)[1])));
+		rv->Assign(3, val_mgr->GetCount(ntohl(((uint32_t*)data)[1])));
 
 		if ( Length() >= 12 )
 			{
 			// Sequence Number and ICV fields can only be extracted if
 			// Payload Len was non-zero for this header.
-			rv->Assign(4, val_mgr->GetCount(ntohl(((uint32*)data)[2])));
-			uint16 off = 3 * sizeof(uint32);
+			rv->Assign(4, val_mgr->GetCount(ntohl(((uint32_t*)data)[2])));
+			uint16_t off = 3 * sizeof(uint32_t);
 			rv->Assign(5, new StringVal(new BroString(data + off, Length() - off, 1)));
 			}
 		}
@@ -167,7 +167,7 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 	case IPPROTO_ESP:
 		{
 		rv = new RecordVal(hdrType(ip6_esp_type, "ip6_esp"));
-		const uint32* esp = (const uint32*)data;
+		const uint32_t* esp = (const uint32_t*)data;
 		rv->Assign(0, val_mgr->GetCount(ntohl(esp[0])));
 		rv->Assign(1, val_mgr->GetCount(ntohl(esp[1])));
 		}
@@ -187,15 +187,15 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		RecordVal* msg = new RecordVal(hdrType(ip6_mob_msg_type, "ip6_mobility_msg"));
 		msg->Assign(0, val_mgr->GetCount(mob->ip6mob_type));
 
-		uint16 off = sizeof(ip6_mobility);
+		uint16_t off = sizeof(ip6_mobility);
 		const u_char* msg_data = data + off;
 
 		switch ( mob->ip6mob_type ) {
 		case 0:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_brr"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16*)msg_data))));
-			off += sizeof(uint16);
+			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
+			off += sizeof(uint16_t);
 			m->Assign(1, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(1, m);
 			}
@@ -204,9 +204,9 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 1:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_hoti"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16*)msg_data))));
-			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64*)(msg_data + sizeof(uint16))))));
-			off += sizeof(uint16) + sizeof(uint64);
+			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
+			off += sizeof(uint16_t) + sizeof(uint64_t);
 			m->Assign(2, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(2, m);
 			break;
@@ -215,9 +215,9 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 2:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_coti"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16*)msg_data))));
-			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64*)(msg_data + sizeof(uint16))))));
-			off += sizeof(uint16) + sizeof(uint64);
+			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
+			off += sizeof(uint16_t) + sizeof(uint64_t);
 			m->Assign(2, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(3, m);
 			break;
@@ -226,10 +226,10 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 3:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_hot"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16*)msg_data))));
-			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64*)(msg_data + sizeof(uint16))))));
-			m->Assign(2, val_mgr->GetCount(ntohll(*((uint64*)(msg_data + sizeof(uint16) + sizeof(uint64))))));
-			off += sizeof(uint16) + 2 * sizeof(uint64);
+			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
+			m->Assign(2, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t) + sizeof(uint64_t))))));
+			off += sizeof(uint16_t) + 2 * sizeof(uint64_t);
 			m->Assign(3, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(4, m);
 			break;
@@ -238,10 +238,10 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 4:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_cot"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16*)msg_data))));
-			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64*)(msg_data + sizeof(uint16))))));
-			m->Assign(2, val_mgr->GetCount(ntohll(*((uint64*)(msg_data + sizeof(uint16) + sizeof(uint64))))));
-			off += sizeof(uint16) + 2 * sizeof(uint64);
+			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
+			m->Assign(2, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t) + sizeof(uint64_t))))));
+			off += sizeof(uint16_t) + 2 * sizeof(uint64_t);
 			m->Assign(3, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(5, m);
 			break;
@@ -250,13 +250,13 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 5:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_bu"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16*)msg_data))));
-			m->Assign(1, val_mgr->GetBool(ntohs(*((uint16*)(msg_data + sizeof(uint16)))) & 0x8000));
-			m->Assign(2, val_mgr->GetBool(ntohs(*((uint16*)(msg_data + sizeof(uint16)))) & 0x4000));
-			m->Assign(3, val_mgr->GetBool(ntohs(*((uint16*)(msg_data + sizeof(uint16)))) & 0x2000));
-			m->Assign(4, val_mgr->GetBool(ntohs(*((uint16*)(msg_data + sizeof(uint16)))) & 0x1000));
-			m->Assign(5, val_mgr->GetCount(ntohs(*((uint16*)(msg_data + 2*sizeof(uint16))))));
-			off += 3 * sizeof(uint16);
+			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(1, val_mgr->GetBool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x8000));
+			m->Assign(2, val_mgr->GetBool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x4000));
+			m->Assign(3, val_mgr->GetBool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x2000));
+			m->Assign(4, val_mgr->GetBool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x1000));
+			m->Assign(5, val_mgr->GetCount(ntohs(*((uint16_t*)(msg_data + 2*sizeof(uint16_t))))));
+			off += 3 * sizeof(uint16_t);
 			m->Assign(6, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(6, m);
 			break;
@@ -265,11 +265,11 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 6:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_back"));
-			m->Assign(0, val_mgr->GetCount(*((uint8*)msg_data)));
-			m->Assign(1, val_mgr->GetBool(*((uint8*)(msg_data + sizeof(uint8))) & 0x80));
-			m->Assign(2, val_mgr->GetCount(ntohs(*((uint16*)(msg_data + sizeof(uint16))))));
-			m->Assign(3, val_mgr->GetCount(ntohs(*((uint16*)(msg_data + 2*sizeof(uint16))))));
-			off += 3 * sizeof(uint16);
+			m->Assign(0, val_mgr->GetCount(*((uint8_t*)msg_data)));
+			m->Assign(1, val_mgr->GetBool(*((uint8_t*)(msg_data + sizeof(uint8_t))) & 0x80));
+			m->Assign(2, val_mgr->GetCount(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t))))));
+			m->Assign(3, val_mgr->GetCount(ntohs(*((uint16_t*)(msg_data + 2*sizeof(uint16_t))))));
+			off += 3 * sizeof(uint16_t);
 			m->Assign(4, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(7, m);
 			break;
@@ -278,10 +278,10 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 7:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_be"));
-			m->Assign(0, val_mgr->GetCount(*((uint8*)msg_data)));
-			const in6_addr* hoa = (const in6_addr*)(msg_data + sizeof(uint16));
+			m->Assign(0, val_mgr->GetCount(*((uint8_t*)msg_data)));
+			const in6_addr* hoa = (const in6_addr*)(msg_data + sizeof(uint16_t));
 			m->Assign(1, new AddrVal(IPAddr(*hoa)));
-			off += sizeof(uint16) + sizeof(in6_addr);
+			off += sizeof(uint16_t) + sizeof(in6_addr);
 			m->Assign(2, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(8, m);
 			break;
@@ -372,8 +372,8 @@ RecordVal* IP_Hdr::BuildPktHdrVal(RecordVal* pkt_hdr, int sindex) const
 
 		tcp_hdr->Assign(0, val_mgr->GetPort(ntohs(tp->th_sport), TRANSPORT_TCP));
 		tcp_hdr->Assign(1, val_mgr->GetPort(ntohs(tp->th_dport), TRANSPORT_TCP));
-		tcp_hdr->Assign(2, val_mgr->GetCount(uint32(ntohl(tp->th_seq))));
-		tcp_hdr->Assign(3, val_mgr->GetCount(uint32(ntohl(tp->th_ack))));
+		tcp_hdr->Assign(2, val_mgr->GetCount(uint32_t(ntohl(tp->th_seq))));
+		tcp_hdr->Assign(3, val_mgr->GetCount(uint32_t(ntohl(tp->th_ack))));
 		tcp_hdr->Assign(4, val_mgr->GetCount(tcp_hdr_len));
 		tcp_hdr->Assign(5, val_mgr->GetCount(data_len));
 		tcp_hdr->Assign(6, val_mgr->GetCount(tp->th_flags));
@@ -428,7 +428,7 @@ RecordVal* IP_Hdr::BuildPktHdrVal(RecordVal* pkt_hdr, int sindex) const
 	return pkt_hdr;
 	}
 
-static inline bool isIPv6ExtHeader(uint8 type)
+static inline bool isIPv6ExtHeader(uint8_t type)
 	{
 	switch (type) {
 	case IPPROTO_HOPOPTS:
@@ -447,10 +447,10 @@ static inline bool isIPv6ExtHeader(uint8 type)
 	}
 
 void IPv6_Hdr_Chain::Init(const struct ip6_hdr* ip6, int total_len,
-                          bool set_next, uint16 next)
+                          bool set_next, uint16_t next)
 	{
 	length = 0;
-	uint8 current_type, next_type;
+	uint8_t current_type, next_type;
 	next_type = IPPROTO_IPV6;
 	const u_char* hdrs = (const u_char*) ip6;
 
@@ -471,7 +471,7 @@ void IPv6_Hdr_Chain::Init(const struct ip6_hdr* ip6, int total_len,
 		IPv6_Hdr* p = new IPv6_Hdr(current_type, hdrs);
 
 		next_type = p->NextHdr();
-		uint16 cur_len = p->Length();
+		uint16_t cur_len = p->Length();
 
 		// If this header is truncated, don't add it to chain, don't go further.
 		if ( cur_len > total_len )
@@ -510,7 +510,7 @@ void IPv6_Hdr_Chain::Init(const struct ip6_hdr* ip6, int total_len,
 				  isIPv6ExtHeader(next_type) );
 	}
 
-void IPv6_Hdr_Chain::ProcessRoutingHeader(const struct ip6_rthdr* r, uint16 len)
+void IPv6_Hdr_Chain::ProcessRoutingHeader(const struct ip6_rthdr* r, uint16_t len)
 	{
 	if ( finalDst )
 		{
@@ -559,11 +559,11 @@ void IPv6_Hdr_Chain::ProcessRoutingHeader(const struct ip6_rthdr* r, uint16 len)
 	}
 
 #ifdef ENABLE_MOBILE_IPV6
-void IPv6_Hdr_Chain::ProcessDstOpts(const struct ip6_dest* d, uint16 len)
+void IPv6_Hdr_Chain::ProcessDstOpts(const struct ip6_dest* d, uint16_t len)
 	{
 	const u_char* data = (const u_char*) d;
-	len -= 2 * sizeof(uint8);
-	data += 2* sizeof(uint8);
+	len -= 2 * sizeof(uint8_t);
+	data += 2* sizeof(uint8_t);
 
 	while ( len > 0 )
 		{
@@ -587,13 +587,13 @@ void IPv6_Hdr_Chain::ProcessDstOpts(const struct ip6_dest* d, uint16 len)
 
 		if ( opt->ip6o_type == 0 )
 			{
-			data += sizeof(uint8);
-			len -= sizeof(uint8);
+			data += sizeof(uint8_t);
+			len -= sizeof(uint8_t);
 			}
 		else
 			{
-			data += 2 * sizeof(uint8) + opt->ip6o_len;
-			len -= 2 * sizeof(uint8) + opt->ip6o_len;
+			data += 2 * sizeof(uint8_t) + opt->ip6o_len;
+			len -= 2 * sizeof(uint8_t) + opt->ip6o_len;
 			}
 		}
 	}
@@ -620,7 +620,7 @@ VectorVal* IPv6_Hdr_Chain::BuildVal() const
 		{
 		RecordVal* v = chain[i]->BuildRecordVal();
 		RecordVal* ext_hdr = new RecordVal(ip6_ext_hdr_type);
-		uint8 type = chain[i]->Type();
+		uint8_t type = chain[i]->Type();
 		ext_hdr->Assign(0, val_mgr->GetCount(type));
 
 		switch (type) {

--- a/src/IP.h
+++ b/src/IP.h
@@ -20,11 +20,11 @@
 #endif
 
 struct ip6_mobility {
-	uint8 ip6mob_payload;
-	uint8 ip6mob_len;
-	uint8 ip6mob_type;
-	uint8 ip6mob_rsv;
-	uint16 ip6mob_chksum;
+	uint8_t ip6mob_payload;
+	uint8_t ip6mob_len;
+	uint8_t ip6mob_type;
+	uint8_t ip6mob_rsv;
+	uint16_t ip6mob_chksum;
 };
 
 #endif //ENABLE_MOBILE_IPV6
@@ -37,12 +37,12 @@ public:
 	/**
 	 * Construct an IPv6 header or extension header from assigned type number.
 	 */
-	IPv6_Hdr(uint8 t, const u_char* d) : type(t), data(d) {}
+	IPv6_Hdr(uint8_t t, const u_char* d) : type(t), data(d) {}
 
 	/**
 	 * Replace the value of the next protocol field.
 	 */
-	void ChangeNext(uint8 next_type)
+	void ChangeNext(uint8_t next_type)
 		{
 		switch ( type ) {
 		case IPPROTO_IPV6:
@@ -70,7 +70,7 @@ public:
 	 * Returns the assigned IPv6 extension header type number of the header
 	 * that immediately follows this one.
 	 */
-	uint8 NextHdr() const
+	uint8_t NextHdr() const
 		{
 		switch ( type ) {
 		case IPPROTO_IPV6:
@@ -93,7 +93,7 @@ public:
 	/**
 	 * Returns the length of the header in bytes.
 	 */
-	uint16 Length() const
+	uint16_t Length() const
 		{
 		switch ( type ) {
 		case IPPROTO_IPV6:
@@ -119,7 +119,7 @@ public:
 	/**
 	 * Returns the RFC 1700 et seq. IANA assigned number for the header.
 	 */
-	uint8 Type() const { return type; }
+	uint8_t Type() const { return type; }
 
 	/**
 	 * Returns pointer to the start of where header structure resides in memory.
@@ -132,7 +132,7 @@ public:
 	RecordVal* BuildRecordVal(VectorVal* chain = 0) const;
 
 protected:
-	uint8 type;
+	uint8_t type;
 	const u_char* data;
 };
 
@@ -171,7 +171,7 @@ public:
 	/**
 	 * Returns the sum of the length of all headers in the chain in bytes.
 	 */
-	uint16 TotalLength() const { return length; }
+	uint16_t TotalLength() const { return length; }
 
 	/**
 	 * Accesses the header at the given location in the chain.
@@ -203,14 +203,14 @@ public:
 	 * If the header chain is a fragment, returns the offset in number of bytes
 	 * relative to the start of the Fragmentable Part of the original packet.
 	 */
-	uint16 FragOffset() const
+	uint16_t FragOffset() const
 		{ return IsFragment() ?
 				(ntohs(GetFragHdr()->ip6f_offlg) & 0xfff8) : 0; }
 
 	/**
 	 * If the header chain is a fragment, returns the identification field.
 	 */
-	uint32 ID() const
+	uint32_t ID() const
 		{ return IsFragment() ?	ntohl(GetFragHdr()->ip6f_ident) : 0; }
 
 	/**
@@ -282,7 +282,7 @@ protected:
 	 * Initializes the header chain from an IPv6 header structure, and replaces
 	 * the first next protocol pointer field that points to a fragment header.
 	 */
-	IPv6_Hdr_Chain(const struct ip6_hdr* ip6, uint16 next, int len) :
+	IPv6_Hdr_Chain(const struct ip6_hdr* ip6, uint16_t next, int len) :
 #ifdef ENABLE_MOBILE_IPV6
 		homeAddr(0),
 #endif
@@ -295,20 +295,20 @@ protected:
 	 * points to a fragment header.
 	 */
 	void Init(const struct ip6_hdr* ip6, int total_len, bool set_next,
-	          uint16 next = 0);
+	          uint16_t next = 0);
 
 	/**
 	 * Process a routing header and allocate/remember the final destination
 	 * address if it has segments left and is a valid routing header.
 	 */
-	void ProcessRoutingHeader(const struct ip6_rthdr* r, uint16 len);
+	void ProcessRoutingHeader(const struct ip6_rthdr* r, uint16_t len);
 
 #ifdef ENABLE_MOBILE_IPV6
 	/**
 	 * Inspect a Destination Option header's options for things we need to
 	 * remember, such as the Home Address option from Mobile IPv6.
 	 */
-	void ProcessDstOpts(const struct ip6_dest* d, uint16 len);
+	void ProcessDstOpts(const struct ip6_dest* d, uint16_t len);
 #endif
 
 	vector<IPv6_Hdr*> chain;
@@ -316,7 +316,7 @@ protected:
 	/**
 	 * The summation of all header lengths in the chain in bytes.
 	 */
-	uint16 length;
+	uint16_t length;
 
 #ifdef ENABLE_MOBILE_IPV6
 	/**
@@ -459,7 +459,7 @@ public:
 	 * Returns the length of the IP packet's payload (length of packet minus
 	 * header length or, for IPv6, also minus length of all extension headers).
 	 */
-	uint16 PayloadLen() const
+	uint16_t PayloadLen() const
 		{
 		if ( ip4 )
 			return ntohs(ip4->ip_len) - ip4->ip_hl * 4;
@@ -470,19 +470,19 @@ public:
 	/**
 	 * Returns the length of the IP packet (length of headers and payload).
 	 */
-	uint32 TotalLen() const
+	uint32_t TotalLen() const
 		{ return ip4 ? ntohs(ip4->ip_len) : ntohs(ip6->ip6_plen) + 40; }
 
 	/**
 	 * Returns length of IP packet header (includes extension headers for IPv6).
 	 */
-	uint16 HdrLen() const
+	uint16_t HdrLen() const
 		{ return ip4 ? ip4->ip_hl * 4 : ip6_hdrs->TotalLength(); }
 
 	/**
 	 * For IPv6 header chains, returns the type of the last header in the chain.
 	 */
-	uint8 LastHeader() const
+	uint8_t LastHeader() const
 		{
 		if ( ip4 )
 			return IPPROTO_RAW;
@@ -528,14 +528,14 @@ public:
 	 * Returns the fragment packet's offset in relation to the original
 	 * packet in bytes.
 	 */
-	uint16 FragOffset() const
+	uint16_t FragOffset() const
 		{ return ip4 ? (ntohs(ip4->ip_off) & 0x1fff) * 8 :
 				ip6_hdrs->FragOffset(); }
 
 	/**
 	 * Returns the fragment packet's identification field.
 	 */
-	uint32 ID() const
+	uint32_t ID() const
 		{ return ip4 ? ntohs(ip4->ip_id) : ip6_hdrs->ID(); }
 
 	/**
@@ -554,7 +554,7 @@ public:
 	/**
 	 * Returns value of an IPv6 header's flow label field or 0 if it's IPv4.
 	 */
-	uint32 FlowLabel() const
+	uint32_t FlowLabel() const
 		{ return ip4 ? 0 : (ntohl(ip6->ip6_flow) & 0x000fffff); }
 
 	/**

--- a/src/IPAddr.cc
+++ b/src/IPAddr.cc
@@ -19,8 +19,8 @@ HashKey* BuildConnIDHashKey(const ConnID& id)
 	struct {
 		in6_addr ip1;
 		in6_addr ip2;
-		uint16 port1;
-		uint16 port2;
+		uint16_t port1;
+		uint16_t port2;
 	} key;
 
 	// Lookup up connection based on canonical ordering, which is
@@ -206,7 +206,7 @@ string IPAddr::PtrName() const
 
 		for ( unsigned int i = 0; i < 4; ++i )
 			{
-			uint32 a = ntohl(p[i]);
+			uint32_t a = ntohl(p[i]);
 			for ( unsigned int j = 1; j <=8; ++j )
 				{
 				ptr_name.insert(0, 1, '.');

--- a/src/IPAddr.h
+++ b/src/IPAddr.h
@@ -609,7 +609,7 @@ public:
 		{
 		struct {
 			in6_addr ip;
-			uint32 len;
+			uint32_t len;
 		} key;
 
 		key.ip = prefix.in6;

--- a/src/Net.cc
+++ b/src/Net.cc
@@ -249,12 +249,12 @@ void net_packet_dispatch(double t, const Packet* pkt, iosource::PktSrc* src_ps)
 
 	if ( load_sample )
 		{
-		static uint32 load_freq = 0;
+		static uint32_t load_freq = 0;
 
 		if ( load_freq == 0 )
-			load_freq = uint32(0xffffffff) / uint32(load_sample_freq);
+			load_freq = uint32_t(0xffffffff) / uint32_t(load_sample_freq);
 
-		if ( uint32(bro_random() & 0xffffffff) < load_freq )
+		if ( uint32_t(bro_random() & 0xffffffff) < load_freq )
 			{
 			// Drain the queued timer events so they're not
 			// charged against this sample.

--- a/src/Notifier.h
+++ b/src/Notifier.h
@@ -108,7 +108,7 @@ protected:
 	virtual ~Modifiable();
 
 	// Number of currently registered receivers.
-	uint64 num_receivers = 0;
+	uint64_t num_receivers = 0;
 };
 
 }

--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -103,7 +103,7 @@ broker::expected<broker::data> OpaqueVal::SerializeType(BroType* t)
 		}
 
 	// A base type.
-	return {broker::vector{false, static_cast<uint64>(t->Tag())}};
+	return {broker::vector{false, static_cast<uint64_t>(t->Tag())}};
 	}
 
 BroType* OpaqueVal::UnserializeType(const broker::data& data)
@@ -133,7 +133,7 @@ BroType* OpaqueVal::UnserializeType(const broker::data& data)
 		return t->Ref();
 		}
 
-	auto tag = caf::get_if<uint64>(&(*v)[1]);
+	auto tag = caf::get_if<uint64_t>(&(*v)[1]);
 	if ( ! tag )
 		return nullptr;
 
@@ -299,17 +299,17 @@ broker::expected<broker::data> MD5Val::DoSerialize() const
 
 	broker::vector d = {
 	    true,
-	    static_cast<uint64>(md->A),
-	    static_cast<uint64>(md->B),
-	    static_cast<uint64>(md->C),
-	    static_cast<uint64>(md->D),
-	    static_cast<uint64>(md->Nl),
-	    static_cast<uint64>(md->Nh),
-	    static_cast<uint64>(md->num)
+	    static_cast<uint64_t>(md->A),
+	    static_cast<uint64_t>(md->B),
+	    static_cast<uint64_t>(md->C),
+	    static_cast<uint64_t>(md->D),
+	    static_cast<uint64_t>(md->Nl),
+	    static_cast<uint64_t>(md->Nh),
+	    static_cast<uint64_t>(md->num)
 	};
 
 	for ( int i = 0; i < MD5_LBLOCK; ++i )
-		d.emplace_back(static_cast<uint64>(md->data[i]));
+		d.emplace_back(static_cast<uint64_t>(md->data[i]));
 
 	return {std::move(d)};
 	}
@@ -439,18 +439,18 @@ broker::expected<broker::data> SHA1Val::DoSerialize() const
 
 	broker::vector d = {
 	    true,
-	    static_cast<uint64>(md->h0),
-	    static_cast<uint64>(md->h1),
-	    static_cast<uint64>(md->h2),
-	    static_cast<uint64>(md->h3),
-	    static_cast<uint64>(md->h4),
-	    static_cast<uint64>(md->Nl),
-	    static_cast<uint64>(md->Nh),
-	    static_cast<uint64>(md->num)
+	    static_cast<uint64_t>(md->h0),
+	    static_cast<uint64_t>(md->h1),
+	    static_cast<uint64_t>(md->h2),
+	    static_cast<uint64_t>(md->h3),
+	    static_cast<uint64_t>(md->h4),
+	    static_cast<uint64_t>(md->Nl),
+	    static_cast<uint64_t>(md->Nh),
+	    static_cast<uint64_t>(md->num)
 	};
 
 	for ( int i = 0; i < SHA_LBLOCK; ++i )
-		d.emplace_back(static_cast<uint64>(md->data[i]));
+		d.emplace_back(static_cast<uint64_t>(md->data[i]));
 
 	return {std::move(d)};
 	}
@@ -582,17 +582,17 @@ broker::expected<broker::data> SHA256Val::DoSerialize() const
 
 	broker::vector d = {
 	    true,
-	    static_cast<uint64>(md->Nl),
-	    static_cast<uint64>(md->Nh),
-	    static_cast<uint64>(md->num),
-	    static_cast<uint64>(md->md_len)
+	    static_cast<uint64_t>(md->Nl),
+	    static_cast<uint64_t>(md->Nh),
+	    static_cast<uint64_t>(md->num),
+	    static_cast<uint64_t>(md->md_len)
 	};
 
 	for ( int i = 0; i < 8; ++i )
-		d.emplace_back(static_cast<uint64>(md->h[i]));
+		d.emplace_back(static_cast<uint64_t>(md->h[i]));
 
 	for ( int i = 0; i < SHA_LBLOCK; ++i )
-		d.emplace_back(static_cast<uint64>(md->data[i]));
+		d.emplace_back(static_cast<uint64_t>(md->data[i]));
 
 	return {std::move(d)};
 	}
@@ -663,29 +663,29 @@ broker::expected<broker::data> EntropyVal::DoSerialize() const
 	{
 	broker::vector d =
 		{
-		static_cast<uint64>(state.totalc),
-		static_cast<uint64>(state.mp),
-		static_cast<uint64>(state.sccfirst),
-		static_cast<uint64>(state.inmont),
-		static_cast<uint64>(state.mcount),
-		static_cast<uint64>(state.cexp),
-		static_cast<uint64>(state.montex),
-		static_cast<uint64>(state.montey),
-		static_cast<uint64>(state.montepi),
-		static_cast<uint64>(state.sccu0),
-		static_cast<uint64>(state.scclast),
-		static_cast<uint64>(state.scct1),
-		static_cast<uint64>(state.scct2),
-		static_cast<uint64>(state.scct3),
+		static_cast<uint64_t>(state.totalc),
+		static_cast<uint64_t>(state.mp),
+		static_cast<uint64_t>(state.sccfirst),
+		static_cast<uint64_t>(state.inmont),
+		static_cast<uint64_t>(state.mcount),
+		static_cast<uint64_t>(state.cexp),
+		static_cast<uint64_t>(state.montex),
+		static_cast<uint64_t>(state.montey),
+		static_cast<uint64_t>(state.montepi),
+		static_cast<uint64_t>(state.sccu0),
+		static_cast<uint64_t>(state.scclast),
+		static_cast<uint64_t>(state.scct1),
+		static_cast<uint64_t>(state.scct2),
+		static_cast<uint64_t>(state.scct3),
 		};
 
 	d.reserve(256 + 3 + RT_MONTEN + 11);
 
 	for ( int i = 0; i < 256; ++i )
-		d.emplace_back(static_cast<uint64>(state.ccount[i]));
+		d.emplace_back(static_cast<uint64_t>(state.ccount[i]));
 
         for ( int i = 0; i < RT_MONTEN; ++i )
-		d.emplace_back(static_cast<uint64>(state.monte[i]));
+		d.emplace_back(static_cast<uint64_t>(state.monte[i]));
 
 	return {std::move(d)};
 	}

--- a/src/PacketDumper.h
+++ b/src/PacketDumper.h
@@ -25,7 +25,7 @@ protected:
 };
 
 struct IP_ID {
-	uint32 ip, id;
+	uint32_t ip, id;
 };
 
 struct ltipid {
@@ -37,6 +37,6 @@ struct ltipid {
 };
 
 typedef set<IP_ID, ltipid> IP_IDSet;
-uint16 NextIP_ID(const uint32 src_addr, const uint16 id);
+uint16_t NextIP_ID(const uint32_t src_addr, const uint16_t id);
 
 #endif

--- a/src/PacketFilter.cc
+++ b/src/PacketFilter.cc
@@ -1,34 +1,34 @@
 #include "PacketFilter.h"
 
-void PacketFilter::AddSrc(const IPAddr& src, uint32 tcp_flags, double probability)
+void PacketFilter::AddSrc(const IPAddr& src, uint32_t tcp_flags, double probability)
 	{
 	Filter* f = new Filter;
 	f->tcp_flags = tcp_flags;
-	f->probability = uint32(probability * RAND_MAX);
+	f->probability = uint32_t(probability * RAND_MAX);
 	src_filter.Insert(src, 128, f);
 	}
 
-void PacketFilter::AddSrc(Val* src, uint32 tcp_flags, double probability)
+void PacketFilter::AddSrc(Val* src, uint32_t tcp_flags, double probability)
 	{
 	Filter* f = new Filter;
 	f->tcp_flags = tcp_flags;
-	f->probability = uint32(probability * RAND_MAX);
+	f->probability = uint32_t(probability * RAND_MAX);
 	src_filter.Insert(src, f);
 	}
 
-void PacketFilter::AddDst(const IPAddr& dst, uint32 tcp_flags, double probability)
+void PacketFilter::AddDst(const IPAddr& dst, uint32_t tcp_flags, double probability)
 	{
 	Filter* f = new Filter;
 	f->tcp_flags = tcp_flags;
-	f->probability = uint32(probability * RAND_MAX);
+	f->probability = uint32_t(probability * RAND_MAX);
 	dst_filter.Insert(dst, 128, f);
 	}
 
-void PacketFilter::AddDst(Val* dst, uint32 tcp_flags, double probability)
+void PacketFilter::AddDst(Val* dst, uint32_t tcp_flags, double probability)
 	{
 	Filter* f = new Filter;
 	f->tcp_flags = tcp_flags;
-	f->probability = uint32(probability * RAND_MAX);
+	f->probability = uint32_t(probability * RAND_MAX);
 	dst_filter.Insert(dst, f);
 	}
 
@@ -87,5 +87,5 @@ bool PacketFilter::MatchFilter(const Filter& f, const IP_Hdr& ip,
 			return false;
 		}
 
-	return uint32(bro_random()) < f.probability;
+	return uint32_t(bro_random()) < f.probability;
 	}

--- a/src/PacketFilter.h
+++ b/src/PacketFilter.h
@@ -14,10 +14,10 @@ public:
 	// Drops all packets from a particular source (which may be given
 	// as an AddrVal or a SubnetVal) which hasn't any of TCP flags set
 	// (TH_*) with the given probability (from 0..MAX_PROB).
-	void AddSrc(const IPAddr& src, uint32 tcp_flags, double probability);
-	void AddSrc(Val* src, uint32 tcp_flags, double probability);
-	void AddDst(const IPAddr& src, uint32 tcp_flags, double probability);
-	void AddDst(Val* src, uint32 tcp_flags, double probability);
+	void AddSrc(const IPAddr& src, uint32_t tcp_flags, double probability);
+	void AddSrc(Val* src, uint32_t tcp_flags, double probability);
+	void AddDst(const IPAddr& src, uint32_t tcp_flags, double probability);
+	void AddDst(Val* src, uint32_t tcp_flags, double probability);
 
 	// Removes the filter entry for the given src/dst
 	// Returns false if filter doesn not exist.
@@ -31,8 +31,8 @@ public:
 
 private:
 	struct Filter {
-		uint32 tcp_flags;
-		uint32 probability;
+		uint32_t tcp_flags;
+		uint32_t probability;
 	};
 
 	bool MatchFilter(const Filter& f, const IP_Hdr& ip, int len, int caplen);

--- a/src/PriorityQueue.h
+++ b/src/PriorityQueue.h
@@ -54,7 +54,7 @@ public:
 
 	int Size() const	{ return heap_size; }
 	int PeakSize() const	{ return peak_heap_size; }
-	uint64 CumulativeNum() const { return cumulative_num; }
+	uint64_t CumulativeNum() const { return cumulative_num; }
 
 protected:
 	int Resize(int new_size);
@@ -94,7 +94,7 @@ protected:
 	int heap_size;
 	int peak_heap_size;
 	int max_heap_size;
-	uint64 cumulative_num;
+	uint64_t cumulative_num;
 };
 
 #endif

--- a/src/RE.h
+++ b/src/RE.h
@@ -34,7 +34,7 @@ extern void synerr(const char str[]);
 
 typedef int AcceptIdx;
 typedef std::set<AcceptIdx> AcceptingSet;
-typedef uint64 MatchPos;
+typedef uint64_t MatchPos;
 typedef std::map<AcceptIdx, MatchPos> AcceptingMatchSet;
 typedef name_list string_list;
 

--- a/src/RandTest.h
+++ b/src/RandTest.h
@@ -20,12 +20,12 @@ class RandTest {
 	private:
 	  friend class EntropyVal;
 
-		int64 ccount[256];  /* Bins to count occurrences of values */
-		int64 totalc;       /* Total bytes counted */
+		int64_t ccount[256];  /* Bins to count occurrences of values */
+		int64_t totalc;       /* Total bytes counted */
 		int mp;
 		int sccfirst;
 		unsigned int monte[RT_MONTEN];
-		int64 inmont, mcount;
+		int64_t inmont, mcount;
 		double cexp, montex, montey, montepi,
 		       sccu0, scclast, scct1, scct2, scct3;
 };

--- a/src/Reassem.cc
+++ b/src/Reassem.cc
@@ -10,7 +10,7 @@
 static const bool DEBUG_reassem = false;
 
 DataBlock::DataBlock(Reassembler* reass, const u_char* data,
-                     uint64 size, uint64 arg_seq, DataBlock* arg_prev,
+                     uint64_t size, uint64_t arg_seq, DataBlock* arg_prev,
                      DataBlock* arg_next, ReassemblerType reassem_type)
 	{
 	seq = arg_seq;
@@ -35,10 +35,10 @@ DataBlock::DataBlock(Reassembler* reass, const u_char* data,
 	Reassembler::total_size += pad_size(size) + padded_sizeof(DataBlock);
 	}
 
-uint64 Reassembler::total_size = 0;
-uint64 Reassembler::sizes[REASSEM_NUM];
+uint64_t Reassembler::total_size = 0;
+uint64_t Reassembler::sizes[REASSEM_NUM];
 
-Reassembler::Reassembler(uint64 init_seq, ReassemblerType reassem_type)
+Reassembler::Reassembler(uint64_t init_seq, ReassemblerType reassem_type)
 	:  blocks(), last_block(), old_blocks(), last_old_block(),
 	  last_reassem_seq(init_seq), trim_seq(init_seq),
 	  max_old_blocks(0), total_old_blocks(0), size_of_all_blocks(0),
@@ -53,7 +53,7 @@ Reassembler::~Reassembler()
 	}
 
 void Reassembler::CheckOverlap(DataBlock *head, DataBlock *tail,
-					uint64 seq, uint64 len, const u_char* data)
+					uint64_t seq, uint64_t len, const u_char* data)
 	{
 	if ( ! head || ! tail )
 		return;
@@ -62,12 +62,12 @@ void Reassembler::CheckOverlap(DataBlock *head, DataBlock *tail,
 		// Special case check for common case of appending to the end.
 		return;
 
-	uint64 upper = (seq + len);
+	uint64_t upper = (seq + len);
 
 	for ( DataBlock* b = head; b; b = b->next )
 		{
-		uint64 nseq = seq;
-		uint64 nupper = upper;
+		uint64_t nseq = seq;
+		uint64_t nupper = upper;
 		const u_char* ndata = data;
 
 		if ( nupper <= b->seq )
@@ -85,20 +85,20 @@ void Reassembler::CheckOverlap(DataBlock *head, DataBlock *tail,
 		if ( nupper > b->upper )
 			nupper = b->upper;
 
-		uint64 overlap_offset = (nseq - b->seq);
-		uint64 overlap_len = (nupper - nseq);
+		uint64_t overlap_offset = (nseq - b->seq);
+		uint64_t overlap_len = (nupper - nseq);
 
 		if ( overlap_len )
 			Overlap(&b->block[overlap_offset], ndata, overlap_len);
 		}
 	}
 
-void Reassembler::NewBlock(double t, uint64 seq, uint64 len, const u_char* data)
+void Reassembler::NewBlock(double t, uint64_t seq, uint64_t len, const u_char* data)
 	{
 	if ( len == 0 )
 		return;
 
-	uint64 upper_seq = seq + len;
+	uint64_t upper_seq = seq + len;
 
 	CheckOverlap(old_blocks, last_old_block, seq, len, data);
 
@@ -110,7 +110,7 @@ void Reassembler::NewBlock(double t, uint64 seq, uint64 len, const u_char* data)
 
 	if ( seq < trim_seq )
 		{ // Partially old data, just keep the good stuff.
-		uint64 amount_old = trim_seq - seq;
+		uint64_t amount_old = trim_seq - seq;
 
 		data += amount_old;
 		seq += amount_old;
@@ -128,9 +128,9 @@ void Reassembler::NewBlock(double t, uint64 seq, uint64 len, const u_char* data)
 	BlockInserted(start_block);
 	}
 
-uint64 Reassembler::TrimToSeq(uint64 seq)
+uint64_t Reassembler::TrimToSeq(uint64_t seq)
 	{
-	uint64 num_missing = 0;
+	uint64_t num_missing = 0;
 
 	// Do this accounting before looking for Undelivered data,
 	// since that will alter last_reassem_seq.
@@ -252,7 +252,7 @@ void Reassembler::ClearOldBlocks()
 	last_old_block = 0;
 	}
 
-uint64 Reassembler::TotalSize() const
+uint64_t Reassembler::TotalSize() const
 	{
 	return size_of_all_blocks;
 	}
@@ -262,13 +262,13 @@ void Reassembler::Describe(ODesc* d) const
 	d->Add("reassembler");
 	}
 
-void Reassembler::Undelivered(uint64 up_to_seq)
+void Reassembler::Undelivered(uint64_t up_to_seq)
 	{
 	// TrimToSeq() expects this.
 	last_reassem_seq = up_to_seq;
 	}
 
-DataBlock* Reassembler::AddAndCheck(DataBlock* b, uint64 seq, uint64 upper,
+DataBlock* Reassembler::AddAndCheck(DataBlock* b, uint64_t seq, uint64_t upper,
 					const u_char* data)
 	{
 	if ( DEBUG_reassem )
@@ -315,7 +315,7 @@ DataBlock* Reassembler::AddAndCheck(DataBlock* b, uint64 seq, uint64 upper,
 	if ( seq < b->seq )
 		{
 		// The new block has a prefix that comes before b.
-		uint64 prefix_len = b->seq - seq;
+		uint64_t prefix_len = b->seq - seq;
 		new_b = new DataBlock(this, data, prefix_len, seq,
 		                      b->prev, b, rtype);
 		if ( b == blocks )
@@ -327,11 +327,11 @@ DataBlock* Reassembler::AddAndCheck(DataBlock* b, uint64 seq, uint64 upper,
 	else
 		new_b = b;
 
-	uint64 overlap_start = seq;
-	uint64 overlap_offset = overlap_start - b->seq;
-	uint64 new_b_len = upper - seq;
-	uint64 b_len = b->upper - overlap_start;
-	uint64 overlap_len = min(new_b_len, b_len);
+	uint64_t overlap_start = seq;
+	uint64_t overlap_offset = overlap_start - b->seq;
+	uint64_t new_b_len = upper - seq;
+	uint64_t b_len = b->upper - overlap_start;
+	uint64_t overlap_len = min(new_b_len, b_len);
 
 	if ( overlap_len < new_b_len )
 		{
@@ -351,7 +351,7 @@ DataBlock* Reassembler::AddAndCheck(DataBlock* b, uint64 seq, uint64 upper,
 	return new_b;
 	}
 
-uint64 Reassembler::MemoryAllocation(ReassemblerType rtype)
+uint64_t Reassembler::MemoryAllocation(ReassemblerType rtype)
 	{
 	return Reassembler::sizes[rtype];
 	}

--- a/src/Reassem.h
+++ b/src/Reassem.h
@@ -23,17 +23,17 @@ class Reassembler;
 class DataBlock {
 public:
 	DataBlock(Reassembler* reass, const u_char* data,
-	          uint64 size, uint64 seq,
+	          uint64_t size, uint64_t seq,
 	          DataBlock* prev, DataBlock* next,
 	          ReassemblerType reassem_type = REASSEM_UNKNOWN);
 
 	~DataBlock();
 
-	uint64 Size() const	{ return upper - seq; }
+	uint64_t Size() const	{ return upper - seq; }
 
 	DataBlock* next;	// next block with higher seq #
 	DataBlock* prev;	// previous block with lower seq #
-	uint64 seq, upper;
+	uint64_t seq, upper;
 	u_char* block;
 	ReassemblerType rtype;
 
@@ -42,49 +42,49 @@ public:
 
 class Reassembler : public BroObj {
 public:
-	Reassembler(uint64 init_seq, ReassemblerType reassem_type = REASSEM_UNKNOWN);
+	Reassembler(uint64_t init_seq, ReassemblerType reassem_type = REASSEM_UNKNOWN);
 	~Reassembler() override;
 
-	void NewBlock(double t, uint64 seq, uint64 len, const u_char* data);
+	void NewBlock(double t, uint64_t seq, uint64_t len, const u_char* data);
 
 	// Throws away all blocks up to seq.  Returns number of bytes
 	// if not all in-sequence, 0 if they were.
-	uint64 TrimToSeq(uint64 seq);
+	uint64_t TrimToSeq(uint64_t seq);
 
 	// Delete all held blocks.
 	void ClearBlocks();
 	void ClearOldBlocks();
 
 	int HasBlocks() const		{ return blocks != 0; }
-	uint64 LastReassemSeq() const	{ return last_reassem_seq; }
+	uint64_t LastReassemSeq() const	{ return last_reassem_seq; }
 
-	uint64 TotalSize() const;	// number of bytes buffered up
+	uint64_t TotalSize() const;	// number of bytes buffered up
 
 	void Describe(ODesc* d) const override;
 
 	// Sum over all data buffered in some reassembler.
-	static uint64 TotalMemoryAllocation()	{ return total_size; }
+	static uint64_t TotalMemoryAllocation()	{ return total_size; }
 
 	// Data buffered by type of reassembler.
-	static uint64 MemoryAllocation(ReassemblerType rtype);
+	static uint64_t MemoryAllocation(ReassemblerType rtype);
 
-	void SetMaxOldBlocks(uint32 count)	{ max_old_blocks = count; }
+	void SetMaxOldBlocks(uint32_t count)	{ max_old_blocks = count; }
 
 protected:
 	Reassembler()	{ }
 
 	friend class DataBlock;
 
-	virtual void Undelivered(uint64 up_to_seq);
+	virtual void Undelivered(uint64_t up_to_seq);
 
 	virtual void BlockInserted(DataBlock* b) = 0;
-	virtual void Overlap(const u_char* b1, const u_char* b2, uint64 n) = 0;
+	virtual void Overlap(const u_char* b1, const u_char* b2, uint64_t n) = 0;
 
-	DataBlock* AddAndCheck(DataBlock* b, uint64 seq,
-				uint64 upper, const u_char* data);
+	DataBlock* AddAndCheck(DataBlock* b, uint64_t seq,
+				uint64_t upper, const u_char* data);
 
 	void CheckOverlap(DataBlock *head, DataBlock *tail,
-				uint64 seq, uint64 len, const u_char* data);
+				uint64_t seq, uint64_t len, const u_char* data);
 
 	DataBlock* blocks;
 	DataBlock* last_block;
@@ -92,16 +92,16 @@ protected:
 	DataBlock* old_blocks;
 	DataBlock* last_old_block;
 
-	uint64 last_reassem_seq;
-	uint64 trim_seq;	// how far we've trimmed
-	uint32 max_old_blocks;
-	uint32 total_old_blocks;
-	uint64 size_of_all_blocks;
+	uint64_t last_reassem_seq;
+	uint64_t trim_seq;	// how far we've trimmed
+	uint32_t max_old_blocks;
+	uint32_t total_old_blocks;
+	uint64_t size_of_all_blocks;
 
 	ReassemblerType rtype;
 
-	static uint64 total_size;
-	static uint64 sizes[REASSEM_NUM];
+	static uint64_t total_size;
+	static uint64_t sizes[REASSEM_NUM];
 };
 
 inline DataBlock::~DataBlock()

--- a/src/Reporter.h
+++ b/src/Reporter.h
@@ -42,7 +42,7 @@ protected:
 class Reporter {
 public:
 	using IPPair = std::pair<IPAddr, IPAddr>;
-	using WeirdCountMap = std::unordered_map<std::string, uint64>;
+	using WeirdCountMap = std::unordered_map<std::string, uint64_t>;
 	using WeirdFlowMap = std::map<IPPair, WeirdCountMap>;
 	using WeirdSet = std::unordered_set<std::string>;
 
@@ -144,7 +144,7 @@ public:
 	 * Return the total number of weirds generated (counts weirds before
 	 * any rate-limiting occurs).
 	 */
-	uint64 GetWeirdCount() const
+	uint64_t GetWeirdCount() const
 		{ return weird_count; }
 
 	/**
@@ -177,7 +177,7 @@ public:
 	 *
 	 * @return weird sampling threshold.
 	 */
-	uint64 GetWeirdSamplingThreshold() const
+	uint64_t GetWeirdSamplingThreshold() const
 		{
 		return weird_sampling_threshold;
 		}
@@ -187,7 +187,7 @@ public:
 	 *
 	 * @param weird_sampling_threshold New weird sampling threshold.
 	 */
-	void SetWeirdSamplingThreshold(uint64 weird_sampling_threshold)
+	void SetWeirdSamplingThreshold(uint64_t weird_sampling_threshold)
 		{
 		this->weird_sampling_threshold = weird_sampling_threshold;
 		}
@@ -197,7 +197,7 @@ public:
 	 *
 	 * @return weird sampling rate.
 	 */
-	uint64 GetWeirdSamplingRate() const
+	uint64_t GetWeirdSamplingRate() const
 		{
 		return weird_sampling_rate;
 		}
@@ -207,7 +207,7 @@ public:
 	 *
 	 * @param weird_sampling_rate New weird sampling rate.
 	 */
-	void SetWeirdSamplingRate(uint64 weird_sampling_rate)
+	void SetWeirdSamplingRate(uint64_t weird_sampling_rate)
 		{
 		this->weird_sampling_rate = weird_sampling_rate;
 		}
@@ -268,14 +268,14 @@ private:
 
 	std::list<std::pair<const Location*, const Location*> > locations;
 
-	uint64 weird_count;
+	uint64_t weird_count;
 	WeirdCountMap weird_count_by_type;
 	WeirdCountMap net_weird_state;
 	WeirdFlowMap flow_weird_state;
 
 	WeirdSet weird_sampling_whitelist;
-	uint64 weird_sampling_threshold;
-	uint64 weird_sampling_rate;
+	uint64_t weird_sampling_threshold;
+	uint64_t weird_sampling_rate;
 	double weird_sampling_duration;
 
 };

--- a/src/Rule.cc
+++ b/src/Rule.cc
@@ -68,7 +68,7 @@ void Rule::PrintDebug()
 	}
 
 void Rule::AddPattern(const char* str, Rule::PatternType type,
-			uint32 offset, uint32 depth)
+			uint32_t offset, uint32_t depth)
 	{
 	Pattern* p = new Pattern;
 	p->pattern = copy_string(str);

--- a/src/Rule.h
+++ b/src/Rule.h
@@ -44,7 +44,7 @@ public:
 	void AddCondition(RuleCondition* cond)	{ conditions.push_back(cond); }
 	void AddHdrTest(RuleHdrTest* hdr_test)	{ hdr_tests.push_back(hdr_test);	}
 	void AddPattern(const char* str, Rule::PatternType type,
-			uint32 offset = 0, uint32 depth = INT_MAX);
+			uint32_t offset = 0, uint32_t depth = INT_MAX);
 	void AddRequires(const char* id, bool opposite_direction, bool negate);
 
 	const Location& GetLocation() const	{ return location; }
@@ -88,8 +88,8 @@ private:
 		char* pattern;	// the pattern itself
 		PatternType type;
 		int id;	// ID of pattern (for identifying it within regexps)
-		uint32 offset;
-		uint32 depth;
+		uint32_t offset;
+		uint32_t depth;
 	};
 
 	typedef PList<Pattern> pattern_list;

--- a/src/RuleCondition.cc
+++ b/src/RuleCondition.cc
@@ -93,7 +93,7 @@ bool RuleConditionPayloadSize::DoMatch(Rule* rule, RuleEndpointState* state,
 		// We are interested in the first non-empty chunk.
 		return false;
 
-	uint32 payload_size = uint32(state->PayloadSize());
+	uint32_t payload_size = uint32_t(state->PayloadSize());
 
 	switch ( comp ) {
 	case RULE_EQ:

--- a/src/RuleCondition.h
+++ b/src/RuleCondition.h
@@ -87,7 +87,7 @@ class RuleConditionPayloadSize : public RuleCondition {
 public:
 	enum Comp { RULE_LE, RULE_GE, RULE_LT, RULE_GT, RULE_EQ, RULE_NE };
 
-	RuleConditionPayloadSize(uint32 arg_val, Comp arg_comp)
+	RuleConditionPayloadSize(uint32_t arg_val, Comp arg_comp)
 		{ val = arg_val; comp = arg_comp; }
 
 	~RuleConditionPayloadSize() override {}
@@ -98,7 +98,7 @@ public:
 	void PrintDebug() override;
 
 private:
-	uint32 val;
+	uint32_t val;
 	Comp comp;
 };
 

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -23,14 +23,14 @@
 //		  - tcp-state always evaluates to true
 //			(implemented but deactivated for comparison to Snort)
 
-uint32 RuleHdrTest::idcounter = 0;
+uint32_t RuleHdrTest::idcounter = 0;
 
 static bool is_member_of(const int_list& l, int_list::value_type v)
 	{
 	return std::find(l.begin(), l.end(), v) != l.end();
 	}
 
-RuleHdrTest::RuleHdrTest(Prot arg_prot, uint32 arg_offset, uint32 arg_size,
+RuleHdrTest::RuleHdrTest(Prot arg_prot, uint32_t arg_offset, uint32_t arg_size,
 				Comp arg_comp, maskedvalue_list* arg_vals)
 	{
 	prot = arg_prot;
@@ -428,17 +428,17 @@ void RuleMatcher::BuildPatternSets(RuleHdrTest::pattern_set_list* dst,
 	}
 
 // Get a 8/16/32-bit value from the given position in the packet header
-static inline uint32 getval(const u_char* data, int size)
+static inline uint32_t getval(const u_char* data, int size)
 	{
 	switch ( size ) {
 	case 1:
-		return *(uint8*) data;
+		return *(uint8_t*) data;
 
 	case 2:
-		return ntohs(*(uint16*) data);
+		return ntohs(*(uint16_t*) data);
 
 	case 4:
-		return ntohl(*(uint32*) data);
+		return ntohl(*(uint32_t*) data);
 
 	default:
 		reporter->InternalError("illegal HdrTest size");
@@ -451,7 +451,7 @@ static inline uint32 getval(const u_char* data, int size)
 
 // Evaluate a value list (matches if at least one value matches).
 template <typename FuncT>
-static inline bool match_or(const maskedvalue_list& mvals, uint32 v, FuncT comp)
+static inline bool match_or(const maskedvalue_list& mvals, uint32_t v, FuncT comp)
 	{
 	// TODO: this could be a find_if
 	for ( const auto& val : mvals )
@@ -479,7 +479,7 @@ static inline bool match_or(const vector<IPPrefix>& prefixes, const IPAddr& a,
 
 // Evaluate a value list (doesn't match if any value matches).
 template <typename FuncT>
-static inline bool match_not_and(const maskedvalue_list& mvals, uint32 v,
+static inline bool match_not_and(const maskedvalue_list& mvals, uint32_t v,
                                  FuncT comp)
 	{
 	// TODO: this could be a find_if
@@ -506,32 +506,32 @@ static inline bool match_not_and(const vector<IPPrefix>& prefixes,
 	return true;
 	}
 
-static inline bool compare(const maskedvalue_list& mvals, uint32 v,
+static inline bool compare(const maskedvalue_list& mvals, uint32_t v,
                            RuleHdrTest::Comp comp)
 	{
 	switch ( comp ) {
 		case RuleHdrTest::EQ:
-			return match_or(mvals, v, std::equal_to<uint32>());
+			return match_or(mvals, v, std::equal_to<uint32_t>());
 			break;
 
 		case RuleHdrTest::NE:
-			return match_not_and(mvals, v, std::equal_to<uint32>());
+			return match_not_and(mvals, v, std::equal_to<uint32_t>());
 			break;
 
 		case RuleHdrTest::LT:
-			return match_or(mvals, v, std::less<uint32>());
+			return match_or(mvals, v, std::less<uint32_t>());
 			break;
 
 		case RuleHdrTest::GT:
-			return match_or(mvals, v, std::greater<uint32>());
+			return match_or(mvals, v, std::greater<uint32_t>());
 			break;
 
 		case RuleHdrTest::LE:
-			return match_or(mvals, v, std::less_equal<uint32>());
+			return match_or(mvals, v, std::less_equal<uint32_t>());
 			break;
 
 		case RuleHdrTest::GE:
-			return match_or(mvals, v, std::greater_equal<uint32>());
+			return match_or(mvals, v, std::greater_equal<uint32_t>());
 			break;
 
 		default:
@@ -617,7 +617,7 @@ bool RuleMatcher::AllRulePatternsMatched(const Rule* r, MatchPos matchpos,
 	}
 
 RuleMatcher::MIME_Matches* RuleMatcher::Match(RuleFileMagicState* state,
-                                              const u_char* data, uint64 len,
+                                              const u_char* data, uint64_t len,
                                               MIME_Matches* rval) const
 	{
 	if ( ! rval )
@@ -1281,8 +1281,8 @@ static bool val_to_maskedval(Val* v, maskedvalue_list* append_to,
 				}
 			else
 				{
-				const uint32* n;
-				uint32 m[4];
+				const uint32_t* n;
+				uint32_t m[4];
 				v->AsSubNet().Prefix().GetBytes(&n);
 				v->AsSubNetVal()->Mask().CopyIPv6(m);
 
@@ -1370,7 +1370,7 @@ error:
 	return dummy;
 	}
 
-uint32 id_to_uint(const char* id)
+uint32_t id_to_uint(const char* id)
 	{
 	Val* v = get_bro_val(id);
 	if ( ! v )

--- a/src/RuleMatcher.h
+++ b/src/RuleMatcher.h
@@ -47,13 +47,13 @@ namespace analyzer {
 // Given a header expression like "ip[offset:len] & mask = val", we parse
 // it into a Range and a MaskedValue.
 struct Range {
-	uint32 offset;
-	uint32 len;
+	uint32_t offset;
+	uint32_t len;
 };
 
 struct MaskedValue {
-	uint32 val;
-	uint32 mask;
+	uint32_t val;
+	uint32_t mask;
 };
 
 typedef PList<MaskedValue> maskedvalue_list;
@@ -64,7 +64,7 @@ typedef PList<BroString> bstr_list;
 extern void id_to_maskedvallist(const char* id, maskedvalue_list* append_to,
                                 vector<IPPrefix>* prefix_vector = 0);
 extern char* id_to_str(const char* id);
-extern uint32 id_to_uint(const char* id);
+extern uint32_t id_to_uint(const char* id);
 
 class RuleHdrTest {
 public:
@@ -72,7 +72,7 @@ public:
 	enum Comp { LE, GE, LT, GT, EQ, NE };
 	enum Prot { NOPROT, IP, IPv6, ICMP, ICMPv6, TCP, UDP, NEXT, IPSrc, IPDst };
 
-	RuleHdrTest(Prot arg_prot, uint32 arg_offset, uint32 arg_size,
+	RuleHdrTest(Prot arg_prot, uint32_t arg_offset, uint32_t arg_size,
 			Comp arg_comp, maskedvalue_list* arg_vals);
 	RuleHdrTest(Prot arg_prot, Comp arg_comp, vector<IPPrefix> arg_v);
 	~RuleHdrTest();
@@ -92,11 +92,11 @@ private:
 	Comp comp;
 	maskedvalue_list* vals;
 	vector<IPPrefix> prefix_vals; // for use with IPSrc/IPDst comparisons
-	uint32 offset;
-	uint32 size;
+	uint32_t offset;
+	uint32_t size;
 
-	uint32 id;	// For debugging, each HdrTest gets an unique ID
-	static uint32 idcounter;
+	uint32_t id;	// For debugging, each HdrTest gets an unique ID
+	static uint32_t idcounter;
 
 	// The following are all set by RuleMatcher::BuildRulesTree().
 	friend class RuleMatcher;
@@ -251,7 +251,7 @@ public:
 	 * @return The results of the signature matching.
 	 */
 	MIME_Matches* Match(RuleFileMagicState* state, const u_char* data,
-	                   uint64 len, MIME_Matches* matches = 0) const;
+	                   uint64_t len, MIME_Matches* matches = 0) const;
 
 
 	/**

--- a/src/SerializationFormat.cc
+++ b/src/SerializationFormat.cc
@@ -18,7 +18,7 @@ SerializationFormat::~SerializationFormat()
 	free(output);
 	}
 
-void SerializationFormat::StartRead(const char* data, uint32 arg_len)
+void SerializationFormat::StartRead(const char* data, uint32_t arg_len)
 	{
 	input = data;
 	input_len = arg_len;
@@ -49,9 +49,9 @@ void SerializationFormat::StartWrite()
 	bytes_written = 0;
 	}
 
-uint32 SerializationFormat::EndWrite(char** data)
+uint32_t SerializationFormat::EndWrite(char** data)
 	{
-	uint32 rval = output_pos;
+	uint32_t rval = output_pos;
 	*data = output;
 	output = 0;
 	output_size = 0;
@@ -101,7 +101,7 @@ BinarySerializationFormat::~BinarySerializationFormat()
 
 bool BinarySerializationFormat::Read(int* v, const char* tag)
 	{
-	uint32 tmp;
+	uint32_t tmp;
 	if ( ! ReadData(&tmp, sizeof(tmp)) )
 		return false;
 
@@ -110,46 +110,46 @@ bool BinarySerializationFormat::Read(int* v, const char* tag)
 	return true;
 	}
 
-bool BinarySerializationFormat::Read(uint16* v, const char* tag)
+bool BinarySerializationFormat::Read(uint16_t* v, const char* tag)
 	{
 	if ( ! ReadData(v, sizeof(*v)) )
 		return false;
 
 	*v = ntohs(*v);
-	DBG_LOG(DBG_SERIAL, "Read uint16 %hu [%s]", *v, tag);
+	DBG_LOG(DBG_SERIAL, "Read uint16_t %hu [%s]", *v, tag);
 	return true;
 	}
 
-bool BinarySerializationFormat::Read(uint32* v, const char* tag)
+bool BinarySerializationFormat::Read(uint32_t* v, const char* tag)
 	{
 	if ( ! ReadData(v, sizeof(*v)) )
 		return false;
 
 	*v = ntohl(*v);
-	DBG_LOG(DBG_SERIAL, "Read uint32 %" PRIu32 " [%s]", *v, tag);
+	DBG_LOG(DBG_SERIAL, "Read uint32_t %" PRIu32 " [%s]", *v, tag);
 	return true;
 	}
 
 
-bool BinarySerializationFormat::Read(int64* v, const char* tag)
+bool BinarySerializationFormat::Read(int64_t* v, const char* tag)
 	{
-	uint32 x[2];
+	uint32_t x[2];
 	if ( ! ReadData(x, sizeof(x)) )
 		return false;
 
-	*v = ((int64(ntohl(x[0]))) << 32) | ntohl(x[1]);
-	DBG_LOG(DBG_SERIAL, "Read int64 %" PRId64 " [%s]", *v, tag);
+	*v = ((int64_t(ntohl(x[0]))) << 32) | ntohl(x[1]);
+	DBG_LOG(DBG_SERIAL, "Read int64_t %" PRId64 " [%s]", *v, tag);
 	return true;
 	}
 
-bool BinarySerializationFormat::Read(uint64* v, const char* tag)
+bool BinarySerializationFormat::Read(uint64_t* v, const char* tag)
 	{
-	uint32 x[2];
+	uint32_t x[2];
 	if ( ! ReadData(x, sizeof(x)) )
 		return false;
 
-	*v = ((uint64(ntohl(x[0]))) << 32) | ntohl(x[1]);
-	DBG_LOG(DBG_SERIAL, "Read uint64 %" PRIu64 " [%s]", *v, tag);
+	*v = ((uint64_t(ntohl(x[0]))) << 32) | ntohl(x[1]);
+	DBG_LOG(DBG_SERIAL, "Read uint64_t %" PRIu64 " [%s]", *v, tag);
 	return true;
 	}
 
@@ -304,16 +304,16 @@ bool BinarySerializationFormat::Write(char v, const char* tag)
 	return WriteData(&v, 1);
 	}
 
-bool BinarySerializationFormat::Write(uint16 v, const char* tag)
+bool BinarySerializationFormat::Write(uint16_t v, const char* tag)
 	{
-	DBG_LOG(DBG_SERIAL, "Write uint16 %hu [%s]", v, tag);
+	DBG_LOG(DBG_SERIAL, "Write uint16_t %hu [%s]", v, tag);
 	v = htons(v);
 	return WriteData(&v, sizeof(v));
 	}
 
-bool BinarySerializationFormat::Write(uint32 v, const char* tag)
+bool BinarySerializationFormat::Write(uint32_t v, const char* tag)
 	{
-	DBG_LOG(DBG_SERIAL, "Write uint32 %" PRIu32 " [%s]", v, tag);
+	DBG_LOG(DBG_SERIAL, "Write uint32_t %" PRIu32 " [%s]", v, tag);
 	v = htonl(v);
 	return WriteData(&v, sizeof(v));
 	}
@@ -321,23 +321,23 @@ bool BinarySerializationFormat::Write(uint32 v, const char* tag)
 bool BinarySerializationFormat::Write(int v, const char* tag)
 	{
 	DBG_LOG(DBG_SERIAL, "Write int %d [%s]", v, tag);
-	uint32 tmp = htonl((uint32) v);
+	uint32_t tmp = htonl((uint32_t) v);
 	return WriteData(&tmp, sizeof(tmp));
 	}
 
-bool BinarySerializationFormat::Write(uint64 v, const char* tag)
+bool BinarySerializationFormat::Write(uint64_t v, const char* tag)
 	{
-	DBG_LOG(DBG_SERIAL, "Write uint64 %" PRIu64 " [%s]", v, tag);
-	uint32 x[2];
+	DBG_LOG(DBG_SERIAL, "Write uint64_t %" PRIu64 " [%s]", v, tag);
+	uint32_t x[2];
 	x[0] = htonl(v >> 32);
 	x[1] = htonl(v & 0xffffffff);
 	return WriteData(x, sizeof(x));
 	}
 
-bool BinarySerializationFormat::Write(int64 v, const char* tag)
+bool BinarySerializationFormat::Write(int64_t v, const char* tag)
 	{
-	DBG_LOG(DBG_SERIAL, "Write int64 %" PRId64 " [%s]", v, tag);
-	uint32 x[2];
+	DBG_LOG(DBG_SERIAL, "Write int64_t %" PRId64 " [%s]", v, tag);
+	uint32_t x[2];
 	x[0] = htonl(v >> 32);
 	x[1] = htonl(v & 0xffffffff);
 	return WriteData(x, sizeof(x));
@@ -432,7 +432,7 @@ bool BinarySerializationFormat::WriteSeparator()
 bool BinarySerializationFormat::Write(const char* buf, int len, const char* tag)
 	{
 	DBG_LOG(DBG_SERIAL, "Write bytes |%s| [%s]", fmt_bytes(buf, len), tag);
-	uint32 l = htonl(len);
+	uint32_t l = htonl(len);
 	return WriteData(&l, sizeof(l)) && WriteData(buf, len);
 	}
 

--- a/src/SerializationFormat.h
+++ b/src/SerializationFormat.h
@@ -19,14 +19,14 @@ public:
 	virtual ~SerializationFormat();
 
 	// Unserialization.
-	virtual void StartRead(const char* data, uint32 len);
+	virtual void StartRead(const char* data, uint32_t len);
 	virtual void EndRead();
 
 	virtual bool Read(int* v, const char* tag) = 0;
-	virtual bool Read(uint16* v, const char* tag) = 0;
-	virtual bool Read(uint32* v, const char* tag) = 0;
-	virtual bool Read(int64* v, const char* tag) = 0;
-	virtual bool Read(uint64* v, const char* tag) = 0;
+	virtual bool Read(uint16_t* v, const char* tag) = 0;
+	virtual bool Read(uint32_t* v, const char* tag) = 0;
+	virtual bool Read(int64_t* v, const char* tag) = 0;
+	virtual bool Read(uint64_t* v, const char* tag) = 0;
 	virtual bool Read(char* v, const char* tag) = 0;
 	virtual bool Read(bool* v, const char* tag) = 0;
 	virtual bool Read(double* d, const char* tag) = 0;
@@ -52,13 +52,13 @@ public:
 	 *             be reclaimed using "free()".
 	 * @return The number of bytes in the buffer object assigned to \a data.
 	 */
-	virtual uint32 EndWrite(char** data);
+	virtual uint32_t EndWrite(char** data);
 
 	virtual bool Write(int v, const char* tag) = 0;
-	virtual bool Write(uint16 v, const char* tag) = 0;
-	virtual bool Write(uint32 v, const char* tag) = 0;
-	virtual bool Write(int64 v, const char* tag) = 0;
-	virtual bool Write(uint64 v, const char* tag) = 0;
+	virtual bool Write(uint16_t v, const char* tag) = 0;
+	virtual bool Write(uint32_t v, const char* tag) = 0;
+	virtual bool Write(int64_t v, const char* tag) = 0;
+	virtual bool Write(uint64_t v, const char* tag) = 0;
 	virtual bool Write(char v, const char* tag) = 0;
 	virtual bool Write(bool v, const char* tag) = 0;
 	virtual bool Write(double d, const char* tag) = 0;
@@ -81,15 +81,15 @@ protected:
 	bool ReadData(void* buf, size_t count);
 	bool WriteData(const void* buf, size_t count);
 
-	static const uint32 INITIAL_SIZE = 65536;
+	static const uint32_t INITIAL_SIZE = 65536;
 	static const float GROWTH_FACTOR;
 	char* output;
-	uint32 output_size;
-	uint32 output_pos;
+	uint32_t output_size;
+	uint32_t output_pos;
 
 	const char* input;
-	uint32 input_len;
-	uint32 input_pos;
+	uint32_t input_len;
+	uint32_t input_pos;
 
 	int bytes_written;
 	int bytes_read;
@@ -101,10 +101,10 @@ public:
 	~BinarySerializationFormat() override;
 
 	bool Read(int* v, const char* tag) override;
-	bool Read(uint16* v, const char* tag) override;
-	bool Read(uint32* v, const char* tag) override;
-	bool Read(int64* v, const char* tag) override;
-	bool Read(uint64* v, const char* tag) override;
+	bool Read(uint16_t* v, const char* tag) override;
+	bool Read(uint32_t* v, const char* tag) override;
+	bool Read(int64_t* v, const char* tag) override;
+	bool Read(uint64_t* v, const char* tag) override;
 	bool Read(char* v, const char* tag) override;
 	bool Read(bool* v, const char* tag) override;
 	bool Read(double* d, const char* tag) override;
@@ -115,10 +115,10 @@ public:
 	bool Read(struct in_addr* addr, const char* tag) override;
 	bool Read(struct in6_addr* addr, const char* tag) override;
 	bool Write(int v, const char* tag) override;
-	bool Write(uint16 v, const char* tag) override;
-	bool Write(uint32 v, const char* tag) override;
-	bool Write(int64 v, const char* tag) override;
-	bool Write(uint64 v, const char* tag) override;
+	bool Write(uint16_t v, const char* tag) override;
+	bool Write(uint32_t v, const char* tag) override;
+	bool Write(int64_t v, const char* tag) override;
+	bool Write(uint64_t v, const char* tag) override;
 	bool Write(char v, const char* tag) override;
 	bool Write(bool v, const char* tag) override;
 	bool Write(double d, const char* tag) override;

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -167,7 +167,7 @@ void NetSessions::NextPacket(double t, const Packet* pkt)
 		return;
 		}
 
-	uint32 caplen = pkt->cap_len - pkt->hdr_size;
+	uint32_t caplen = pkt->cap_len - pkt->hdr_size;
 
 	if ( pkt->l3_proto == L3_IPV4 )
 		{
@@ -264,7 +264,7 @@ int NetSessions::CheckConnectionTag(Connection* conn)
 	return 1;
 	}
 
-static unsigned int gre_header_len(uint16 flags)
+static unsigned int gre_header_len(uint16_t flags)
 	{
 	unsigned int len = 4;  // Always has 2 byte flags and 2 byte protocol type.
 
@@ -292,10 +292,10 @@ static unsigned int gre_header_len(uint16 flags)
 void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr,
 			       const EncapsulationStack* encapsulation)
 	{
-	uint32 caplen = pkt->cap_len - pkt->hdr_size;
+	uint32_t caplen = pkt->cap_len - pkt->hdr_size;
 	const struct ip* ip4 = ip_hdr->IP4_Hdr();
 
-	uint32 len = ip_hdr->TotalLen();
+	uint32_t len = ip_hdr->TotalLen();
 	if ( len == 0 )
 		{
 		// TCP segmentation offloading can zero out the ip_len field.
@@ -313,7 +313,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 
 	// For both of these it is safe to pass ip_hdr because the presence
 	// is guaranteed for the functions that pass data to us.
-	uint16 ip_hdr_len = ip_hdr->HdrLen();
+	uint16_t ip_hdr_len = ip_hdr->HdrLen();
 	if ( ip_hdr_len > len )
 		{
 		Weird("invalid_IP_header_size", ip_hdr, encapsulation);
@@ -491,8 +491,8 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 			return;
 			}
 
-		uint16 flags_ver = ntohs(*((uint16*)(data + 0)));
-		uint16 proto_typ = ntohs(*((uint16*)(data + 2)));
+		uint16_t flags_ver = ntohs(*((uint16_t*)(data + 0)));
+		uint16_t proto_typ = ntohs(*((uint16_t*)(data + 2)));
 		int gre_version = flags_ver & 0x0007;
 
 		// If a carried packet has ethernet, this will help skip it.
@@ -515,7 +515,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 				if ( len > gre_len + 14 )
 					{
 					eth_len = 14;
-					proto_typ = ntohs(*((uint16*)(data + gre_len + eth_len - 2)));
+					proto_typ = ntohs(*((uint16_t*)(data + gre_len + eth_len - 2)));
 					}
 				else
 					{
@@ -531,7 +531,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 					{
 					erspan_len = 8;
 					eth_len = 14;
-					proto_typ = ntohs(*((uint16*)(data + gre_len + erspan_len + eth_len - 2)));
+					proto_typ = ntohs(*((uint16_t*)(data + gre_len + erspan_len + eth_len - 2)));
 					}
 				else
 					{
@@ -562,7 +562,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 							}
 						}
 
-					proto_typ = ntohs(*((uint16*)(data + gre_len + erspan_len + eth_len - 2)));
+					proto_typ = ntohs(*((uint16_t*)(data + gre_len + erspan_len + eth_len - 2)));
 					}
 				else
 					{
@@ -618,7 +618,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 
 		if ( gre_version == 1 )
 			{
-			uint16 ppp_proto = ntohs(*((uint16*)(data + gre_len + 2)));
+			uint16_t ppp_proto = ntohs(*((uint16_t*)(data + gre_len + 2)));
 
 			if ( ppp_proto != 0x0021 && ppp_proto != 0x0057 )
 				{
@@ -809,7 +809,7 @@ void NetSessions::DoNextInnerPacket(double t, const Packet* pkt,
 		const IP_Hdr* inner, const EncapsulationStack* prev,
 		const EncapsulatingConn& ec)
 	{
-	uint32 caplen, len;
+	uint32_t caplen, len;
 	caplen = len = inner->TotalLen();
 
 	pkt_timeval ts;
@@ -883,16 +883,16 @@ int NetSessions::ParseIPPacket(int caplen, const u_char* const pkt, int proto,
 		return -1;
 		}
 
-	if ( (uint32)caplen != inner->TotalLen() )
-		return (uint32)caplen < inner->TotalLen() ? -1 : 1;
+	if ( (uint32_t)caplen != inner->TotalLen() )
+		return (uint32_t)caplen < inner->TotalLen() ? -1 : 1;
 
 	return 0;
 	}
 
-bool NetSessions::CheckHeaderTrunc(int proto, uint32 len, uint32 caplen,
+bool NetSessions::CheckHeaderTrunc(int proto, uint32_t len, uint32_t caplen,
                                    const Packet* p, const EncapsulationStack* encap)
 	{
-	uint32 min_hdr_len = 0;
+	uint32_t min_hdr_len = 0;
 	switch ( proto ) {
 	case IPPROTO_TCP:
 		min_hdr_len = sizeof(struct tcphdr);
@@ -938,7 +938,7 @@ bool NetSessions::CheckHeaderTrunc(int proto, uint32 len, uint32 caplen,
 FragReassembler* NetSessions::NextFragment(double t, const IP_Hdr* ip,
 					const u_char* pkt)
 	{
-	uint32 frag_id = ip->ID();
+	uint32_t frag_id = ip->ID();
 
 	ListVal* key = new ListVal(TYPE_ANY);
 	key->Append(new AddrVal(ip->SrcAddr()));
@@ -1207,7 +1207,7 @@ void NetSessions::GetStats(SessionStats& s) const
 	}
 
 Connection* NetSessions::NewConn(HashKey* k, double t, const ConnID* id,
-					const u_char* data, int proto, uint32 flow_label,
+					const u_char* data, int proto, uint32_t flow_label,
 					const Packet* pkt, const EncapsulationStack* encapsulation)
 	{
 	// FIXME: This should be cleaned up a bit, it's too protocol-specific.
@@ -1282,7 +1282,7 @@ Connection* NetSessions::NewConn(HashKey* k, double t, const ConnID* id,
 	return conn;
 	}
 
-bool NetSessions::IsLikelyServerPort(uint32 port, TransportProto proto) const
+bool NetSessions::IsLikelyServerPort(uint32_t port, TransportProto proto) const
 	{
 	// We keep a cached in-core version of the table to speed up the lookup.
 	static set<bro_uint_t> port_cache;
@@ -1309,9 +1309,9 @@ bool NetSessions::IsLikelyServerPort(uint32 port, TransportProto proto) const
 	return port_cache.find(port) != port_cache.end();
 	}
 
-bool NetSessions::WantConnection(uint16 src_port, uint16 dst_port,
+bool NetSessions::WantConnection(uint16_t src_port, uint16_t dst_port,
 					TransportProto transport_proto,
-					uint8 tcp_flags, bool& flip_roles)
+					uint8_t tcp_flags, bool& flip_roles)
 	{
 	flip_roles = false;
 
@@ -1402,7 +1402,7 @@ void NetSessions::DumpPacket(const Packet *pkt, int len)
 
 	if ( len != 0 )
 		{
-		if ( (uint32)len > pkt->cap_len )
+		if ( (uint32_t)len > pkt->cap_len )
 			reporter->Warning("bad modified caplen");
 		else
 			const_cast<Packet *>(pkt)->cap_len = len;

--- a/src/Sessions.h
+++ b/src/Sessions.h
@@ -29,19 +29,19 @@ namespace analyzer { namespace arp { class ARP_Analyzer; } }
 struct SessionStats {
 	int num_TCP_conns;
 	int max_TCP_conns;
-	uint64 cumulative_TCP_conns;
+	uint64_t cumulative_TCP_conns;
 
 	int num_UDP_conns;
 	int max_UDP_conns;
-	uint64 cumulative_UDP_conns;
+	uint64_t cumulative_UDP_conns;
 
 	int num_ICMP_conns;
 	int max_ICMP_conns;
-	uint64 cumulative_ICMP_conns;
+	uint64_t cumulative_ICMP_conns;
 
 	int num_fragments;
 	int max_fragments;
-	uint64 num_packets;
+	uint64_t num_packets;
 };
 
 // Drains and deletes a timer manager if it hasn't seen any advances
@@ -173,7 +173,7 @@ protected:
 	friend class IPTunnelTimer;
 
 	Connection* NewConn(HashKey* k, double t, const ConnID* id,
-			const u_char* data, int proto, uint32 flow_label,
+			const u_char* data, int proto, uint32_t flow_label,
 			const Packet* pkt, const EncapsulationStack* encapsulation);
 
 	// Check whether the tag of the current packet is consistent with
@@ -189,7 +189,7 @@ protected:
 	// generally a likely server port, false otherwise.
 	//
 	// Note, port is in host order.
-	bool IsLikelyServerPort(uint32 port,
+	bool IsLikelyServerPort(uint32_t port,
 				TransportProto transport_proto) const;
 
 	// Upon seeing the first packet of a connection, checks whether
@@ -197,9 +197,9 @@ protected:
 	// connections), and, if yes, whether we should flip the roles of
 	// originator and responder (based on known ports or such).
 	// Use tcp_flags=0 for non-TCP.
-	bool WantConnection(uint16 src_port, uint16 dest_port,
+	bool WantConnection(uint16_t src_port, uint16_t dest_port,
 				TransportProto transport_proto,
-				uint8 tcp_flags, bool& flip_roles);
+				uint8_t tcp_flags, bool& flip_roles);
 
 	// Record the given packet (if a dumper is active).  If len=0
 	// then the whole packet is recorded, otherwise just the first
@@ -209,7 +209,7 @@ protected:
 	// For a given protocol, checks whether the header's length as derived
 	// from lower-level headers or the length actually captured is less
 	// than that protocol's minimum header size.
-	bool CheckHeaderTrunc(int proto, uint32 len, uint32 caplen,
+	bool CheckHeaderTrunc(int proto, uint32_t len, uint32_t caplen,
 			      const Packet *pkt, const EncapsulationStack* encap);
 
 	CompositeHash* ch;
@@ -229,7 +229,7 @@ protected:
 	Discarder* discarder;
 	PacketFilter* packet_filter;
 	int dump_this_packet;	// if true, current packet should be recorded
-	uint64 num_packets_processed;
+	uint64_t num_packets_processed;
 	PacketProfiler* pkt_profiler;
 
 	// We may use independent timer managers for different sets of related

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -11,12 +11,12 @@
 #include "threading/Manager.h"
 #include "broker/Manager.h"
 
-uint64 killed_by_inactivity = 0;
+uint64_t killed_by_inactivity = 0;
 
-uint64 tot_ack_events = 0;
-uint64 tot_ack_bytes = 0;
-uint64 tot_gap_events = 0;
-uint64 tot_gap_bytes = 0;
+uint64_t tot_ack_events = 0;
+uint64_t tot_ack_bytes = 0;
+uint64_t tot_gap_events = 0;
+uint64_t tot_gap_bytes = 0;
 
 
 class ProfileTimer : public Timer {
@@ -79,7 +79,7 @@ void ProfileLogger::Log()
 	struct timeval tv_utime = r.ru_utime;
 	struct timeval tv_stime = r.ru_stime;
 
-	uint64 total, malloced;
+	uint64_t total, malloced;
 	get_memory_usage(&total, &malloced);
 
 	static unsigned int first_total = 0;
@@ -460,7 +460,7 @@ void PacketProfiler::ProfilePkt(double t, unsigned int bytes)
 		double curr_Rtime =
 			ptimestamp.tv_sec + ptimestamp.tv_usec / 1e6;
 
-		uint64 curr_mem;
+		uint64_t curr_mem;
 		get_memory_usage(&curr_mem, 0);
 
 		file->Write(fmt("%.06f %.03f %" PRIu64 " %" PRIu64 " %.03f %.03f %.03f %" PRIu64 "\n",

--- a/src/Stats.h
+++ b/src/Stats.h
@@ -102,13 +102,13 @@ extern ProfileLogger* segment_logger;
 extern SampleLogger* sample_logger;
 
 // Connection statistics.
-extern uint64 killed_by_inactivity;
+extern uint64_t killed_by_inactivity;
 
 // Content gap statistics.
-extern uint64 tot_ack_events;
-extern uint64 tot_ack_bytes;
-extern uint64 tot_gap_events;
-extern uint64 tot_gap_bytes;
+extern uint64_t tot_ack_events;
+extern uint64_t tot_ack_bytes;
+extern uint64_t tot_gap_events;
+extern uint64_t tot_gap_bytes;
 
 class PacketProfiler {
 public:
@@ -127,9 +127,9 @@ protected:
 	double update_freq;
 	double last_Utime, last_Stime, last_Rtime;
 	double last_timestamp, time;
-	uint64 last_mem;
-	uint64 pkt_cnt;
-	uint64 byte_cnt;
+	uint64_t last_mem;
+	uint64_t pkt_cnt;
+	uint64_t byte_cnt;
 };
 
 #endif

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -54,7 +54,7 @@ public:
 
 	void RegisterAccess() const	{ last_access = network_time; access_count++; }
 	void AccessStats(ODesc* d) const;
-	uint32 GetAccessCount() const { return access_count; }
+	uint32_t GetAccessCount() const { return access_count; }
 
 	void Describe(ODesc* d) const override;
 
@@ -83,7 +83,7 @@ protected:
 
 	// FIXME: Learn the exact semantics of mutable.
 	mutable double last_access;	// time of last execution
-	mutable uint32 access_count;	// number of executions
+	mutable uint32_t access_count;	// number of executions
 };
 
 class ExprListStmt : public Stmt {

--- a/src/Tag.cc
+++ b/src/Tag.cc
@@ -9,7 +9,7 @@ Tag::Tag(EnumType* etype, type_t arg_type, subtype_t arg_subtype)
 
 	type = arg_type;
 	subtype = arg_subtype;
-	int64_t i = (int64)(type) | ((int64)subtype << 31);
+	int64_t i = (int64_t)(type) | ((int64_t)subtype << 31);
 	Ref(etype);
 	val = etype->GetVal(i);
 	}
@@ -21,7 +21,7 @@ Tag::Tag(EnumVal* arg_val)
 	val = arg_val;
 	Ref(val);
 
-	int64 i = val->InternalInt();
+	int64_t i = val->InternalInt();
 	type = i & 0xffffffff;
 	subtype = (i >> 31) & 0xffffffff;
 	}

--- a/src/Tag.h
+++ b/src/Tag.h
@@ -32,12 +32,12 @@ public:
 	/**
 	 * Type for the analyzer's main type.
 	 */
-	typedef uint32 type_t;
+	typedef uint32_t type_t;
 
 	/**
 	 * Type for the analyzer's subtype.
 	 */
-	typedef uint32 subtype_t;
+	typedef uint32_t subtype_t;
 
 	/**
 	 * Returns the tag's main type.

--- a/src/Timer.h
+++ b/src/Timer.h
@@ -102,7 +102,7 @@ public:
 
 	virtual int Size() const = 0;
 	virtual int PeakSize() const = 0;
-	virtual uint64 CumulativeNum() const = 0;
+	virtual uint64_t CumulativeNum() const = 0;
 
 	double LastTimestamp() const	{ return last_timestamp; }
 	// Returns time of last advance in global network time.
@@ -142,7 +142,7 @@ public:
 
 	int Size() const override { return q->Size(); }
 	int PeakSize() const override { return q->PeakSize(); }
-	uint64 CumulativeNum() const override { return q->CumulativeNum(); }
+	uint64_t CumulativeNum() const override { return q->CumulativeNum(); }
 
 protected:
 	int DoAdvance(double t, int max_expire) override;
@@ -164,7 +164,7 @@ public:
 
 	int Size() const override { return cq_size(cq); }
 	int PeakSize() const override { return cq_max_size(cq); }
-	uint64 CumulativeNum() const override { return cq_cumulative_num(cq); }
+	uint64_t CumulativeNum() const override { return cq_cumulative_num(cq); }
 	unsigned int MemoryUsage() const;
 
 protected:

--- a/src/TunnelEncapsulation.h
+++ b/src/TunnelEncapsulation.h
@@ -116,8 +116,8 @@ public:
 protected:
 	IPAddr src_addr;
 	IPAddr dst_addr;
-	uint16 src_port;
-	uint16 dst_port;
+	uint16_t src_port;
+	uint16_t dst_port;
 	TransportProto proto;
 	BifEnum::Tunnel::Type type;
 	Bro::UID uid;

--- a/src/UID.cc
+++ b/src/UID.cc
@@ -7,7 +7,7 @@
 using namespace Bro;
 using namespace std;
 
-void UID::Set(bro_uint_t bits, const uint64* v, size_t n)
+void UID::Set(bro_uint_t bits, const uint64_t* v, size_t n)
 	{
 	initialized = true;
 

--- a/src/UID.h
+++ b/src/UID.h
@@ -28,7 +28,7 @@ public:
 	 * Construct a UID of a given bit-length, optionally from given values.
 	 * @see UID::Set
 	 */
-	explicit UID(bro_uint_t bits, const uint64* v = 0, size_t n = 0)
+	explicit UID(bro_uint_t bits, const uint64_t* v = 0, size_t n = 0)
 		{ Set(bits, v, n); }
 
 	/**
@@ -47,7 +47,7 @@ public:
 	 *          64, then a value is truncated to bit in desired bit-length.
 	 * @param n number of 64-bit elements in array pointed to by \a v.
 	 */
-	void Set(bro_uint_t bits, const uint64* v = 0, size_t n = 0);
+	void Set(bro_uint_t bits, const uint64_t* v = 0, size_t n = 0);
 
 	/**
 	 * Returns a base62 (characters 0-9, A-Z, a-z) representation of the UID.
@@ -81,7 +81,7 @@ public:
 		{ return ! ( u1 == u2 ); }
 
 private:
-	uint64 uid[BRO_UID_LEN];
+	uint64_t uid[BRO_UID_LEN];
 	bool initialized; // Since technically uid == 0 is a legit UID
 };
 

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -701,17 +701,17 @@ void IntervalVal::ValDescribe(ODesc* d) const
 	DO_UNIT(Microseconds, "usec")
 	}
 
-PortVal* PortManager::Get(uint32 port_num) const
+PortVal* PortManager::Get(uint32_t port_num) const
 	{
 	return val_mgr->GetPort(port_num);
 	}
 
-PortVal* PortManager::Get(uint32 port_num, TransportProto port_type) const
+PortVal* PortManager::Get(uint32_t port_num, TransportProto port_type) const
 	{
 	return val_mgr->GetPort(port_num, port_type);
 	}
 
-uint32 PortVal::Mask(uint32 port_num, TransportProto port_type)
+uint32_t PortVal::Mask(uint32_t port_num, TransportProto port_type)
 	{
 	// Note, for ICMP one-way connections:
 	// src_port = icmp_type, dst_port = icmp_code.
@@ -742,18 +742,18 @@ uint32 PortVal::Mask(uint32 port_num, TransportProto port_type)
 	return port_num;
 	}
 
-PortVal::PortVal(uint32 p, TransportProto port_type) : Val(TYPE_PORT)
+PortVal::PortVal(uint32_t p, TransportProto port_type) : Val(TYPE_PORT)
 	{
 	auto port_num = PortVal::Mask(p, port_type);
 	val.uint_val = static_cast<bro_uint_t>(port_num);
 	}
 
-PortVal::PortVal(uint32 p, bool unused) : Val(TYPE_PORT)
+PortVal::PortVal(uint32_t p, bool unused) : Val(TYPE_PORT)
 	{
 	val.uint_val = static_cast<bro_uint_t>(p);
 	}
 
-PortVal::PortVal(uint32 p) : Val(TYPE_PORT)
+PortVal::PortVal(uint32_t p) : Val(TYPE_PORT)
 	{
 	if ( p >= 65536 * NUM_PORT_SPACES )
 		{
@@ -764,9 +764,9 @@ PortVal::PortVal(uint32 p) : Val(TYPE_PORT)
 	val.uint_val = static_cast<bro_uint_t>(p);
 	}
 
-uint32 PortVal::Port() const
+uint32_t PortVal::Port() const
 	{
-	uint32 p = static_cast<uint32>(val.uint_val);
+	uint32_t p = static_cast<uint32_t>(val.uint_val);
 	return p & ~PORT_SPACE_MASK;
 	}
 
@@ -799,7 +799,7 @@ int PortVal::IsICMP() const
 
 void PortVal::ValDescribe(ODesc* d) const
 	{
-	uint32 p = static_cast<uint32>(val.uint_val);
+	uint32_t p = static_cast<uint32_t>(val.uint_val);
 	d->Add(p & ~PORT_SPACE_MASK);
 	d->Add("/");
 	d->Add(Protocol());
@@ -821,13 +821,13 @@ AddrVal::AddrVal(const std::string& text) : Val(TYPE_ADDR)
 	val.addr_val = new IPAddr(text);
 	}
 
-AddrVal::AddrVal(uint32 addr) : Val(TYPE_ADDR)
+AddrVal::AddrVal(uint32_t addr) : Val(TYPE_ADDR)
 	{
 	// ### perhaps do gethostbyaddr here?
 	val.addr_val = new IPAddr(IPv4, &addr, IPAddr::Network);
 	}
 
-AddrVal::AddrVal(const uint32 addr[4]) : Val(TYPE_ADDR)
+AddrVal::AddrVal(const uint32_t addr[4]) : Val(TYPE_ADDR)
 	{
 	val.addr_val = new IPAddr(IPv6, addr, IPAddr::Network);
 	}
@@ -874,13 +874,13 @@ SubNetVal::SubNetVal(const char* text, int width) : Val(TYPE_SUBNET)
 	val.subnet_val = new IPPrefix(text, width);
 	}
 
-SubNetVal::SubNetVal(uint32 addr, int width) : Val(TYPE_SUBNET)
+SubNetVal::SubNetVal(uint32_t addr, int width) : Val(TYPE_SUBNET)
 	{
 	IPAddr a(IPv4, &addr, IPAddr::Network);
 	val.subnet_val = new IPPrefix(a, width);
 	}
 
-SubNetVal::SubNetVal(const uint32* addr, int width) : Val(TYPE_SUBNET)
+SubNetVal::SubNetVal(const uint32_t* addr, int width) : Val(TYPE_SUBNET)
 	{
 	IPAddr a(IPv6, addr, IPAddr::Network);
 	val.subnet_val = new IPPrefix(a, width);
@@ -933,17 +933,17 @@ IPAddr SubNetVal::Mask() const
 		{
 		// We need to special-case a mask width of zero, since
 		// the compiler doesn't guarantee that 1 << 32 yields 0.
-		uint32 m[4];
+		uint32_t m[4];
 		for ( unsigned int i = 0; i < 4; ++i )
 			m[i] = 0;
 		IPAddr rval(IPv6, m, IPAddr::Host);
 		return rval;
 		}
 
-	uint32 m[4];
-	uint32* mp = m;
+	uint32_t m[4];
+	uint32_t* mp = m;
 
-	uint32 w;
+	uint32_t w;
 	for ( w = val.subnet_val->Length(); w >= 32; w -= 32 )
 		   *(mp++) = 0xffffffff;
 
@@ -3229,7 +3229,7 @@ StringVal* ValManager::GetEmptyString() const
 	return empty_string;
 	}
 
-PortVal* ValManager::GetPort(uint32 port_num, TransportProto port_type) const
+PortVal* ValManager::GetPort(uint32_t port_num, TransportProto port_type) const
 	{
 	if ( port_num >= 65536 )
 		{
@@ -3242,7 +3242,7 @@ PortVal* ValManager::GetPort(uint32 port_num, TransportProto port_type) const
 	return rval;
 	}
 
-PortVal* ValManager::GetPort(uint32 port_num) const
+PortVal* ValManager::GetPort(uint32_t port_num) const
 	{
 	auto mask = port_num & PORT_SPACE_MASK;
 	port_num &= ~PORT_SPACE_MASK;

--- a/src/Val.h
+++ b/src/Val.h
@@ -97,7 +97,7 @@ public:
 		}
 
 	ZEEK_DEPRECATED("Remove in v3.1: use val_mgr->GetBool, GetFalse/GetTrue, GetInt, or GetCount instead")
-	Val(int32 i, TypeTag t)
+	Val(int32_t i, TypeTag t)
 		{
 		val.int_val = bro_int_t(i);
 		type = base_type(t);
@@ -107,7 +107,7 @@ public:
 		}
 
 	ZEEK_DEPRECATED("Remove in v3.1: use val_mgr->GetBool, GetFalse/GetTrue, GetInt, or GetCount instead")
-	Val(uint32 u, TypeTag t)
+	Val(uint32_t u, TypeTag t)
 		{
 		val.uint_val = bro_uint_t(u);
 		type = base_type(t);
@@ -117,7 +117,7 @@ public:
 		}
 
 	ZEEK_DEPRECATED("Remove in v3.1: use val_mgr->GetBool, GetFalse/GetTrue, GetInt, or GetCount instead")
-	Val(int64 i, TypeTag t)
+	Val(int64_t i, TypeTag t)
 		{
 		val.int_val = i;
 		type = base_type(t);
@@ -127,7 +127,7 @@ public:
 		}
 
 	ZEEK_DEPRECATED("Remove in v3.1: use val_mgr->GetBool, GetFalse/GetTrue, GetInt, or GetCount instead")
-	Val(uint64 u, TypeTag t)
+	Val(uint64_t u, TypeTag t)
 		{
 		val.uint_val = u;
 		type = base_type(t);
@@ -434,15 +434,15 @@ class PortManager {
 public:
 	// Port number given in host order.
 	ZEEK_DEPRECATED("Remove in v3.1: use val_mgr->GetPort() instead")
-	PortVal* Get(uint32 port_num, TransportProto port_type) const;
+	PortVal* Get(uint32_t port_num, TransportProto port_type) const;
 
 	// Host-order port number already masked with port space protocol mask.
 	ZEEK_DEPRECATED("Remove in v3.1: use val_mgr->GetPort() instead")
-	PortVal* Get(uint32 port_num) const;
+	PortVal* Get(uint32_t port_num) const;
 
 	// Returns a masked port number
 	ZEEK_DEPRECATED("Remove in v3.1: use PortVal::Mask() instead")
-	uint32 Mask(uint32 port_num, TransportProto port_type) const;
+	uint32_t Mask(uint32_t port_num, TransportProto port_type) const;
 };
 
 extern PortManager* port_mgr;
@@ -471,13 +471,13 @@ public:
 	inline Val* GetBool(bool b) const
 		{ return b ? b_true->Ref() : b_false->Ref(); }
 
-	inline Val* GetInt(int64 i) const
+	inline Val* GetInt(int64_t i) const
 		{
 		return i < PREALLOCATED_INT_LOWEST || i > PREALLOCATED_INT_HIGHEST ?
 		    Val::MakeInt(i) : ints[i - PREALLOCATED_INT_LOWEST]->Ref();
 		}
 
-	inline Val* GetCount(uint64 i) const
+	inline Val* GetCount(uint64_t i) const
 		{
 		return i >= PREALLOCATED_COUNTS ? Val::MakeCount(i) : counts[i]->Ref();
 		}
@@ -485,10 +485,10 @@ public:
 	StringVal* GetEmptyString() const;
 
 	// Port number given in host order.
-	PortVal* GetPort(uint32 port_num, TransportProto port_type) const;
+	PortVal* GetPort(uint32_t port_num, TransportProto port_type) const;
 
 	// Host-order port number already masked with port space protocol mask.
-	PortVal* GetPort(uint32 port_num) const;
+	PortVal* GetPort(uint32_t port_num) const;
 
 private:
 
@@ -524,16 +524,16 @@ class PortVal : public Val {
 public:
 	// Port number given in host order.
 	ZEEK_DEPRECATED("Remove in v3.1: use val_mgr->GetPort() instead")
-	PortVal(uint32 p, TransportProto port_type);
+	PortVal(uint32_t p, TransportProto port_type);
 
 	// Host-order port number already masked with port space protocol mask.
 	ZEEK_DEPRECATED("Remove in v3.1: use val_mgr->GetPort() instead")
-	explicit PortVal(uint32 p);
+	explicit PortVal(uint32_t p);
 
 	Val* SizeVal() const override	{ return val_mgr->GetInt(val.uint_val); }
 
 	// Returns the port number in host order (not including the mask).
-	uint32 Port() const;
+	uint32_t Port() const;
 	string Protocol() const;
 
 	// Tests for protocol types.
@@ -554,13 +554,13 @@ public:
 		}
 
 	// Returns a masked port number
-	static uint32 Mask(uint32 port_num, TransportProto port_type);
+	static uint32_t Mask(uint32_t port_num, TransportProto port_type);
 
 protected:
 	friend class Val;
 	friend class ValManager;
 	PortVal()	{}
-	PortVal(uint32 p, bool unused);
+	PortVal(uint32_t p, bool unused);
 
 	void ValDescribe(ODesc* d) const override;
 	Val* DoClone(CloneState* state) override;
@@ -575,8 +575,8 @@ public:
 	Val* SizeVal() const override;
 
 	// Constructor for address already in network order.
-	explicit AddrVal(uint32 addr);          // IPv4.
-	explicit AddrVal(const uint32 addr[4]); // IPv6.
+	explicit AddrVal(uint32_t addr);          // IPv4.
+	explicit AddrVal(const uint32_t addr[4]); // IPv6.
 	explicit AddrVal(const IPAddr& addr);
 
 	unsigned int MemoryAllocation() const override;
@@ -594,8 +594,8 @@ class SubNetVal : public Val {
 public:
 	explicit SubNetVal(const char* text);
 	SubNetVal(const char* text, int width);
-	SubNetVal(uint32 addr, int width); // IPv4.
-	SubNetVal(const uint32 addr[4], int width); // IPv6.
+	SubNetVal(uint32_t addr, int width); // IPv4.
+	SubNetVal(const uint32_t addr[4], int width); // IPv6.
 	SubNetVal(const IPAddr& addr, int width);
 	explicit SubNetVal(const IPPrefix& prefix);
 	~SubNetVal() override;
@@ -1034,7 +1034,7 @@ public:
 	~VectorVal() override;
 
 	Val* SizeVal() const override
-		{ return val_mgr->GetCount(uint32(val.vector_val->size())); }
+		{ return val_mgr->GetCount(uint32_t(val.vector_val->size())); }
 
 	// Returns false if the type of the argument was wrong.
 	// The vector will automatically grow to accomodate the index.

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -204,7 +204,7 @@ void Analyzer::Done()
 	finished = true;
 	}
 
-void Analyzer::NextPacket(int len, const u_char* data, bool is_orig, uint64 seq,
+void Analyzer::NextPacket(int len, const u_char* data, bool is_orig, uint64_t seq,
 				const IP_Hdr* ip, int caplen)
 	{
 	if ( skip )
@@ -251,7 +251,7 @@ void Analyzer::NextStream(int len, const u_char* data, bool is_orig)
 		}
 	}
 
-void Analyzer::NextUndelivered(uint64 seq, int len, bool is_orig)
+void Analyzer::NextUndelivered(uint64_t seq, int len, bool is_orig)
 	{
 	if ( skip )
 		return;
@@ -288,7 +288,7 @@ void Analyzer::NextEndOfData(bool is_orig)
 	}
 
 void Analyzer::ForwardPacket(int len, const u_char* data, bool is_orig,
-				uint64 seq, const IP_Hdr* ip, int caplen)
+				uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	if ( output_handler )
 		output_handler->DeliverPacket(len, data, is_orig, seq,
@@ -336,7 +336,7 @@ void Analyzer::ForwardStream(int len, const u_char* data, bool is_orig)
 	AppendNewChildren();
 	}
 
-void Analyzer::ForwardUndelivered(uint64 seq, int len, bool is_orig)
+void Analyzer::ForwardUndelivered(uint64_t seq, int len, bool is_orig)
 	{
 	if ( output_handler )
 		output_handler->Undelivered(seq, len, is_orig);
@@ -610,7 +610,7 @@ SupportAnalyzer* Analyzer::FirstSupportAnalyzer(bool orig)
 	}
 
 void Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
-				uint64 seq, const IP_Hdr* ip, int caplen)
+				uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	DBG_LOG(DBG_ANALYZER, "%s DeliverPacket(%d, %s, %" PRIu64", %p, %d) [%s%s]",
 			fmt_analyzer(this).c_str(), len, is_orig ? "T" : "F", seq, ip, caplen,
@@ -624,7 +624,7 @@ void Analyzer::DeliverStream(int len, const u_char* data, bool is_orig)
 			fmt_bytes((const char*) data, min(40, len)), len > 40 ? "..." : "");
 	}
 
-void Analyzer::Undelivered(uint64 seq, int len, bool is_orig)
+void Analyzer::Undelivered(uint64_t seq, int len, bool is_orig)
 	{
 	DBG_LOG(DBG_ANALYZER, "%s Undelivered(%" PRIu64", %d, %s)",
 			fmt_analyzer(this).c_str(), seq, len, is_orig ? "T" : "F");
@@ -816,7 +816,7 @@ SupportAnalyzer* SupportAnalyzer::Sibling(bool only_active) const
 	}
 
 void SupportAnalyzer::ForwardPacket(int len, const u_char* data, bool is_orig,
-					uint64 seq, const IP_Hdr* ip, int caplen)
+					uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	// We do not call parent's method, as we're replacing the functionality.
 
@@ -857,7 +857,7 @@ void SupportAnalyzer::ForwardStream(int len, const u_char* data, bool is_orig)
 		Parent()->DeliverStream(len, data, is_orig);
 	}
 
-void SupportAnalyzer::ForwardUndelivered(uint64 seq, int len, bool is_orig)
+void SupportAnalyzer::ForwardUndelivered(uint64_t seq, int len, bool is_orig)
 	{
 	// We do not call parent's method, as we're replacing the functionality.
 

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -26,7 +26,7 @@ class SupportAnalyzer;
 class OutputHandler;
 
 typedef list<Analyzer*> analyzer_list;
-typedef uint32 ID;
+typedef uint32_t ID;
 typedef void (Analyzer::*analyzer_timer_func)(double t);
 
 /**
@@ -44,7 +44,7 @@ public:
 	 * Analyzer::DeliverPacket().
 	 */
 	virtual void DeliverPacket(int len, const u_char* data,
-				   bool orig, uint64 seq,
+				   bool orig, uint64_t seq,
 				   const IP_Hdr* ip, int caplen)
 		{ }
 
@@ -59,7 +59,7 @@ public:
 	 * Hook for receiving notification of stream gaps. Parameters are the
 	 * same as for Analyzer::Undelivered().
 	 */
-	virtual void Undelivered(uint64 seq, int len, bool orig)	{ }
+	virtual void Undelivered(uint64_t seq, int len, bool orig)	{ }
 };
 
 /**
@@ -143,7 +143,7 @@ public:
 	 * @param caplen The packet's capture length, if available.
 	 */
 	void NextPacket(int len, const u_char* data, bool is_orig,
-			uint64 seq = -1, const IP_Hdr* ip = 0, int caplen = 0);
+			uint64_t seq = -1, const IP_Hdr* ip = 0, int caplen = 0);
 
 	/**
 	 * Passes stream input to the analyzer for processing. The analyzer
@@ -173,7 +173,7 @@ public:
 	 *
 	 * @param is_orig True if this is about originator-side input.
 	 */
-	void NextUndelivered(uint64 seq, int len, bool is_orig);
+	void NextUndelivered(uint64_t seq, int len, bool is_orig);
 
 	/**
 	 * Reports a message boundary.  This is a generic method that can be
@@ -195,7 +195,7 @@ public:
 	 * Parameters are the same as for NextPacket().
 	 */
 	virtual void ForwardPacket(int len, const u_char* data,
-					bool orig, uint64 seq,
+					bool orig, uint64_t seq,
 					const IP_Hdr* ip, int caplen);
 
 	/**
@@ -212,7 +212,7 @@ public:
 	 *
 	 * Parameters are the same as for NextUndelivered().
 	 */
-	virtual void ForwardUndelivered(uint64 seq, int len, bool orig);
+	virtual void ForwardUndelivered(uint64_t seq, int len, bool orig);
 
 	/**
 	 * Forwards an end-of-data notification on to all child analyzers.
@@ -227,7 +227,7 @@ public:
 	 * Parameters are the same.
 	 */
 	virtual void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen);
+					uint64_t seq, const IP_Hdr* ip, int caplen);
 
 	/**
 	 * Hook for accessing stream input for parsing. This is called by
@@ -241,7 +241,7 @@ public:
 	 * NextUndelivered() and can be overridden by derived classes.
 	 * Parameters are the same.
 	 */
-	virtual void Undelivered(uint64 seq, int len, bool orig);
+	virtual void Undelivered(uint64_t seq, int len, bool orig);
 
 	/**
 	 * Hook for accessing end-of-data notifications. This is called by
@@ -768,7 +768,7 @@ public:
 	* Parameters same as for Analyzer::ForwardPacket.
 	*/
 	void ForwardPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	/**
 	* Passes stream input to the next sibling SupportAnalyzer if any, or
@@ -788,7 +788,7 @@ public:
 	*
 	* Parameters same as for Analyzer::ForwardPacket.
 	*/
-	void ForwardUndelivered(uint64 seq, int len, bool orig) override;
+	void ForwardUndelivered(uint64_t seq, int len, bool orig) override;
 
 protected:
 	friend class Analyzer;

--- a/src/analyzer/Manager.cc
+++ b/src/analyzer/Manager.cc
@@ -19,7 +19,7 @@
 using namespace analyzer;
 
 Manager::ConnIndex::ConnIndex(const IPAddr& _orig, const IPAddr& _resp,
-				     uint16 _resp_p, uint16 _proto)
+				     uint16_t _resp_p, uint16_t _proto)
 	{
 	if ( _orig == IPAddr(string("0.0.0.0")) )
 		// don't use the IPv4 mapping, use the literal unspecified address
@@ -255,7 +255,7 @@ bool Manager::UnregisterAnalyzerForPort(EnumVal* val, PortVal* port)
 	return UnregisterAnalyzerForPort(p->Tag(), port->PortType(), port->Port());
 	}
 
-bool Manager::RegisterAnalyzerForPort(Tag tag, TransportProto proto, uint32 port)
+bool Manager::RegisterAnalyzerForPort(Tag tag, TransportProto proto, uint32_t port)
 	{
 	tag_set* l = LookupPort(proto, port, true);
 
@@ -271,7 +271,7 @@ bool Manager::RegisterAnalyzerForPort(Tag tag, TransportProto proto, uint32 port
 	return true;
 	}
 
-bool Manager::UnregisterAnalyzerForPort(Tag tag, TransportProto proto, uint32 port)
+bool Manager::UnregisterAnalyzerForPort(Tag tag, TransportProto proto, uint32_t port)
 	{
 	tag_set* l = LookupPort(proto, port, true);
 
@@ -326,7 +326,7 @@ Analyzer* Manager::InstantiateAnalyzer(const char* name, Connection* conn)
 	return tag ? InstantiateAnalyzer(tag, conn) : 0;
 	}
 
-Manager::tag_set* Manager::LookupPort(TransportProto proto, uint32 port, bool add_if_not_found)
+Manager::tag_set* Manager::LookupPort(TransportProto proto, uint32_t port, bool add_if_not_found)
 	{
 	analyzer_map_by_port* m = 0;
 
@@ -464,7 +464,7 @@ bool Manager::BuildInitialAnalyzerTree(Connection* conn)
 			// handle non-reassembled data, it doesn't really fit into
 			// our general framing ...  Better would be to turn it
 			// on *after* we discover we have interactive traffic.
-			uint16 resp_port = ntohs(conn->RespPort());
+			uint16_t resp_port = ntohs(conn->RespPort());
 			if ( resp_port == 22 || resp_port == 23 || resp_port == 513 )
 				{
 				AddrVal src(conn->OrigAddr());
@@ -541,7 +541,7 @@ void Manager::ExpireScheduledAnalyzers()
 	}
 
 void Manager::ScheduleAnalyzer(const IPAddr& orig, const IPAddr& resp,
-			uint16 resp_p,
+			uint16_t resp_p,
 			TransportProto proto, Tag analyzer,
 			double timeout)
 	{
@@ -566,7 +566,7 @@ void Manager::ScheduleAnalyzer(const IPAddr& orig, const IPAddr& resp,
 	}
 
 void Manager::ScheduleAnalyzer(const IPAddr& orig, const IPAddr& resp,
-			uint16 resp_p,
+			uint16_t resp_p,
 			TransportProto proto, const char* analyzer,
 			double timeout)
 	{

--- a/src/analyzer/Manager.h
+++ b/src/analyzer/Manager.h
@@ -180,7 +180,7 @@ public:
 	 *
 	 * @return True if successful.
 	 */
-	bool RegisterAnalyzerForPort(Tag tag, TransportProto proto, uint32 port);
+	bool RegisterAnalyzerForPort(Tag tag, TransportProto proto, uint32_t port);
 
 	/**
 	 * Unregisters a well-known port for an anlyzers.
@@ -208,7 +208,7 @@ public:
 	 * @param tag The analyzer's tag as an enum of script type \c
 	 * Analyzer::Tag.
 	 */
-	bool UnregisterAnalyzerForPort(Tag tag, TransportProto proto, uint32 port);
+	bool UnregisterAnalyzerForPort(Tag tag, TransportProto proto, uint32_t port);
 
 	/**
 	 * Instantiates a new analyzer instance for a connection.
@@ -269,7 +269,7 @@ public:
 	 * @param timeout An interval after which to timeout the request to
 	 * schedule this analyzer. Must be non-zero.
 	 */
-	void ScheduleAnalyzer(const IPAddr& orig, const IPAddr& resp, uint16 resp_p,
+	void ScheduleAnalyzer(const IPAddr& orig, const IPAddr& resp, uint16_t resp_p,
 				TransportProto proto, Tag analyzer, double timeout);
 
 	/**
@@ -293,7 +293,7 @@ public:
 	 * @param timeout An interval after which to timeout the request to
 	 * schedule this analyzer. Must be non-zero.
 	 */
-	void ScheduleAnalyzer(const IPAddr& orig, const IPAddr& resp, uint16 resp_p,
+	void ScheduleAnalyzer(const IPAddr& orig, const IPAddr& resp, uint16_t resp_p,
 				TransportProto proto, const char* analyzer,
 				double timeout);
 
@@ -339,15 +339,15 @@ public:
 	/**
 	 * @return the UDP port numbers to be associated with VXLAN traffic.
 	 */
-	const std::vector<uint16>& GetVxlanPorts() const
+	const std::vector<uint16_t>& GetVxlanPorts() const
 		{ return vxlan_ports; }
 
 private:
 	typedef set<Tag> tag_set;
-	typedef map<uint32, tag_set*> analyzer_map_by_port;
+	typedef map<uint32_t, tag_set*> analyzer_map_by_port;
 
 	tag_set* LookupPort(PortVal* val, bool add_if_not_found);
-	tag_set* LookupPort(TransportProto proto, uint32 port, bool add_if_not_found);
+	tag_set* LookupPort(TransportProto proto, uint32_t port, bool add_if_not_found);
 
 	tag_set GetScheduled(const Connection* conn);
 	void ExpireScheduledAnalyzers();
@@ -365,11 +365,11 @@ private:
 	struct ConnIndex {
 		IPAddr orig;
 		IPAddr resp;
-		uint16 resp_p;
-		uint16 proto;
+		uint16_t resp_p;
+		uint16_t proto;
 
 		ConnIndex(const IPAddr& _orig, const IPAddr& _resp,
-			     uint16 _resp_p, uint16 _proto);
+			     uint16_t _resp_p, uint16_t _proto);
 		ConnIndex();
 
 		bool operator<(const ConnIndex& other) const;
@@ -395,7 +395,7 @@ private:
 
 	conns_map conns;
 	conns_queue conns_by_timeout;
-	std::vector<uint16> vxlan_ports;
+	std::vector<uint16_t> vxlan_ports;
 };
 
 }

--- a/src/analyzer/protocol/arp/ARP.cc
+++ b/src/analyzer/protocol/arp/ARP.cc
@@ -225,7 +225,7 @@ void ARP_Analyzer::RREvent(EventHandlerPtr e,
 AddrVal* ARP_Analyzer::ConstructAddrVal(const void* addr)
 	{
 	// ### For now, we only handle IPv4 addresses.
-	return new AddrVal(*(const uint32*) addr);
+	return new AddrVal(*(const uint32_t*) addr);
 	}
 
 StringVal* ARP_Analyzer::EthAddrToStr(const u_char* addr)

--- a/src/analyzer/protocol/ayiya/AYIYA.cc
+++ b/src/analyzer/protocol/ayiya/AYIYA.cc
@@ -21,7 +21,7 @@ void AYIYA_Analyzer::Done()
 	Event(udp_session_done);
 	}
 
-void AYIYA_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64 seq, const IP_Hdr* ip, int caplen)
+void AYIYA_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/ayiya/AYIYA.h
+++ b/src/analyzer/protocol/ayiya/AYIYA.h
@@ -12,7 +12,7 @@ public:
 
 	virtual void Done();
 	virtual void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen);
+					uint64_t seq, const IP_Hdr* ip, int caplen);
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new AYIYA_Analyzer(conn); }

--- a/src/analyzer/protocol/bittorrent/BitTorrent.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrent.cc
@@ -30,7 +30,7 @@ void BitTorrent_Analyzer::Done()
 
 void BitTorrent_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	{
-	uint64& this_stream_len = orig ? stream_len_orig : stream_len_resp;
+	uint64_t& this_stream_len = orig ? stream_len_orig : stream_len_resp;
 	bool& this_stop = orig ? stop_orig : stop_resp;
 
 	tcp::TCP_ApplicationAnalyzer::DeliverStream(len, data, orig);
@@ -68,7 +68,7 @@ void BitTorrent_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void BitTorrent_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void BitTorrent_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 
@@ -77,10 +77,10 @@ void BitTorrent_Analyzer::Undelivered(uint64 seq, int len, bool orig)
 	// The way it's currently tracking the next message offset isn't
 	// compatible with new 64bit int support in binpac either.
 
-	//uint64 entry_offset = orig ?
+	//uint64_t entry_offset = orig ?
 	//	*interp->upflow()->next_message_offset() :
 	//	*interp->downflow()->next_message_offset();
-	//uint64& this_stream_len = orig ? stream_len_orig : stream_len_resp;
+	//uint64_t& this_stream_len = orig ? stream_len_orig : stream_len_resp;
 	//bool& this_stop = orig ? stop_orig : stop_resp;
 	//
 	//this_stream_len += len;

--- a/src/analyzer/protocol/bittorrent/BitTorrent.h
+++ b/src/analyzer/protocol/bittorrent/BitTorrent.h
@@ -16,7 +16,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void EndpointEOF(bool is_orig) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
@@ -27,7 +27,7 @@ protected:
 
 	binpac::BitTorrent::BitTorrent_Conn* interp;
 	bool stop_orig, stop_resp;
-	uint64 stream_len_orig, stream_len_resp;
+	uint64_t stream_len_orig, stream_len_resp;
 };
 
 } } // namespace analyzer::* 

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -207,7 +207,7 @@ void BitTorrentTracker_Analyzer::ServerReply(int len, const u_char* data)
 		}
 	}
 
-void BitTorrentTracker_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void BitTorrentTracker_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 
@@ -477,8 +477,8 @@ void BitTorrentTracker_Analyzer::ResponseBenc(int name_len, char* name,
 			// addresses in network order but PortVal's
 			// take ports in host order.  BitTorrent specifies
 			// that both are in network order here.
-			uint32 ad = extract_uint32((u_char*) value);
-			uint16 pt = ntohs((value[4] << 8) | value[5]);
+			uint32_t ad = extract_uint32((u_char*) value);
+			uint16_t pt = ntohs((value[4] << 8) | value[5]);
 
 			RecordVal* peer = new RecordVal(bittorrent_peer);
 			peer->Assign(0, new AddrVal(ad));

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.h
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.h
@@ -49,7 +49,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void EndpointEOF(bool is_orig) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)

--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -43,7 +43,7 @@ void ConnSize_Analyzer::Done()
 	Analyzer::Done();
 	}
 
-void ConnSize_Analyzer::ThresholdEvent(EventHandlerPtr f, uint64 threshold, bool is_orig)
+void ConnSize_Analyzer::ThresholdEvent(EventHandlerPtr f, uint64_t threshold, bool is_orig)
 	{
 	if ( ! f )
 		return;
@@ -100,7 +100,7 @@ void ConnSize_Analyzer::CheckThresholds(bool is_orig)
 		}
 	}
 
-void ConnSize_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig, uint64 seq, const IP_Hdr* ip, int caplen)
+void ConnSize_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig, uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, is_orig, seq, ip, caplen);
 
@@ -118,7 +118,7 @@ void ConnSize_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 	CheckThresholds(is_orig);
 	}
 
-void ConnSize_Analyzer::SetByteAndPacketThreshold(uint64 threshold, bool bytes, bool orig)
+void ConnSize_Analyzer::SetByteAndPacketThreshold(uint64_t threshold, bool bytes, bool orig)
 	{
 	if ( bytes )
 		{

--- a/src/analyzer/protocol/conn-size/ConnSize.h
+++ b/src/analyzer/protocol/conn-size/ConnSize.h
@@ -22,7 +22,7 @@ public:
 	void FlipRoles() override;
 
 	void SetByteAndPacketThreshold(uint64_t threshold, bool bytes, bool orig);
-	uint64 GetByteAndPacketThreshold(bool bytes, bool orig);
+	uint64_t GetByteAndPacketThreshold(bool bytes, bool orig);
 
 	void SetDurationThreshold(double duration);
 	double GetDurationThreshold() { return duration_thresh; };
@@ -32,10 +32,10 @@ public:
 
 protected:
 	void DeliverPacket(int len, const u_char* data, bool is_orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					   uint64_t seq, const IP_Hdr* ip, int caplen) override;
 	void CheckThresholds(bool is_orig);
 
-	void ThresholdEvent(EventHandlerPtr f, uint64 threshold, bool is_orig);
+	void ThresholdEvent(EventHandlerPtr f, uint64_t threshold, bool is_orig);
 
 	uint64_t orig_bytes;
 	uint64_t resp_bytes;

--- a/src/analyzer/protocol/dce-rpc/DCE_RPC.cc
+++ b/src/analyzer/protocol/dce-rpc/DCE_RPC.cc
@@ -39,7 +39,7 @@ void DCE_RPC_Analyzer::EndpointEOF(bool is_orig)
 	interp->FlowEOF(is_orig);
 	}
 
-void DCE_RPC_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void DCE_RPC_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	had_gap = true;

--- a/src/analyzer/protocol/dce-rpc/DCE_RPC.h
+++ b/src/analyzer/protocol/dce-rpc/DCE_RPC.h
@@ -19,10 +19,10 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void EndpointEOF(bool is_orig) override;
 
-	bool SetFileID(uint64 fid_in)
+	bool SetFileID(uint64_t fid_in)
 		{ interp->set_file_id(fid_in); return true; }
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)

--- a/src/analyzer/protocol/dhcp/DHCP.cc
+++ b/src/analyzer/protocol/dhcp/DHCP.cc
@@ -22,7 +22,7 @@ void DHCP_Analyzer::Done()
 	}
 
 void DHCP_Analyzer::DeliverPacket(int len, const u_char* data,
-			bool orig, uint64 seq, const IP_Hdr* ip, int caplen)
+			bool orig, uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/dhcp/DHCP.h
+++ b/src/analyzer/protocol/dhcp/DHCP.h
@@ -14,7 +14,7 @@ public:
 
 	void Done() override;
 	void DeliverPacket(int len, const u_char* data, bool orig,
-	                   uint64 seq, const IP_Hdr* ip, int caplen) override;
+	                   uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new DHCP_Analyzer(conn); }

--- a/src/analyzer/protocol/dnp3/DNP3.cc
+++ b/src/analyzer/protocol/dnp3/DNP3.cc
@@ -418,7 +418,7 @@ void DNP3_TCP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void DNP3_TCP_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void DNP3_TCP_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	Interpreter()->NewGap(orig, len);
@@ -439,7 +439,7 @@ DNP3_UDP_Analyzer::~DNP3_UDP_Analyzer()
 	{
 	}
 
-void DNP3_UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64 seq, const IP_Hdr* ip, int caplen)
+void DNP3_UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/dnp3/DNP3.h
+++ b/src/analyzer/protocol/dnp3/DNP3.h
@@ -69,7 +69,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void EndpointEOF(bool is_orig) override;
 
 	static Analyzer* Instantiate(Connection* conn)
@@ -82,7 +82,7 @@ public:
 	~DNP3_UDP_Analyzer() override;
 
 	void DeliverPacket(int len, const u_char* data, bool orig,
-                    uint64 seq, const IP_Hdr* ip, int caplen) override;
+                    uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new DNP3_UDP_Analyzer(conn); }

--- a/src/analyzer/protocol/dnp3/events.bif
+++ b/src/analyzer/protocol/dnp3/events.bif
@@ -77,8 +77,8 @@ event dnp3_header_block%(c: connection, is_orig: bool, len: count, ctrl: count, 
 ## Generated for a DNP3 "Response_Data_Object".
 ## The "Response_Data_Object" contains two parts: object prefix and object
 ## data. In most cases, object data are defined by new record types. But
-## in a few cases, object data are directly basic types, such as int16, or
-## int8; thus we use an additional *data_value* to record the values of those
+## in a few cases, object data are directly basic types, such as int16_t, or
+## int8_t; thus we use an additional *data_value* to record the values of those
 ## object data.
 ##
 ## c: The connection the DNP3 communication is part of.

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -475,12 +475,12 @@ int DNS_Interpreter::ExtractLabel(const u_char*& data, int& len,
 	return 1;
 	}
 
-uint16 DNS_Interpreter::ExtractShort(const u_char*& data, int& len)
+uint16_t DNS_Interpreter::ExtractShort(const u_char*& data, int& len)
 	{
 	if ( len < 2 )
 		return 0;
 
-	uint16 val;
+	uint16_t val;
 
 	val = data[0] << 8;
 
@@ -495,12 +495,12 @@ uint16 DNS_Interpreter::ExtractShort(const u_char*& data, int& len)
 	return val;
 	}
 
-uint32 DNS_Interpreter::ExtractLong(const u_char*& data, int& len)
+uint32_t DNS_Interpreter::ExtractLong(const u_char*& data, int& len)
 	{
 	if ( len < 4 )
 		return 0;
 
-	uint32 val;
+	uint32_t val;
 
 	val = data[0] << 24;
 	val |= data[1] << 16;
@@ -588,11 +588,11 @@ int DNS_Interpreter::ParseRR_SOA(DNS_MsgInfo* msg,
 	if ( len < 20 )
 		return 0;
 
-	uint32 serial = ExtractLong(data, len);
-	uint32 refresh = ExtractLong(data, len);
-	uint32 retry = ExtractLong(data, len);
-	uint32 expire = ExtractLong(data, len);
-	uint32 minimum = ExtractLong(data, len);
+	uint32_t serial = ExtractLong(data, len);
+	uint32_t refresh = ExtractLong(data, len);
+	uint32_t retry = ExtractLong(data, len);
+	uint32_t expire = ExtractLong(data, len);
+	uint32_t minimum = ExtractLong(data, len);
 
 	if ( data - data_start != rdlength )
 		analyzer->Weird("DNS_RR_length_mismatch");
@@ -727,7 +727,7 @@ int DNS_Interpreter::ParseRR_EDNS(DNS_MsgInfo* msg,
 void DNS_Interpreter::ExtractOctets(const u_char*& data, int& len,
                                     BroString** p)
 	{
-	uint16 dlen = ExtractShort(data, len);
+	uint16_t dlen = ExtractShort(data, len);
 	dlen = min(len, static_cast<int>(dlen));
 
 	if ( p )
@@ -762,7 +762,7 @@ int DNS_Interpreter::ParseRR_TSIG(DNS_MsgInfo* msg,
 	if ( ! alg_name_end )
 		return 0;
 
-	uint32 sign_time_sec = ExtractLong(data, len);
+	uint32_t sign_time_sec = ExtractLong(data, len);
 	unsigned int sign_time_msec = ExtractShort(data, len);
 	unsigned int fudge = ExtractShort(data, len);
 	BroString* request_MAC;
@@ -809,13 +809,13 @@ int DNS_Interpreter::ParseRR_RRSIG(DNS_MsgInfo* msg,
 
 	unsigned int type_covered = ExtractShort(data, len);
 	// split the two bytes for algo and labels extraction
-	uint32 algo_lab = ExtractShort(data, len);
+	uint32_t algo_lab = ExtractShort(data, len);
 	unsigned int algo = (algo_lab >> 8) & 0xff;
 	unsigned int lab = algo_lab & 0xff;
 
-	uint32 orig_ttl = ExtractLong(data, len);
-	uint32 sign_exp = ExtractLong(data, len);
-	uint32 sign_incp = ExtractLong(data, len);
+	uint32_t orig_ttl = ExtractLong(data, len);
+	uint32_t sign_exp = ExtractLong(data, len);
+	uint32_t sign_incp = ExtractLong(data, len);
 	unsigned int key_tag = ExtractShort(data, len);
 
 	//implement signer's name with the msg_start offset
@@ -1015,7 +1015,7 @@ int DNS_Interpreter::ParseRR_NSEC(DNS_MsgInfo* msg,
 
 	while ( typebitmaps_len > 0 && len > 0 )
 		{
-		uint32 block_bmlen = ExtractShort(data, len);
+		uint32_t block_bmlen = ExtractShort(data, len);
 		unsigned int win_blck = (block_bmlen >> 8) & 0xff;
 		unsigned int bmlen = block_bmlen & 0xff;
 
@@ -1059,12 +1059,12 @@ int DNS_Interpreter::ParseRR_NSEC3(DNS_MsgInfo* msg,
 		return 0;
 
 	const u_char* data_start = data;
-	uint32 halgo_flags = ExtractShort(data, len);
+	uint32_t halgo_flags = ExtractShort(data, len);
 	unsigned int hash_algo = (halgo_flags >> 8) & 0xff;
 	unsigned int nsec_flags = halgo_flags & 0xff;
 	unsigned int iter = ExtractShort(data, len);
 
-	uint8 salt_len = 0;
+	uint8_t salt_len = 0;
 
 	if ( len > 0 )
 		{
@@ -1075,7 +1075,7 @@ int DNS_Interpreter::ParseRR_NSEC3(DNS_MsgInfo* msg,
 
 	auto salt_val = ExtractStream(data, len, static_cast<int>(salt_len));
 
-	uint8 hash_len = 0;
+	uint8_t hash_len = 0;
 
 	if ( len > 0 )
 		{
@@ -1092,7 +1092,7 @@ int DNS_Interpreter::ParseRR_NSEC3(DNS_MsgInfo* msg,
 
 	while ( typebitmaps_len > 0 && len > 0 )
 		{
-		uint32 block_bmlen = ExtractShort(data, len);
+		uint32_t block_bmlen = ExtractShort(data, len);
 		unsigned int win_blck = ( block_bmlen >> 8) & 0xff;
 		unsigned int bmlen = block_bmlen & 0xff;
 
@@ -1146,7 +1146,7 @@ int DNS_Interpreter::ParseRR_DS(DNS_MsgInfo* msg,
 
 	unsigned int ds_key_tag = ExtractShort(data, len);
 	// split the two bytes for algorithm and digest type extraction
-	uint32 ds_algo_dtype = ExtractShort(data, len);
+	uint32_t ds_algo_dtype = ExtractShort(data, len);
 	unsigned int ds_algo = (ds_algo_dtype >> 8) & 0xff;
 	unsigned int ds_dtype = ds_algo_dtype & 0xff;
 	DNSSEC_Digest ds_digest_type = DNSSEC_Digest(ds_dtype);
@@ -1197,7 +1197,7 @@ int DNS_Interpreter::ParseRR_A(DNS_MsgInfo* msg,
 		return 0;
 		}
 
-	uint32 addr = ExtractLong(data, len);
+	uint32_t addr = ExtractLong(data, len);
 
 	if ( dns_A_reply && ! msg->skip_event )
 		{
@@ -1215,7 +1215,7 @@ int DNS_Interpreter::ParseRR_A(DNS_MsgInfo* msg,
 int DNS_Interpreter::ParseRR_AAAA(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength)
 	{
-	uint32 addr[4];
+	uint32_t addr[4];
 
 	for ( int i = 0; i < 4; ++i )
 		{
@@ -1273,7 +1273,7 @@ static StringVal* extract_char_string(analyzer::Analyzer* analyzer,
 	if ( rdlen <= 0 )
 		return 0;
 
-	uint8 str_size = data[0];
+	uint8_t str_size = data[0];
 
 	--rdlen;
 	--len;
@@ -1755,7 +1755,7 @@ void DNS_Analyzer::Done()
 	}
 
 void DNS_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen)
+					uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	tcp::TCP_ApplicationAnalyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 	interp->ParseMessage(data, len, orig);

--- a/src/analyzer/protocol/dns/DNS.h
+++ b/src/analyzer/protocol/dns/DNS.h
@@ -143,7 +143,7 @@ struct RRSIG_DATA {
 	unsigned short type_covered;	// 16 : ExtractShort(data, len)
 	unsigned short algorithm;		// 8
 	unsigned short labels;			// 8
-	uint32 orig_ttl;				// 32
+	uint32_t orig_ttl;				// 32
 	unsigned long sig_exp;			// 32
 	unsigned long sig_incep;		// 32
 	unsigned short key_tag;			//16
@@ -208,7 +208,7 @@ public:
 	StringVal* query_name;
 	RR_Type atype;
 	int aclass;	///< normally = 1, inet
-	uint32 ttl;
+	uint32_t ttl;
 
 	DNS_AnswerType answer_type;
 	int skip_event;		///< if true, don't generate corresponding events
@@ -249,8 +249,8 @@ protected:
 			 u_char*& label, int& label_len,
 			 const u_char* msg_start);
 
-	uint16 ExtractShort(const u_char*& data, int& len);
-	uint32 ExtractLong(const u_char*& data, int& len);
+	uint16_t ExtractShort(const u_char*& data, int& len);
+	uint32_t ExtractLong(const u_char*& data, int& len);
 	void ExtractOctets(const u_char*& data, int& len, BroString** p);
 
 	BroString* ExtractStream(const u_char*& data, int& len, int sig_len);
@@ -353,7 +353,7 @@ public:
 	~DNS_Analyzer() override;
 
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	void Init() override;
 	void Done() override;

--- a/src/analyzer/protocol/file/File.cc
+++ b/src/analyzer/protocol/file/File.cc
@@ -40,7 +40,7 @@ void File_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		                                orig, file_id_resp);
 	}
 
-void File_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void File_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 

--- a/src/analyzer/protocol/file/File.h
+++ b/src/analyzer/protocol/file/File.h
@@ -17,7 +17,7 @@ public:
 
 	void DeliverStream(int len, const u_char* data, bool orig) override;
 
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 //	static analyzer::Analyzer* Instantiate(Connection* conn)
 //		{ return new File_Analyzer(conn); }

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -50,7 +50,7 @@ void FTP_Analyzer::Done()
 		Weird("partial_ftp_request");
 	}
 
-static uint32 get_reply_code(int len, const char* line)
+static uint32_t get_reply_code(int len, const char* line)
 	{
 	if ( len >= 3 && isdigit(line[0]) && isdigit(line[1]) && isdigit(line[2]) )
 		return (line[0] - '0') * 100 + (line[1] - '0') * 10 + (line[2] - '0');
@@ -113,7 +113,7 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 		}
 	else
 		{
-		uint32 reply_code = get_reply_code(length, line);
+		uint32_t reply_code = get_reply_code(length, line);
 
 		int cont_resp;
 
@@ -232,7 +232,7 @@ void FTP_ADAT_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 				// that the fourth and fifth bytes indicating the length of
 				// the record match the length of the decoded data.
 				if ( msg_len < 5 || msg[0] != 0x16 ||
-				     msg_len - 5 != ntohs(*((uint16*)(msg + 3))) )
+				     msg_len - 5 != ntohs(*((uint16_t*)(msg + 3))) )
 					{
 					// Doesn't look like TLS/SSL, so done analyzing.
 					done = true;
@@ -251,7 +251,7 @@ void FTP_ADAT_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 
 	else
 		{
-		uint32 reply_code = get_reply_code(len, line);
+		uint32_t reply_code = get_reply_code(len, line);
 
 		switch ( reply_code ) {
 		case 232:

--- a/src/analyzer/protocol/ftp/FTP.h
+++ b/src/analyzer/protocol/ftp/FTP.h
@@ -23,7 +23,7 @@ public:
 protected:
 	login::NVT_Analyzer* nvt_orig;
 	login::NVT_Analyzer* nvt_resp;
-	uint32 pending_reply;	// code associated with multi-line reply, or 0
+	uint32_t pending_reply;	// code associated with multi-line reply, or 0
 	string auth_requested;	// AUTH method requested
 };
 

--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -21,9 +21,9 @@ static Val* parse_port(const char* line)
 				break;
 				}
 
-		uint32 addr = (bytes[0] << 24) | (bytes[1] << 16) |
+		uint32_t addr = (bytes[0] << 24) | (bytes[1] << 16) |
 				(bytes[2] << 8) | bytes[3];
-		uint32 port = (bytes[4] << 8) | bytes[5];
+		uint32_t port = (bytes[4] << 8) | bytes[5];
 
 		// Since port is unsigned, no need to check for < 0.
 		if ( port > 65535 )
@@ -38,7 +38,7 @@ static Val* parse_port(const char* line)
 		}
 	else
 		{
-		r->Assign(0, new AddrVal(uint32(0)));
+		r->Assign(0, new AddrVal(uint32_t(0)));
 		r->Assign(1, val_mgr->GetPort(0, TRANSPORT_TCP));
 		r->Assign(2, val_mgr->GetBool(0));
 		}
@@ -199,12 +199,12 @@ function parse_ftp_epsv%(str: string%): ftp_port
 ## .. zeek:see:: parse_ftp_port parse_eftp_port parse_ftp_pasv parse_ftp_epsv
 function fmt_ftp_port%(a: addr, p: port%): string
 	%{
-	const uint32* addr;
+	const uint32_t* addr;
 	int len = a->AsAddr().GetBytes(&addr);
 	if ( len == 1 )
 		{
-		uint32 a = ntohl(addr[0]);
-		uint32 pn = p->Port();
+		uint32_t a = ntohl(addr[0]);
+		uint32_t pn = p->Port();
 		return new StringVal(fmt("%d,%d,%d,%d,%d,%d",
 						a >> 24, (a >> 16) & 0xff,
 						(a >> 8) & 0xff, a & 0xff,

--- a/src/analyzer/protocol/gssapi/GSSAPI.cc
+++ b/src/analyzer/protocol/gssapi/GSSAPI.cc
@@ -49,7 +49,7 @@ void GSSAPI_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void GSSAPI_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void GSSAPI_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	interp->NewGap(orig, len);

--- a/src/analyzer/protocol/gssapi/GSSAPI.h
+++ b/src/analyzer/protocol/gssapi/GSSAPI.h
@@ -22,7 +22,7 @@ public:
 	void Done() override;
 
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	// Overriden from tcp::TCP_ApplicationAnalyzer.
 	void EndpointEOF(bool is_orig) override;

--- a/src/analyzer/protocol/gtpv1/GTPv1.cc
+++ b/src/analyzer/protocol/gtpv1/GTPv1.cc
@@ -23,7 +23,7 @@ void GTPv1_Analyzer::Done()
 	Event(udp_session_done);
 	}
 
-void GTPv1_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64 seq, const IP_Hdr* ip, int caplen)
+void GTPv1_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 	try

--- a/src/analyzer/protocol/gtpv1/GTPv1.h
+++ b/src/analyzer/protocol/gtpv1/GTPv1.h
@@ -12,7 +12,7 @@ public:
 
 	virtual void Done();
 	virtual void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen);
+					uint64_t seq, const IP_Hdr* ip, int caplen);
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new GTPv1_Analyzer(conn); }

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -1091,7 +1091,7 @@ void HTTP_Analyzer::DeliverStream(int len, const u_char* data, bool is_orig)
 		}
 	}
 
-void HTTP_Analyzer::Undelivered(uint64 seq, int len, bool is_orig)
+void HTTP_Analyzer::Undelivered(uint64_t seq, int len, bool is_orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, is_orig);
 

--- a/src/analyzer/protocol/http/HTTP.h
+++ b/src/analyzer/protocol/http/HTTP.h
@@ -168,7 +168,7 @@ public:
 	// Overriden from Analyzer.
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	// Overriden from tcp::TCP_ApplicationAnalyzer
 	void EndpointEOF(bool is_orig) override;

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -31,7 +31,7 @@ void ICMP_Analyzer::Done()
 	}
 
 void ICMP_Analyzer::DeliverPacket(int len, const u_char* data,
-			bool is_orig, uint64 seq, const IP_Hdr* ip, int caplen)
+			bool is_orig, uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	assert(ip);
 
@@ -238,10 +238,10 @@ RecordVal* ICMP_Analyzer::BuildICMPVal(const struct icmp* icmpp, int len,
 	return icmp_conn_val;
 	}
 
-TransportProto ICMP_Analyzer::GetContextProtocol(const IP_Hdr* ip_hdr, uint32* src_port, uint32* dst_port)
+TransportProto ICMP_Analyzer::GetContextProtocol(const IP_Hdr* ip_hdr, uint32_t* src_port, uint32_t* dst_port)
 	{
 	const u_char* transport_hdr;
-	uint32 ip_hdr_len = ip_hdr->HdrLen();
+	uint32_t ip_hdr_len = ip_hdr->HdrLen();
 	bool ip4 = ip_hdr->IP4_Hdr();
 
 	if ( ip4 )
@@ -308,15 +308,15 @@ RecordVal* ICMP_Analyzer::ExtractICMP4Context(int len, const u_char*& data)
 	const IP_Hdr ip_hdr_data((const struct ip*) data, false);
 	const IP_Hdr* ip_hdr = &ip_hdr_data;
 
-	uint32 ip_hdr_len = ip_hdr->HdrLen();
+	uint32_t ip_hdr_len = ip_hdr->HdrLen();
 
-	uint32 ip_len, frag_offset;
+	uint32_t ip_len, frag_offset;
 	TransportProto proto = TRANSPORT_UNKNOWN;
 	int DF, MF, bad_hdr_len, bad_checksum;
 	IPAddr src_addr, dst_addr;
-	uint32 src_port, dst_port;
+	uint32_t src_port, dst_port;
 
-	if ( len < (int)sizeof(struct ip) || ip_hdr_len > uint32(len) )
+	if ( len < (int)sizeof(struct ip) || ip_hdr_len > uint32_t(len) )
 		{
 		// We don't have an entire IP header.
 		bad_hdr_len = 1;
@@ -338,7 +338,7 @@ RecordVal* ICMP_Analyzer::ExtractICMP4Context(int len, const u_char*& data)
 		MF = ip_hdr->MF();
 		frag_offset = ip_hdr->FragOffset();
 
-		if ( uint32(len) >= ip_hdr_len + 4 )
+		if ( uint32_t(len) >= ip_hdr_len + 4 )
 			proto = GetContextProtocol(ip_hdr, &src_port, &dst_port);
 		else
 			{
@@ -376,8 +376,8 @@ RecordVal* ICMP_Analyzer::ExtractICMP6Context(int len, const u_char*& data)
 
 	IPAddr src_addr;
 	IPAddr dst_addr;
-	uint32 ip_len, frag_offset = 0;
-	uint32 src_port, dst_port;
+	uint32_t ip_len, frag_offset = 0;
+	uint32_t src_port, dst_port;
 
 	if ( len < (int)sizeof(struct ip6_hdr) )
 		{
@@ -397,7 +397,7 @@ RecordVal* ICMP_Analyzer::ExtractICMP6Context(int len, const u_char*& data)
 		MF = ip_hdr->MF();
 		DF = ip_hdr->DF();
 
-		if ( uint32(len) >= uint32(ip_hdr->HdrLen() + 4) )
+		if ( uint32_t(len) >= uint32_t(ip_hdr->HdrLen() + 4) )
 			proto = GetContextProtocol(ip_hdr, &src_port, &dst_port);
 		else
 			{
@@ -530,7 +530,7 @@ void ICMP_Analyzer::RouterAdvert(double t, const struct icmp* icmpp, int len,
 	if ( ! f )
 		return;
 
-	uint32 reachable = 0, retrans = 0;
+	uint32_t reachable = 0, retrans = 0;
 
 	if ( caplen >= (int)sizeof(reachable) )
 		memcpy(&reachable, data, sizeof(reachable));
@@ -744,8 +744,8 @@ VectorVal* ICMP_Analyzer::BuildNDOptionsVal(int caplen, const u_char* data)
 			break;
 			}
 
-		uint8 type = *((const uint8*)data);
-		uint8 length = *((const uint8*)(data + 1));
+		uint8_t type = *((const uint8_t*)data);
+		uint8_t length = *((const uint8_t*)(data + 1));
 
 		if ( length == 0 )
 			{
@@ -788,11 +788,11 @@ VectorVal* ICMP_Analyzer::BuildNDOptionsVal(int caplen, const u_char* data)
 			if ( caplen >= 30 )
 				{
 				RecordVal* info = new RecordVal(icmp6_nd_prefix_info_type);
-				uint8 prefix_len = *((const uint8*)(data));
-				bool L_flag = (*((const uint8*)(data + 1)) & 0x80) != 0;
-				bool A_flag = (*((const uint8*)(data + 1)) & 0x40) != 0;
-				uint32 valid_life = *((const uint32*)(data + 2));
-				uint32 prefer_life = *((const uint32*)(data + 6));
+				uint8_t prefix_len = *((const uint8_t*)(data));
+				bool L_flag = (*((const uint8_t*)(data + 1)) & 0x80) != 0;
+				bool A_flag = (*((const uint8_t*)(data + 1)) & 0x40) != 0;
+				uint32_t valid_life = *((const uint32_t*)(data + 2));
+				uint32_t prefer_life = *((const uint32_t*)(data + 6));
 				in6_addr prefix = *((const in6_addr*)(data + 14));
 				info->Assign(0, val_mgr->GetCount(prefix_len));
 				info->Assign(1, val_mgr->GetBool(L_flag));
@@ -827,7 +827,7 @@ VectorVal* ICMP_Analyzer::BuildNDOptionsVal(int caplen, const u_char* data)
 			// MTU option
 			{
 			if ( caplen >= 6 )
-				rv->Assign(5, val_mgr->GetCount(ntohl(*((const uint32*)(data + 2)))));
+				rv->Assign(5, val_mgr->GetCount(ntohl(*((const uint32_t*)(data + 2)))));
 			else
 				set_payload_field = true;
 

--- a/src/analyzer/protocol/icmp/ICMP.h
+++ b/src/analyzer/protocol/icmp/ICMP.h
@@ -27,7 +27,7 @@ public:
 protected:
 	void Done() override;
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 	bool IsReuse(double t, const u_char* pkt) override;
 	unsigned int MemoryAllocation() const override;
 
@@ -60,8 +60,8 @@ protected:
 	void Context4(double t, const struct icmp* icmpp, int len, int caplen,
 			const u_char*& data, const IP_Hdr* ip_hdr);
 
-	TransportProto GetContextProtocol(const IP_Hdr* ip_hdr, uint32* src_port,
-			uint32* dst_port);
+	TransportProto GetContextProtocol(const IP_Hdr* ip_hdr, uint32_t* src_port,
+			uint32_t* dst_port);
 
 	void NextICMP6(double t, const struct icmp* icmpp, int len, int caplen,
 			const u_char*& data, const IP_Hdr* ip_hdr );

--- a/src/analyzer/protocol/imap/IMAP.cc
+++ b/src/analyzer/protocol/imap/IMAP.cc
@@ -65,7 +65,7 @@ void IMAP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void IMAP_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void IMAP_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	had_gap = true;

--- a/src/analyzer/protocol/imap/IMAP.h
+++ b/src/analyzer/protocol/imap/IMAP.h
@@ -18,7 +18,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	// Overriden from tcp::TCP_ApplicationAnalyzer.
 	void EndpointEOF(bool is_orig) override;

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -650,7 +650,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			// Calculate IP address.
-			uint32 raw_ip = 0;
+			uint32_t raw_ip = 0;
 			for ( unsigned int i = 0; i < parts[3].size(); ++i )
 				{
 				string s = parts[3].substr(i, 1);

--- a/src/analyzer/protocol/krb/KRB.cc
+++ b/src/analyzer/protocol/krb/KRB.cc
@@ -65,7 +65,7 @@ void KRB_Analyzer::Done()
 	}
 
 void KRB_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
-				 uint64 seq, const IP_Hdr* ip, int caplen)
+				 uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/krb/KRB.h
+++ b/src/analyzer/protocol/krb/KRB.h
@@ -21,7 +21,7 @@ public:
 
 	virtual void Done();
 	virtual void DeliverPacket(int len, const u_char* data, bool orig,
-							   uint64 seq, const IP_Hdr* ip, int caplen);
+							   uint64_t seq, const IP_Hdr* ip, int caplen);
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new KRB_Analyzer(conn); }

--- a/src/analyzer/protocol/krb/KRB_TCP.cc
+++ b/src/analyzer/protocol/krb/KRB_TCP.cc
@@ -57,7 +57,7 @@ void KRB_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void KRB_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void KRB_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	had_gap = true;

--- a/src/analyzer/protocol/krb/KRB_TCP.h
+++ b/src/analyzer/protocol/krb/KRB_TCP.h
@@ -17,7 +17,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	// Overriden from tcp::TCP_ApplicationAnalyzer.
 	void EndpointEOF(bool is_orig) override;

--- a/src/analyzer/protocol/mime/MIME.h
+++ b/src/analyzer/protocol/mime/MIME.h
@@ -257,7 +257,7 @@ protected:
 
 	BroString* data_buffer;
 
-	uint64 cur_entity_len;
+	uint64_t cur_entity_len;
 	string cur_entity_id;
 };
 

--- a/src/analyzer/protocol/modbus/Modbus.cc
+++ b/src/analyzer/protocol/modbus/Modbus.cc
@@ -31,7 +31,7 @@ void ModbusTCP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	interp->NewData(orig, data, data + len);
 	}
 
-void ModbusTCP_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void ModbusTCP_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	interp->NewGap(orig, len);

--- a/src/analyzer/protocol/modbus/Modbus.h
+++ b/src/analyzer/protocol/modbus/Modbus.h
@@ -14,7 +14,7 @@ public:
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
 
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void EndpointEOF(bool is_orig) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)

--- a/src/analyzer/protocol/mqtt/MQTT.cc
+++ b/src/analyzer/protocol/mqtt/MQTT.cc
@@ -59,7 +59,7 @@ void MQTT_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void MQTT_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void MQTT_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	interp->NewGap(orig, len);

--- a/src/analyzer/protocol/mqtt/MQTT.h
+++ b/src/analyzer/protocol/mqtt/MQTT.h
@@ -18,7 +18,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void EndpointEOF(bool is_orig) override;
 
 	static analyzer::Analyzer* InstantiateAnalyzer(Connection* conn)

--- a/src/analyzer/protocol/mysql/MySQL.cc
+++ b/src/analyzer/protocol/mysql/MySQL.cc
@@ -57,7 +57,7 @@ void MySQL_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void MySQL_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void MySQL_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	had_gap = true;

--- a/src/analyzer/protocol/mysql/MySQL.h
+++ b/src/analyzer/protocol/mysql/MySQL.h
@@ -22,7 +22,7 @@ public:
 	void Done() override;
 
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	// Overriden from tcp::TCP_ApplicationAnalyzer.
 	void EndpointEOF(bool is_orig) override;

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -241,7 +241,7 @@ void Contents_NCP_Analyzer::DeliverStream(int len, const u_char* data, bool orig
 		}
 	}
 
-void Contents_NCP_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void Contents_NCP_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_SupportAnalyzer::Undelivered(seq, len, orig);
 

--- a/src/analyzer/protocol/ncp/NCP.h
+++ b/src/analyzer/protocol/ncp/NCP.h
@@ -69,7 +69,7 @@ protected:
 
 	size_t hdr_len;
 	u_char* msg_buf;
-	uint64 msg_len;
+	uint64_t msg_len;
 	size_t buf_n;	// number of bytes in msg_buf
 	size_t buf_len;	// size off msg_buf
 };
@@ -91,7 +91,7 @@ public:
 
 protected:
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	NCP_FrameBuffer buffer;
 	NCP_Session* session;

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -518,7 +518,7 @@ void NetbiosSSN_Analyzer::ConnectionClosed(tcp::TCP_Endpoint* endpoint,
 	}
 
 void NetbiosSSN_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen)
+					uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	tcp::TCP_ApplicationAnalyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/netbios/NetbiosSSN.h
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.h
@@ -146,7 +146,7 @@ public:
 
 	void Done() override;
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new NetbiosSSN_Analyzer(conn); }

--- a/src/analyzer/protocol/ntlm/NTLM.cc
+++ b/src/analyzer/protocol/ntlm/NTLM.cc
@@ -49,7 +49,7 @@ void NTLM_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void NTLM_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void NTLM_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	interp->NewGap(orig, len);

--- a/src/analyzer/protocol/ntlm/NTLM.h
+++ b/src/analyzer/protocol/ntlm/NTLM.h
@@ -22,7 +22,7 @@ public:
 	void Done() override;
 
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	// Overriden from tcp::TCP_ApplicationAnalyzer.
 	void EndpointEOF(bool is_orig) override;

--- a/src/analyzer/protocol/ntp/NTP.cc
+++ b/src/analyzer/protocol/ntp/NTP.cc
@@ -24,7 +24,7 @@ NTP_Analyzer::~NTP_Analyzer()
 	}
 
 void NTP_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
-                                 uint64 seq, const IP_Hdr* ip, int caplen)
+                                 uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/ntp/NTP.h
+++ b/src/analyzer/protocol/ntp/NTP.h
@@ -18,7 +18,7 @@ public:
 	// Overriden from Analyzer.
 	void Done() override;
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new NTP_Analyzer(conn); }

--- a/src/analyzer/protocol/pia/PIA.cc
+++ b/src/analyzer/protocol/pia/PIA.cc
@@ -30,7 +30,7 @@ void PIA::ClearBuffer(Buffer* buffer)
 	buffer->size = 0;
 	}
 
-void PIA::AddToBuffer(Buffer* buffer, uint64 seq, int len, const u_char* data,
+void PIA::AddToBuffer(Buffer* buffer, uint64_t seq, int len, const u_char* data,
 			bool is_orig, const IP_Hdr* ip)
 	{
 	u_char* tmp = 0;
@@ -79,7 +79,7 @@ void PIA::PIA_Done()
 	FinishEndpointMatcher();
 	}
 
-void PIA::PIA_DeliverPacket(int len, const u_char* data, bool is_orig, uint64 seq,
+void PIA::PIA_DeliverPacket(int len, const u_char* data, bool is_orig, uint64_t seq,
 				const IP_Hdr* ip, int caplen, bool clear_state)
 	{
 	if ( pkt_buffer.state == SKIPPING )
@@ -261,7 +261,7 @@ void PIA_TCP::DeliverStream(int len, const u_char* data, bool is_orig)
 	stream_buffer.state = new_state;
 	}
 
-void PIA_TCP::Undelivered(uint64 seq, int len, bool is_orig)
+void PIA_TCP::Undelivered(uint64_t seq, int len, bool is_orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, is_orig);
 
@@ -342,8 +342,8 @@ void PIA_TCP::ActivateAnalyzer(analyzer::Tag tag, const Rule* rule)
 		new tcp::TCP_Reassembler(this, tcp, tcp::TCP_Reassembler::Direct,
 					tcp->Resp());
 
-	uint64 orig_seq = 0;
-	uint64 resp_seq = 0;
+	uint64_t orig_seq = 0;
+	uint64_t resp_seq = 0;
 
 	for ( DataBlock* b = pkt_buffer.head; b; b = b->next )
 		{

--- a/src/analyzer/protocol/pia/PIA.h
+++ b/src/analyzer/protocol/pia/PIA.h
@@ -42,7 +42,7 @@ public:
 protected:
 	void PIA_Done();
 	void PIA_DeliverPacket(int len, const u_char* data, bool is_orig,
-				uint64 seq, const IP_Hdr* ip, int caplen, bool clear_state);
+				uint64_t seq, const IP_Hdr* ip, int caplen, bool clear_state);
 
 	enum State { INIT, BUFFERING, MATCHING_ONLY, SKIPPING } state;
 
@@ -53,7 +53,7 @@ protected:
 		const u_char* data;
 		bool is_orig;
 		int len;
-		uint64 seq;
+		uint64_t seq;
 		DataBlock* next;
 	};
 
@@ -66,7 +66,7 @@ protected:
 		State state;
 	};
 
-	void AddToBuffer(Buffer* buffer, uint64 seq, int len,
+	void AddToBuffer(Buffer* buffer, uint64_t seq, int len,
 				const u_char* data, bool is_orig, const IP_Hdr* ip = 0);
 	void AddToBuffer(Buffer* buffer, int len,
 				const u_char* data, bool is_orig, const IP_Hdr* ip = 0);
@@ -106,7 +106,7 @@ protected:
 		}
 
 	void DeliverPacket(int len, const u_char* data, bool is_orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override
+					uint64_t seq, const IP_Hdr* ip, int caplen) override
 		{
 		Analyzer::DeliverPacket(len, data, is_orig, seq, ip, caplen);
 		PIA_DeliverPacket(len, data, is_orig, seq, ip, caplen, true);
@@ -151,14 +151,14 @@ protected:
 		}
 
 	void DeliverPacket(int len, const u_char* data, bool is_orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override
+					uint64_t seq, const IP_Hdr* ip, int caplen) override
 		{
 		Analyzer::DeliverPacket(len, data, is_orig, seq, ip, caplen);
 		PIA_DeliverPacket(len, data, is_orig, seq, ip, caplen, false);
 		}
 
 	void DeliverStream(int len, const u_char* data, bool is_orig) override;
-	void Undelivered(uint64 seq, int len, bool is_orig) override;
+	void Undelivered(uint64_t seq, int len, bool is_orig) override;
 
 	void ActivateAnalyzer(analyzer::Tag tag,
 					const Rule* rule = 0) override;

--- a/src/analyzer/protocol/radius/RADIUS.cc
+++ b/src/analyzer/protocol/radius/RADIUS.cc
@@ -25,7 +25,7 @@ void RADIUS_Analyzer::Done()
 	}
 
 void RADIUS_Analyzer::DeliverPacket(int len, const u_char* data,
-				    bool orig, uint64 seq, const IP_Hdr* ip, int caplen)
+				    bool orig, uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/radius/RADIUS.h
+++ b/src/analyzer/protocol/radius/RADIUS.h
@@ -20,7 +20,7 @@ public:
 	// Overriden from Analyzer.
 	void Done() override;
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new RADIUS_Analyzer(conn); }

--- a/src/analyzer/protocol/rdp/RDP.cc
+++ b/src/analyzer/protocol/rdp/RDP.cc
@@ -93,7 +93,7 @@ void RDP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void RDP_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void RDP_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	had_gap = true;

--- a/src/analyzer/protocol/rdp/RDP.h
+++ b/src/analyzer/protocol/rdp/RDP.h
@@ -20,7 +20,7 @@ public:
 	// Overriden from Analyzer.
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void EndpointEOF(bool is_orig) override;
 
 	static analyzer::Analyzer* InstantiateAnalyzer(Connection* conn)

--- a/src/analyzer/protocol/rfb/RFB.cc
+++ b/src/analyzer/protocol/rfb/RFB.cc
@@ -70,7 +70,7 @@ void RFB_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void RFB_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void RFB_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	had_gap = true;

--- a/src/analyzer/protocol/rfb/RFB.h
+++ b/src/analyzer/protocol/rfb/RFB.h
@@ -22,7 +22,7 @@ public:
 	void Done() override;
 
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	// Overriden from tcp::TCP_ApplicationAnalyzer.
 	void EndpointEOF(bool is_orig) override;

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -19,7 +19,7 @@ int MOUNT_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 	if ( c->Program() != 100005 )
 		Weird("bad_RPC_program", fmt("%d", c->Program()));
 
-	uint32 proc = c->Proc();
+	uint32_t proc = c->Proc();
 	// The call arguments, depends on the call type obviously ...
 	Val *callarg = 0;
 

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -19,7 +19,7 @@ int NFS_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 	if ( c->Program() != 100003 )
 		Weird("bad_RPC_program", fmt("%d", c->Program()));
 
-	uint32 proc = c->Proc();
+	uint32_t proc = c->Proc();
 	// The call arguments, depends on the call type obviously ...
 	Val *callarg = 0;
 

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -90,7 +90,7 @@ int PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status status
 	case PMAPPROC_SET:
 		if ( success )
 			{
-			uint32 status = extract_XDR_uint32(buf, n);
+			uint32_t status = extract_XDR_uint32(buf, n);
 			if ( ! buf )
 				return 0;
 
@@ -105,7 +105,7 @@ int PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status status
 	case PMAPPROC_UNSET:
 		if ( success )
 			{
-			uint32 status = extract_XDR_uint32(buf, n);
+			uint32_t status = extract_XDR_uint32(buf, n);
 			if ( ! buf )
 				return 0;
 
@@ -120,7 +120,7 @@ int PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status status
 	case PMAPPROC_GETPORT:
 		if ( success )
 			{
-			uint32 port = extract_XDR_uint32(buf, n);
+			uint32_t port = extract_XDR_uint32(buf, n);
 			if ( ! buf )
 				return 0;
 
@@ -140,7 +140,7 @@ int PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status status
 		if ( success )
 			{
 			TableVal* mappings = new TableVal(pm_mappings);
-			uint32 nmap = 0;
+			uint32_t nmap = 0;
 
 			// Each call in the loop test pulls the next "opted"
 			// element to see if there are more mappings.
@@ -171,7 +171,7 @@ int PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status status
 	case PMAPPROC_CALLIT:
 		if ( success )
 			{
-			uint32 port = extract_XDR_uint32(buf, n);
+			uint32_t port = extract_XDR_uint32(buf, n);
 			int reply_n;
 			const u_char* opaque_reply =
 				extract_XDR_opaque(buf, n, reply_n);
@@ -201,7 +201,7 @@ Val* PortmapperInterp::ExtractMapping(const u_char*& buf, int& len)
 	mapping->Assign(1, val_mgr->GetCount(extract_XDR_uint32(buf, len)));
 
 	int is_tcp = extract_XDR_uint32(buf, len) == IPPROTO_TCP;
-	uint32 port = extract_XDR_uint32(buf, len);
+	uint32_t port = extract_XDR_uint32(buf, len);
 	mapping->Assign(2, val_mgr->GetPort(CheckPort(port),
 			is_tcp ? TRANSPORT_TCP : TRANSPORT_UDP));
 
@@ -255,7 +255,7 @@ Val* PortmapperInterp::ExtractCallItRequest(const u_char*& buf, int& len)
 	return c;
 	}
 
-uint32 PortmapperInterp::CheckPort(uint32 port)
+uint32_t PortmapperInterp::CheckPort(uint32_t port)
 	{
 	if ( port >= 65536 )
 		{

--- a/src/analyzer/protocol/rpc/Portmap.h
+++ b/src/analyzer/protocol/rpc/Portmap.h
@@ -16,7 +16,7 @@ protected:
 	int RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status success,
 			   const u_char*& buf, int& n, double start_time,
 			   double last_time, int reply_len) override;
-	uint32 CheckPort(uint32 port);
+	uint32_t CheckPort(uint32_t port);
 
 	void Event(EventHandlerPtr f, Val* request, BifEnum::rpc_status status, Val* reply);
 

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -25,7 +25,7 @@ namespace { // local namespace
 #define MAX_RPC_LEN 65536
 
 
-RPC_CallInfo::RPC_CallInfo(uint32 arg_xid, const u_char*& buf, int& n, double arg_start_time, double arg_last_time, int arg_rpc_len)
+RPC_CallInfo::RPC_CallInfo(uint32_t arg_xid, const u_char*& buf, int& n, double arg_start_time, double arg_last_time, int arg_rpc_len)
 	{
 	v = nullptr;
 	xid = arg_xid;
@@ -116,8 +116,8 @@ RPC_Interpreter::~RPC_Interpreter()
 int RPC_Interpreter::DeliverRPC(const u_char* buf, int n, int rpclen,
 				int is_orig, double start_time, double last_time)
 	{
-	uint32 xid = extract_XDR_uint32(buf, n);
-	uint32 msg_type = extract_XDR_uint32(buf, n);
+	uint32_t xid = extract_XDR_uint32(buf, n);
+	uint32_t msg_type = extract_XDR_uint32(buf, n);
 	int rpc_len = n;
 
 	if ( ! buf )
@@ -186,7 +186,7 @@ int RPC_Interpreter::DeliverRPC(const u_char* buf, int n, int rpclen,
 		if ( is_orig )
 			Weird("originator_RPC_reply");
 
-		uint32 reply_stat = extract_XDR_uint32(buf, n);
+		uint32_t reply_stat = extract_XDR_uint32(buf, n);
 		if ( ! buf )
 			return 0;
 
@@ -195,7 +195,7 @@ int RPC_Interpreter::DeliverRPC(const u_char* buf, int n, int rpclen,
 		if ( reply_stat == RPC_MSG_ACCEPTED )
 			{
 			(void) skip_XDR_opaque_auth(buf, n);
-			uint32 accept_stat = extract_XDR_uint32(buf, n);
+			uint32_t accept_stat = extract_XDR_uint32(buf, n);
 
 			// The first members of BifEnum::RPC_* correspond
 			// to accept_stat.
@@ -217,7 +217,7 @@ int RPC_Interpreter::DeliverRPC(const u_char* buf, int n, int rpclen,
 
 		else if ( reply_stat == RPC_MSG_DENIED )
 			{
-			uint32 reject_stat = extract_XDR_uint32(buf, n);
+			uint32_t reject_stat = extract_XDR_uint32(buf, n);
 			if ( ! buf )
 				return 0;
 
@@ -432,7 +432,7 @@ Contents_RPC::~Contents_RPC()
 	{
 	}
 
-void Contents_RPC::Undelivered(uint64 seq, int len, bool orig)
+void Contents_RPC::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_SupportAnalyzer::Undelivered(seq, len, orig);
 	NeedResync();
@@ -440,10 +440,10 @@ void Contents_RPC::Undelivered(uint64 seq, int len, bool orig)
 
 bool Contents_RPC::CheckResync(int& len, const u_char*& data, bool orig)
 	{
-	uint32 frame_len;
+	uint32_t frame_len;
 	bool last_frag;
-	uint32 xid;
-	uint32 frame_type;
+	uint32_t xid;
+	uint32_t frame_type;
 
 	bool discard_this_chunk = false;
 
@@ -621,7 +621,7 @@ bool Contents_RPC::CheckResync(int& len, const u_char*& data, bool orig)
 void Contents_RPC::DeliverStream(int len, const u_char* data, bool orig)
 	{
 	tcp::TCP_SupportAnalyzer::DeliverStream(len, data, orig);
-	uint32 marker;
+	uint32_t marker;
 	bool last_frag;
 
 	if ( ! CheckResync(len, data, orig) )
@@ -735,7 +735,7 @@ RPC_Analyzer::~RPC_Analyzer()
 	}
 
 void RPC_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen)
+					uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	tcp::TCP_ApplicationAnalyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 	len = min(len, caplen);

--- a/src/analyzer/protocol/rpc/RPC.h
+++ b/src/analyzer/protocol/rpc/RPC.h
@@ -49,7 +49,7 @@ enum {
 
 class RPC_CallInfo {
 public:
-	RPC_CallInfo(uint32 xid, const u_char*& buf, int& n, double start_time,
+	RPC_CallInfo(uint32_t xid, const u_char*& buf, int& n, double start_time,
 		     double last_time, int rpc_len);
 	~RPC_CallInfo();
 
@@ -59,12 +59,12 @@ public:
 
 	int CompareRexmit(const u_char* buf, int n) const;
 
-	uint32 Program() const		{ return prog; }
-	uint32 Version() const		{ return vers; }
-	uint32 Proc() const		{ return proc; }
-	uint32 Uid() const { return uid; }
-	uint32 Gid() const { return gid; }
-	uint32 Stamp() const { return stamp; }
+	uint32_t Program() const		{ return prog; }
+	uint32_t Version() const		{ return vers; }
+	uint32_t Proc() const		{ return proc; }
+	uint32_t Uid() const { return uid; }
+	uint32_t Gid() const { return gid; }
+	uint32_t Stamp() const { return stamp; }
 	const std::string& MachineName() const { return machinename; }
 	const std::vector<int>& AuxGIDs() const { return auxgids; }
 
@@ -76,17 +76,17 @@ public:
 	int RPCLen() const	{ return rpc_len; }
 	int HeaderLen() const	{ return header_len; }
 
-	uint32 XID() const		{ return xid; }
+	uint32_t XID() const		{ return xid; }
 
 	void SetValidCall()		{ valid_call = true; }
 	bool IsValidCall() const	{ return valid_call; }
 
 protected:
-	uint32 xid, rpc_version, prog, vers, proc;
-	uint32 cred_flavor, stamp;
-	uint32 uid, gid;
+	uint32_t xid, rpc_version, prog, vers, proc;
+	uint32_t cred_flavor, stamp;
+	uint32_t uid, gid;
 	std::vector<int> auxgids;
-	uint32 verf_flavor;
+	uint32_t verf_flavor;
 	u_char* call_buf;	// copy of original call buffer
 	std::string machinename;
 	double start_time;
@@ -210,7 +210,7 @@ protected:
 	void Init() override;
 	virtual bool CheckResync(int& len, const u_char*& data, bool orig);
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	virtual void NeedResync() {
 		resync_state = NEED_RESYNC;
@@ -241,7 +241,7 @@ public:
 
 protected:
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	void ExpireTimer(double t);
 

--- a/src/analyzer/protocol/rpc/XDR.cc
+++ b/src/analyzer/protocol/rpc/XDR.cc
@@ -10,7 +10,7 @@
 
 using namespace analyzer::rpc;
 
-uint32 analyzer::rpc::extract_XDR_uint32(const u_char*& buf, int& len)
+uint32_t analyzer::rpc::extract_XDR_uint32(const u_char*& buf, int& len)
 	{
 	if ( ! buf )
 		return 0;
@@ -22,7 +22,7 @@ uint32 analyzer::rpc::extract_XDR_uint32(const u_char*& buf, int& len)
 		}
 
 	// Takes care of alignment and endianess differences. 
-	uint32 bits32 = (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
+	uint32_t bits32 = (buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3];
 
 	buf += 4;
 	len -= 4;
@@ -30,7 +30,7 @@ uint32 analyzer::rpc::extract_XDR_uint32(const u_char*& buf, int& len)
 	return bits32;
 	}
 
-uint64 analyzer::rpc::extract_XDR_uint64(const u_char*& buf, int& len)
+uint64_t analyzer::rpc::extract_XDR_uint64(const u_char*& buf, int& len)
 	{
 	if ( ! buf || len < 8 )
 		{
@@ -38,8 +38,8 @@ uint64 analyzer::rpc::extract_XDR_uint64(const u_char*& buf, int& len)
 		return 0;
 		}
 
-	uint64 uhi = extract_XDR_uint32(buf, len);
-	uint64 ulo = extract_XDR_uint32(buf, len);
+	uint64_t uhi = extract_XDR_uint32(buf, len);
+	uint64_t ulo = extract_XDR_uint32(buf, len);
 
 	return (uhi << 32) + ulo;
 	}
@@ -52,8 +52,8 @@ double analyzer::rpc::extract_XDR_time(const u_char*& buf, int& len)
 		return 0.0;
 		}
 
-	uint32 uhi = extract_XDR_uint32(buf, len);
-	uint32 ulo = extract_XDR_uint32(buf, len);
+	uint32_t uhi = extract_XDR_uint32(buf, len);
+	uint32_t ulo = extract_XDR_uint32(buf, len);
 
 	return double(uhi) + double(ulo) / 1e9;
 	}
@@ -101,9 +101,9 @@ const u_char* analyzer::rpc::extract_XDR_opaque_fixed(const u_char*& buf, int& l
 	}
 
 
-uint32 analyzer::rpc::skip_XDR_opaque_auth(const u_char*& buf, int& len)
+uint32_t analyzer::rpc::skip_XDR_opaque_auth(const u_char*& buf, int& len)
 	{
-	uint32 auth_flavor = extract_XDR_uint32(buf, len);
+	uint32_t auth_flavor = extract_XDR_uint32(buf, len);
 	if ( ! buf )
 		return 0;
 

--- a/src/analyzer/protocol/rpc/XDR.h
+++ b/src/analyzer/protocol/rpc/XDR.h
@@ -10,13 +10,13 @@
 
 namespace analyzer { namespace rpc {
 
-extern uint32 extract_XDR_uint32(const u_char*& buf, int& len);
-extern uint64 extract_XDR_uint64(const u_char*& buf, int& len);
+extern uint32_t extract_XDR_uint32(const u_char*& buf, int& len);
+extern uint64_t extract_XDR_uint64(const u_char*& buf, int& len);
 extern double extract_XDR_time(const u_char*& buf, int& len);
 extern const u_char* extract_XDR_opaque(const u_char*& buf, int& len,
 					int& n, int max_len=8192, bool short_buf_ok=false);
 extern const u_char* extract_XDR_opaque_fixed(const u_char*& buf, int& len, int n);
-extern uint32 skip_XDR_opaque_auth(const u_char*& buf, int& len);
+extern uint32_t skip_XDR_opaque_auth(const u_char*& buf, int& len);
 
 } } // namespace analyzer::* 
 

--- a/src/analyzer/protocol/sip/SIP.cc
+++ b/src/analyzer/protocol/sip/SIP.cc
@@ -21,7 +21,7 @@ void SIP_Analyzer::Done()
 	}
 
 void SIP_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
-								 uint64 seq, const IP_Hdr* ip, int caplen)
+								 uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	bool real_orig = true;
 	if ( len > 6 && data[0] == 'S' && data[1] == 'I' && data[2] == 'P' && data[3] == '/' )

--- a/src/analyzer/protocol/sip/SIP.h
+++ b/src/analyzer/protocol/sip/SIP.h
@@ -17,7 +17,7 @@ public:
 
 	void Done() override;
 	void DeliverPacket(int len, const u_char* data, bool orig,
-				   	   uint64 seq, const IP_Hdr* ip, int caplen) override;
+				   	   uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 	{ return new SIP_Analyzer(conn); }

--- a/src/analyzer/protocol/sip/SIP_TCP.cc
+++ b/src/analyzer/protocol/sip/SIP_TCP.cc
@@ -59,7 +59,7 @@ void SIP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void SIP_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void SIP_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	had_gap = true;

--- a/src/analyzer/protocol/sip/SIP_TCP.h
+++ b/src/analyzer/protocol/sip/SIP_TCP.h
@@ -19,7 +19,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	// Overriden from tcp::TCP_ApplicationAnalyzer.
 	void EndpointEOF(bool is_orig) override;

--- a/src/analyzer/protocol/smb/SMB.cc
+++ b/src/analyzer/protocol/smb/SMB.cc
@@ -34,7 +34,7 @@ void SMB_Analyzer::EndpointEOF(bool is_orig)
 	interp->FlowEOF(is_orig);
 	}
 
-void SMB_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void SMB_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 

--- a/src/analyzer/protocol/smb/SMB.h
+++ b/src/analyzer/protocol/smb/SMB.h
@@ -13,7 +13,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void EndpointEOF(bool is_orig) override;
 
 	bool HasSMBHeader(int len, const u_char* data);
@@ -27,7 +27,7 @@ protected:
 
 	// Count the number of chunks received by the analyzer
 	// but only used to count the first few.
-	uint8 chunks;
+	uint8_t chunks;
 
 	bool need_sync;
 };

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -78,7 +78,7 @@ void SMTP_Analyzer::Done()
 		EndData();
 	}
 
-void SMTP_Analyzer::Undelivered(uint64 seq, int len, bool is_orig)
+void SMTP_Analyzer::Undelivered(uint64_t seq, int len, bool is_orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, is_orig);
 

--- a/src/analyzer/protocol/smtp/SMTP.h
+++ b/src/analyzer/protocol/smtp/SMTP.h
@@ -45,7 +45,7 @@ public:
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
 	void ConnectionFinished(int half_finished) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	void SkipData()	{ skip_data = 1; }	// skip delivery of data lines
 

--- a/src/analyzer/protocol/snmp/SNMP.cc
+++ b/src/analyzer/protocol/snmp/SNMP.cc
@@ -25,7 +25,7 @@ void SNMP_Analyzer::Done()
 	}
 
 void SNMP_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
-                                  uint64 seq, const IP_Hdr* ip, int caplen)
+                                  uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/snmp/SNMP.h
+++ b/src/analyzer/protocol/snmp/SNMP.h
@@ -16,7 +16,7 @@ public:
 
 	virtual void Done();
 	virtual void DeliverPacket(int len, const u_char* data, bool orig,
-	                           uint64 seq, const IP_Hdr* ip, int caplen);
+	                           uint64_t seq, const IP_Hdr* ip, int caplen);
 
 	static analyzer::Analyzer* InstantiateAnalyzer(Connection* conn)
 		{ return new SNMP_Analyzer(conn); }

--- a/src/analyzer/protocol/socks/SOCKS.cc
+++ b/src/analyzer/protocol/socks/SOCKS.cc
@@ -85,7 +85,7 @@ void SOCKS_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void SOCKS_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void SOCKS_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	interp->NewGap(orig, len);

--- a/src/analyzer/protocol/socks/SOCKS.h
+++ b/src/analyzer/protocol/socks/SOCKS.h
@@ -23,7 +23,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void EndpointEOF(bool is_orig) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)

--- a/src/analyzer/protocol/ssh/SSH.cc
+++ b/src/analyzer/protocol/ssh/SSH.cc
@@ -76,7 +76,7 @@ void SSH_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void SSH_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void SSH_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	had_gap = true;

--- a/src/analyzer/protocol/ssh/SSH.h
+++ b/src/analyzer/protocol/ssh/SSH.h
@@ -19,7 +19,7 @@ namespace analyzer {
 			// Overriden from Analyzer.
 			void Done() override;
 			void DeliverStream(int len, const u_char* data, bool orig) override;
-			void Undelivered(uint64 seq, int len, bool orig) override;
+			void Undelivered(uint64_t seq, int len, bool orig) override;
 
 			// Overriden from tcp::TCP_ApplicationAnalyzer.
 			void EndpointEOF(bool is_orig) override;

--- a/src/analyzer/protocol/ssl/DTLS.cc
+++ b/src/analyzer/protocol/ssl/DTLS.cc
@@ -32,7 +32,7 @@ void DTLS_Analyzer::Done()
 	handshake_interp->FlowEOF(false);
 	}
 
-void DTLS_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64 seq, const IP_Hdr* ip, int caplen)
+void DTLS_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 
@@ -51,15 +51,15 @@ void DTLS_Analyzer::EndOfData(bool is_orig)
 	}
 
 
-void DTLS_Analyzer::SendHandshake(uint16 raw_tls_version, uint8 msg_type, uint32 length, const u_char* begin, const u_char* end, bool orig)
+void DTLS_Analyzer::SendHandshake(uint16_t raw_tls_version, uint8_t msg_type, uint32_t length, const u_char* begin, const u_char* end, bool orig)
 	{
 	handshake_interp->set_record_version(raw_tls_version);
 	try
 		{
 		handshake_interp->NewData(orig, (const unsigned char*) &msg_type, (const unsigned char*) &msg_type + 1);
-		uint32 host_length = htonl(length);
-		// the parser inspects a uint24 - since it is big-endian, it should be ok to just skip
-		// the first byte of the uint32. Since we get the data from an uint24 from the dtls-parser, this should
+		uint32_t host_length = htonl(length);
+		// the parser inspects a uint24_t - since it is big-endian, it should be ok to just skip
+		// the first byte of the uint32._t Since we get the data from an uint24_t from the dtls-parser, this should
 		// always yield the correct result.
 		handshake_interp->NewData(orig, (const unsigned char*) &host_length + 1, (const unsigned char*) &host_length + sizeof(host_length));
 		handshake_interp->NewData(orig, begin, end);

--- a/src/analyzer/protocol/ssl/DTLS.h
+++ b/src/analyzer/protocol/ssl/DTLS.h
@@ -19,10 +19,10 @@ public:
 	// Overriden from Analyzer.
 	void Done() override;
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 	void EndOfData(bool is_orig) override;
 
-	void SendHandshake(uint16 raw_tls_version, uint8 msg_type, uint32 length, const u_char* begin, const u_char* end, bool orig);
+	void SendHandshake(uint16_t raw_tls_version, uint8_t msg_type, uint32_t length, const u_char* begin, const u_char* end, bool orig);
 
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)

--- a/src/analyzer/protocol/ssl/SSL.cc
+++ b/src/analyzer/protocol/ssl/SSL.cc
@@ -71,7 +71,7 @@ void SSL_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void SSL_Analyzer::SendHandshake(uint16 raw_tls_version, const u_char* begin, const u_char* end, bool orig)
+void SSL_Analyzer::SendHandshake(uint16_t raw_tls_version, const u_char* begin, const u_char* end, bool orig)
 	{
 	handshake_interp->set_record_version(raw_tls_version);
 	try
@@ -84,7 +84,7 @@ void SSL_Analyzer::SendHandshake(uint16 raw_tls_version, const u_char* begin, co
 		}
 	}
 
-void SSL_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void SSL_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	had_gap = true;

--- a/src/analyzer/protocol/ssl/SSL.h
+++ b/src/analyzer/protocol/ssl/SSL.h
@@ -19,9 +19,9 @@ public:
 	// Overriden from Analyzer.
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
-	void SendHandshake(uint16 raw_tls_version, const u_char* begin, const u_char* end, bool orig);
+	void SendHandshake(uint16_t raw_tls_version, const u_char* begin, const u_char* end, bool orig);
 
 	// Tell the analyzer that encryption has started.
 	void StartEncryption();

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -63,7 +63,7 @@ void SteppingStoneEndpoint::Done()
 	Event(stp_remove_endp, stp_id);
 	}
 
-int SteppingStoneEndpoint::DataSent(double t, uint64 seq, int len, int caplen,
+int SteppingStoneEndpoint::DataSent(double t, uint64_t seq, int len, int caplen,
 		const u_char* data, const IP_Hdr* /* ip */,
 		const struct tcphdr* tp)
 	{
@@ -89,8 +89,8 @@ int SteppingStoneEndpoint::DataSent(double t, uint64 seq, int len, int caplen,
 			break;
 		}
 
-	uint64 ack = endp->ToRelativeSeqSpace(endp->AckSeq(), endp->AckWraps());
-	uint64 top_seq = seq + len;
+	uint64_t ack = endp->ToRelativeSeqSpace(endp->AckSeq(), endp->AckWraps());
+	uint64_t top_seq = seq + len;
 
 	if ( top_seq <= ack || top_seq <= stp_max_top_seq )
 		// There is no new data in this packet
@@ -175,7 +175,7 @@ void SteppingStone_Analyzer::Init()
 	}
 
 void SteppingStone_Analyzer::DeliverPacket(int len, const u_char* data,
-						bool is_orig, uint64 seq,
+						bool is_orig, uint64_t seq,
 						const IP_Hdr* ip, int caplen)
 	{
 	tcp::TCP_ApplicationAnalyzer::DeliverPacket(len, data, is_orig, seq,

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.h
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.h
@@ -19,7 +19,7 @@ public:
 	~SteppingStoneEndpoint() override;
 	void Done();
 
-	int DataSent(double t, uint64 seq, int len, int caplen, const u_char* data,
+	int DataSent(double t, uint64_t seq, int len, int caplen, const u_char* data,
 		     const IP_Hdr* ip, const struct tcphdr* tp);
 
 protected:
@@ -27,7 +27,7 @@ protected:
 	void CreateEndpEvent(int is_orig);
 
 	tcp::TCP_Endpoint* endp;
-	uint64 stp_max_top_seq;
+	uint64_t stp_max_top_seq;
 	double stp_last_time;
 	double stp_resume_time;
 	SteppingStoneManager* stp_manager;
@@ -57,7 +57,7 @@ protected:
 	// We support both packet and stream input and can be put in place even
 	// if the TCP analyzer is not yet reassebmling.
 	void DeliverPacket(int len, const u_char* data, bool is_orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 	void DeliverStream(int len, const u_char* data, bool is_orig) override;
 
 	int orig_stream_pos;

--- a/src/analyzer/protocol/syslog/Syslog.cc
+++ b/src/analyzer/protocol/syslog/Syslog.cc
@@ -28,7 +28,7 @@ void Syslog_Analyzer::Done()
 		Event(udp_session_done);
 	}
 
-void Syslog_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64 seq, const IP_Hdr* ip, int caplen)
+void Syslog_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 	interp->NewData(orig, data, data + len);
@@ -88,7 +88,7 @@ void Syslog_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint
 //	interp->NewData(orig, data, data + len);
 //	}
 
-//void Syslog_tcp::TCP_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+//void Syslog_tcp::TCP_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 //	{
 //	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 //	interp->NewGap(orig, len);

--- a/src/analyzer/protocol/syslog/Syslog.h
+++ b/src/analyzer/protocol/syslog/Syslog.h
@@ -16,7 +16,7 @@ public:
 
 	void Done() override;
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new Syslog_Analyzer(conn); }
@@ -36,7 +36,7 @@ protected:
 //
 //	virtual void Done();
 //	virtual void DeliverStream(int len, const u_char* data, bool orig);
-//	virtual void Undelivered(uint64 seq, int len, bool orig);
+//	virtual void Undelivered(uint64_t seq, int len, bool orig);
 //	virtual void EndpointEOF(tcp::TCP_Reassembler* endp);
 //
 //	static analyzer::Analyzer* Instantiate(Connection* conn)

--- a/src/analyzer/protocol/tcp/ContentLine.cc
+++ b/src/analyzer/protocol/tcp/ContentLine.cc
@@ -110,7 +110,7 @@ void ContentLine_Analyzer::DeliverStream(int len, const u_char* data,
 	seq += len;
 	}
 
-void ContentLine_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void ContentLine_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	ForwardUndelivered(seq, len, orig);
 	}

--- a/src/analyzer/protocol/tcp/ContentLine.h
+++ b/src/analyzer/protocol/tcp/ContentLine.h
@@ -66,7 +66,7 @@ protected:
 	ContentLine_Analyzer(const char* name, Connection* conn, bool orig, int max_line_length=DEFAULT_MAX_LINE_LENGTH);
 
 	void DeliverStream(int len, const u_char* data, bool is_orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void EndpointEOF(bool is_orig) override;
 
 	class State;

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -232,7 +232,7 @@ const struct tcphdr* TCP_Analyzer::ExtractTCP_Header(const u_char*& data,
 							int& len, int& caplen)
 	{
 	const struct tcphdr* tp = (const struct tcphdr*) data;
-	uint32 tcp_hdr_len = tp->th_off * 4;
+	uint32_t tcp_hdr_len = tp->th_off * 4;
 
 	if ( tcp_hdr_len < sizeof(struct tcphdr) )
 		{
@@ -240,8 +240,8 @@ const struct tcphdr* TCP_Analyzer::ExtractTCP_Header(const u_char*& data,
 		return 0;
 		}
 
-	if ( tcp_hdr_len > uint32(len) ||
-	     tcp_hdr_len > uint32(caplen) )
+	if ( tcp_hdr_len > uint32_t(len) ||
+	     tcp_hdr_len > uint32_t(caplen) )
 		{
 		// This can happen even with the above test, due to TCP
 		// options.
@@ -285,7 +285,7 @@ void TCP_Analyzer::SetPartialStatus(TCP_Flags flags, bool is_orig)
 	}
 
 static void update_history(TCP_Flags flags, TCP_Endpoint* endpoint,
-			   uint64 rel_seq, int len)
+			   uint64_t rel_seq, int len)
 	{
 	int bits_set = (flags.SYN() ? 1 : 0) + (flags.FIN() ? 1 : 0) +
 			(flags.RST() ? 1 : 0);
@@ -343,8 +343,8 @@ static void update_history(TCP_Flags flags, TCP_Endpoint* endpoint,
 	}
 
 static void init_window(TCP_Endpoint* endpoint, TCP_Endpoint* peer,
-			TCP_Flags flags, bro_int_t scale, uint32 base_seq,
-			uint32 ack_seq)
+			TCP_Flags flags, bro_int_t scale, uint32_t base_seq,
+			uint32_t ack_seq)
 	{
 	// ### In the following, we could be fooled by an
 	// inconsistent SYN retransmission.  Where's a normalizer
@@ -381,7 +381,7 @@ static void init_window(TCP_Endpoint* endpoint, TCP_Endpoint* peer,
 	}
 
 static void update_window(TCP_Endpoint* endpoint, unsigned int window,
-                          uint32 base_seq, uint32 ack_seq, TCP_Flags flags)
+                          uint32_t base_seq, uint32_t ack_seq, TCP_Flags flags)
 	{
 	// Note, applying scaling here would be incorrect for an initial SYN,
 	// whose window value is always unscaled.  However, we don't
@@ -421,9 +421,9 @@ static void update_window(TCP_Endpoint* endpoint, unsigned int window,
 		if ( seq_delta(base_seq, endpoint->window_seq) >= 0 &&
 		     seq_delta(ack_seq, endpoint->window_ack_seq) >= 0 )
 			{
-			uint32 new_edge = ack_seq + window;
-			uint32 old_edge = endpoint->window_ack_seq + endpoint->window;
-			int32 advance = seq_delta(new_edge, old_edge);
+			uint32_t new_edge = ack_seq + window;
+			uint32_t old_edge = endpoint->window_ack_seq + endpoint->window;
+			int32_t advance = seq_delta(new_edge, old_edge);
 
 			if ( advance < 0 )
 				{
@@ -461,7 +461,7 @@ static void syn_weirds(TCP_Flags flags, TCP_Endpoint* endpoint, int data_len)
 
 void TCP_Analyzer::UpdateInactiveState(double t,
 			TCP_Endpoint* endpoint, TCP_Endpoint* peer,
-			uint32 base_seq, uint32 ack_seq,
+			uint32_t base_seq, uint32_t ack_seq,
 			int len, int is_orig, TCP_Flags flags,
 			int& do_close, int& gen_event)
 	{
@@ -683,7 +683,7 @@ void TCP_Analyzer::UpdateEstablishedState(
 	}
 
 void TCP_Analyzer::UpdateClosedState(double t, TCP_Endpoint* endpoint,
-				int32 delta_last, TCP_Flags flags, int& do_close)
+				int32_t delta_last, TCP_Flags flags, int& do_close)
 	{
 	if ( flags.SYN() )
 		Weird("SYN_after_close");
@@ -728,8 +728,8 @@ void TCP_Analyzer::UpdateResetState(int len, TCP_Flags flags)
 
 void TCP_Analyzer::UpdateStateMachine(double t,
 			TCP_Endpoint* endpoint, TCP_Endpoint* peer,
-			uint32 base_seq, uint32 ack_seq,
-			int len, int32 delta_last, int is_orig, TCP_Flags flags,
+			uint32_t base_seq, uint32_t ack_seq,
+			int len, int32_t delta_last, int is_orig, TCP_Flags flags,
 			int& do_close, int& gen_event)
 	{
 	do_close = 0;	// whether to report the connection as closed
@@ -765,7 +765,7 @@ void TCP_Analyzer::UpdateStateMachine(double t,
 	}
 
 void TCP_Analyzer::GeneratePacketEvent(
-					uint64 rel_seq, uint64 rel_ack,
+					uint64_t rel_seq, uint64_t rel_ack,
 					const u_char* data, int len, int caplen,
 					int is_orig, TCP_Flags flags)
 	{
@@ -784,7 +784,7 @@ void TCP_Analyzer::GeneratePacketEvent(
 
 int TCP_Analyzer::DeliverData(double t, const u_char* data, int len, int caplen,
 				const IP_Hdr* ip, const struct tcphdr* tp,
-				TCP_Endpoint* endpoint, uint64 rel_data_seq,
+				TCP_Endpoint* endpoint, uint64_t rel_data_seq,
 				int is_orig, TCP_Flags flags)
 	{
 	return endpoint->DataSent(t, rel_data_seq, len, caplen, data, ip, tp);
@@ -820,11 +820,11 @@ void TCP_Analyzer::CheckPIA_FirstPacket(int is_orig, const IP_Hdr* ip)
 		}
 	}
 
-uint64 TCP_Analyzer::get_relative_seq(const TCP_Endpoint* endpoint,
-                                      uint32 cur_base, uint32 last,
-                                      uint32 wraps, bool* underflow)
+uint64_t TCP_Analyzer::get_relative_seq(const TCP_Endpoint* endpoint,
+                                      uint32_t cur_base, uint32_t last,
+                                      uint32_t wraps, bool* underflow)
 	{
-	int32 delta = seq_delta(cur_base, last);
+	int32_t delta = seq_delta(cur_base, last);
 
 	if ( delta < 0 )
 		{
@@ -875,7 +875,7 @@ int TCP_Analyzer::get_segment_len(int payload_len, TCP_Flags flags)
 	}
 
 static void init_endpoint(TCP_Endpoint* endpoint, TCP_Flags flags,
-                          uint32 first_seg_seq, uint32 last_seq, double t)
+                          uint32_t first_seg_seq, uint32_t last_seq, double t)
 	{
 	switch ( endpoint->state ) {
 	case TCP_ENDPOINT_INACTIVE:
@@ -951,7 +951,7 @@ static void init_endpoint(TCP_Endpoint* endpoint, TCP_Flags flags,
 	}
 
 static void init_peer(TCP_Endpoint* peer, TCP_Endpoint* endpoint,
-                      TCP_Flags flags, uint32 ack_seq)
+                      TCP_Flags flags, uint32_t ack_seq)
 	{
 	if ( ! flags.SYN() && ! flags.FIN() && ! flags.RST() )
 		{
@@ -976,9 +976,9 @@ static void init_peer(TCP_Endpoint* peer, TCP_Endpoint* endpoint,
 	peer->InitLastSeq(ack_seq - 1);
 	}
 
-static void update_ack_seq(TCP_Endpoint* endpoint, uint32 ack_seq)
+static void update_ack_seq(TCP_Endpoint* endpoint, uint32_t ack_seq)
 	{
-	int32 delta_ack = seq_delta(ack_seq, endpoint->AckSeq());
+	int32_t delta_ack = seq_delta(ack_seq, endpoint->AckSeq());
 
 	if ( ack_seq == 0 && delta_ack > TOO_LARGE_SEQ_DELTA )
 		// More likely that this is a broken ack than a
@@ -991,10 +991,10 @@ static void update_ack_seq(TCP_Endpoint* endpoint, uint32 ack_seq)
 
 // Returns the difference between last_seq and the last sequence
 // seen by the endpoint (may be negative).
-static int32 update_last_seq(TCP_Endpoint* endpoint, uint32 last_seq,
+static int32_t update_last_seq(TCP_Endpoint* endpoint, uint32_t last_seq,
                              TCP_Flags flags, int len)
 	{
-	int32 delta_last = seq_delta(last_seq, endpoint->LastSeq());
+	int32_t delta_last = seq_delta(last_seq, endpoint->LastSeq());
 
 	if ( (flags.SYN() || flags.RST()) &&
 	     (delta_last > TOO_LARGE_SEQ_DELTA ||
@@ -1028,7 +1028,7 @@ static int32 update_last_seq(TCP_Endpoint* endpoint, uint32 last_seq,
 	}
 
 void TCP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
-					uint64 seq, const IP_Hdr* ip, int caplen)
+					uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	TransportLayerAnalyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 
@@ -1047,21 +1047,21 @@ void TCP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 	if ( ! ValidateChecksum(tp, endpoint, len, caplen) )
 		return;
 
-	uint32 tcp_hdr_len = data - (const u_char*) tp;
+	uint32_t tcp_hdr_len = data - (const u_char*) tp;
 	TCP_Flags flags(tp);
 	SetPartialStatus(flags, endpoint->IsOrig());
 
-	uint32 base_seq = ntohl(tp->th_seq);
-	uint32 ack_seq = ntohl(tp->th_ack);
+	uint32_t base_seq = ntohl(tp->th_seq);
+	uint32_t ack_seq = ntohl(tp->th_ack);
 
 	int seg_len = get_segment_len(len, flags);
-	uint32 seq_one_past_segment = base_seq + seg_len;
+	uint32_t seq_one_past_segment = base_seq + seg_len;
 
 	init_endpoint(endpoint, flags, base_seq, seq_one_past_segment,
 	              current_timestamp);
 
 	bool seq_underflow = false;
-	uint64 rel_seq = get_relative_seq(endpoint, base_seq, endpoint->LastSeq(),
+	uint64_t rel_seq = get_relative_seq(endpoint, base_seq, endpoint->LastSeq(),
 					  endpoint->SeqWraps(), &seq_underflow);
 
 	if ( seq_underflow && ! flags.RST() )
@@ -1122,7 +1122,7 @@ void TCP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 		PacketWithRST();
 		}
 
-	uint64 rel_ack = 0;
+	uint64_t rel_ack = 0;
 
 	if ( flags.ACK() )
 		{
@@ -1156,7 +1156,7 @@ void TCP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 			}
 		}
 
-	int32 delta_last = update_last_seq(endpoint, seq_one_past_segment, flags, len);
+	int32_t delta_last = update_last_seq(endpoint, seq_one_past_segment, flags, len);
 	endpoint->last_time = current_timestamp;
 
 	int do_close;
@@ -1178,7 +1178,7 @@ void TCP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 		                    flags);
 
 	if ( tcp_option && tcp_hdr_len > sizeof(*tp) &&
-	     tcp_hdr_len <= uint32(caplen) )
+	     tcp_hdr_len <= uint32_t(caplen) )
 		ParseTCPOptions(tp, TCPOptionEvent, this, is_orig, 0);
 
 	if ( DEBUG_tcp_data_sent )
@@ -1187,7 +1187,7 @@ void TCP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 			  network_time, len, caplen, Skipping());
 		}
 
-	uint64 rel_data_seq = flags.SYN() ? rel_seq + 1 : rel_seq;
+	uint64_t rel_data_seq = flags.SYN() ? rel_seq + 1 : rel_seq;
 
 	int need_contents = 0;
 	if ( len > 0 && (caplen >= len || packet_children.size()) &&
@@ -1223,7 +1223,7 @@ void TCP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	Analyzer::DeliverStream(len, data, orig);
 	}
 
-void TCP_Analyzer::Undelivered(uint64 seq, int len, bool is_orig)
+void TCP_Analyzer::Undelivered(uint64_t seq, int len, bool is_orig)
 	{
 	Analyzer::Undelivered(seq, len, orig);
 	}
@@ -1692,7 +1692,7 @@ bool TCP_Analyzer::IsReuse(double t, const u_char* pkt)
 
 	if ( ! IsClosed() )
 		{
-		uint32 base_seq = ntohl(tp->th_seq);
+		uint32_t base_seq = ntohl(tp->th_seq);
 		if ( base_seq == conn_orig->StartSeq() )
 			return false;
 
@@ -1753,7 +1753,7 @@ void TCP_ApplicationAnalyzer::ProtocolViolation(const char* reason,
 	}
 
 void TCP_ApplicationAnalyzer::DeliverPacket(int len, const u_char* data,
-						bool is_orig, uint64 seq,
+						bool is_orig, uint64_t seq,
 						const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, is_orig, seq, ip, caplen);
@@ -1834,7 +1834,7 @@ int endian_flip(int n)
 	return ((n & 0xff) << 8) | ((n & 0xff00) >> 8);
 	}
 
-int TCPStats_Endpoint::DataSent(double /* t */, uint64 seq, int len, int caplen,
+int TCPStats_Endpoint::DataSent(double /* t */, uint64_t seq, int len, int caplen,
 			const u_char* /* data */,
 			const IP_Hdr* ip, const struct tcphdr* /* tp */)
 	{
@@ -1894,13 +1894,13 @@ int TCPStats_Endpoint::DataSent(double /* t */, uint64 seq, int len, int caplen,
 
 	++num_in_order;
 
-	uint64 top_seq = seq + len;
+	uint64_t top_seq = seq + len;
 
-	int32 data_in_flight = seq_delta(endp->LastSeq(), endp->AckSeq());
+	int32_t data_in_flight = seq_delta(endp->LastSeq(), endp->AckSeq());
 	if ( data_in_flight < 0 )
 		data_in_flight = 0;
 
-	int64 sequence_delta = top_seq - max_top_seq;
+	int64_t sequence_delta = top_seq - max_top_seq;
 	if ( sequence_delta <= 0 )
 		{
 		if ( ! BifConst::ignore_keep_alive_rexmit || len > 1 || data_in_flight > 0 )
@@ -1977,7 +1977,7 @@ void TCPStats_Analyzer::Done()
 		});
 	}
 
-void TCPStats_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig, uint64 seq, const IP_Hdr* ip, int caplen)
+void TCPStats_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig, uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	TCP_ApplicationAnalyzer::DeliverPacket(len, data, is_orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/tcp/TCP.h
+++ b/src/analyzer/protocol/tcp/TCP.h
@@ -51,8 +51,8 @@ public:
 	int RespState() const	{ return resp->state; }
 	int OrigPrevState() const	{ return orig->prev_state; }
 	int RespPrevState() const	{ return resp->prev_state; }
-	uint32 OrigSeq() const	{ return orig->LastSeq(); }
-	uint32 RespSeq() const	{ return resp->LastSeq(); }
+	uint32_t OrigSeq() const	{ return orig->LastSeq(); }
+	uint32_t RespSeq() const	{ return resp->LastSeq(); }
 
 	// True if either endpoint still has pending data.  closing_endp
 	// is an endpoint that has indicated it is closing (i.e., for
@@ -89,9 +89,9 @@ protected:
 	// Analyzer interface.
 	void Init() override;
 	void Done() override;
-	void DeliverPacket(int len, const u_char* data, bool orig, uint64 seq, const IP_Hdr* ip, int caplen) override;
+	void DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen) override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 	void FlipRoles() override;
 	bool IsReuse(double t, const u_char* pkt) override;
 
@@ -116,13 +116,13 @@ protected:
 	// this fact.
 	void UpdateStateMachine(double t,
 			TCP_Endpoint* endpoint, TCP_Endpoint* peer,
-			uint32 base_seq, uint32 ack_seq,
-			int len, int32 delta_last, int is_orig, TCP_Flags flags,
+			uint32_t base_seq, uint32_t ack_seq,
+			int len, int32_t delta_last, int is_orig, TCP_Flags flags,
 			int& do_close, int& gen_event);
 
 	void UpdateInactiveState(double t,
 				TCP_Endpoint* endpoint, TCP_Endpoint* peer,
-				uint32 base_seq, uint32 ack_seq,
+				uint32_t base_seq, uint32_t ack_seq,
 				int len, int is_orig, TCP_Flags flags,
 				int& do_close, int& gen_event);
 
@@ -134,18 +134,18 @@ protected:
 				    TCP_Flags flags, int& do_close, int& gen_event);
 
 	void UpdateClosedState(double t, TCP_Endpoint* endpoint,
-				int32 delta_last, TCP_Flags flags,
+				int32_t delta_last, TCP_Flags flags,
 				int& do_close);
 
 	void UpdateResetState(int len, TCP_Flags flags);
 
-	void GeneratePacketEvent(uint64 rel_seq, uint64 rel_ack,
+	void GeneratePacketEvent(uint64_t rel_seq, uint64_t rel_ack,
 				 const u_char* data, int len, int caplen,
 				 int is_orig, TCP_Flags flags);
 
 	int DeliverData(double t, const u_char* data, int len, int caplen,
 			const IP_Hdr* ip, const struct tcphdr* tp,
-			TCP_Endpoint* endpoint, uint64 rel_data_seq,
+			TCP_Endpoint* endpoint, uint64_t rel_data_seq,
 			int is_orig, TCP_Flags flags);
 
 	void CheckRecording(int need_contents, TCP_Flags flags);
@@ -175,9 +175,9 @@ protected:
 				  bool is_orig, void* cookie);
 
 	// A couple utility functions that may also be useful to derived analyzers.
-	static uint64 get_relative_seq(const TCP_Endpoint* endpoint,
-	                               uint32 cur_base, uint32 last,
-	                               uint32 wraps, bool* underflow = 0);
+	static uint64_t get_relative_seq(const TCP_Endpoint* endpoint,
+	                               uint32_t cur_base, uint32_t last,
+	                               uint32_t wraps, bool* underflow = 0);
 
 	static int get_segment_len(int payload_len, TCP_Flags flags);
 
@@ -245,7 +245,7 @@ public:
 	virtual void PacketWithRST();
 
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 	void Init() override;
 
 	// This suppresses violations if the TCP connection wasn't
@@ -282,7 +282,7 @@ class TCPStats_Endpoint {
 public:
 	explicit TCPStats_Endpoint(TCP_Endpoint* endp);
 
-	int DataSent(double t, uint64 seq, int len, int caplen, const u_char* data,
+	int DataSent(double t, uint64_t seq, int len, int caplen, const u_char* data,
 			const IP_Hdr* ip, const struct tcphdr* tp);
 
 	RecordVal* BuildStats();
@@ -295,7 +295,7 @@ protected:
 	int num_in_order;
 	int num_OO;
 	int num_repl;
-	uint64 max_top_seq;
+	uint64_t max_top_seq;
 	int last_id;
 	int endian_type;
 };
@@ -313,7 +313,7 @@ public:
 
 protected:
 	void DeliverPacket(int len, const u_char* data, bool is_orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	TCPStats_Endpoint* orig_stats;
 	TCPStats_Endpoint* resp_stats;

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.cc
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.cc
@@ -111,8 +111,8 @@ void TCP_Endpoint::CheckEOF()
 		contents_processor->CheckEOF();
 	}
 
-void TCP_Endpoint::SizeBufferedData(uint64& waiting_on_hole,
-                                    uint64& waiting_on_ack)
+void TCP_Endpoint::SizeBufferedData(uint64_t& waiting_on_hole,
+                                    uint64_t& waiting_on_ack)
 	{
 	if ( contents_processor )
 		contents_processor->SizeBufferedData(waiting_on_hole, waiting_on_ack);
@@ -122,7 +122,7 @@ void TCP_Endpoint::SizeBufferedData(uint64& waiting_on_hole,
 
 int TCP_Endpoint::ValidChecksum(const struct tcphdr* tp, int len) const
 	{
-	uint32 sum = checksum_base;
+	uint32_t sum = checksum_base;
 	int tcp_len = tp->th_off * 4 + len;
 
 	if ( len % 2 == 1 )
@@ -163,7 +163,7 @@ void TCP_Endpoint::SetState(EndpointState new_state)
 		}
 	}
 
-uint64 TCP_Endpoint::Size() const
+uint64_t TCP_Endpoint::Size() const
 	{
 	if ( prev_state == TCP_ENDPOINT_SYN_SENT && state == TCP_ENDPOINT_RESET &&
 	     peer->state == TCP_ENDPOINT_INACTIVE && ! NoDataAcked() )
@@ -172,9 +172,9 @@ uint64 TCP_Endpoint::Size() const
 		// and there was never a chance for this endpoint to send data anyway.
 		return 0;
 
-	uint64 size;
-	uint64 last_seq_64 = ToFullSeqSpace(LastSeq(), SeqWraps());
-	uint64 ack_seq_64 = ToFullSeqSpace(AckSeq(), AckWraps());
+	uint64_t size;
+	uint64_t last_seq_64 = ToFullSeqSpace(LastSeq(), SeqWraps());
+	uint64_t ack_seq_64 = ToFullSeqSpace(AckSeq(), AckWraps());
 
 	// Going straight to relative sequence numbers and comparing those might
 	// make more sense, but there's some cases (e.g. due to RSTs) where
@@ -198,7 +198,7 @@ uint64 TCP_Endpoint::Size() const
 	return size;
 	}
 
-int TCP_Endpoint::DataSent(double t, uint64 seq, int len, int caplen,
+int TCP_Endpoint::DataSent(double t, uint64_t seq, int len, int caplen,
 				const u_char* data,
 				const IP_Hdr* ip, const struct tcphdr* tp)
 	{
@@ -218,7 +218,7 @@ int TCP_Endpoint::DataSent(double t, uint64 seq, int len, int caplen,
 	if ( contents_file && ! contents_processor &&
 	     seq + len > contents_start_seq )
 		{
-		int64 under_seq = contents_start_seq - seq;
+		int64_t under_seq = contents_start_seq - seq;
 		if ( under_seq > 0 )
 			{
 			seq += under_seq;
@@ -249,7 +249,7 @@ int TCP_Endpoint::DataSent(double t, uint64 seq, int len, int caplen,
 	return status;
 	}
 
-void TCP_Endpoint::AckReceived(uint64 seq)
+void TCP_Endpoint::AckReceived(uint64_t seq)
 	{
 	if ( contents_processor )
 		contents_processor->AckReceived(seq);
@@ -268,7 +268,7 @@ void TCP_Endpoint::SetContentsFile(BroFile* f)
 		contents_processor->SetContentsFile(contents_file);
 	}
 
-int TCP_Endpoint::CheckHistory(uint32 mask, char code)
+int TCP_Endpoint::CheckHistory(uint32_t mask, char code)
 	{
 	if ( ! IsOrig() )
 		{
@@ -289,7 +289,7 @@ void TCP_Endpoint::AddHistory(char code)
 
 void TCP_Endpoint::ChecksumError()
 	{
-	uint32 t = chk_thresh;
+	uint32_t t = chk_thresh;
 	if ( Conn()->ScaledHistoryEntry(IsOrig() ? 'C' : 'c',
 	                                chk_cnt, chk_thresh) )
 		Conn()->HistoryThresholdEvent(tcp_multiple_checksum_errors,
@@ -298,7 +298,7 @@ void TCP_Endpoint::ChecksumError()
 
 void TCP_Endpoint::DidRxmit()
 	{
-	uint32 t = rxmt_thresh;
+	uint32_t t = rxmt_thresh;
 	if ( Conn()->ScaledHistoryEntry(IsOrig() ? 'T' : 't',
 	                                rxmt_cnt, rxmt_thresh) )
 		Conn()->HistoryThresholdEvent(tcp_multiple_retransmissions,
@@ -307,16 +307,16 @@ void TCP_Endpoint::DidRxmit()
 
 void TCP_Endpoint::ZeroWindow()
 	{
-	uint32 t = win0_thresh;
+	uint32_t t = win0_thresh;
 	if ( Conn()->ScaledHistoryEntry(IsOrig() ? 'W' : 'w',
 	                                win0_cnt, win0_thresh) )
 		Conn()->HistoryThresholdEvent(tcp_multiple_zero_windows,
 		                              IsOrig(), t);
 	}
 
-void TCP_Endpoint::Gap(uint64 seq, uint64 len)
+void TCP_Endpoint::Gap(uint64_t seq, uint64_t len)
 	{
-	uint32 t = gap_thresh;
+	uint32_t t = gap_thresh;
 	if ( Conn()->ScaledHistoryEntry(IsOrig() ? 'G' : 'g',
 					gap_cnt, gap_thresh) )
 		Conn()->HistoryThresholdEvent(tcp_multiple_gap, IsOrig(), t);

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.h
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.h
@@ -38,7 +38,7 @@ public:
 
 	EndpointState State() const 	{ return state; }
 	void SetState(EndpointState new_state);
-	uint64 Size() const;
+	uint64_t Size() const;
 	int IsActive() const
 		{ return state != TCP_ENDPOINT_INACTIVE && ! did_close; }
 
@@ -48,45 +48,45 @@ public:
 	/**
 	 * @return The starting TCP sequence number for this endpoint.
 	 */
-	uint32 StartSeq() const		{ return static_cast<uint32>(start_seq); }
+	uint32_t StartSeq() const		{ return static_cast<uint32_t>(start_seq); }
 
 	/**
 	 * @return The starting TCP sequence number for this endpoint, in terms
 	 *         of a signed sequence space, which may account for initial
 	 *         sequence space wraparounds (underflow/overflow).
 	 */
-	int64 StartSeqI64() const { return start_seq; }
+	int64_t StartSeqI64() const { return start_seq; }
 
 	/**
 	 * @return The sequence number after the last TCP sequence number seen
 	 *         from this endpoint.
 	 */
-	uint32 LastSeq() const		{ return last_seq; }
+	uint32_t LastSeq() const		{ return last_seq; }
 
 	/**
 	 * @return The last TCP acknowledgement number seen from this endpoint.
 	 */
-	uint32 AckSeq() const		{ return ack_seq; }
+	uint32_t AckSeq() const		{ return ack_seq; }
 
 	/**
 	 * @return The number of times the TCP sequence has wrapped around
-	 *         for this endpoint (i.e. overflowed a uint32).
+	 *         for this endpoint (i.e. overflowed a uint32_t).
 	 */
-	uint32 SeqWraps() const		{ return seq_wraps; }
+	uint32_t SeqWraps() const		{ return seq_wraps; }
 
 	/**
 	 * @return The number of times the TCP acknowledgement sequence has
-	 *         wrapped around for this endpoint (i.e. overflowed a uint32).
+	 *         wrapped around for this endpoint (i.e. overflowed a uint32_t).
 	 */
-	uint32 AckWraps() const		{ return ack_wraps; }
+	uint32_t AckWraps() const		{ return ack_wraps; }
 
 	/**
 	 * @param wraps Number of times a 32-bit sequence space has wrapped.
 	 * @return A 64-bit sequence space number it would take to overflow
 	 *         a 32-bit sequence space \a wraps number of times.
 	 */
-	static uint64 ToFullSeqSpace(uint32 wraps)
-		{ return (uint64(wraps) << 32); }
+	static uint64_t ToFullSeqSpace(uint32_t wraps)
+		{ return (uint64_t(wraps) << 32); }
 
 	/**
 	 * @param tcp_seq_num A 32-bit TCP sequence space number.
@@ -94,7 +94,7 @@ public:
 	 * @return \a tcp_seq_num expanded out in to a 64-bit sequence space,
 	 *         accounting for the number of times the 32-bit space overflowed.
 	 */
-	static uint64 ToFullSeqSpace(uint32 tcp_seq_num, uint32 wraparounds)
+	static uint64_t ToFullSeqSpace(uint32_t tcp_seq_num, uint32_t wraparounds)
 		{ return ToFullSeqSpace(wraparounds) + tcp_seq_num; }
 
 	/**
@@ -104,16 +104,16 @@ public:
 	 *         accounting for the number of times the 32-bit space overflowed
 	 *         and relative to the starting sequence number for this endpoint.
 	 */
-	uint64 ToRelativeSeqSpace(uint32 tcp_seq_num, uint32 wraparounds) const
+	uint64_t ToRelativeSeqSpace(uint32_t tcp_seq_num, uint32_t wraparounds) const
 		{
 		return ToFullSeqSpace(tcp_seq_num, wraparounds) - StartSeqI64();
 		}
 
-	void InitStartSeq(int64 seq) 	{ start_seq = seq; }
-	void InitLastSeq(uint32 seq) 	{ last_seq = seq; }
-	void InitAckSeq(uint32 seq) 	{ ack_seq = seq; }
+	void InitStartSeq(int64_t seq) 	{ start_seq = seq; }
+	void InitLastSeq(uint32_t seq) 	{ last_seq = seq; }
+	void InitAckSeq(uint32_t seq) 	{ ack_seq = seq; }
 
-	void UpdateLastSeq(uint32 seq)
+	void UpdateLastSeq(uint32_t seq)
 		{
 		if ( seq < last_seq )
 			++seq_wraps;
@@ -121,7 +121,7 @@ public:
 		last_seq = seq;
 		}
 
-	void UpdateAckSeq(uint32 seq)
+	void UpdateAckSeq(uint32_t seq)
 		{
 		if ( seq < ack_seq )
 			++ack_wraps;
@@ -134,8 +134,8 @@ public:
 	// an initial SYN exchange.
 	int NoDataAcked() const
 		{
-		uint64 ack = ToFullSeqSpace(ack_seq, ack_wraps);
-		uint64 start = static_cast<uint64>(StartSeqI64());
+		uint64_t ack = ToFullSeqSpace(ack_seq, ack_wraps);
+		uint64_t start = static_cast<uint64_t>(StartSeqI64());
 		return ack == start || ack == start + 1;
 		}
 
@@ -162,7 +162,7 @@ public:
 	//
 	// If we're not processing contents, then naturally each of
 	// these is empty.
-	void SizeBufferedData(uint64& waiting_on_hole, uint64& waiting_on_ack);
+	void SizeBufferedData(uint64_t& waiting_on_hole, uint64_t& waiting_on_ack);
 
 	int ValidChecksum(const struct tcphdr* tp, int len) const;
 
@@ -176,14 +176,14 @@ public:
 	void ZeroWindow();
 
 	// Called to inform endpoint that a gap occurred.
-	void Gap(uint64 seq, uint64 len);
+	void Gap(uint64_t seq, uint64_t len);
 
 	// Returns true if the data was used (and hence should be recorded
 	// in the save file), false otherwise.
-	int DataSent(double t, uint64 seq, int len, int caplen, const u_char* data,
+	int DataSent(double t, uint64_t seq, int len, int caplen, const u_char* data,
 			const IP_Hdr* ip, const struct tcphdr* tp);
 
-	void AckReceived(uint64 seq);
+	void AckReceived(uint64_t seq);
 
 	void SetContentsFile(BroFile* f);
 	BroFile* GetContentsFile() const	{ return contents_file; }
@@ -201,7 +201,7 @@ public:
 #define HIST_CORRUPT_PKT 0x80
 #define HIST_RXMIT 0x100
 #define HIST_WIN0 0x200
-	int CheckHistory(uint32 mask, char code);
+	int CheckHistory(uint32_t mask, char code);
 	void AddHistory(char code);
 
 	//### combine into a set of flags:
@@ -210,17 +210,17 @@ public:
 	TCP_Reassembler* contents_processor;
 	TCP_Analyzer* tcp_analyzer;
 	BroFile* contents_file;
-	uint32 checksum_base;
+	uint32_t checksum_base;
 
 	double start_time, last_time;
 	IPAddr src_addr; // the other endpoint
 	IPAddr dst_addr; // this endpoint
-	uint32 window; // current advertised window (*scaled*, not pre-scaling)
+	uint32_t window; // current advertised window (*scaled*, not pre-scaling)
 	int window_scale;  // from the TCP option
-	uint32 window_ack_seq; // at which ack_seq number did we record 'window'
-	uint32 window_seq; // at which sending sequence number did we record 'window'
-	uint64 contents_start_seq;	// relative seq # where contents file starts
-	uint64 FIN_seq;		// relative seq # to start_seq
+	uint32_t window_ack_seq; // at which ack_seq number did we record 'window'
+	uint32_t window_seq; // at which sending sequence number did we record 'window'
+	uint64_t contents_start_seq;	// relative seq # where contents file starts
+	uint64_t FIN_seq;		// relative seq # to start_seq
 	int SYN_cnt, FIN_cnt, RST_cnt;
 	int did_close;		// whether we've reported it closing
 	int is_orig;
@@ -228,22 +228,22 @@ public:
 	// Relative sequence numbers associated with last control packets.
 	// Used to determine whether ones seen again are interesting,
 	// for tracking history.
-	uint64 hist_last_SYN, hist_last_FIN, hist_last_RST;
+	uint64_t hist_last_SYN, hist_last_FIN, hist_last_RST;
 
 protected:
-	int64 start_seq;	// Initial TCP sequence number in host order.
+	int64_t start_seq;	// Initial TCP sequence number in host order.
 				// Signed 64-bit to detect initial sequence wrapping.
 				// Use StartSeq() accessor if need it in terms of
 				// an absolute TCP sequence number.
-	uint32 last_seq, ack_seq;	// in host order
-	uint32 seq_wraps, ack_wraps;	// Number of times 32-bit TCP sequence space
+	uint32_t last_seq, ack_seq;	// in host order
+	uint32_t seq_wraps, ack_wraps;	// Number of times 32-bit TCP sequence space
 					// has wrapped around (overflowed).
 
 	// Performance history accounting.
-	uint32 chk_cnt, chk_thresh;
-	uint32 rxmt_cnt, rxmt_thresh;
-	uint32 win0_cnt, win0_thresh;
-	uint32 gap_cnt, gap_thresh;
+	uint32_t chk_cnt, chk_thresh;
+	uint32_t rxmt_cnt, rxmt_thresh;
+	uint32_t win0_cnt, win0_thresh;
+	uint32_t gap_cnt, gap_thresh;
 };
 
 #define ENDIAN_UNKNOWN 0

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -74,8 +74,8 @@ void TCP_Reassembler::Done()
 		}
 	}
 
-void TCP_Reassembler::SizeBufferedData(uint64& waiting_on_hole,
-					uint64& waiting_on_ack) const
+void TCP_Reassembler::SizeBufferedData(uint64_t& waiting_on_hole,
+					uint64_t& waiting_on_ack) const
 	{
 	waiting_on_hole = waiting_on_ack = 0;
 	for ( DataBlock* b = blocks; b; b = b->next )
@@ -130,7 +130,7 @@ static inline bool report_gap(const TCP_Endpoint* a, const TCP_Endpoint* b)
 	         established_or_cleanly_closing(a, b) );
 	}
 
-void TCP_Reassembler::Gap(uint64 seq, uint64 len)
+void TCP_Reassembler::Gap(uint64_t seq, uint64_t len)
 	{
 	// Only report on content gaps for connections that
 	// are in a cleanly established or closing  state. In
@@ -159,7 +159,7 @@ void TCP_Reassembler::Gap(uint64 seq, uint64 len)
 	had_gap = true;
 	}
 
-void TCP_Reassembler::Undelivered(uint64 up_to_seq)
+void TCP_Reassembler::Undelivered(uint64_t up_to_seq)
 	{
 	TCP_Endpoint* endpoint = endp;
 	TCP_Endpoint* peer = endpoint->peer;
@@ -245,8 +245,8 @@ void TCP_Reassembler::Undelivered(uint64 up_to_seq)
 					// Block is beyond what we need to process at this point.
 					break;
 
-				uint64 gap_at_seq = last_reassem_seq;
-				uint64 gap_len = b->seq - last_reassem_seq;
+				uint64_t gap_at_seq = last_reassem_seq;
+				uint64_t gap_len = b->seq - last_reassem_seq;
 
 				Gap(gap_at_seq, gap_len);
 				last_reassem_seq += gap_len;
@@ -275,7 +275,7 @@ void TCP_Reassembler::Undelivered(uint64 up_to_seq)
 		last_reassem_seq = up_to_seq;	// we've done our best ...
 	}
 
-void TCP_Reassembler::MatchUndelivered(uint64 up_to_seq, bool use_last_upper)
+void TCP_Reassembler::MatchUndelivered(uint64_t up_to_seq, bool use_last_upper)
 	{
 	if ( ! blocks || ! rule_matcher )
 		return;
@@ -306,7 +306,7 @@ void TCP_Reassembler::MatchUndelivered(uint64 up_to_seq, bool use_last_upper)
 	ASSERT(b);
 	}
 
-void TCP_Reassembler::RecordToSeq(uint64 start_seq, uint64 stop_seq, BroFile* f)
+void TCP_Reassembler::RecordToSeq(uint64_t start_seq, uint64_t stop_seq, BroFile* f)
 	{
 	DataBlock* b = blocks;
 	// Skip over blocks up to the start seq.
@@ -316,7 +316,7 @@ void TCP_Reassembler::RecordToSeq(uint64 start_seq, uint64 stop_seq, BroFile* f)
 	if ( ! b )
 		return;
 
-	uint64 last_seq = start_seq;
+	uint64_t last_seq = start_seq;
 	while ( b && b->upper <= stop_seq )
 		{
 		if ( b->seq > last_seq )
@@ -350,7 +350,7 @@ void TCP_Reassembler::RecordBlock(DataBlock* b, BroFile* f)
 		}
 	}
 
-void TCP_Reassembler::RecordGap(uint64 start_seq, uint64 upper_seq, BroFile* f)
+void TCP_Reassembler::RecordGap(uint64_t start_seq, uint64_t upper_seq, BroFile* f)
 	{
 	if ( f->Write(fmt("\n<<gap %" PRIu64">>\n", upper_seq - start_seq)) )
 		return;
@@ -384,8 +384,8 @@ void TCP_Reassembler::BlockInserted(DataBlock* start_block)
 		{
 		if ( b->seq == last_reassem_seq )
 			{ // New stuff.
-			uint64 len = b->Size();
-			uint64 seq = last_reassem_seq;
+			uint64_t len = b->Size();
+			uint64_t seq = last_reassem_seq;
 			last_reassem_seq += len;
 
 			if ( record_contents_file )
@@ -404,7 +404,7 @@ void TCP_Reassembler::BlockInserted(DataBlock* start_block)
 		TrimToSeq(last_reassem_seq);
 
 	else if ( e->NoDataAcked() && tcp_max_initial_window &&
-		  e->Size() > static_cast<uint64>(tcp_max_initial_window) )
+		  e->Size() > static_cast<uint64_t>(tcp_max_initial_window) )
 		// We've sent quite a bit of data, yet none of it has
 		// been acked.  Presume that we're not seeing the peer's
 		// acks (perhaps due to filtering or split routing) and
@@ -418,7 +418,7 @@ void TCP_Reassembler::BlockInserted(DataBlock* start_block)
 	// TCP_Connection::NextPacket.
 	}
 
-void TCP_Reassembler::Overlap(const u_char* b1, const u_char* b2, uint64 n)
+void TCP_Reassembler::Overlap(const u_char* b1, const u_char* b2, uint64_t n)
 	{
 	if ( DEBUG_tcp_contents )
 		DEBUG_MSG("%.6f TCP contents overlap: %" PRIu64" IsOrig()=%d\n", network_time,  n, IsOrig());
@@ -441,7 +441,7 @@ void TCP_Reassembler::Overlap(const u_char* b1, const u_char* b2, uint64 n)
 		}
 	}
 
-void TCP_Reassembler::Deliver(uint64 seq, int len, const u_char* data)
+void TCP_Reassembler::Deliver(uint64_t seq, int len, const u_char* data)
 	{
 	if ( type == Direct )
 		dst_analyzer->NextStream(len, data, IsOrig());
@@ -449,11 +449,11 @@ void TCP_Reassembler::Deliver(uint64 seq, int len, const u_char* data)
 		dst_analyzer->ForwardStream(len, data, IsOrig());
 	}
 
-int TCP_Reassembler::DataSent(double t, uint64 seq, int len,
+int TCP_Reassembler::DataSent(double t, uint64_t seq, int len,
 				const u_char* data, TCP_Flags arg_flags, bool replaying)
 	{
-	uint64 ack = endp->ToRelativeSeqSpace(endp->AckSeq(), endp->AckWraps());
-	uint64 upper_seq = seq + len;
+	uint64_t ack = endp->ToRelativeSeqSpace(endp->AckSeq(), endp->AckWraps());
+	uint64_t upper_seq = seq + len;
 
 	if ( DEBUG_tcp_contents )
 		{
@@ -475,7 +475,7 @@ int TCP_Reassembler::DataSent(double t, uint64 seq, int len,
 		// packet held [a, a+b) and this packet holds [a, a+c) for c>b
 		// (which some TCP's will do when retransmitting).  Trim the
 		// packet to just the unacked data.
-		uint64 amount_acked = ack - seq;
+		uint64_t amount_acked = ack - seq;
 		seq += amount_acked;
 		data += amount_acked;
 		len -= amount_acked;
@@ -486,7 +486,7 @@ int TCP_Reassembler::DataSent(double t, uint64 seq, int len,
 	flags = TCP_Flags();
 
 	if ( Endpoint()->NoDataAcked() && tcp_max_above_hole_without_any_acks &&
-	     NumUndeliveredBytes() > static_cast<uint64>(tcp_max_above_hole_without_any_acks) )
+	     NumUndeliveredBytes() > static_cast<uint64_t>(tcp_max_above_hole_without_any_acks) )
 		{
 		tcp_analyzer->Weird("above_hole_data_without_any_acks");
 		ClearBlocks();
@@ -494,7 +494,7 @@ int TCP_Reassembler::DataSent(double t, uint64 seq, int len,
 		}
 
 	if ( tcp_excessive_data_without_further_acks &&
-	     size_of_all_blocks > static_cast<uint64>(tcp_excessive_data_without_further_acks) )
+	     size_of_all_blocks > static_cast<uint64_t>(tcp_excessive_data_without_further_acks) )
 		{
 		tcp_analyzer->Weird("excessive_data_without_further_acks");
 		ClearBlocks();
@@ -505,7 +505,7 @@ int TCP_Reassembler::DataSent(double t, uint64 seq, int len,
 	}
 
 
-void TCP_Reassembler::AckReceived(uint64 seq)
+void TCP_Reassembler::AckReceived(uint64_t seq)
 	{
 	if ( endp->FIN_cnt > 0 && seq >= endp->FIN_seq )
 		seq = endp->FIN_seq - 1;
@@ -519,7 +519,7 @@ void TCP_Reassembler::AckReceived(uint64 seq)
 			(endp->state == TCP_ENDPOINT_ESTABLISHED &&
 				endp->peer->state == TCP_ENDPOINT_ESTABLISHED ) );
 
-	uint64 num_missing = TrimToSeq(seq);
+	uint64_t num_missing = TrimToSeq(seq);
 
 	if ( test_active )
 		{
@@ -574,14 +574,14 @@ void TCP_Reassembler::CheckEOF()
 // Deliver, DeliverBlock is not virtual, and this allows us to insert
 // operations that apply to all connections using TCP_Contents.
 
-void TCP_Reassembler::DeliverBlock(uint64 seq, int len, const u_char* data)
+void TCP_Reassembler::DeliverBlock(uint64_t seq, int len, const u_char* data)
 	{
 	if ( seq + len <= seq_to_skip )
 		return;
 
 	if ( seq < seq_to_skip )
 		{
-		uint64 to_skip = seq_to_skip - seq;
+		uint64_t to_skip = seq_to_skip - seq;
 		len -= to_skip;
 		data += to_skip;
 		seq = seq_to_skip;
@@ -615,7 +615,7 @@ void TCP_Reassembler::DeliverBlock(uint64 seq, int len, const u_char* data)
 
 	}
 
-void TCP_Reassembler::SkipToSeq(uint64 seq)
+void TCP_Reassembler::SkipToSeq(uint64_t seq)
 	{
 	if ( seq > seq_to_skip )
 		{
@@ -632,8 +632,8 @@ int TCP_Reassembler::DataPending() const
 	if ( skip_deliveries )
 		return 0;
 
-	uint64 delivered_seq = Endpoint()->StartSeqI64() + DataSeq();
-	uint64 last_seq = TCP_Endpoint::ToFullSeqSpace(Endpoint()->LastSeq(),
+	uint64_t delivered_seq = Endpoint()->StartSeqI64() + DataSeq();
+	uint64_t last_seq = TCP_Endpoint::ToFullSeqSpace(Endpoint()->LastSeq(),
 	                                               Endpoint()->SeqWraps());
 
 	if ( last_seq < delivered_seq )

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.h
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.h
@@ -39,12 +39,12 @@ public:
 	//
 	// If we're not processing contents, then naturally each of
 	// these is empty.
-	void SizeBufferedData(uint64& waiting_on_hole, uint64& waiting_on_ack) const;
+	void SizeBufferedData(uint64_t& waiting_on_hole, uint64_t& waiting_on_ack) const;
 
 	// How much data is pending delivery since it's not yet reassembled.
 	// Includes the data due to holes (so this value is a bit different
 	// from waiting_on_hole above; and is computed in a different fashion).
-	uint64 NumUndeliveredBytes() const
+	uint64_t NumUndeliveredBytes() const
 		{
 		if ( last_block )
 			return last_block->upper - last_reassem_seq;
@@ -55,15 +55,15 @@ public:
 	void SetContentsFile(BroFile* f);
 	BroFile* GetContentsFile() const	{ return record_contents_file; }
 
-	void MatchUndelivered(uint64 up_to_seq, bool use_last_upper);
+	void MatchUndelivered(uint64_t up_to_seq, bool use_last_upper);
 
 	// Skip up to seq, as if there's a content gap.
 	// Can be used to skip HTTP data for performance considerations.
-	void SkipToSeq(uint64 seq);
+	void SkipToSeq(uint64_t seq);
 
-	int DataSent(double t, uint64 seq, int len, const u_char* data,
+	int DataSent(double t, uint64_t seq, int len, const u_char* data,
 		     analyzer::tcp::TCP_Flags flags, bool replaying=true);
-	void AckReceived(uint64 seq);
+	void AckReceived(uint64_t seq);
 
 	// Checks if we have delivered all contents that we can possibly
 	// deliver for this endpoint.  Calls TCP_Analyzer::EndpointEOF()
@@ -73,31 +73,31 @@ public:
 	int HasUndeliveredData() const	{ return HasBlocks(); }
 	int HadGap() const	{ return had_gap; }
 	int DataPending() const;
-	uint64 DataSeq() const		{ return LastReassemSeq(); }
+	uint64_t DataSeq() const		{ return LastReassemSeq(); }
 
-	void DeliverBlock(uint64 seq, int len, const u_char* data);
-	virtual void Deliver(uint64 seq, int len, const u_char* data);
+	void DeliverBlock(uint64_t seq, int len, const u_char* data);
+	virtual void Deliver(uint64_t seq, int len, const u_char* data);
 
 	TCP_Endpoint* Endpoint()		{ return endp; }
 	const TCP_Endpoint* Endpoint() const	{ return endp; }
 
 	int IsOrig() const	{ return endp->IsOrig(); }
 
-	bool IsSkippedContents(uint64 seq, int length) const
+	bool IsSkippedContents(uint64_t seq, int length) const
 		{ return seq + length <= seq_to_skip; }
 
 private:
 	TCP_Reassembler()	{ }
 
-	void Undelivered(uint64 up_to_seq) override;
-	void Gap(uint64 seq, uint64 len);
+	void Undelivered(uint64_t up_to_seq) override;
+	void Gap(uint64_t seq, uint64_t len);
 
-	void RecordToSeq(uint64 start_seq, uint64 stop_seq, BroFile* f);
+	void RecordToSeq(uint64_t start_seq, uint64_t stop_seq, BroFile* f);
 	void RecordBlock(DataBlock* b, BroFile* f);
-	void RecordGap(uint64 start_seq, uint64 upper_seq, BroFile* f);
+	void RecordGap(uint64_t start_seq, uint64_t upper_seq, BroFile* f);
 
 	void BlockInserted(DataBlock* b) override;
-	void Overlap(const u_char* b1, const u_char* b2, uint64 n) override;
+	void Overlap(const u_char* b1, const u_char* b2, uint64_t n) override;
 
 	TCP_Endpoint* endp;
 
@@ -106,7 +106,7 @@ private:
 	unsigned int did_EOF:1;
 	unsigned int skip_deliveries:1;
 
-	uint64 seq_to_skip;
+	uint64_t seq_to_skip;
 
 	bool in_delivery;
 	analyzer::tcp::TCP_Flags flags;

--- a/src/analyzer/protocol/teredo/Teredo.cc
+++ b/src/analyzer/protocol/teredo/Teredo.cc
@@ -24,7 +24,7 @@ bool TeredoEncapsulation::DoParse(const u_char* data, int& len,
 		return false;
 		}
 
-	uint16 tag = ntohs((*((const uint16*)data)));
+	uint16_t tag = ntohs((*((const uint16_t*)data)));
 
 	if ( tag == 0 )
 		{
@@ -59,9 +59,9 @@ bool TeredoEncapsulation::DoParse(const u_char* data, int& len,
 			return false;
 			}
 
-		uint8 id_len = data[2];
-		uint8 au_len = data[3];
-		uint16 tot_len = 4 + id_len + au_len + 8 + 1;
+		uint8_t id_len = data[2];
+		uint8_t au_len = data[3];
+		uint16_t tot_len = 4 + id_len + au_len + 8 + 1;
 
 		if ( len < tot_len )
 			{
@@ -112,10 +112,10 @@ RecordVal* TeredoEncapsulation::BuildVal(const IP_Hdr* inner) const
 	if ( auth )
 		{
 		RecordVal* teredo_auth = new RecordVal(teredo_auth_type);
-		uint8 id_len = *((uint8*)(auth + 2));
-		uint8 au_len = *((uint8*)(auth + 3));
-		uint64 nonce = ntohll(*((uint64*)(auth + 4 + id_len + au_len)));
-		uint8 conf = *((uint8*)(auth + 4 + id_len + au_len + 8));
+		uint8_t id_len = *((uint8_t*)(auth + 2));
+		uint8_t au_len = *((uint8_t*)(auth + 3));
+		uint64_t nonce = ntohll(*((uint64_t*)(auth + 4 + id_len + au_len)));
+		uint8_t conf = *((uint8_t*)(auth + 4 + id_len + au_len + 8));
 		teredo_auth->Assign(0, new StringVal(
 		    new BroString(auth + 4, id_len, 1)));
 		teredo_auth->Assign(1, new StringVal(
@@ -128,8 +128,8 @@ RecordVal* TeredoEncapsulation::BuildVal(const IP_Hdr* inner) const
 	if ( origin_indication )
 		{
 		RecordVal* teredo_origin = new RecordVal(teredo_origin_type);
-		uint16 port = ntohs(*((uint16*)(origin_indication + 2))) ^ 0xFFFF;
-		uint32 addr = ntohl(*((uint32*)(origin_indication + 4))) ^ 0xFFFFFFFF;
+		uint16_t port = ntohs(*((uint16_t*)(origin_indication + 2))) ^ 0xFFFF;
+		uint32_t addr = ntohl(*((uint32_t*)(origin_indication + 4))) ^ 0xFFFFFFFF;
 		teredo_origin->Assign(0, val_mgr->GetPort(port, TRANSPORT_UDP));
 		teredo_origin->Assign(1, new AddrVal(htonl(addr)));
 		teredo_hdr->Assign(1, teredo_origin);
@@ -140,7 +140,7 @@ RecordVal* TeredoEncapsulation::BuildVal(const IP_Hdr* inner) const
 	}
 
 void Teredo_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
-                                    uint64 seq, const IP_Hdr* ip, int caplen)
+                                    uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/teredo/Teredo.h
+++ b/src/analyzer/protocol/teredo/Teredo.h
@@ -19,7 +19,7 @@ public:
 	void Done() override;
 
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new Teredo_Analyzer(conn); }

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -42,7 +42,7 @@ void UDP_Analyzer::Done()
 	}
 
 void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
-					uint64 seq, const IP_Hdr* ip, int caplen)
+					uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	assert(ip);
 
@@ -105,14 +105,14 @@ void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 
 			if ( is_orig )
 				{
-				uint32 t = req_chk_thresh;
+				uint32_t t = req_chk_thresh;
 				if ( Conn()->ScaledHistoryEntry('C', req_chk_cnt,
 				                                req_chk_thresh) )
 					ChecksumEvent(is_orig, t);
 				}
 			else
 				{
-				uint32 t = rep_chk_thresh;
+				uint32_t t = rep_chk_thresh;
 				if ( Conn()->ScaledHistoryEntry('c', rep_chk_cnt,
 				                                rep_chk_thresh) )
 					ChecksumEvent(is_orig, t);
@@ -246,7 +246,7 @@ unsigned int UDP_Analyzer::MemoryAllocation() const
 	return Analyzer::MemoryAllocation() + padded_sizeof(*this) - 24;
 	}
 
-void UDP_Analyzer::ChecksumEvent(bool is_orig, uint32 threshold)
+void UDP_Analyzer::ChecksumEvent(bool is_orig, uint32_t threshold)
 	{
 	Conn()->HistoryThresholdEvent(udp_multiple_checksum_errors,
 	                              is_orig, threshold);
@@ -254,7 +254,7 @@ void UDP_Analyzer::ChecksumEvent(bool is_orig, uint32 threshold)
 
 bool UDP_Analyzer::ValidateChecksum(const IP_Hdr* ip, const udphdr* up, int len)
 	{
-	uint32 sum;
+	uint32_t sum;
 
 	if ( len % 2 == 1 )
 		// Add in pad byte.

--- a/src/analyzer/protocol/udp/UDP.h
+++ b/src/analyzer/protocol/udp/UDP.h
@@ -27,11 +27,11 @@ public:
 protected:
 	void Done() override;
 	void DeliverPacket(int len, const u_char* data, bool orig,
-					uint64 seq, const IP_Hdr* ip, int caplen) override;
+					uint64_t seq, const IP_Hdr* ip, int caplen) override;
 	bool IsReuse(double t, const u_char* pkt) override;
 	unsigned int MemoryAllocation() const override;
 
-	void ChecksumEvent(bool is_orig, uint32 threshold);
+	void ChecksumEvent(bool is_orig, uint32_t threshold);
 
 	// Returns true if the checksum is valid, false if not
 	static bool ValidateChecksum(const IP_Hdr* ip, const struct udphdr* up,
@@ -48,8 +48,8 @@ private:
 #define HIST_RESP_CORRUPT_PKT 0x8
 
 	// For tracking checksum history.
-	uint32 req_chk_cnt, req_chk_thresh;
-	uint32 rep_chk_cnt, rep_chk_thresh;
+	uint32_t req_chk_cnt, req_chk_thresh;
+	uint32_t rep_chk_cnt, rep_chk_thresh;
 };
 
 } } // namespace analyzer::* 

--- a/src/analyzer/protocol/vxlan/VXLAN.cc
+++ b/src/analyzer/protocol/vxlan/VXLAN.cc
@@ -17,7 +17,7 @@ void VXLAN_Analyzer::Done()
 	}
 
 void VXLAN_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
-                                   uint64 seq, const IP_Hdr* ip, int caplen)
+                                   uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 

--- a/src/analyzer/protocol/vxlan/VXLAN.h
+++ b/src/analyzer/protocol/vxlan/VXLAN.h
@@ -18,7 +18,7 @@ public:
 	void Done() override;
 
 	void DeliverPacket(int len, const u_char* data, bool orig,
-	                   uint64 seq, const IP_Hdr* ip, int caplen) override;
+	                   uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new VXLAN_Analyzer(conn); }

--- a/src/analyzer/protocol/xmpp/XMPP.cc
+++ b/src/analyzer/protocol/xmpp/XMPP.cc
@@ -64,7 +64,7 @@ void XMPP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		}
 	}
 
-void XMPP_Analyzer::Undelivered(uint64 seq, int len, bool orig)
+void XMPP_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	tcp::TCP_ApplicationAnalyzer::Undelivered(seq, len, orig);
 	had_gap = true;

--- a/src/analyzer/protocol/xmpp/XMPP.h
+++ b/src/analyzer/protocol/xmpp/XMPP.h
@@ -16,7 +16,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void Undelivered(uint64 seq, int len, bool orig) override;
+	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	// Overriden from tcp::TCP_ApplicationAnalyzer.
 	void EndpointEOF(bool is_orig) override;

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -322,7 +322,7 @@ void Manager::Peer(const string& addr, uint16_t port, double retry)
 		// Ensure that it doesn't get turned into zero.
 		retry = 1.0;
 
-	auto secs = broker::timeout::seconds(static_cast<uint64>(retry));
+	auto secs = broker::timeout::seconds(static_cast<uint64_t>(retry));
 	bstate->endpoint.peer_nosync(addr, port, secs);
 
 	auto counts_as_iosource = get_option("Broker::peer_counts_as_iosource")->AsBool();

--- a/src/broker/messaging.bif
+++ b/src/broker/messaging.bif
@@ -112,7 +112,7 @@ function Broker::publish%(topic: string, ...%): bool
 function Broker::__flush_logs%(%): count
 	%{
 	auto rval = broker_mgr->FlushLogBuffers();
-	return val_mgr->GetCount(static_cast<uint64>(rval));
+	return val_mgr->GetCount(static_cast<uint64_t>(rval));
 	%}
 
 function Broker::__publish_id%(topic: string, id: string%): bool

--- a/src/file_analysis/Analyzer.h
+++ b/src/file_analysis/Analyzer.h
@@ -13,7 +13,7 @@ namespace file_analysis {
 
 class File;
 
-typedef uint32 ID;
+typedef uint32_t ID;
 
 /**
  * Base class for analyzers that can be attached to file_analysis::File objects.
@@ -47,7 +47,7 @@ public:
 	 * @return true if the analyzer is still in a valid state to continue
 	 *         receiving data/events or false if it's essentially "done".
 	 */
-	virtual bool DeliverChunk(const u_char* data, uint64 len, uint64 offset)
+	virtual bool DeliverChunk(const u_char* data, uint64_t len, uint64_t offset)
 		{ return true; }
 
 	/**
@@ -57,7 +57,7 @@ public:
 	 * @return true if the analyzer is still in a valid state to continue
 	 *         receiving data/events or false if it's essentially "done".
 	 */
-	virtual bool DeliverStream(const u_char* data, uint64 len)
+	virtual bool DeliverStream(const u_char* data, uint64_t len)
 		{ return true; }
 
 	/**
@@ -78,7 +78,7 @@ public:
 	 * @return true if the analyzer is still in a valid state to continue
 	 *         receiving data/events or false if it's essentially "done".
 	 */
-	virtual bool Undelivered(uint64 offset, uint64 len)
+	virtual bool Undelivered(uint64_t offset, uint64_t len)
 		{ return true; }
 
 	/**

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -162,10 +162,10 @@ void File::RaiseFileOverNewConnection(Connection* conn, bool is_orig)
 		}
 	}
 
-uint64 File::LookupFieldDefaultCount(int idx) const
+uint64_t File::LookupFieldDefaultCount(int idx) const
 	{
 	Val* v = val->LookupWithDefault(idx);
-	uint64 rval = v->AsCount();
+	uint64_t rval = v->AsCount();
 	Unref(v);
 	return rval;
 	}
@@ -211,7 +211,7 @@ void File::SetTimeoutInterval(double interval)
 	val->Assign(timeout_interval_idx, new Val(interval, TYPE_INTERVAL));
 	}
 
-bool File::SetExtractionLimit(RecordVal* args, uint64 bytes)
+bool File::SetExtractionLimit(RecordVal* args, uint64_t bytes)
 	{
 	Analyzer* a = analyzers.Find(file_mgr->GetComponentTag("EXTRACT"), args);
 
@@ -227,13 +227,13 @@ bool File::SetExtractionLimit(RecordVal* args, uint64 bytes)
 	return true;
 	}
 
-void File::IncrementByteCount(uint64 size, int field_idx)
+void File::IncrementByteCount(uint64_t size, int field_idx)
 	{
-	uint64 old = LookupFieldDefaultCount(field_idx);
+	uint64_t old = LookupFieldDefaultCount(field_idx);
 	val->Assign(field_idx, val_mgr->GetCount(old + size));
 	}
 
-void File::SetTotalBytes(uint64 size)
+void File::SetTotalBytes(uint64_t size)
 	{
 	DBG_LOG(DBG_FILE_ANALYSIS, "[%s] Total bytes %" PRIu64, id.c_str(), size);
 	val->Assign(total_bytes_idx, val_mgr->GetCount(size));
@@ -287,7 +287,7 @@ void File::DisableReassembly()
 	file_reassembler = 0;
 	}
 
-void File::SetReassemblyBuffer(uint64 max)
+void File::SetReassemblyBuffer(uint64_t max)
 	{
 	reassembly_max_buffer = max;
 	}
@@ -332,7 +332,7 @@ void File::InferMetadata()
 
 	RuleMatcher::MIME_Matches matches;
 	const u_char* data = bof_buffer_val->AsString()->Bytes();
-	uint64 len = bof_buffer_val->AsString()->Len();
+	uint64_t len = bof_buffer_val->AsString()->Len();
 	len = min(len, LookupFieldDefaultCount(bof_buffer_size_idx));
 	file_mgr->DetectMIME(data, len, &matches);
 
@@ -350,12 +350,12 @@ void File::InferMetadata()
 	return;
 	}
 
-bool File::BufferBOF(const u_char* data, uint64 len)
+bool File::BufferBOF(const u_char* data, uint64_t len)
 	{
 	if ( bof_buffer.full )
 		return false;
 
-	uint64 desired_size = LookupFieldDefaultCount(bof_buffer_size_idx);
+	uint64_t desired_size = LookupFieldDefaultCount(bof_buffer_size_idx);
 
 	bof_buffer.chunks.push_back(new BroString(data, len, 0));
 	bof_buffer.size += len;
@@ -374,7 +374,7 @@ bool File::BufferBOF(const u_char* data, uint64 len)
 	return false;
 	}
 
-void File::DeliverStream(const u_char* data, uint64 len)
+void File::DeliverStream(const u_char* data, uint64_t len)
 	{
 	bool bof_was_full = bof_buffer.full;
 	// Buffer enough data for the BOF buffer
@@ -407,7 +407,7 @@ void File::DeliverStream(const u_char* data, uint64 len)
 				// as it will get delivered on its own.
 				num_bof_chunks_behind -= 1;
 
-			uint64 bytes_delivered = 0;
+			uint64_t bytes_delivered = 0;
 
 			// Catch this analyzer up with the BOF buffer.
 			for ( int i = 0; i < num_bof_chunks_behind; ++i )
@@ -444,7 +444,7 @@ void File::DeliverStream(const u_char* data, uint64 len)
 	IncrementByteCount(len, seen_bytes_idx);
 	}
 
-void File::DeliverChunk(const u_char* data, uint64 len, uint64 offset)
+void File::DeliverChunk(const u_char* data, uint64_t len, uint64_t offset)
 	{
 	// Potentially handle reassembly and deliver to the stream analyzers.
 	if ( file_reassembler )
@@ -452,8 +452,8 @@ void File::DeliverChunk(const u_char* data, uint64 len, uint64 offset)
 		if ( reassembly_max_buffer > 0 &&
 		     reassembly_max_buffer < file_reassembler->TotalSize() )
 			{
-			uint64 current_offset = stream_offset;
-			uint64 gap_bytes = file_reassembler->Flush();
+			uint64_t current_offset = stream_offset;
+			uint64_t gap_bytes = file_reassembler->Flush();
 			IncrementByteCount(gap_bytes, overflow_bytes_idx);
 
 			if ( FileEventAvailable(file_reassembly_overflow) )
@@ -520,14 +520,14 @@ void File::DoneWithAnalyzer(Analyzer* analyzer)
 	done_analyzers.push_back(analyzer);
 	}
 
-void File::DataIn(const u_char* data, uint64 len, uint64 offset)
+void File::DataIn(const u_char* data, uint64_t len, uint64_t offset)
 	{
 	analyzers.DrainModifications();
 	DeliverChunk(data, len, offset);
 	analyzers.DrainModifications();
 	}
 
-void File::DataIn(const u_char* data, uint64 len)
+void File::DataIn(const u_char* data, uint64_t len)
 	{
 	analyzers.DrainModifications();
 	DeliverChunk(data, len, stream_offset);
@@ -573,7 +573,7 @@ void File::EndOfFile()
 	analyzers.DrainModifications();
 	}
 
-void File::Gap(uint64 offset, uint64 len)
+void File::Gap(uint64_t offset, uint64_t len)
 	{
 	DBG_LOG(DBG_FILE_ANALYSIS, "[%s] Gap of size %" PRIu64 " at offset %" PRIu64,
 		id.c_str(), len, offset);
@@ -649,7 +649,7 @@ void File::FileEvent(EventHandlerPtr h, val_list vl)
 		}
 	}
 
-bool File::PermitWeird(const char* name, uint64 threshold, uint64 rate,
+bool File::PermitWeird(const char* name, uint64_t threshold, uint64_t rate,
                        double duration)
 	{
 	return ::PermitWeird(weird_state, name, threshold, rate, duration);

--- a/src/file_analysis/File.h
+++ b/src/file_analysis/File.h
@@ -65,7 +65,7 @@ public:
 	 * @param bytes new limit.
 	 * @return false if no extraction analyzer is active, else true.
 	 */
-	bool SetExtractionLimit(RecordVal* args, uint64 bytes);
+	bool SetExtractionLimit(RecordVal* args, uint64_t bytes);
 
 	/**
 	 * @return value of the "id" field from #val record.
@@ -86,7 +86,7 @@ public:
 	 * Set "total_bytes" field of #val record to \a size.
 	 * @param size the new value of the "total_bytes" field.
 	 */
-	void SetTotalBytes(uint64 size);
+	void SetTotalBytes(uint64_t size);
 
 	/**
 	 * @return true if file analysis is complete for the file, else false.
@@ -131,14 +131,14 @@ public:
 	 * @param len number of bytes in the data chunk.
 	 * @param offset number of bytes from start of file at which chunk occurs.
 	 */
-	void DataIn(const u_char* data, uint64 len, uint64 offset);
+	void DataIn(const u_char* data, uint64_t len, uint64_t offset);
 
 	/**
 	 * Pass in sequential data and deliver to attached analyzers.
 	 * @param data pointer to start of a chunk of file data.
 	 * @param len number of bytes in the data chunk.
 	 */
-	void DataIn(const u_char* data, uint64 len);
+	void DataIn(const u_char* data, uint64_t len);
 
 	/**
 	 * Inform attached analyzers about end of file being seen.
@@ -150,7 +150,7 @@ public:
 	 * @param offset number of bytes in to file at which missing chunk starts.
 	 * @param len length in bytes of the missing chunk of file data.
 	 */
-	void Gap(uint64 offset, uint64 len);
+	void Gap(uint64_t offset, uint64_t len);
 
 	/**
 	 * @param h pointer to an event handler.
@@ -203,7 +203,7 @@ public:
 	 * Whether to permit a weird to carry on through the full reporter/weird
 	 * framework.
 	 */
-	bool PermitWeird(const char* name, uint64 threshold, uint64 rate,
+	bool PermitWeird(const char* name, uint64_t threshold, uint64_t rate,
 	                 double duration);
 
 protected:
@@ -243,7 +243,7 @@ protected:
 	 * @param size number of bytes by which to increment.
 	 * @param field_idx the index of the field in \c fa_file to increment.
 	 */
-	void IncrementByteCount(uint64 size, int field_idx);
+	void IncrementByteCount(uint64_t size, int field_idx);
 
 	/**
 	 * Wrapper to RecordVal::LookupWithDefault for the field in #val at index
@@ -251,7 +251,7 @@ protected:
 	 * @param idx the index of a field of type "count" in \c fa_file.
 	 * @return the value of the field, which may be it &default.
 	 */
-	uint64 LookupFieldDefaultCount(int idx) const;
+	uint64_t LookupFieldDefaultCount(int idx) const;
 
 	/**
 	 * Wrapper to RecordVal::LookupWithDefault for the field in #val at index
@@ -267,7 +267,7 @@ protected:
 	 * @param len number of bytes in the data chunk.
 	 * @return true if buffering is still required, else false
 	 */
-	bool BufferBOF(const u_char* data, uint64 len);
+	bool BufferBOF(const u_char* data, uint64_t len);
 
 	/**
 	 * Does metadata inference (e.g. mime type detection via file
@@ -291,17 +291,17 @@ protected:
 	/**
 	 * Set a maximum allowed bytes of memory for file reassembly for this file.
 	 */
-	void SetReassemblyBuffer(uint64 max);
+	void SetReassemblyBuffer(uint64_t max);
 
 	/**
 	 * Perform stream-wise delivery for analyzers that need it.
 	 */
-	void DeliverStream(const u_char* data, uint64 len);
+	void DeliverStream(const u_char* data, uint64_t len);
 
 	/** 
 	 * Perform chunk-wise delivery for analyzers that need it.
 	 */
-	void DeliverChunk(const u_char* data, uint64 len, uint64 offset);
+	void DeliverChunk(const u_char* data, uint64_t len, uint64_t offset);
 
 	/**
 	 * Lookup a record field index/offset by name.
@@ -320,8 +320,8 @@ protected:
 	string id;                 /**< A pretty hash that likely identifies file */
 	RecordVal* val;            /**< \c fa_file from script layer. */
 	FileReassembler* file_reassembler; /**< A reassembler for the file if it's needed. */
-	uint64 stream_offset;      /**< The offset of the file which has been forwarded. */
-	uint64 reassembly_max_buffer;      /**< Maximum allowed buffer for reassembly. */
+	uint64_t stream_offset;      /**< The offset of the file which has been forwarded. */
+	uint64_t reassembly_max_buffer;      /**< Maximum allowed buffer for reassembly. */
 	bool did_metadata_inference;        /**< Whether the metadata inference has already been attempted. */
 	bool reassembly_enabled;           /**< Whether file stream reassembly is needed. */
 	bool postpone_timeout;     /**< Whether postponing timeout is requested. */
@@ -335,7 +335,7 @@ protected:
 			{ for ( size_t i = 0; i < chunks.size(); ++i ) delete chunks[i]; }
 
 		bool full;
-		uint64 size;
+		uint64_t size;
 		BroString::CVec chunks;
 	} bof_buffer;              /**< Beginning of file buffer. */
 

--- a/src/file_analysis/FileReassembler.cc
+++ b/src/file_analysis/FileReassembler.cc
@@ -7,7 +7,7 @@ namespace file_analysis {
 
 class File;
 
-FileReassembler::FileReassembler(File *f, uint64 starting_offset)
+FileReassembler::FileReassembler(File *f, uint64_t starting_offset)
 	: Reassembler(starting_offset, REASSEM_FILE), the_file(f), flushing(false)
 	{
 	}
@@ -21,7 +21,7 @@ FileReassembler::~FileReassembler()
 	{
 	}
 
-uint64 FileReassembler::Flush()
+uint64_t FileReassembler::Flush()
 	{
 	if ( flushing )
 		return 0;
@@ -30,7 +30,7 @@ uint64 FileReassembler::Flush()
 		{
 		// This is expected to call back into FileReassembler::Undelivered().
 		flushing = true;
-		uint64 rval = TrimToSeq(last_block->upper);
+		uint64_t rval = TrimToSeq(last_block->upper);
 		flushing = false;
 		return rval;
 		}
@@ -38,13 +38,13 @@ uint64 FileReassembler::Flush()
 	return 0;
 	}
 
-uint64 FileReassembler::FlushTo(uint64 sequence)
+uint64_t FileReassembler::FlushTo(uint64_t sequence)
 	{
 	if ( flushing )
 		return 0;
 
 	flushing = true;
-	uint64 rval = TrimToSeq(sequence);
+	uint64_t rval = TrimToSeq(sequence);
 	flushing = false;
 	last_reassem_seq = sequence;
 	return rval;
@@ -61,7 +61,7 @@ void FileReassembler::BlockInserted(DataBlock* start_block)
 		{
 		if ( b->seq == last_reassem_seq )
 			{ // New stuff.
-			uint64 len = b->Size();
+			uint64_t len = b->Size();
 			last_reassem_seq += len;
 			the_file->DeliverStream(b->block, len);
 			}
@@ -71,7 +71,7 @@ void FileReassembler::BlockInserted(DataBlock* start_block)
 	TrimToSeq(last_reassem_seq);
 	}
 
-void FileReassembler::Undelivered(uint64 up_to_seq)
+void FileReassembler::Undelivered(uint64_t up_to_seq)
 	{
 	// If we have blocks that begin below up_to_seq, deliver them.
 	DataBlock* b = blocks;
@@ -89,8 +89,8 @@ void FileReassembler::Undelivered(uint64 up_to_seq)
 			// Block is beyond what we need to process at this point.
 			break;
 
-		uint64 gap_at_seq = last_reassem_seq;
-		uint64 gap_len = b->seq - last_reassem_seq;
+		uint64_t gap_at_seq = last_reassem_seq;
+		uint64_t gap_len = b->seq - last_reassem_seq;
 		the_file->Gap(gap_at_seq, gap_len);
 		last_reassem_seq += gap_len;
 		BlockInserted(b);
@@ -106,7 +106,7 @@ void FileReassembler::Undelivered(uint64 up_to_seq)
 		}
 	}
 
-void FileReassembler::Overlap(const u_char* b1, const u_char* b2, uint64 n)
+void FileReassembler::Overlap(const u_char* b1, const u_char* b2, uint64_t n)
 	{
 	// Not doing anything here yet.
 	}

--- a/src/file_analysis/FileReassembler.h
+++ b/src/file_analysis/FileReassembler.h
@@ -14,7 +14,7 @@ class File;
 class FileReassembler : public Reassembler {
 public:
 
-	FileReassembler(File* f, uint64 starting_offset);
+	FileReassembler(File* f, uint64_t starting_offset);
 	~FileReassembler() override;
 
 	void Done();
@@ -29,7 +29,7 @@ public:
 	 * appropriate.
 	 * @return the number of new bytes now detected as gaps in the file.
 	 */
-	uint64 Flush();
+	uint64_t Flush();
 
 	/**
 	 * Discards all contents of the reassembly buffer up to a given sequence
@@ -38,7 +38,7 @@ public:
 	 * @param sequence the sequence number to flush until.
 	 * @return the number of new bytes now detected as gaps in the file.
 	 */
-	uint64 FlushTo(uint64 sequence);
+	uint64_t FlushTo(uint64_t sequence);
 
 	/**
 	 * @return whether the reassembler is currently is the process of flushing
@@ -50,9 +50,9 @@ public:
 protected:
 	FileReassembler();
 
-	void Undelivered(uint64 up_to_seq) override;
+	void Undelivered(uint64_t up_to_seq) override;
 	void BlockInserted(DataBlock* b) override;
-	void Overlap(const u_char* b1, const u_char* b2, uint64 n) override;
+	void Overlap(const u_char* b1, const u_char* b2, uint64_t n) override;
 
 	File* the_file;
 	bool flushing;

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -91,7 +91,7 @@ string Manager::HashHandle(const string& handle) const
 	if ( salt.empty() )
 		salt = BifConst::Files::salt->CheckString();
 
-	uint64 hash[2];
+	uint64_t hash[2];
 	string msg(handle + salt);
 
 	internal_md5(reinterpret_cast<const u_char*>(msg.data()), msg.size(),
@@ -118,7 +118,7 @@ void Manager::SetHandle(const string& handle)
 	current_file_id = HashHandle(handle);
 	}
 
-string Manager::DataIn(const u_char* data, uint64 len, uint64 offset,
+string Manager::DataIn(const u_char* data, uint64_t len, uint64_t offset,
                        analyzer::Tag tag, Connection* conn, bool is_orig,
                        const string& precomputed_id, const string& mime_type)
 	{
@@ -148,7 +148,7 @@ string Manager::DataIn(const u_char* data, uint64 len, uint64 offset,
 	return id;
 	}
 
-string Manager::DataIn(const u_char* data, uint64 len, analyzer::Tag tag,
+string Manager::DataIn(const u_char* data, uint64_t len, analyzer::Tag tag,
 		       Connection* conn, bool is_orig, const string& precomputed_id,
 		       const string& mime_type)
 	{
@@ -174,7 +174,7 @@ string Manager::DataIn(const u_char* data, uint64 len, analyzer::Tag tag,
 	return id;
 	}
 
-void Manager::DataIn(const u_char* data, uint64 len, const string& file_id,
+void Manager::DataIn(const u_char* data, uint64_t len, const string& file_id,
                      const string& source)
 	{
 	File* file = GetFile(file_id, 0, analyzer::Tag::Error, false, false,
@@ -206,7 +206,7 @@ void Manager::EndOfFile(const string& file_id)
 	RemoveFile(file_id);
 	}
 
-string Manager::Gap(uint64 offset, uint64 len, analyzer::Tag tag,
+string Manager::Gap(uint64_t offset, uint64_t len, analyzer::Tag tag,
                     Connection* conn, bool is_orig, const string& precomputed_id)
 	{
 	string id = precomputed_id.empty() ? GetFileID(tag, conn, is_orig) : precomputed_id;
@@ -219,7 +219,7 @@ string Manager::Gap(uint64 offset, uint64 len, analyzer::Tag tag,
 	return id;
 	}
 
-string Manager::SetSize(uint64 size, analyzer::Tag tag, Connection* conn,
+string Manager::SetSize(uint64_t size, analyzer::Tag tag, Connection* conn,
                         bool is_orig, const string& precomputed_id)
 	{
 	string id = precomputed_id.empty() ? GetFileID(tag, conn, is_orig) : precomputed_id;
@@ -275,7 +275,7 @@ bool Manager::DisableReassembly(const string& file_id)
 	return true;
 	}
 
-bool Manager::SetReassemblyBuffer(const string& file_id, uint64 max)
+bool Manager::SetReassemblyBuffer(const string& file_id, uint64_t max)
 	{
 	File* file = LookupFile(file_id);
 
@@ -287,7 +287,7 @@ bool Manager::SetReassemblyBuffer(const string& file_id, uint64 max)
 	}
 
 bool Manager::SetExtractionLimit(const string& file_id, RecordVal* args,
-                                 uint64 n) const
+                                 uint64_t n) const
 	{
 	File* file = LookupFile(file_id);
 
@@ -502,7 +502,7 @@ Analyzer* Manager::InstantiateAnalyzer(Tag tag, RecordVal* args, File* f) const
 	return a;
 	}
 
-RuleMatcher::MIME_Matches* Manager::DetectMIME(const u_char* data, uint64 len,
+RuleMatcher::MIME_Matches* Manager::DetectMIME(const u_char* data, uint64_t len,
         RuleMatcher::MIME_Matches* rval) const
 	{
 	if ( ! magic_state )
@@ -513,7 +513,7 @@ RuleMatcher::MIME_Matches* Manager::DetectMIME(const u_char* data, uint64 len,
 	return rval;
 	}
 
-string Manager::DetectMIME(const u_char* data, uint64 len) const
+string Manager::DetectMIME(const u_char* data, uint64_t len) const
 	{
 	RuleMatcher::MIME_Matches matches;
 	DetectMIME(data, len, &matches);

--- a/src/file_analysis/Manager.h
+++ b/src/file_analysis/Manager.h
@@ -105,7 +105,7 @@ public:
 	 *         the \c get_file_handle script-layer event).  An empty string
 	 *         indicates the associate file is not going to be analyzed further.
 	 */
-	std::string DataIn(const u_char* data, uint64 len, uint64 offset,
+	std::string DataIn(const u_char* data, uint64_t len, uint64_t offset,
 	                   analyzer::Tag tag, Connection* conn, bool is_orig,
 	                   const std::string& precomputed_file_id = "",
 	                   const std::string& mime_type = "");
@@ -132,7 +132,7 @@ public:
 	 *         the \c get_file_handle script-layer event).  An empty string
 	 *         indicates the associated file is not going to be analyzed further.
 	 */
-	std::string DataIn(const u_char* data, uint64 len, analyzer::Tag tag,
+	std::string DataIn(const u_char* data, uint64_t len, analyzer::Tag tag,
 	                   Connection* conn, bool is_orig,
 	                   const std::string& precomputed_file_id = "",
 	                   const std::string& mime_type = "");
@@ -146,7 +146,7 @@ public:
 	 *        in human-readable form where the file input is coming from (e.g.
 	 *        a local file path).
 	 */
-	void DataIn(const u_char* data, uint64 len, const string& file_id,
+	void DataIn(const u_char* data, uint64_t len, const string& file_id,
 	            const string& source);
 
 	/**
@@ -187,7 +187,7 @@ public:
 	 *         the \c get_file_handle script-layer event).  An empty string
 	 *         indicates the associate file is not going to be analyzed further.
 	 */
-	std::string Gap(uint64 offset, uint64 len, analyzer::Tag tag,
+	std::string Gap(uint64_t offset, uint64_t len, analyzer::Tag tag,
 	                Connection* conn, bool is_orig,
 	                const std::string& precomputed_file_id = "");
 
@@ -206,7 +206,7 @@ public:
 	 *         the \c get_file_handle script-layer event).  An empty string
 	 *         indicates the associate file is not going to be analyzed further.
 	 */
-	std::string SetSize(uint64 size, analyzer::Tag tag, Connection* conn,
+	std::string SetSize(uint64_t size, analyzer::Tag tag, Connection* conn,
 	                    bool is_orig, const std::string& precomputed_file_id = "");
 
 	/**
@@ -240,7 +240,7 @@ public:
 	/**
 	 * Set the reassembly for a file in bytes.
 	 */
-	bool SetReassemblyBuffer(const string& file_id, uint64 max);
+	bool SetReassemblyBuffer(const string& file_id, uint64_t max);
 
 	/**
 	 * Sets a limit on the maximum size allowed for extracting the file
@@ -253,7 +253,7 @@ public:
 	 *         else true.
 	 */
 	bool SetExtractionLimit(const string& file_id, RecordVal* args,
-	                        uint64 n) const;
+	                        uint64_t n) const;
 
 	/**
 	 * Try to retrieve a file that's being analyzed, using its identifier/hash.
@@ -312,7 +312,7 @@ public:
 	 * @return Set of all matching file magic signatures, which may be
 	 *         an object allocated by the method if \a rval is a null pointer.
 	 */
-	RuleMatcher::MIME_Matches* DetectMIME(const u_char* data, uint64 len,
+	RuleMatcher::MIME_Matches* DetectMIME(const u_char* data, uint64_t len,
 					      RuleMatcher::MIME_Matches* rval) const;
 
 	/**
@@ -322,15 +322,15 @@ public:
 	 * @returns The MIME type string of the strongest file magic signature
 	 *          match, or an empty string if nothing matched.
 	 */
-	std::string DetectMIME(const u_char* data, uint64 len) const;
+	std::string DetectMIME(const u_char* data, uint64_t len) const;
 
-	uint64 CurrentFiles()
+	uint64_t CurrentFiles()
 		{ return id_map.Length(); }
 
-	uint64 MaxFiles()
+	uint64_t MaxFiles()
 		{ return id_map.MaxLength(); }
 
-	uint64 CumulativeFiles()
+	uint64_t CumulativeFiles()
 		{ return id_map.NumCumulativeInserts(); }
 
 protected:

--- a/src/file_analysis/analyzer/data_event/DataEvent.cc
+++ b/src/file_analysis/analyzer/data_event/DataEvent.cc
@@ -37,7 +37,7 @@ file_analysis::Analyzer* DataEvent::Instantiate(RecordVal* args, File* file)
 	return new DataEvent(args, file, chunk, stream);
 	}
 
-bool DataEvent::DeliverChunk(const u_char* data, uint64 len, uint64 offset)
+bool DataEvent::DeliverChunk(const u_char* data, uint64_t len, uint64_t offset)
 	{
 	if ( ! chunk_event ) return true;
 
@@ -50,7 +50,7 @@ bool DataEvent::DeliverChunk(const u_char* data, uint64 len, uint64 offset)
 	return true;
 	}
 
-bool DataEvent::DeliverStream(const u_char* data, uint64 len)
+bool DataEvent::DeliverStream(const u_char* data, uint64_t len)
 	{
 	if ( ! stream_event ) return true;
 

--- a/src/file_analysis/analyzer/data_event/DataEvent.h
+++ b/src/file_analysis/analyzer/data_event/DataEvent.h
@@ -25,7 +25,7 @@ public:
 	 * @param offset number of bytes from start of file at which chunk occurs.
 	 * @return always true
 	 */
-	bool DeliverChunk(const u_char* data, uint64 len, uint64 offset) override;
+	bool DeliverChunk(const u_char* data, uint64_t len, uint64_t offset) override;
 
 	/**
 	 * Generates the event, if any, specified by the "stream_event" field of
@@ -34,7 +34,7 @@ public:
 	 * @param len number of bytes in the data chunk.
 	 * @return always true
 	 */
-	bool DeliverStream(const u_char* data, uint64 len) override;
+	bool DeliverStream(const u_char* data, uint64_t len) override;
 
 	/**
 	 * Create a new instance of a DataEvent analyzer.

--- a/src/file_analysis/analyzer/entropy/Entropy.cc
+++ b/src/file_analysis/analyzer/entropy/Entropy.cc
@@ -27,7 +27,7 @@ file_analysis::Analyzer* Entropy::Instantiate(RecordVal* args, File* file)
 	return new Entropy(args, file);
 	}
 
-bool Entropy::DeliverStream(const u_char* data, uint64 len)
+bool Entropy::DeliverStream(const u_char* data, uint64_t len)
 	{
 	if ( ! fed )
 		fed = len > 0;
@@ -42,7 +42,7 @@ bool Entropy::EndOfFile()
 	return false;
 	}
 
-bool Entropy::Undelivered(uint64 offset, uint64 len)
+bool Entropy::Undelivered(uint64_t offset, uint64_t len)
 	{
 	return false;
 	}

--- a/src/file_analysis/analyzer/entropy/Entropy.h
+++ b/src/file_analysis/analyzer/entropy/Entropy.h
@@ -40,7 +40,7 @@ public:
 	 * @param len number of bytes in the data chunk.
 	 * @return false if the digest is in an invalid state, else true.
 	 */
-	bool DeliverStream(const u_char* data, uint64 len) override;
+	bool DeliverStream(const u_char* data, uint64_t len) override;
 
 	/**
 	 * Finalizes the hash and raises a "file_entropy_test" event.
@@ -55,7 +55,7 @@ public:
 	 * @param len number of missing bytes.
 	 * @return always false so analyzer will detach from file.
 	 */
-	bool Undelivered(uint64 offset, uint64 len) override;
+	bool Undelivered(uint64_t offset, uint64_t len) override;
 
 protected:
 

--- a/src/file_analysis/analyzer/extract/Extract.cc
+++ b/src/file_analysis/analyzer/extract/Extract.cc
@@ -11,7 +11,7 @@
 using namespace file_analysis;
 
 Extract::Extract(RecordVal* args, File* file, const string& arg_filename,
-                 uint64 arg_limit)
+                 uint64_t arg_limit)
     : file_analysis::Analyzer(file_mgr->GetComponentTag("EXTRACT"), args, file),
       filename(arg_filename), limit(arg_limit), depth(0)
 	{
@@ -54,7 +54,7 @@ file_analysis::Analyzer* Extract::Instantiate(RecordVal* args, File* file)
 	                   limit->AsCount());
 	}
 
-static bool check_limit_exceeded(uint64 lim, uint64 depth, uint64 len, uint64* n)
+static bool check_limit_exceeded(uint64_t lim, uint64_t depth, uint64_t len, uint64_t* n)
 	{
 	if ( lim == 0 )
 		{
@@ -80,12 +80,12 @@ static bool check_limit_exceeded(uint64 lim, uint64 depth, uint64 len, uint64* n
 	return false;
 	}
 
-bool Extract::DeliverStream(const u_char* data, uint64 len)
+bool Extract::DeliverStream(const u_char* data, uint64_t len)
 	{
 	if ( ! fd )
 		return false;
 
-	uint64 towrite = 0;
+	uint64_t towrite = 0;
 	bool limit_exceeded = check_limit_exceeded(limit, depth, len, &towrite);
 
 	if ( limit_exceeded && file_extraction_limit )
@@ -111,7 +111,7 @@ bool Extract::DeliverStream(const u_char* data, uint64 len)
 	return ( ! limit_exceeded );
 	}
 
-bool Extract::Undelivered(uint64 offset, uint64 len)
+bool Extract::Undelivered(uint64_t offset, uint64_t len)
 	{
 	if ( depth == offset )
 		{

--- a/src/file_analysis/analyzer/extract/Extract.h
+++ b/src/file_analysis/analyzer/extract/Extract.h
@@ -31,7 +31,7 @@ public:
 	 * @return false if there was no extraction file open and the data couldn't
 	 *         be written, else true.
 	 */
-	bool DeliverStream(const u_char* data, uint64 len) override;
+	bool DeliverStream(const u_char* data, uint64_t len) override;
 
 	/**
 	 * Report undelivered bytes.
@@ -39,7 +39,7 @@ public:
 	 * @param len number of bytes undelivered.
 	 * @return true
 	 */
-	bool Undelivered(uint64 offset, uint64 len) override;
+	bool Undelivered(uint64_t offset, uint64_t len) override;
 
 	/**
 	 * Create a new instance of an Extract analyzer.
@@ -55,7 +55,7 @@ public:
 	 * "no limit".
 	 * @param bytes number of bytes allowed to be extracted
 	 */
-	void SetLimit(uint64 bytes) { limit = bytes; }
+	void SetLimit(uint64_t bytes) { limit = bytes; }
 
 protected:
 
@@ -68,13 +68,13 @@ protected:
 	 * @param arg_limit the maximum allowed file size.
 	 */
 	Extract(RecordVal* args, File* file, const string& arg_filename,
-	        uint64 arg_limit);
+	        uint64_t arg_limit);
 
 private:
 	string filename;
 	int fd;
-	uint64 limit;
-	uint64 depth;
+	uint64_t limit;
+	uint64_t depth;
 };
 
 } // namespace file_analysis

--- a/src/file_analysis/analyzer/hash/Hash.cc
+++ b/src/file_analysis/analyzer/hash/Hash.cc
@@ -20,7 +20,7 @@ Hash::~Hash()
 	Unref(hash);
 	}
 
-bool Hash::DeliverStream(const u_char* data, uint64 len)
+bool Hash::DeliverStream(const u_char* data, uint64_t len)
 	{
 	if ( ! hash->IsValid() )
 		return false;
@@ -38,7 +38,7 @@ bool Hash::EndOfFile()
 	return false;
 	}
 
-bool Hash::Undelivered(uint64 offset, uint64 len)
+bool Hash::Undelivered(uint64_t offset, uint64_t len)
 	{
 	return false;
 	}

--- a/src/file_analysis/analyzer/hash/Hash.h
+++ b/src/file_analysis/analyzer/hash/Hash.h
@@ -31,7 +31,7 @@ public:
 	 * @param len number of bytes in the data chunk.
 	 * @return false if the digest is in an invalid state, else true.
 	 */
-	bool DeliverStream(const u_char* data, uint64 len) override;
+	bool DeliverStream(const u_char* data, uint64_t len) override;
 
 	/**
 	 * Finalizes the hash and raises a "file_hash" event.
@@ -46,7 +46,7 @@ public:
 	 * @param len number of missing bytes.
 	 * @return always false so analyzer will detach from file.
 	 */
-	bool Undelivered(uint64 offset, uint64 len) override;
+	bool Undelivered(uint64_t offset, uint64_t len) override;
 
 protected:
 

--- a/src/file_analysis/analyzer/pe/PE.cc
+++ b/src/file_analysis/analyzer/pe/PE.cc
@@ -17,7 +17,7 @@ PE::~PE()
 	delete conn;
 	}
 
-bool PE::DeliverStream(const u_char* data, uint64 len)
+bool PE::DeliverStream(const u_char* data, uint64_t len)
 	{
 	if ( conn->is_done() )
 		return false;

--- a/src/file_analysis/analyzer/pe/PE.h
+++ b/src/file_analysis/analyzer/pe/PE.h
@@ -19,7 +19,7 @@ public:
 	static file_analysis::Analyzer* Instantiate(RecordVal* args, File* file)
 		{ return new PE(args, file); }
 
-	virtual bool DeliverStream(const u_char* data, uint64 len);
+	virtual bool DeliverStream(const u_char* data, uint64_t len);
 
 	virtual bool EndOfFile();
 

--- a/src/file_analysis/analyzer/unified2/Unified2.cc
+++ b/src/file_analysis/analyzer/unified2/Unified2.cc
@@ -21,7 +21,7 @@ file_analysis::Analyzer* Unified2::Instantiate(RecordVal* args, File* file)
 	return new Unified2(args, file);
 	}
 
-bool Unified2::DeliverStream(const u_char* data, uint64 len)
+bool Unified2::DeliverStream(const u_char* data, uint64_t len)
 	{
 	try
 		{

--- a/src/file_analysis/analyzer/unified2/Unified2.h
+++ b/src/file_analysis/analyzer/unified2/Unified2.h
@@ -19,7 +19,7 @@ class Unified2 : public file_analysis::Analyzer {
 public:
 	~Unified2() override;
 
-	bool DeliverStream(const u_char* data, uint64 len) override;
+	bool DeliverStream(const u_char* data, uint64_t len) override;
 
 	static file_analysis::Analyzer* Instantiate(RecordVal* args, File* file);
 

--- a/src/file_analysis/analyzer/x509/OCSP.cc
+++ b/src/file_analysis/analyzer/x509/OCSP.cc
@@ -135,13 +135,13 @@ file_analysis::OCSP::OCSP(RecordVal* args, file_analysis::File* file, bool arg_r
 	{
 	}
 
-bool file_analysis::OCSP::DeliverStream(const u_char* data, uint64 len)
+bool file_analysis::OCSP::DeliverStream(const u_char* data, uint64_t len)
 	{
 	ocsp_data.append(reinterpret_cast<const char*>(data), len);
 	return true;
 	}
 
-bool file_analysis::OCSP::Undelivered(uint64 offset, uint64 len)
+bool file_analysis::OCSP::Undelivered(uint64_t offset, uint64_t len)
 	{
 	return false;
 	}
@@ -365,7 +365,7 @@ static Val* parse_basic_resp_data_version(OCSP_BASICRESP* basic_resp)
 	return val_mgr->GetCount(asn1_int);
 	}
 
-static uint64 parse_request_version(OCSP_REQUEST* req)
+static uint64_t parse_request_version(OCSP_REQUEST* req)
 	{
 	int der_req_len = 0;
 	unsigned char* der_req_dat = nullptr;
@@ -414,11 +414,11 @@ void file_analysis::OCSP::ParseRequest(OCSP_REQUEST* req)
 	char buf[OCSP_STRING_BUF_SIZE]; // we need a buffer for some of the openssl functions
 	memset(buf, 0, sizeof(buf));
 
-	uint64 version = 0;
+	uint64_t version = 0;
 
 #if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
 	if ( req->tbsRequest->version )
-		version = (uint64)ASN1_INTEGER_get(req->tbsRequest->version);
+		version = (uint64_t)ASN1_INTEGER_get(req->tbsRequest->version);
 #else
 	version = parse_request_version(req);
 	// TODO: try to parse out general name ?
@@ -507,7 +507,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPONSE *resp)
 	vl.push_back(status_val);
 
 #if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
-	vl.push_back(val_mgr->GetCount((uint64)ASN1_INTEGER_get(resp_data->version)));
+	vl.push_back(val_mgr->GetCount((uint64_t)ASN1_INTEGER_get(resp_data->version)));
 #else
 	vl.push_back(parse_basic_resp_data_version(basic_resp));
 #endif

--- a/src/file_analysis/analyzer/x509/OCSP.h
+++ b/src/file_analysis/analyzer/x509/OCSP.h
@@ -15,8 +15,8 @@ namespace file_analysis {
 
 class OCSP : public file_analysis::X509Common {
 public:
-	bool DeliverStream(const u_char* data, uint64 len) override;
-	bool Undelivered(uint64 offset, uint64 len) override;
+	bool DeliverStream(const u_char* data, uint64_t len) override;
+	bool Undelivered(uint64_t offset, uint64_t len) override;
 	bool EndOfFile() override;
 
 	static file_analysis::Analyzer* InstantiateRequest(RecordVal* args, File* file);

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -26,14 +26,14 @@ file_analysis::X509::X509(RecordVal* args, file_analysis::File* file)
 	cert_data.clear();
 	}
 
-bool file_analysis::X509::DeliverStream(const u_char* data, uint64 len)
+bool file_analysis::X509::DeliverStream(const u_char* data, uint64_t len)
 	{
 	// just add it to the data we have so far, since we cannot do anything else anyways...
 	cert_data.append(reinterpret_cast<const char*>(data), len);
 	return true;
 	}
 
-bool file_analysis::X509::Undelivered(uint64 offset, uint64 len)
+bool file_analysis::X509::Undelivered(uint64_t offset, uint64_t len)
 	{
 	return false;
 	}
@@ -96,7 +96,7 @@ RecordVal* file_analysis::X509::ParseCertificate(X509Val* cert_val, File* f)
 	RecordVal* pX509Cert = new RecordVal(BifType::Record::X509::Certificate);
 	BIO *bio = BIO_new(BIO_s_mem());
 
-	pX509Cert->Assign(0, val_mgr->GetCount((uint64) X509_get_version(ssl_cert) + 1));
+	pX509Cert->Assign(0, val_mgr->GetCount((uint64_t) X509_get_version(ssl_cert) + 1));
 	i2a_ASN1_INTEGER(bio, X509_get_serialNumber(ssl_cert));
 	int len = BIO_read(bio, buf, sizeof(buf));
 	pX509Cert->Assign(1, new StringVal(len, buf));
@@ -330,7 +330,7 @@ void file_analysis::X509::ParseSAN(X509_EXTENSION* ext)
 				if ( ips == 0 )
 					ips = new VectorVal(internal_type("addr_vec")->AsVectorType());
 
-				uint32* addr = (uint32*) gen->d.ip->data;
+				uint32_t* addr = (uint32_t*) gen->d.ip->data;
 
 				if( gen->d.ip->length == 4 )
 					ips->Assign(ips->Size(), new AddrVal(*addr));

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -68,8 +68,8 @@ class X509Val;
 
 class X509 : public file_analysis::X509Common {
 public:
-	bool DeliverStream(const u_char* data, uint64 len) override;
-	bool Undelivered(uint64 offset, uint64 len) override;
+	bool DeliverStream(const u_char* data, uint64_t len) override;
+	bool Undelivered(uint64_t offset, uint64_t len) override;
 	bool EndOfFile() override;
 
 	/**

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -41,7 +41,7 @@ X509_STORE* x509_get_root_store(TableVal* root_certs)
 		Val* key = idxs->Index(i);
 		StringVal *sv = root_certs->Lookup(key)->AsStringVal();
 		assert(sv);
-		const uint8* data = sv->Bytes();
+		const uint8_t* data = sv->Bytes();
 		X509* x = d2i_X509(NULL, &data, sv->Len());
 		if ( ! x )
 			{
@@ -710,7 +710,7 @@ function sct_verify%(cert: opaque of x509, logid: string, log_key: string, signa
 		}
 
 	unsigned char *cert_out = nullptr;
-	uint32 cert_length;
+	uint32_t cert_length;
 	if ( precert )
 		{
 #if ( OPENSSL_VERSION_NUMBER < 0x10002000L ) || defined(LIBRESSL_VERSION_NUMBER)
@@ -724,7 +724,7 @@ function sct_verify%(cert: opaque of x509, logid: string, log_key: string, signa
 	else
 		cert_length = i2d_X509(x, &cert_out);
 	assert( cert_out );
-	uint32 cert_length_network = htonl(cert_length);
+	uint32_t cert_length_network = htonl(cert_length);
 	assert( sizeof(cert_length_network) == 4);
 
 	data.append(reinterpret_cast<const char*>(&cert_length_network)+1, 3); // 3 bytes certificate length

--- a/src/iosource/BPF_Program.cc
+++ b/src/iosource/BPF_Program.cc
@@ -41,7 +41,7 @@ pcap_t* pcap_open_dead(int linktype, int snaplen)
 
 int pcap_compile_nopcap(int snaplen_arg, int linktype_arg,
 			struct bpf_program* program, char* buf,
-			int optimize, bpf_u_int32 mask)
+			int optimize, bpf_u_int32_t mask)
 	{
 	pcap_t* p;
 	int ret;
@@ -74,7 +74,7 @@ BPF_Program::~BPF_Program()
 	FreeCode();
 	}
 
-bool BPF_Program::Compile(pcap_t* pcap, const char* filter, uint32 netmask,
+bool BPF_Program::Compile(pcap_t* pcap, const char* filter, uint32_t netmask,
 			  char* errbuf, unsigned int errbuf_len, bool optimize)
 	{
 	if ( ! pcap )
@@ -99,7 +99,7 @@ bool BPF_Program::Compile(pcap_t* pcap, const char* filter, uint32 netmask,
 	}
 
 bool BPF_Program::Compile(int snaplen, int linktype, const char* filter,
-			  uint32 netmask, char* errbuf, unsigned int errbuf_len,
+			  uint32_t netmask, char* errbuf, unsigned int errbuf_len,
 			  bool optimize)
 	{
 	FreeCode();

--- a/src/iosource/BPF_Program.h
+++ b/src/iosource/BPF_Program.h
@@ -22,7 +22,7 @@ public:
 	// Creates a BPF program for the given pcap handle.
 	// Parameters are like in pcap_compile(). Returns true
 	// for successful compilation, false otherwise.
-	bool Compile(pcap_t* pcap, const char* filter, uint32 netmask,
+	bool Compile(pcap_t* pcap, const char* filter, uint32_t netmask,
 		 char* errbuf = 0, unsigned int errbuf_len = 0,
 		 bool optimize = true);
 
@@ -30,7 +30,7 @@ public:
 	// similarly to pcap_compile_nopcap(). Parameters are
 	// similar. Returns true on success.
 	bool Compile(int snaplen, int linktype, const char* filter,
-		uint32 netmask, char* errbuf = 0, unsigned int errbuf_len = 0,
+		uint32_t netmask, char* errbuf = 0, unsigned int errbuf_len = 0,
 		bool optimize = true);
 
 	// Returns true if this program currently contains compiled

--- a/src/iosource/Packet.cc
+++ b/src/iosource/Packet.cc
@@ -16,8 +16,8 @@ extern "C" {
 #endif
 }
 
-void Packet::Init(int arg_link_type, pkt_timeval *arg_ts, uint32 arg_caplen,
-		  uint32 arg_len, const u_char *arg_data, int arg_copy,
+void Packet::Init(int arg_link_type, pkt_timeval *arg_ts, uint32_t arg_caplen,
+		  uint32_t arg_len, const u_char *arg_data, int arg_copy,
 		  std::string arg_tag)
 	{
 	if ( data && copy )
@@ -407,7 +407,7 @@ void Packet::ProcessLayer2()
 		{
 		// See https://www.tcpdump.org/linktypes/LINKTYPE_NFLOG.html
 
-		uint8 protocol = pdata[0];
+		uint8_t protocol = pdata[0];
 
 		if ( protocol == AF_INET )
 			l3_proto = L3_IPV4;
@@ -419,7 +419,7 @@ void Packet::ProcessLayer2()
 			return;
 			}
 
-		uint8 version = pdata[1];
+		uint8_t version = pdata[1];
 
 		if ( version != 0 )
 			{
@@ -430,8 +430,8 @@ void Packet::ProcessLayer2()
 		// Skip to TLVs.
 		pdata += 4;
 
-		uint16 tlv_len;
-		uint16 tlv_type;
+		uint16_t tlv_len;
+		uint16_t tlv_type;
 
 		while ( true )
 			{
@@ -444,8 +444,8 @@ void Packet::ProcessLayer2()
 			// TLV Type and Length values are specified in host byte order
 			// (libpcap should have done any needed byteswapping already).
 
-			tlv_len = *(reinterpret_cast<const uint16*>(pdata));
-			tlv_type = *(reinterpret_cast<const uint16*>(pdata + 2));
+			tlv_len = *(reinterpret_cast<const uint16_t*>(pdata));
+			tlv_type = *(reinterpret_cast<const uint16_t*>(pdata + 2));
 
 			auto constexpr nflog_type_payload = 9;
 

--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -49,8 +49,8 @@ public:
 	 * @param tag A textual tag to associate with the packet for
 	 * differentiating the input streams.
 	 */
-	Packet(int link_type, pkt_timeval *ts, uint32 caplen,
-	       uint32 len, const u_char *data, int copy = false,
+	Packet(int link_type, pkt_timeval *ts, uint32_t caplen,
+	       uint32_t len, const u_char *data, int copy = false,
 	       std::string tag = std::string(""))
 	           : data(0), l2_src(0), l2_dst(0)
 	       {
@@ -97,8 +97,8 @@ public:
 	 * @param tag A textual tag to associate with the packet for
 	 * differentiating the input streams.
 	 */
-	void Init(int link_type, pkt_timeval *ts, uint32 caplen,
-		uint32 len, const u_char *data, int copy = false,
+	void Init(int link_type, pkt_timeval *ts, uint32_t caplen,
+		uint32_t len, const u_char *data, int copy = false,
 		std::string tag = std::string(""));
 
 	/**
@@ -148,9 +148,9 @@ public:
 	double time;			/// Timestamp reconstituted as float
 	pkt_timeval ts;			/// Capture timestamp
 	const u_char* data;		/// Packet data.
-	uint32 len;			/// Actual length on wire
-	uint32 cap_len;			/// Captured packet length
-	uint32 link_type;		/// pcap link_type (DLT_EN10MB, DLT_RAW, etc)
+	uint32_t len;			/// Actual length on wire
+	uint32_t cap_len;			/// Captured packet length
+	uint32_t link_type;		/// pcap link_type (DLT_EN10MB, DLT_RAW, etc)
 
 	// These are computed from Layer 2 data. These fields are only valid if
 	// Layer2Valid() returns true.
@@ -158,7 +158,7 @@ public:
 	/**
 	 * Layer 2 header size. Valid iff Layer2Valid() returns true.
 	 */
-	uint32 hdr_size;
+	uint32_t hdr_size;
 
 	/**
 	 * Layer 3 protocol identified (if any). Valid iff Layer2Valid()
@@ -170,7 +170,7 @@ public:
 	 * If layer 2 is Ethernet, innermost ethertype field. Valid iff
 	 * Layer2Valid() returns true.
 	 */
-	uint32 eth_type;
+	uint32_t eth_type;
 
 	/**
 	 * Layer 2 source address. Valid iff Layer2Valid() returns true.
@@ -187,13 +187,13 @@ public:
 	 * (Outermost) VLAN tag if any, else 0. Valid iff Layer2Valid()
 	 * returns true.
 	 */
-	uint32 vlan;
+	uint32_t vlan;
 
 	/**
 	 * (Innermost) VLAN tag if any, else 0. Valid iff Layer2Valid()
 	 * returns true.
 	 */
-	uint32 inner_vlan;
+	uint32_t inner_vlan;
 
 private:
 	// Calculate layer 2 attributes. Sets

--- a/src/iosource/PktSrc.cc
+++ b/src/iosource/PktSrc.cc
@@ -59,7 +59,7 @@ int PktSrc::LinkType() const
 	return IsOpen() ? props.link_type : -1;
 	}
 
-uint32 PktSrc::Netmask() const
+uint32_t PktSrc::Netmask() const
 	{
 	return IsOpen() ? props.netmask : NETMASK_UNKNOWN;
 	}

--- a/src/iosource/PktSrc.h
+++ b/src/iosource/PktSrc.h
@@ -26,23 +26,23 @@ public:
 		/**
 		 * Packets received by source after filtering (w/o drops).
 		 */
-		uint64 received;
+		uint64_t received;
 
 		/**
 		 * Packets dropped by source.
 		 */
-		uint64 dropped;	// pkts dropped
+		uint64_t dropped;	// pkts dropped
 
 		/**
 		 * Total number of packets on link before filtering.
 		 * Optional, can be left unset if not available.
 		 */
-		uint64 link;
+		uint64_t link;
 
 		/**
 		  * Bytes received by source after filtering (w/o drops).
 		*/
-		uint64 bytes_received;
+		uint64_t bytes_received;
 
 		Stats()	{ received = dropped = link = bytes_received = 0; }
 	};
@@ -77,7 +77,7 @@ public:
 	 * Returns the netmask associated with the source, or \c
 	 * NETMASK_UNKNOWN if unknown.
 	 */
-	uint32 Netmask() const;
+	uint32_t Netmask() const;
 
 	/**
 	 * Returns true if the source has flagged an error.
@@ -236,7 +236,7 @@ protected:
 		 * Returns the netmask associated with the source, or \c
 		 * NETMASK_UNKNOWN if unknown.
 		 */
-		uint32 netmask;
+		uint32_t netmask;
 
 		/**
 		 * True if the source is reading live inout, false for

--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -68,7 +68,7 @@ void PcapSource::OpenLive()
 		}
 
 	// Determine network and netmask.
-	uint32 net;
+	uint32_t net;
 	if ( pcap_lookupnet(props.path.c_str(), &net, &props.netmask, tmp_errbuf) < 0 )
 		{
 		// ### The lookup can fail if no address is assigned to

--- a/src/main.cc
+++ b/src/main.cc
@@ -1066,8 +1066,8 @@ int main(int argc, char** argv)
 
 		double time_net_start = current_time(true);;
 
-		uint64 mem_net_start_total;
-		uint64 mem_net_start_malloced;
+		uint64_t mem_net_start_total;
+		uint64_t mem_net_start_malloced;
 
 		if ( time_bro )
 			{
@@ -1084,8 +1084,8 @@ int main(int argc, char** argv)
 
 		double time_net_done = current_time(true);;
 
-		uint64 mem_net_done_total;
-		uint64 mem_net_done_malloced;
+		uint64_t mem_net_done_total;
+		uint64_t mem_net_done_malloced;
 
 		if ( time_bro )
 			{

--- a/src/net_util.cc
+++ b/src/net_util.cc
@@ -16,7 +16,7 @@
 
 // - adapted from tcpdump
 // Returns the ones-complement checksum of a chunk of b short-aligned bytes.
-int ones_complement_checksum(const void* p, int b, uint32 sum)
+int ones_complement_checksum(const void* p, int b, uint32_t sum)
 	{
 	const unsigned char* sp = (unsigned char*) p;
 
@@ -35,16 +35,16 @@ int ones_complement_checksum(const void* p, int b, uint32 sum)
 	return sum;
 	}
 
-int ones_complement_checksum(const IPAddr& a, uint32 sum)
+int ones_complement_checksum(const IPAddr& a, uint32_t sum)
 	{
-	const uint32* bytes;
+	const uint32_t* bytes;
 	int len = a.GetBytes(&bytes);
 	return ones_complement_checksum(bytes, len*4, sum);
 	}
 
 int icmp_checksum(const struct icmp* icmpp, int len)
 	{
-	uint32 sum;
+	uint32_t sum;
 
 	if ( len % 2 == 1 )
 		// Add in pad byte.
@@ -64,8 +64,8 @@ int mobility_header_checksum(const IP_Hdr* ip)
 
 	if ( ! mh ) return 0;
 
-	uint32 sum = 0;
-	uint8 mh_len = 8 + 8 * mh->ip6mob_len;
+	uint32_t sum = 0;
+	uint8_t mh_len = 8 + 8 * mh->ip6mob_len;
 
 	if ( mh_len % 2 == 1 )
 		reporter->Weird(ip->SrcAddr(), ip->DstAddr(), "odd_mobility_hdr_len");
@@ -87,7 +87,7 @@ int icmp6_checksum(const struct icmp* icmpp, const IP_Hdr* ip, int len)
 	{
 	// ICMP6 uses the same checksum function as ICMP4 but a different
 	// pseudo-header over which it is computed.
-	uint32 sum;
+	uint32_t sum;
 
 	if ( len % 2 == 1 )
 		// Add in pad byte.
@@ -98,10 +98,10 @@ int icmp6_checksum(const struct icmp* icmpp, const IP_Hdr* ip, int len)
 	// Pseudo-header as for UDP over IPv6 above.
 	sum = ones_complement_checksum(ip->SrcAddr(), sum);
 	sum = ones_complement_checksum(ip->DstAddr(), sum);
-	uint32 l = htonl(len);
+	uint32_t l = htonl(len);
 	sum = ones_complement_checksum((void*) &l, 4, sum);
 
-	uint32 addl_pseudo = htons(IPPROTO_ICMPV6);
+	uint32_t addl_pseudo = htons(IPPROTO_ICMPV6);
 	sum = ones_complement_checksum((void*) &addl_pseudo, 4, sum);
 
 	sum = ones_complement_checksum((void*) icmpp, len, sum);
@@ -117,7 +117,7 @@ int icmp6_checksum(const struct icmp* icmpp, const IP_Hdr* ip, int len)
 #define CLASS_E 0xf0000000
 
 #define CHECK_CLASS(addr,class) (((addr) & (class)) == (class))
-char addr_to_class(uint32 addr)
+char addr_to_class(uint32_t addr)
 	{
 	if ( CHECK_CLASS(addr, CLASS_E) )
 		return 'E';
@@ -131,8 +131,8 @@ char addr_to_class(uint32 addr)
 		return 'A';
 	}
 
-const char* fmt_conn_id(const IPAddr& src_addr, uint32 src_port,
-			const IPAddr& dst_addr, uint32 dst_port)
+const char* fmt_conn_id(const IPAddr& src_addr, uint32_t src_port,
+			const IPAddr& dst_addr, uint32_t dst_port)
 	{
 	static char buffer[512];
 
@@ -143,8 +143,8 @@ const char* fmt_conn_id(const IPAddr& src_addr, uint32 src_port,
 	return buffer;
 	}
 
-const char* fmt_conn_id(const uint32* src_addr, uint32 src_port,
-			const uint32* dst_addr, uint32 dst_port)
+const char* fmt_conn_id(const uint32_t* src_addr, uint32_t src_port,
+			const uint32_t* dst_addr, uint32_t dst_port)
 	{
 	IPAddr src(IPv6, src_addr, IPAddr::Network);
 	IPAddr dst(IPv6, dst_addr, IPAddr::Network);
@@ -171,9 +171,9 @@ std::string fmt_mac(const unsigned char* m, int len)
 	return buf;
 	}
 
-uint32 extract_uint32(const u_char* data)
+uint32_t extract_uint32(const u_char* data)
 	{
-	uint32 val;
+	uint32_t val;
 
 	val = data[0] << 24;
 	val |= data[1] << 16;

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -34,15 +34,15 @@ typedef enum { IPv4, IPv6 } IPFamily;
 
 #ifndef HAVE_IP6_OPT
 struct ip6_opt {
-	uint8  ip6o_type;
-	uint8  ip6o_len;
+	uint8_t  ip6o_type;
+	uint8_t  ip6o_len;
 };
 #endif // HAVE_IP6_OPT
 
 #ifndef HAVE_IP6_EXT
 struct ip6_ext {
-	uint8 ip6e_nxt;
-	uint8 ip6e_len;
+	uint8_t ip6e_nxt;
+	uint8_t ip6e_len;
 };
 #endif // HAVE_IP6_EXT
 
@@ -51,13 +51,13 @@ struct ip6_ext {
 struct ip6_hdr {
 	union {
 		struct ip6_hdrctl {
-			uint32 ip6_un1_flow; /* 4 bits version, 8 bits TC, 20 bits
+			uint32_t ip6_un1_flow; /* 4 bits version, 8 bits TC, 20 bits
                                       flow-ID */
-			uint16 ip6_un1_plen; /* payload length */
-			uint8  ip6_un1_nxt;  /* next header */
-			uint8  ip6_un1_hlim; /* hop limit */
+			uint16_t ip6_un1_plen; /* payload length */
+			uint8_t  ip6_un1_nxt;  /* next header */
+			uint8_t  ip6_un1_hlim; /* hop limit */
 		} ip6_un1;
-		uint8 ip6_un2_vfc;     /* 4 bits version, top 4 bits tclass */
+		uint8_t ip6_un2_vfc;     /* 4 bits version, top 4 bits tclass */
 	} ip6_ctlun;
 	struct in6_addr ip6_src;   /* source address */
 	struct in6_addr ip6_dst;   /* destination address */
@@ -71,39 +71,39 @@ struct ip6_hdr {
 #define ip6_hops  ip6_ctlun.ip6_un1.ip6_un1_hlim
 
 struct ip6_opt {
-	uint8  ip6o_type;
-	uint8  ip6o_len;
+	uint8_t  ip6o_type;
+	uint8_t  ip6o_len;
 };
 
 struct ip6_ext {
-	uint8 ip6e_nxt;
-	uint8 ip6e_len;
+	uint8_t ip6e_nxt;
+	uint8_t ip6e_len;
 };
 
 struct ip6_frag {
-	uint8   ip6f_nxt;       /* next header */
-	uint8   ip6f_reserved;  /* reserved field */
-	uint16  ip6f_offlg;     /* offset, reserved, and flag */
-	uint32  ip6f_ident;     /* identification */
+	uint8_t   ip6f_nxt;       /* next header */
+	uint8_t   ip6f_reserved;  /* reserved field */
+	uint16_t  ip6f_offlg;     /* offset, reserved, and flag */
+	uint32_t  ip6f_ident;     /* identification */
 };
 
 struct ip6_hbh {
-	uint8  ip6h_nxt;        /* next header */
-	uint8  ip6h_len;        /* length in units of 8 octets */
+	uint8_t  ip6h_nxt;        /* next header */
+	uint8_t  ip6h_len;        /* length in units of 8 octets */
 	/* followed by options */
 };
 
 struct ip6_dest {
-	uint8  ip6d_nxt;        /* next header */
-	uint8  ip6d_len;        /* length in units of 8 octets */
+	uint8_t  ip6d_nxt;        /* next header */
+	uint8_t  ip6d_len;        /* length in units of 8 octets */
 	/* followed by options */
 };
 
 struct ip6_rthdr {
-	uint8  ip6r_nxt;        /* next header */
-	uint8  ip6r_len;        /* length in units of 8 octets */
-	uint8  ip6r_type;       /* routing type */
-	uint8  ip6r_segleft;    /* segments left */
+	uint8_t  ip6r_nxt;        /* next header */
+	uint8_t  ip6r_len;        /* length in units of 8 octets */
+	uint8_t  ip6r_type;       /* routing type */
+	uint8_t  ip6r_segleft;    /* segments left */
 	/* followed by routing type specific data */
 };
 #endif // HAVE_NETINET_IP6_H
@@ -119,7 +119,7 @@ struct ip6_rthdr {
 
 // True if sequence # a is between b and c (b <= a <= c).  It must be true
 // that b <= c in the sequence space.
-inline bool seq_between(uint32 a, uint32 b, uint32 c)
+inline bool seq_between(uint32_t a, uint32_t b, uint32_t c)
 	{
 	if ( b <= c )
 		return a >= b && a <= c;
@@ -128,7 +128,7 @@ inline bool seq_between(uint32 a, uint32 b, uint32 c)
 	}
 
 // Returns a - b, adjusted for sequence wraparound.
-inline int32 seq_delta(uint32 a, uint32 b)
+inline int32_t seq_delta(uint32_t a, uint32_t b)
 	{
 	return a - b;
 	}
@@ -137,9 +137,9 @@ class IPAddr;
 class IP_Hdr;
 
 // Returns the ones-complement checksum of a chunk of b short-aligned bytes.
-extern int ones_complement_checksum(const void* p, int b, uint32 sum);
+extern int ones_complement_checksum(const void* p, int b, uint32_t sum);
 
-extern int ones_complement_checksum(const IPAddr& a, uint32 sum);
+extern int ones_complement_checksum(const IPAddr& a, uint32_t sum);
 
 extern int icmp6_checksum(const struct icmp* icmpp, const IP_Hdr* ip, int len);
 extern int icmp_checksum(const struct icmp* icmpp, int len);
@@ -149,12 +149,12 @@ extern int mobility_header_checksum(const IP_Hdr* ip);
 #endif
 
 // Returns 'A', 'B', 'C' or 'D'
-extern char addr_to_class(uint32 addr);
+extern char addr_to_class(uint32_t addr);
 
-extern const char* fmt_conn_id(const IPAddr& src_addr, uint32 src_port,
-				const IPAddr& dst_addr, uint32 dst_port);
-extern const char* fmt_conn_id(const uint32* src_addr, uint32 src_port,
-				const uint32* dst_addr, uint32 dst_port);
+extern const char* fmt_conn_id(const IPAddr& src_addr, uint32_t src_port,
+				const IPAddr& dst_addr, uint32_t dst_port);
+extern const char* fmt_conn_id(const uint32_t* src_addr, uint32_t src_port,
+				const uint32_t* dst_addr, uint32_t dst_port);
 
 /**
 * Given a MAC address, formats it in hex as 00:de:ad:be:ef.
@@ -169,7 +169,7 @@ extern const char* fmt_conn_id(const uint32* src_addr, uint32 src_port,
 extern std::string fmt_mac(const unsigned char* m, int len);
 
 // Read 4 bytes from data and return in network order.
-extern uint32 extract_uint32(const u_char* data);
+extern uint32_t extract_uint32(const u_char* data);
 
 // Endian conversions for double.
 // This is certainly not a very clean solution but should work on the
@@ -182,8 +182,8 @@ inline double ntohd(double d)	{ return d; }
 inline double htond(double d)	{ return d; }
 
 #ifndef HAVE_BYTEORDER_64
-inline uint64 ntohll(uint64 i)	{ return i; }
-inline uint64 htonll(uint64 i)	{ return i; }
+inline uint64_t ntohll(uint64_t i)	{ return i; }
+inline uint64_t htonll(uint64_t i)	{ return i; }
 #endif
 
 #else
@@ -211,11 +211,11 @@ inline double ntohd(double d)
 inline double htond(double d) { return ntohd(d); }
 
 #ifndef HAVE_BYTEORDER_64
-inline uint64 ntohll(uint64 i)
+inline uint64_t ntohll(uint64_t i)
 	{
 	u_char c;
 	union {
-		uint64 i;
+		uint64_t i;
 		u_char c[8];
 	} x;
 
@@ -227,7 +227,7 @@ inline uint64 ntohll(uint64 i)
 	return x.i;
 	}
 
-inline uint64 htonll(uint64 i) { return ntohll(i); }
+inline uint64_t htonll(uint64_t i) { return ntohll(i); }
 #endif
 
 #endif

--- a/src/probabilistic/BitVector.cc
+++ b/src/probabilistic/BitVector.cc
@@ -491,10 +491,10 @@ BitVector::size_type BitVector::FindNext(size_type i) const
 	return block ? bi * bits_per_block + lowest_bit(block) : find_from(bi + 1);
 	}
 
-uint64 BitVector::Hash() const
+uint64_t BitVector::Hash() const
 	{
 	u_char buf[SHA256_DIGEST_LENGTH];
-	uint64 digest;
+	uint64_t digest;
 	EVP_MD_CTX* ctx = hash_init(Hash_SHA256);
 
 	for ( size_type i = 0; i < Blocks(); ++i )
@@ -507,11 +507,11 @@ uint64 BitVector::Hash() const
 
 broker::expected<broker::data> BitVector::Serialize() const
 	{
-	broker::vector v = {static_cast<uint64>(num_bits), static_cast<uint64>(bits.size())};
+	broker::vector v = {static_cast<uint64_t>(num_bits), static_cast<uint64_t>(bits.size())};
 	v.reserve(2 + bits.size());
 
 	for ( size_t i = 0; i < bits.size(); ++i )
-		v.emplace_back(static_cast<uint64>(bits[i]));
+		v.emplace_back(static_cast<uint64_t>(bits[i]));
 
 	return {std::move(v)};
 	}
@@ -522,8 +522,8 @@ std::unique_ptr<BitVector> BitVector::Unserialize(const broker::data& data)
 	if ( ! (v && v->size() >= 2) )
 		return nullptr;
 
-	auto num_bits = caf::get_if<uint64>(&(*v)[0]);
-	auto size = caf::get_if<uint64>(&(*v)[1]);
+	auto num_bits = caf::get_if<uint64_t>(&(*v)[0]);
+	auto size = caf::get_if<uint64_t>(&(*v)[1]);
 
 	if ( ! (num_bits && size) )
 		return nullptr;
@@ -536,7 +536,7 @@ std::unique_ptr<BitVector> BitVector::Unserialize(const broker::data& data)
 
 	for ( size_t i = 0; i < *size; ++i )
 		{
-		auto x = caf::get_if<uint64>(&(*v)[2 + i]);
+		auto x = caf::get_if<uint64_t>(&(*v)[2 + i]);
 		if ( ! x )
 			return nullptr;
 

--- a/src/probabilistic/BloomFilter.cc
+++ b/src/probabilistic/BloomFilter.cc
@@ -42,7 +42,7 @@ broker::expected<broker::data> BloomFilter::Serialize() const
 	if ( ! d )
 		return broker::ec::invalid_data; // Cannot serialize
 
-	return {broker::vector{static_cast<uint64>(Type()), std::move(*h), std::move(*d)}};
+	return {broker::vector{static_cast<uint64_t>(Type()), std::move(*h), std::move(*d)}};
 	}
 
 std::unique_ptr<BloomFilter> BloomFilter::Unserialize(const broker::data& data)
@@ -52,7 +52,7 @@ std::unique_ptr<BloomFilter> BloomFilter::Unserialize(const broker::data& data)
 	if ( ! (v && v->size() == 3) )
 		return nullptr;
 
-	auto type = caf::get_if<uint64>(&(*v)[0]);
+	auto type = caf::get_if<uint64_t>(&(*v)[0]);
 	if ( ! type )
 		return nullptr;
 

--- a/src/probabilistic/CardinalityCounter.cc
+++ b/src/probabilistic/CardinalityCounter.cc
@@ -87,7 +87,7 @@ CardinalityCounter::CardinalityCounter(CardinalityCounter&& o)
 CardinalityCounter::CardinalityCounter(double error_margin, double confidence)
 	{
 	int b = OptimalB(error_margin, confidence);
-	Init((uint64) pow(2, b));
+	Init((uint64_t) pow(2, b));
 
 	assert(b == p);
 	}
@@ -202,7 +202,7 @@ broker::expected<broker::data> CardinalityCounter::Serialize() const
 	v.reserve(3 + m);
 
 	for ( size_t i = 0; i < m; ++i )
-		v.emplace_back(static_cast<uint64>(buckets[i]));
+		v.emplace_back(static_cast<uint64_t>(buckets[i]));
 
 	return {std::move(v)};
 	}
@@ -213,8 +213,8 @@ std::unique_ptr<CardinalityCounter> CardinalityCounter::Unserialize(const broker
 	if ( ! (v && v->size() >= 3) )
 		return nullptr;
 
-	auto m = caf::get_if<uint64>(&(*v)[0]);
-	auto V = caf::get_if<uint64>(&(*v)[1]);
+	auto m = caf::get_if<uint64_t>(&(*v)[0]);
+	auto V = caf::get_if<uint64_t>(&(*v)[1]);
 	auto alpha_m = caf::get_if<double>(&(*v)[2]);
 
 	if ( ! (m && V && alpha_m) )
@@ -230,7 +230,7 @@ std::unique_ptr<CardinalityCounter> CardinalityCounter::Unserialize(const broker
 
 	for ( size_t i = 0; i < *m; ++i )
 		{
-		auto x = caf::get_if<uint64>(&(*v)[3 + i]);
+		auto x = caf::get_if<uint64_t>(&(*v)[3 + i]);
 		if ( ! x )
 			return nullptr;
 

--- a/src/probabilistic/CounterVector.cc
+++ b/src/probabilistic/CounterVector.cc
@@ -167,7 +167,7 @@ broker::expected<broker::data> CounterVector::Serialize() const
 	if ( ! b )
 		return broker::ec::invalid_data; // Cannot serialize
 
-	return {broker::vector{static_cast<uint64>(width), std::move(*b)}};
+	return {broker::vector{static_cast<uint64_t>(width), std::move(*b)}};
 	}
 
 std::unique_ptr<CounterVector> CounterVector::Unserialize(const broker::data& data)
@@ -176,7 +176,7 @@ std::unique_ptr<CounterVector> CounterVector::Unserialize(const broker::data& da
 	if ( ! (v && v->size() >= 2) )
 		return nullptr;
 
-	auto width = caf::get_if<uint64>(&(*v)[0]);
+	auto width = caf::get_if<uint64_t>(&(*v)[0]);
 	auto bits = BitVector::Unserialize((*v)[1]);
 
 	if ( ! (width && bits) )

--- a/src/probabilistic/Hasher.cc
+++ b/src/probabilistic/Hasher.cc
@@ -49,7 +49,7 @@ Hasher::Hasher(size_t arg_k, seed_t arg_seed)
 broker::expected<broker::data> Hasher::Serialize() const
 	{
 	return {broker::vector{
-		static_cast<uint64>(Type()), static_cast<uint64>(k),
+		static_cast<uint64_t>(Type()), static_cast<uint64_t>(k),
 		seed.h1, seed.h2 }};
 	}
 
@@ -60,10 +60,10 @@ std::unique_ptr<Hasher> Hasher::Unserialize(const broker::data& data)
 	if ( ! (v && v->size() == 4) )
 		return nullptr;
 
-	auto type = caf::get_if<uint64>(&(*v)[0]);
-	auto k = caf::get_if<uint64>(&(*v)[1]);
-	auto h1 = caf::get_if<uint64>(&(*v)[2]);
-	auto h2 = caf::get_if<uint64>(&(*v)[3]);
+	auto type = caf::get_if<uint64_t>(&(*v)[0]);
+	auto k = caf::get_if<uint64_t>(&(*v)[1]);
+	auto h1 = caf::get_if<uint64_t>(&(*v)[2]);
+	auto h2 = caf::get_if<uint64_t>(&(*v)[3]);
 
 	if ( ! (type && k && h1 && h2) )
 		return nullptr;

--- a/src/probabilistic/Topk.cc
+++ b/src/probabilistic/Topk.cc
@@ -38,7 +38,7 @@ HashKey* TopkVal::GetHash(Val* v) const
 	return key;
 	}
 
-TopkVal::TopkVal(uint64 arg_size) : OpaqueVal(topk_type)
+TopkVal::TopkVal(uint64_t arg_size) : OpaqueVal(topk_type)
 	{
 	elementDict = new PDict<Element>;
 	elementDict->SetDeleteFunc(topk_element_hash_delete_func);
@@ -364,7 +364,7 @@ void TopkVal::Encountered(Val* encountered)
 void TopkVal::IncrementCounter(Element* e, unsigned int count)
 	{
 	Bucket* currBucket = e->parent;
-	uint64 currcount = currBucket->count;
+	uint64_t currcount = currBucket->count;
 
 	// well, let's test if there is a bucket for currcount++
 	std::list<Bucket*>::iterator bucketIter = currBucket->bucketPos;
@@ -432,7 +432,7 @@ broker::expected<broker::data> TopkVal::DoSerialize() const
 		Bucket* b = *it;
 		uint32_t elements_count = b->elements.size();
 
-		d.emplace_back(static_cast<uint64>(b->elements.size()));
+		d.emplace_back(static_cast<uint64_t>(b->elements.size()));
 		d.emplace_back(b->count);
 
 		std::list<Element*>::const_iterator eit = b->elements.begin();
@@ -465,8 +465,8 @@ bool TopkVal::DoUnserialize(const broker::data& data)
 	if ( ! (v && v->size() >= 4) )
 		return false;
 
-	auto size_ = caf::get_if<uint64>(&(*v)[0]);
-	auto numElements_ = caf::get_if<uint64>(&(*v)[1]);
+	auto size_ = caf::get_if<uint64_t>(&(*v)[0]);
+	auto numElements_ = caf::get_if<uint64_t>(&(*v)[1]);
 	auto pruned_ = caf::get_if<bool>(&(*v)[2]);
 
 	if ( ! (size_ && numElements_ && pruned_) )
@@ -492,8 +492,8 @@ bool TopkVal::DoUnserialize(const broker::data& data)
 
 	while ( i < numElements )
 		{
-		auto elements_count = caf::get_if<uint64>(&(*v)[idx++]);
-		auto count = caf::get_if<uint64>(&(*v)[idx++]);
+		auto elements_count = caf::get_if<uint64_t>(&(*v)[idx++]);
+		auto count = caf::get_if<uint64_t>(&(*v)[idx++]);
 
 		if ( ! (elements_count && count) )
 			return false;
@@ -504,7 +504,7 @@ bool TopkVal::DoUnserialize(const broker::data& data)
 
 		for ( uint64_t j = 0; j < *elements_count; j++ )
 			{
-			auto epsilon = caf::get_if<uint64>(&(*v)[idx++]);
+			auto epsilon = caf::get_if<uint64_t>(&(*v)[idx++]);
 			Val* val = bro_broker::data_to_val((*v)[idx++], type);
 
 			if ( ! (epsilon && val) )

--- a/src/probabilistic/Topk.h
+++ b/src/probabilistic/Topk.h
@@ -16,7 +16,7 @@ namespace probabilistic {
 struct Element;
 
 struct Bucket {
-	uint64 count;
+	uint64_t count;
 	std::list<Element*> elements;
 
 	// Iterators only get invalidated for removed elements. This one
@@ -26,7 +26,7 @@ struct Bucket {
 };
 
 struct Element {
-	uint64 epsilon;
+	uint64_t epsilon;
 	Val* value;
 	Bucket* parent;
 
@@ -43,7 +43,7 @@ public:
 	 *
 	 * @return A newly initialized TopkVal
 	 */
-	explicit TopkVal(uint64 size);
+	explicit TopkVal(uint64_t size);
 
 	/**
 	 * Destructor.
@@ -167,8 +167,8 @@ private:
 	CompositeHash* hash;
 	std::list<Bucket*> buckets;
 	PDict<Element>* elementDict;
-	uint64 size; // how many elements are we tracking?
-	uint64 numElements; // how many elements do we have at the moment
+	uint64_t size; // how many elements are we tracking?
+	uint64_t numElements; // how many elements do we have at the moment
 	bool pruned; // was this data structure pruned?
 };
 

--- a/src/probabilistic/bloom-filter.bif
+++ b/src/probabilistic/bloom-filter.bif
@@ -126,7 +126,7 @@ function bloomfilter_counting_init%(k: count, cells: count, max: count,
 
 	const Hasher* h = new DefaultHasher(k, seed);
 
-	uint16 width = 1;
+	uint16_t width = 1;
 	while ( max >>= 1 )
 		++width;
 
@@ -180,7 +180,7 @@ function bloomfilter_lookup%(bf: opaque of bloomfilter, x: any%): count
 		reporter->Error("incompatible Bloom filter types");
 
 	else
-		return val_mgr->GetCount(static_cast<uint64>(bfv->Count(x)));
+		return val_mgr->GetCount(static_cast<uint64_t>(bfv->Count(x)));
 
 	return val_mgr->GetCount(0);
 	%}

--- a/src/rule-scan.l
+++ b/src/rule-scan.l
@@ -162,12 +162,12 @@ finger	{ rules_lval.val = Rule::FINGER; return TOK_PATTERN_TYPE; }
 	}
 
 {D}	{
-	rules_lval.val = (uint32) atoi(yytext);
+	rules_lval.val = (uint32_t) atoi(yytext);
 	return TOK_INT;
 	}
 
 0x{H}	{
-	rules_lval.val = (uint32) strtol(yytext, 0, 16);
+	rules_lval.val = (uint32_t) strtol(yytext, 0, 16);
 	return TOK_INT;
 	}
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -469,7 +469,7 @@ F	RET_CONST(val_mgr->GetFalse())
 {FLOAT}		RET_CONST(new Val(atof(yytext), TYPE_DOUBLE))
 
 {D}"/tcp"	{
-		uint32 p = atoi(yytext);
+		uint32_t p = atoi(yytext);
 		if ( p > 65535 )
 			{
 			reporter->Error("bad port number - %s", yytext);
@@ -478,7 +478,7 @@ F	RET_CONST(val_mgr->GetFalse())
 		RET_CONST(val_mgr->GetPort(p, TRANSPORT_TCP))
 		}
 {D}"/udp"	{
-		uint32 p = atoi(yytext);
+		uint32_t p = atoi(yytext);
 		if ( p > 65535 )
 			{
 			reporter->Error("bad port number - %s", yytext);
@@ -487,7 +487,7 @@ F	RET_CONST(val_mgr->GetFalse())
 		RET_CONST(val_mgr->GetPort(p, TRANSPORT_UDP))
 		}
 {D}"/icmp"	{
-		uint32 p = atoi(yytext);
+		uint32_t p = atoi(yytext);
 		if ( p > 255 )
 			{
 			reporter->Error("bad port number - %s", yytext);
@@ -496,7 +496,7 @@ F	RET_CONST(val_mgr->GetFalse())
 		RET_CONST(val_mgr->GetPort(p, TRANSPORT_ICMP))
 		}
 {D}"/unknown"	{
-		uint32 p = atoi(yytext);
+		uint32_t p = atoi(yytext);
 		if ( p > 255 )
 			{
 			reporter->Error("bad port number - %s", yytext);

--- a/src/stats.bif
+++ b/src/stats.bif
@@ -39,10 +39,10 @@ RecordType* ReporterStats;
 ##              get_reporter_stats
 function get_net_stats%(%): NetStats
 	%{
-	uint64 recv = 0;
-	uint64 drop = 0;
-	uint64 link = 0;
-	uint64 bytes_recv = 0;
+	uint64_t recv = 0;
+	uint64_t drop = 0;
+	uint64_t link = 0;
+	uint64_t bytes_recv = 0;
 
 	const iosource::Manager::PktSrcList& pkt_srcs(iosource_mgr->GetPktSrcs());
 
@@ -164,7 +164,7 @@ function get_proc_stats%(%): ProcStats
 	r->Assign(n++, new IntervalVal(user_time, Seconds));
 	r->Assign(n++, new IntervalVal(system_time, Seconds));
 
-	uint64 total_mem;
+	uint64_t total_mem;
 	get_memory_usage(&total_mem, NULL);
 	r->Assign(n++, val_mgr->GetCount(unsigned(total_mem)));
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -453,14 +453,14 @@ template int atoi_n<uint32_t>(int len, const char* s, const char** end, int base
 template int atoi_n<int64_t>(int len, const char* s, const char** end, int base, int64_t& result);
 template int atoi_n<uint64_t>(int len, const char* s, const char** end, int base, uint64_t& result);
 
-char* uitoa_n(uint64 value, char* str, int n, int base, const char* prefix)
+char* uitoa_n(uint64_t value, char* str, int n, int base, const char* prefix)
 	{
 	static char dig[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 	assert(n);
 
 	int i = 0;
-	uint64 v;
+	uint64_t v;
 	char* p, *q;
 	char c;
 
@@ -707,10 +707,10 @@ std::string strstrip(std::string s)
 	}
 
 bool hmac_key_set = false;
-uint8 shared_hmac_md5_key[16];
+uint8_t shared_hmac_md5_key[16];
 
 bool siphash_key_set = false;
-uint8 shared_siphash_key[SIPHASH_KEYLEN];
+uint8_t shared_siphash_key[SIPHASH_KEYLEN];
 
 void hmac_md5(size_t size, const unsigned char* bytes, unsigned char digest[16])
 	{
@@ -725,8 +725,8 @@ void hmac_md5(size_t size, const unsigned char* bytes, unsigned char digest[16])
 	internal_md5(digest, 16, digest);
 	}
 
-static bool read_random_seeds(const char* read_file, uint32* seed,
-				uint32* buf, int bufsiz)
+static bool read_random_seeds(const char* read_file, uint32_t* seed,
+				uint32_t* buf, int bufsiz)
 	{
 	FILE* f = 0;
 
@@ -761,8 +761,8 @@ static bool read_random_seeds(const char* read_file, uint32* seed,
 	return true;
 	}
 
-static bool write_random_seeds(const char* write_file, uint32 seed,
-				uint32* buf, int bufsiz)
+static bool write_random_seeds(const char* write_file, uint32_t seed,
+				uint32_t* buf, int bufsiz)
 	{
 	FILE* f = 0;
 
@@ -806,11 +806,11 @@ void bro_srandom(unsigned int seed)
 void init_random_seed(const char* read_file, const char* write_file)
 	{
 	static const int bufsiz = 20;
-	uint32 buf[bufsiz];
+	uint32_t buf[bufsiz];
 	memset(buf, 0, sizeof(buf));
 	int pos = 0;	// accumulates entropy
 	bool seeds_done = false;
-	uint32 seed = 0;
+	uint32_t seed = 0;
 
 	if ( read_file )
 		{
@@ -825,7 +825,7 @@ void init_random_seed(const char* read_file, const char* write_file)
 		{
 		// Gather up some entropy.
 		gettimeofday((struct timeval *)(buf + pos), 0);
-		pos += sizeof(struct timeval) / sizeof(uint32);
+		pos += sizeof(struct timeval) / sizeof(uint32_t);
 
 		// use urandom. For reasons see e.g. http://www.2uo.de/myths-about-urandom/
 #if defined(O_NONBLOCK)
@@ -839,11 +839,11 @@ void init_random_seed(const char* read_file, const char* write_file)
 		if ( fd >= 0 )
 			{
 			int amt = read(fd, buf + pos,
-					sizeof(uint32) * (bufsiz - pos));
+					sizeof(uint32_t) * (bufsiz - pos));
 			safe_close(fd);
 
 			if ( amt > 0 )
-				pos += amt / sizeof(uint32);
+				pos += amt / sizeof(uint32_t);
 			else
 				// Clear errno, which can be set on some
 				// systems due to a lack of entropy.
@@ -930,9 +930,9 @@ long int bro_random()
 	}
 
 // Returns a 64-bit random string.
-uint64 rand64bit()
+uint64_t rand64bit()
 	{
-	uint64 base = 0;
+	uint64_t base = 0;
 	int i;
 
 	for ( i = 1; i <= 4; ++i )
@@ -1545,12 +1545,12 @@ int time_compare(struct timeval* tv_a, struct timeval* tv_b)
 
 struct UIDEntry {
 	UIDEntry() : key(0, 0), needs_init(true) { }
-	UIDEntry(const uint64 i) : key(i, 0), needs_init(false) { }
+	UIDEntry(const uint64_t i) : key(i, 0), needs_init(false) { }
 
 	struct UIDKey {
-		UIDKey(uint64 i, uint64 c) : instance(i), counter(c) { }
-		uint64 instance;
-		uint64 counter;
+		UIDKey(uint64_t i, uint64_t c) : instance(i), counter(c) { }
+		uint64_t instance;
+		uint64_t counter;
 	} key;
 
 	bool needs_init;
@@ -1558,14 +1558,14 @@ struct UIDEntry {
 
 static std::vector<UIDEntry> uid_pool;
 
-uint64 calculate_unique_id()
+uint64_t calculate_unique_id()
 	{
 	return calculate_unique_id(UID_POOL_DEFAULT_INTERNAL);
 	}
 
-uint64 calculate_unique_id(size_t pool)
+uint64_t calculate_unique_id(size_t pool)
 	{
-	uint64 uid_instance = 0;
+	uint64_t uid_instance = 0;
 
 	if( pool >= uid_pool.size() )
 		{
@@ -1589,7 +1589,7 @@ uint64 calculate_unique_id(size_t pool)
 			// globally unique.
 			struct {
 				char hostname[120];
-				uint64 pool;
+				uint64_t pool;
 				struct timeval time;
 				pid_t pid;
 				int rnd;
@@ -1599,7 +1599,7 @@ uint64 calculate_unique_id(size_t pool)
 			gethostname(unique.hostname, 120);
 			unique.hostname[sizeof(unique.hostname)-1] = '\0';
 			gettimeofday(&unique.time, 0);
-			unique.pool = (uint64) pool;
+			unique.pool = (uint64_t) pool;
 			unique.pid = getpid();
 			unique.rnd = bro_random();
 
@@ -1706,9 +1706,9 @@ extern "C" void out_of_memory(const char* where)
 	abort();
 	}
 
-void get_memory_usage(uint64* total, uint64* malloced)
+void get_memory_usage(uint64_t* total, uint64_t* malloced)
 	{
-	uint64 ret_total;
+	uint64_t ret_total;
 
 #ifdef HAVE_MALLINFO
 	struct mallinfo mi = mallinfo();

--- a/src/util.h
+++ b/src/util.h
@@ -22,8 +22,8 @@
 #define __STDC_LIMIT_MACROS
 #endif
 
-#include <inttypes.h>
-#include <stdint.h>
+#include <cinttypes>
+#include <cstdint>
 
 #include <string>
 #include <array>
@@ -62,31 +62,39 @@ extern HeapLeakChecker* heap_checker;
 
 #include <stdint.h>
 
+ZEEK_DEPRECATED("Remove in v4.1. Use uint64_t instead.")
 typedef uint64_t uint64;
+ZEEK_DEPRECATED("Remove in v4.1. Use uint32_t instead.")
 typedef uint32_t uint32;
+ZEEK_DEPRECATED("Remove in v4.1. Use uint16_t instead.")
 typedef uint16_t uint16;
+ZEEK_DEPRECATED("Remove in v4.1. Use uint8_t instead.")
 typedef uint8_t uint8;
 
+ZEEK_DEPRECATED("Remove in v4.1. Use int64_t instead.")
 typedef int64_t int64;
+ZEEK_DEPRECATED("Remove in v4.1. Use int32_t instead.")
 typedef int32_t int32;
+ZEEK_DEPRECATED("Remove in v4.1. Use int16_t instead.")
 typedef int16_t int16;
+ZEEK_DEPRECATED("Remove in v4.1. Use int8_t instead.")
 typedef int8_t int8;
 
-typedef int64 bro_int_t;
-typedef uint64 bro_uint_t;
+typedef int64_t bro_int_t;
+typedef uint64_t bro_uint_t;
 
 // "ptr_compat_uint" and "ptr_compat_int" are (un)signed integers of
 // pointer size. They can be cast safely to a pointer, e.g. in Lists,
 // which represent their entities as void* pointers.
 //
 #if SIZEOF_VOID_P == 8
-typedef uint64 ptr_compat_uint;
-typedef int64 ptr_compat_int;
+typedef uint64_t ptr_compat_uint;
+typedef int64_t ptr_compat_int;
 #define PRI_PTR_COMPAT_INT PRId64 // Format to use with printf.
 #define PRI_PTR_COMPAT_UINT PRIu64
 #elif SIZEOF_VOID_P == 4
-typedef uint32 ptr_compat_uint;
-typedef int32 ptr_compat_int;
+typedef uint32_t ptr_compat_uint;
+typedef int32_t ptr_compat_int;
 #define PRI_PTR_COMPAT_INT PRId32
 #define PRI_PTR_COMPAT_UINT PRIu32
 #else
@@ -157,7 +165,7 @@ extern char* strcasestr(const char* s, const char* find);
 #endif
 extern const char* strpbrk_n(size_t len, const char* s, const char* charset);
 template<class T> int atoi_n(int len, const char* s, const char** end, int base, T& result);
-extern char* uitoa_n(uint64 value, char* str, int n, int base, const char* prefix=0);
+extern char* uitoa_n(uint64_t value, char* str, int n, int base, const char* prefix=0);
 int strstr_n(const int big_len, const unsigned char* big,
 		const int little_len, const unsigned char* little);
 extern int fputs(int len, const char* s, FILE* fp);
@@ -191,9 +199,9 @@ extern std::string strreplace(const std::string& s, const std::string& o, const 
 extern std::string strstrip(std::string s);
 
 extern bool hmac_key_set;
-extern uint8 shared_hmac_md5_key[16];
+extern uint8_t shared_hmac_md5_key[16];
 extern bool siphash_key_set;
-extern uint8 shared_siphash_key[SIPHASH_KEYLEN];
+extern uint8_t shared_siphash_key[SIPHASH_KEYLEN];
 
 extern void hmac_md5(size_t size, const unsigned char* bytes,
 			unsigned char digest[16]);
@@ -226,7 +234,7 @@ long int bro_random();
 // in deterministic mode, else it updates the state of the deterministic PRNG.
 void bro_srandom(unsigned int seed);
 
-extern uint64 rand64bit();
+extern uint64_t rand64bit();
 
 // Each event source that may generate events gets an internally unique ID.
 // This is always LOCAL for a local Bro. For remote event sources, it gets
@@ -424,8 +432,8 @@ extern int time_compare(struct timeval* tv_a, struct timeval* tv_b);
 #define UID_POOL_DEFAULT_INTERNAL 1
 #define UID_POOL_DEFAULT_SCRIPT   2
 #define UID_POOL_CUSTOM_SCRIPT    10 // First available custom script level pool.
-extern uint64 calculate_unique_id();
-extern uint64 calculate_unique_id(const size_t pool);
+extern uint64_t calculate_unique_id();
+extern uint64_t calculate_unique_id(const size_t pool);
 
 // For now, don't use hash_maps - they're not fully portable.
 #if 0
@@ -523,7 +531,7 @@ inline int safe_vsnprintf(char* str, size_t size, const char* format, va_list al
 
 // Returns total memory allocations and (if available) amount actually
 // handed out by malloc.
-extern void get_memory_usage(uint64* total, uint64* malloced);
+extern void get_memory_usage(uint64_t* total, uint64_t* malloced);
 
 // Class to be used as a third argument for STL maps to be able to use
 // char*'s as keys. Otherwise the pointer values will be compared instead of

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -198,7 +198,7 @@ static void do_fmt(const char*& fmt, Val* v, ODesc* d)
 				if ( v->Type()->Tag() == TYPE_PORT )
 					u = v->AsPortVal()->Port();
 				else
-					u = ntohl(uint32(u));
+					u = ntohl(uint32_t(u));
 				}
 
 			snprintf(fmt_buf, sizeof(fmt_buf), "%%%s%s", num_fmt,
@@ -871,13 +871,13 @@ function fnv1a32%(input: any%): count
 	input->Describe(&desc);
 	auto bytes = desc.Bytes();
 
-	uint32 offset32 = 2166136261;
-	uint32 prime32 = 16777619;
-	uint32 rval = offset32;
+	uint32_t offset32 = 2166136261;
+	uint32_t prime32 = 16777619;
+	uint32_t rval = offset32;
 
 	for ( auto i = 0; i < desc.Len(); ++i )
 		{
-		rval ^= (uint32) bytes[i];
+		rval ^= (uint32_t) bytes[i];
 		rval *= prime32;
 		}
 
@@ -899,14 +899,14 @@ function fnv1a32%(input: any%): count
 ## .. zeek:see:: fnv1a32
 function hrw_weight%(key_digest: count, site_id: count%): count
 	%{
-	uint32 d = key_digest;
+	uint32_t d = key_digest;
 	d &= 0x7fffffff; // 31-bit digest
-	uint32 si = site_id;
+	uint32_t si = site_id;
 	auto a = 1103515245;
 	auto b = 12345;
 	auto m = 2147483648; // 2**31
 
-	uint32 rval = (a * ((a * si + b) ^ d) + b) % m;
+	uint32_t rval = (a * ((a * si + b) ^ d) + b) % m;
 
 	return val_mgr->GetCount(rval);
 	%}
@@ -1116,7 +1116,7 @@ function entropy_test_finish%(handle: opaque of entropy%): entropy_test_result
 function unique_id%(prefix: string%) : string
 	%{
 	char tmp[20];
-	uint64 uid = calculate_unique_id(UID_POOL_DEFAULT_SCRIPT);
+	uint64_t uid = calculate_unique_id(UID_POOL_DEFAULT_SCRIPT);
 	return new StringVal(uitoa_n(uid, tmp, sizeof(tmp), 62, prefix->CheckString()));
 	%}
 
@@ -1134,7 +1134,7 @@ function unique_id_from%(pool: int, prefix: string%) : string
 	pool += UID_POOL_CUSTOM_SCRIPT; // Make sure we don't conflict with internal pool.
 
 	char tmp[20];
-	uint64 uid = calculate_unique_id(pool);
+	uint64_t uid = calculate_unique_id(pool);
 	return new StringVal(uitoa_n(uid, tmp, sizeof(tmp), 62, prefix->CheckString()));
 	%}
 
@@ -2028,7 +2028,7 @@ function is_local_interface%(ip: addr%) : bool
 	if ( ent )
 		{
 		for ( unsigned int len = 0; ent->h_addr_list[len]; ++len )
-			addrs.push_back(IPAddr(IPv4, (uint32*)ent->h_addr_list[len],
+			addrs.push_back(IPAddr(IPv4, (uint32_t*)ent->h_addr_list[len],
 			                       IPAddr::Network));
 		}
 
@@ -2037,7 +2037,7 @@ function is_local_interface%(ip: addr%) : bool
 	if ( ent )
 		{
 		for ( unsigned int len = 0; ent->h_addr_list[len]; ++len )
-			addrs.push_back(IPAddr(IPv6, (uint32*)ent->h_addr_list[len],
+			addrs.push_back(IPAddr(IPv6, (uint32_t*)ent->h_addr_list[len],
 			                       IPAddr::Network));
 		}
 
@@ -2181,7 +2181,7 @@ function routing0_data_to_addrs%(s: string%): addr_vec
 
 	while ( len > 0 )
 		{
-		IPAddr a(IPv6, (const uint32*) bytes, IPAddr::Network);
+		IPAddr a(IPv6, (const uint32_t*) bytes, IPAddr::Network);
 		rval->Assign(rval->Size(), new AddrVal(a));
 		bytes += 16;
 		len -= 16;
@@ -2201,7 +2201,7 @@ function routing0_data_to_addrs%(s: string%): addr_vec
 function addr_to_counts%(a: addr%): index_vec
 	%{
 	VectorVal* rval = new VectorVal(internal_type("index_vec")->AsVectorType());
-	const uint32* bytes;
+	const uint32_t* bytes;
 	int len = a->AsAddr().GetBytes(&bytes);
 
 	for ( int i = 0; i < len; ++i )
@@ -2226,7 +2226,7 @@ function counts_to_addr%(v: index_vec%): addr
 		}
 	else if ( v->AsVector()->size() == 4 )
 		{
-		uint32 bytes[4];
+		uint32_t bytes[4];
 		for ( int i = 0; i < 4; ++i )
 			bytes[i] = htonl((*v->AsVector())[i]->AsCount());
 		return new AddrVal(bytes);
@@ -2234,7 +2234,7 @@ function counts_to_addr%(v: index_vec%): addr
 	else
 		{
 		builtin_error("invalid vector size", @ARG@[0]);
-		uint32 bytes[4];
+		uint32_t bytes[4];
 		memset(bytes, 0, sizeof(bytes));
 		return new AddrVal(bytes);
 		}
@@ -2324,7 +2324,7 @@ function to_count%(str: string%): count
 	const char* s = str->CheckString();
 	char* end_s;
 
-	uint64 u = (uint64) strtoull(s, &end_s, 10);
+	uint64_t u = (uint64_t) strtoull(s, &end_s, 10);
 
 	if ( s[0] == '\0' || end_s[0] != '\0' )
     	{
@@ -2544,10 +2544,10 @@ function count_to_v4_addr%(ip: count%): addr
 	if ( ip > 4294967295LU )
 		{
 		builtin_error("conversion of non-IPv4 count to addr", @ARG@[0]);
-		return new AddrVal(uint32(0));
+		return new AddrVal(uint32_t(0));
 		}
 
-	return new AddrVal(htonl(uint32(ip)));
+	return new AddrVal(htonl(uint32_t(ip)));
 	%}
 
 ## Converts a :zeek:type:`string` of bytes into an IPv4 address. In particular,
@@ -2561,7 +2561,7 @@ function count_to_v4_addr%(ip: count%): addr
 ## .. zeek:see:: raw_bytes_to_v4_addr to_addr to_subnet
 function raw_bytes_to_v4_addr%(b: string%): addr
 	%{
-	uint32 a = 0;
+	uint32_t a = 0;
 
 	if ( b->Len() < 4 )
 		builtin_error("too short a string as input to raw_bytes_to_v4_addr()");
@@ -2646,69 +2646,69 @@ function bytestring_to_count%(s: string, is_le: bool &default=F%): count
 	unsigned int i;
 
 	switch ( s->Len() ) {
-	case sizeof(uint8):
+	case sizeof(uint8_t):
 		{
-		uint8 value = 0;
-		memcpy(&value, p, sizeof(uint8));
+		uint8_t value = 0;
+		memcpy(&value, p, sizeof(uint8_t));
 		return val_mgr->GetCount(value);
 		}
 
-	case sizeof(uint16):
+	case sizeof(uint16_t):
 		{
-		uint16 value = 0;
+		uint16_t value = 0;
 
 		if ( (host_bigendian && is_le) || (! host_bigendian && ! is_le) )
 			{
-			char buf[sizeof(uint16)];
-			char *d = &buf[sizeof(uint16)-1];
+			char buf[sizeof(uint16_t)];
+			char *d = &buf[sizeof(uint16_t)-1];
 
-			for ( i = 0; i < sizeof(uint16); i++ )
+			for ( i = 0; i < sizeof(uint16_t); i++ )
 				*d-- = *p++;
 
-			memcpy(&value, buf, sizeof(uint16));
+			memcpy(&value, buf, sizeof(uint16_t));
 			}
 		else
-			memcpy(&value, p, sizeof(uint16));
-
-		return val_mgr->GetCount(value);
-		}
-
-	case sizeof(uint32):
-		{
-		uint32 value = 0;
-
-		if ( (host_bigendian && is_le) || (! host_bigendian && ! is_le) )
-			{
-			char buf[sizeof(uint32)];
-			char *d = &buf[sizeof(uint32)-1];
-
-			for ( i = 0; i < sizeof(uint32); i++ )
-				*d-- = *p++;
-
-			memcpy(&value, buf, sizeof(uint32));
-			}
-		else
-			memcpy(&value, p, sizeof(uint32));
+			memcpy(&value, p, sizeof(uint16_t));
 
 		return val_mgr->GetCount(value);
 		}
 
-	case sizeof(uint64):
+	case sizeof(uint32_t):
 		{
-		uint64 value = 0;
+		uint32_t value = 0;
 
 		if ( (host_bigendian && is_le) || (! host_bigendian && ! is_le) )
 			{
-			char buf[sizeof(uint64)];
-			char *d = &buf[sizeof(uint64)-1];
+			char buf[sizeof(uint32_t)];
+			char *d = &buf[sizeof(uint32_t)-1];
 
-			for ( i = 0; i < sizeof(uint64); i++ )
+			for ( i = 0; i < sizeof(uint32_t); i++ )
 				*d-- = *p++;
 
-			memcpy(&value, buf, sizeof(uint64));
+			memcpy(&value, buf, sizeof(uint32_t));
 			}
 		else
-			memcpy(&value, p, sizeof(uint64));
+			memcpy(&value, p, sizeof(uint32_t));
+
+		return val_mgr->GetCount(value);
+		}
+
+	case sizeof(uint64_t):
+		{
+		uint64_t value = 0;
+
+		if ( (host_bigendian && is_le) || (! host_bigendian && ! is_le) )
+			{
+			char buf[sizeof(uint64_t)];
+			char *d = &buf[sizeof(uint64_t)-1];
+
+			for ( i = 0; i < sizeof(uint64_t); i++ )
+				*d-- = *p++;
+
+			memcpy(&value, buf, sizeof(uint64_t));
+			}
+		else
+			memcpy(&value, p, sizeof(uint64_t));
 
 		return val_mgr->GetCount(value);
 		}
@@ -2731,7 +2731,7 @@ function ptr_name_to_addr%(s: string%): addr
 	if ( s->Len() != 72 )
 		{
 		int a[4];
-		uint32 addr;
+		uint32_t addr;
 		char ss[13]; // this will contain "in-addr.arpa"
 
 		if ( sscanf(s->CheckString(),
@@ -2749,8 +2749,8 @@ function ptr_name_to_addr%(s: string%): addr
 		}
 	else
 		{
-		uint32 addr6[4];
-		uint32 b[32];
+		uint32_t addr6[4];
+		uint32_t b[32];
 		char ss[9]; // this will contain "ip6.arpa"
 		if ( sscanf(s->CheckString(),
 			"%1x.%1x.%1x.%1x.%1x.%1x.%1x.%1x."
@@ -2770,7 +2770,7 @@ function ptr_name_to_addr%(s: string%): addr
 			{
 			for ( unsigned int i = 0; i < 4; ++i )
 				{
-				uint32 a = 0;
+				uint32_t a = 0;
 				for ( unsigned int j = 1; j <= 8; ++j )
 					a |= b[8*i+j-1] << (32-j*4);
 
@@ -2941,12 +2941,12 @@ function decode_base64_conn%(cid: conn_id, s: string, a: string &default=""%): s
 
 %%{
 typedef struct {
-	uint32 time_low;
-	uint16 time_mid;
-	uint16 time_hi_and_version;
-	uint8 clock_seq_hi_and_reserved;
-	uint8 clock_seq_low;
-	uint8 node[6];
+	uint32_t time_low;
+	uint16_t time_mid;
+	uint16_t time_hi_and_version;
+	uint8_t clock_seq_hi_and_reserved;
+	uint8_t clock_seq_low;
+	uint8_t node[6];
 } bro_uuid_t;
 %%}
 
@@ -3323,9 +3323,9 @@ const char* conn_id_string(Val* c)
 	const val_list* vl = id->AsRecord();
 
 	const IPAddr& orig_h = (*vl)[0]->AsAddr();
-	uint32 orig_p = (*vl)[1]->AsPortVal()->Port();
+	uint32_t orig_p = (*vl)[1]->AsPortVal()->Port();
 	const IPAddr& resp_h = (*vl)[2]->AsAddr();
-	uint32 resp_p = (*vl)[3]->AsPortVal()->Port();
+	uint32_t resp_p = (*vl)[3]->AsPortVal()->Port();
 
 	return fmt("%s/%u -> %s/%u\n", orig_h.AsString().c_str(), orig_p,
 	                               resp_h.AsString().c_str(), resp_p);
@@ -3387,8 +3387,8 @@ function get_current_packet%(%) : pcap_packet
 		return pkt;
 		}
 
-	pkt->Assign(0, val_mgr->GetCount(uint32(p->ts.tv_sec)));
-	pkt->Assign(1, val_mgr->GetCount(uint32(p->ts.tv_usec)));
+	pkt->Assign(0, val_mgr->GetCount(uint32_t(p->ts.tv_sec)));
+	pkt->Assign(1, val_mgr->GetCount(uint32_t(p->ts.tv_usec)));
 	pkt->Assign(2, val_mgr->GetCount(p->cap_len));
 	pkt->Assign(3, val_mgr->GetCount(p->len));
 	pkt->Assign(4, new StringVal(p->cap_len, (const char*)p->data));
@@ -3440,7 +3440,7 @@ function dump_packet%(pkt: pcap_packet, file_name: string%) : bool
 	if ( ! addl_pkt_dumper->IsError() )
 		{
 		pkt_timeval ts;
-		uint32 caplen, len, link_type;
+		uint32_t caplen, len, link_type;
 		u_char *data;
 
 		const val_list* pkt_vl = pkt->AsRecord();
@@ -4979,7 +4979,7 @@ function preserve_prefix%(a: addr, width: count%): any
 			builtin_error("preserve_prefix() not supported for IPv6 addresses");
 		else
 			{
-			const uint32* bytes;
+			const uint32_t* bytes;
 			a->AsAddr().GetBytes(&bytes);
 			ip_anon->PreservePrefix(*bytes, width);
 			}
@@ -5006,7 +5006,7 @@ function preserve_subnet%(a: subnet%): any
 			builtin_error("preserve_subnet() not supported for IPv6 addresses");
 		else
 			{
-			const uint32* bytes;
+			const uint32_t* bytes;
 			a->AsSubNet().Prefix().GetBytes(&bytes);
 			ip_anon->PreservePrefix(*bytes, a->AsSubNet().Length());
 			}
@@ -5045,7 +5045,7 @@ function anonymize_addr%(a: addr, cl: IPAddrAnonymizationClass%): addr
 		}
 	else
 		{
-		const uint32* bytes;
+		const uint32_t* bytes;
 		a->AsAddr().GetBytes(&bytes);
 		return new AddrVal(anonymize_ip(*bytes,
 			(enum ip_addr_anonymization_class_t) anon_class));


### PR DESCRIPTION
This PR deprecates the internal types in favor of the ones that they're based on. The deprecated types can't be removed until 4.1, but this will at least start warning about them.