### PR TITLE
Use _exit() in Reporter::FatalError

### DIFF
--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -2,6 +2,7 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 //
 
+#include <unistd.h>
 #include <syslog.h>
 
 #include "zeek-config.h"
@@ -117,7 +118,9 @@ void Reporter::FatalError(const char* fmt, ...)
 	va_end(ap);
 
 	set_processing_status("TERMINATED", "fatal_error");
-	exit(1);
+	fflush(stderr);
+	fflush(stdout);
+	_exit(1);
 	}
 
 void Reporter::FatalErrorWithCore(const char* fmt, ...)


### PR DESCRIPTION
Using exit() here may generally not work well since:

* That will result in calling global destructors

* We have global state that we potentially modify at run-time and
  are in the middle of modiying at the time the FatalError occurs.
  E.g. out-of-memory is one situation where it's likely we could
  call the dtor of an object in which operation on it's internal
  state is no longer consistent/safe.