### PR TITLE
GH-533: use consistent "lib" install dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,15 @@ project(Zeek C CXX)
 # aux/zeek-aux/plugin-support/skeleton/CMakeLists.txt
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
+if ( NOT CMAKE_INSTALL_LIBDIR )
+    # Currently, some sub-projects may use GNUInstallDirs.cmake to choose the
+    # library install dir, while others just default to "lib".  For sake of
+    # consistency, this just overrides the former to always use "lib" in case
+    # it would have chosen something else, like "lib64", but a thing for the
+    # future may be to standardize all sub-projects to use GNUInstallDirs.
+    set(CMAKE_INSTALL_LIBDIR lib)
+endif ()
+
 include(cmake/CommonCMakeConfig.cmake)
 
 ########################################################################


### PR DESCRIPTION
This is the simplest fix I can think to do for 3.0.0, with the goal of just using a consistent install dir for libraries.  If the goal is to standardize on using `GNUInstallDirs.cmake` for each sub-project to pick the most appropriate libdir for the platform, I'd prefer not to do that for 3.0.0 since that's even more in the "enhancement" realm rather than "bugfix" realm and also has to touch code in several submodules.

(This PR is to merge into master, but also pick it into `release/3.0` if that all sounds fine).