### PR TITLE
Stop incorrect language identification on github.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
-*.sig linguist-language=none
-*.pac linguist-language=none
-testing/btest/Baseline/** linguist-language=none
+*.sig linguist-detectable=false
+*.pac linguist-detectable=false
+*.bif linguist-detectable=false
+testing/btest/Baseline/** linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sig linguist-language=none
+*.pac linguist-language=none
+testing/btest/Baseline/** linguist-language=none


### PR DESCRIPTION
If you look at the languages that github is implemented in according
to our page on github, it has several incorrect things. PAC files and
SIG files being the big misidentifications. In my opinion it would look
better to mark these as no language so that javascript and ML stop showing
up as languages that Zeek is implemented in.

This change should make fix that on github according to:
	https://github.com/github/linguist#overrides