### PR TITLE
Zeekify thread naming.

### DIFF
--- a/src/input/ReaderBackend.cc
+++ b/src/input/ReaderBackend.cc
@@ -257,7 +257,7 @@ bool ReaderBackend::Init(const int arg_num_fields,
 
 	disabled = false;
 
-	SetOSName(Fmt("bro: %s", Name()));
+	SetOSName(Fmt("zk.%s", Name()));
 
 	num_fields = arg_num_fields;
 	fields = arg_fields;

--- a/src/logging/WriterBackend.cc
+++ b/src/logging/WriterBackend.cc
@@ -179,7 +179,7 @@ void WriterBackend::DisableFrontend()
 
 bool WriterBackend::Init(int arg_num_fields, const Field* const* arg_fields)
 	{
-	SetOSName(Fmt("bro: %s", Name()));
+	SetOSName(Fmt("zk.%s", Name()));
 	num_fields = arg_num_fields;
 	fields = arg_fields;
 


### PR DESCRIPTION
I copied the same style that caf uses ("zk" with single dot and no space).
This gives some consistency with caf and avoids us wasting more
space beyond "bro: ".  OSs only give 16 characters for thread names
so anything we can gain here is nice.