### PR TITLE
Add/use unspecified IPAddr constants

### DIFF
--- a/src/IPAddr.cc
+++ b/src/IPAddr.cc
@@ -14,6 +14,10 @@ const uint8_t IPAddr::v4_mapped_prefix[12] = { 0, 0, 0, 0,
                                                0, 0, 0, 0,
                                                0, 0, 0xff, 0xff };
 
+const IPAddr IPAddr::v4_unspecified = IPAddr(in4_addr{});
+
+const IPAddr IPAddr::v6_unspecified = IPAddr();
+
 ConnIDKey BuildConnIDKey(const ConnID& id)
 	{
 	ConnIDKey key;

--- a/src/IPAddr.h
+++ b/src/IPAddr.h
@@ -430,6 +430,16 @@ public:
 		return ConvertString(s, &tmp);
 		}
 
+	/**
+	 * Unspecified IPv4 addr, "0.0.0.0".
+	 */
+	static const IPAddr v4_unspecified;
+
+	/**
+	 * Unspecified IPv6 addr, "::".
+	 */
+	static const IPAddr v6_unspecified;
+
 private:
 	friend class IPPrefix;
 

--- a/src/analyzer/Manager.cc
+++ b/src/analyzer/Manager.cc
@@ -21,10 +21,10 @@ using namespace analyzer;
 Manager::ConnIndex::ConnIndex(const IPAddr& _orig, const IPAddr& _resp,
 				     uint16_t _resp_p, uint16_t _proto)
 	{
-	if ( _orig == IPAddr(string("0.0.0.0")) )
+	if ( _orig == IPAddr::v4_unspecified )
 		// don't use the IPv4 mapping, use the literal unspecified address
 		// to indicate a wildcard
-		orig = IPAddr(string("::"));
+		orig = IPAddr::v6_unspecified;
 	else
 		orig = _orig;
 
@@ -35,7 +35,7 @@ Manager::ConnIndex::ConnIndex(const IPAddr& _orig, const IPAddr& _resp,
 
 Manager::ConnIndex::ConnIndex()
 	{
-	orig = resp = IPAddr("0.0.0.0");
+	orig = resp = IPAddr::v4_unspecified;
 	resp_p = 0;
 	proto = 0;
 	}
@@ -596,7 +596,7 @@ Manager::tag_set Manager::GetScheduled(const Connection* conn)
 		result.insert(i->second->analyzer);
 
 	// Try wildcard for originator.
-	c.orig = IPAddr(string("::"));
+	c.orig = IPAddr::v6_unspecified;
 	all = conns.equal_range(c);
 
 	for ( conns_map::iterator i = all.first; i != all.second; i++ )


### PR DESCRIPTION
The analyzer-scheduling code was otherwise frequently converting the
unspecified v4/v6 addresses from strings.