### PR TITLE
file signature optimizations

### DIFF
--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -205,6 +205,7 @@ RuleMatcher::RuleMatcher(int arg_RE_level)
 				new maskedvalue_list);
 	RE_level = arg_RE_level;
 	parse_error = false;
+	has_non_file_magic_rule = false;
 	}
 
 RuleMatcher::~RuleMatcher()
@@ -284,6 +285,25 @@ void RuleMatcher::BuildRulesTree()
 		{
 		if ( ! rule->Active() )
 			continue;
+
+		const auto& pats = rule->patterns;
+
+		if ( ! has_non_file_magic_rule )
+			{
+			if ( pats.length() > 0 )
+				{
+				for ( const auto& p : pats )
+					{
+					if ( p->type != Rule::FILE_MAGIC )
+						{
+						has_non_file_magic_rule = true;
+						break;
+						}
+					}
+				}
+			else
+				has_non_file_magic_rule = true;
+			}
 
 		rule->SortHdrTests();
 		InsertRuleIntoTree(rule, 0, root, 0);

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -732,7 +732,7 @@ RuleEndpointState* RuleMatcher::InitEndpoint(analyzer::Analyzer* analyzer,
 		// pattern matching to do.
 		if ( hdr_test->level <= RE_level )
 			{
-			for ( int i = 0; i < Rule::TYPES; ++i )
+			for ( int i = Rule::PAYLOAD; i < Rule::TYPES; ++i )
 				{
 				for ( const auto& set : hdr_test->psets[i] )
 					{

--- a/src/RuleMatcher.h
+++ b/src/RuleMatcher.h
@@ -286,6 +286,8 @@ public:
 	void AddRule(Rule* rule);
 	void SetParseError()		{ parse_error = true; }
 
+	bool HasNonFileMagicRule() const	{ return has_non_file_magic_rule; }
+
 	// Interface to for getting some statistics
 	struct Stats {
 		unsigned int matchers;	// # distinct RE matchers
@@ -356,6 +358,7 @@ private:
 	                                   const AcceptingMatchSet& ams);
 
 	int RE_level;
+	bool has_non_file_magic_rule;
 	bool parse_error;
 	RuleHdrTest* root;
 	rule_list rules;

--- a/src/analyzer/protocol/pia/PIA.cc
+++ b/src/analyzer/protocol/pia/PIA.cc
@@ -130,6 +130,9 @@ void PIA::DoMatch(const u_char* data, int len, bool is_orig, bool bol, bool eol,
 	if ( ! rule_matcher )
 		return;
 
+	if ( ! rule_matcher->HasNonFileMagicRule() )
+		return;
+
 	if ( ! MatcherInitialized(is_orig) )
 		InitEndpointMatcher(AsAnalyzer(), ip, len, is_orig, this);
 


### PR DESCRIPTION
Fixes #554

See individual commit messages for explanations.

If there's no objection, I'll also plan to include 8c9b3bd3aebfe71fc6a7c4b1c3f5c45d9c3776e8 into the 3.0 branch since it's such a small change for a big benefit (the other commit doesn't make a difference for the typical use-case since it only benefits `zeek -b` mode).