### PR TITLE
Improve reassembly worst-case performance

### DIFF
--- a/src/Frag.h
+++ b/src/Frag.h
@@ -37,7 +37,7 @@ public:
 	const FragReassemblerKey& Key() const	{ return key; }
 
 protected:
-	void BlockInserted(const DataBlock* start_block) override;
+	void BlockInserted(DataBlockMap::const_iterator it) override;
 	void Overlap(const u_char* b1, const u_char* b2, uint64_t n) override;
 	void Weird(const char* name) const;
 

--- a/src/Frag.h
+++ b/src/Frag.h
@@ -37,7 +37,7 @@ public:
 	const FragReassemblerKey& Key() const	{ return key; }
 
 protected:
-	void BlockInserted(DataBlock* start_block) override;
+	void BlockInserted(const DataBlock* start_block) override;
 	void Overlap(const u_char* b1, const u_char* b2, uint64_t n) override;
 	void Weird(const char* name) const;
 

--- a/src/Reassem.cc
+++ b/src/Reassem.cc
@@ -73,7 +73,7 @@ void DataBlockList::Append(DataBlock block, uint64_t limit)
 		Delete(block_map.begin());
 	}
 
-DataBlockMap::const_iterator DataBlockList::FindFirstBlockBefore(uint64_t seq) const
+DataBlockMap::const_iterator DataBlockList::FirstBlockAtOrBefore(uint64_t seq) const
 	{
 	// Upper sequence number doesn't matter for the search
 	auto it = block_map.upper_bound(seq);
@@ -122,7 +122,7 @@ DataBlockList::Insert(uint64_t seq, uint64_t upper, const u_char* data,
 		it = *hint;
 	else
 		{
-		it = FindFirstBlockBefore(seq);
+		it = FirstBlockAtOrBefore(seq);
 
 		if ( it == block_map.end() )
 			it = block_map.begin();
@@ -275,7 +275,7 @@ void Reassembler::CheckOverlap(const DataBlockList& list,
 
 	uint64_t upper = (seq + len);
 
-	auto it = list.FindFirstBlockBefore(seq);
+	auto it = list.FirstBlockAtOrBefore(seq);
 
 	if ( it == list.End() )
 		it = list.Begin();

--- a/src/Reassem.cc
+++ b/src/Reassem.cc
@@ -19,8 +19,6 @@ DataBlock::DataBlock(const u_char* data, uint64_t size, uint64_t arg_seq)
 
 void DataBlockList::DataSize(uint64_t seq_cutoff, uint64_t* below, uint64_t* above) const
 	{
-	// TODO: add warnings that this is O(n) and slow
-
 	for ( const auto& e : block_map )
 		{
 		const auto& b = e.second;

--- a/src/Reassem.cc
+++ b/src/Reassem.cc
@@ -23,32 +23,31 @@ void DataBlockList::DataSize(uint64_t seq_cutoff, uint64_t* below, uint64_t* abo
 
 	for ( const auto& e : block_map )
 		{
-		auto b = e.second;
+		const auto& b = e.second;
 
-		if ( b->seq <= seq_cutoff )
-			*above += b->Size();
+		if ( b.seq <= seq_cutoff )
+			*above += b.Size();
 		else
-			*below += b->Size();
+			*below += b.Size();
 		}
 	}
 
 void DataBlockList::Delete(DataBlockMap::const_iterator it)
 	{
-	auto b = it->second;
-	auto size = b->Size();
+	const auto& b = it->second;
+	auto size = b.Size();
 
 	block_map.erase(it);
 	total_data_size -= size;
 
-	delete b;
 	Reassembler::total_size -= size + sizeof(DataBlock);
 	Reassembler::sizes[reassembler->rtype] -= size + sizeof(DataBlock);
 	}
 
-DataBlock* DataBlockList::Remove(DataBlockMap::const_iterator it)
+DataBlock DataBlockList::Remove(DataBlockMap::const_iterator it)
 	{
-	auto b = it->second;
-	auto size = b->Size();
+	auto b = std::move(it->second);
+	auto size = b.Size();
 
 	block_map.erase(it);
 	total_data_size -= size;
@@ -58,18 +57,19 @@ DataBlock* DataBlockList::Remove(DataBlockMap::const_iterator it)
 
 void DataBlockList::Clear()
 	{
-	// TODO: maybe can just use clear()
-	while ( ! block_map.empty() )
-		Delete(block_map.begin());
-
+	auto total_db_size = sizeof(DataBlock) * block_map.size();
+	auto total = total_data_size + total_db_size;
+	Reassembler::total_size -= total;
+	Reassembler::sizes[reassembler->rtype] -= total;
+	total_data_size = 0;
 	block_map.clear();
 	}
 
-void DataBlockList::Append(DataBlock* block, uint64_t limit)
+void DataBlockList::Append(DataBlock block, uint64_t limit)
 	{
-	total_data_size += block->Size();
+	total_data_size += block.Size();
 
-	block_map.emplace_hint(block_map.end(), block->seq, block);
+	block_map.emplace_hint(block_map.end(), block.seq, std::move(block));
 
 	while ( block_map.size() > limit )
 		Delete(block_map.begin());
@@ -94,9 +94,7 @@ DataBlockList::Insert(uint64_t seq, uint64_t upper, const u_char* data,
                       DataBlockMap::const_iterator hint)
 	{
 	auto size = upper - seq;
-	auto db = new DataBlock(data, size, seq);
-
-	auto rval = block_map.emplace_hint(hint, seq, db);
+	auto rval = block_map.emplace_hint(hint, seq, DataBlock(data, size, seq));
 
 	total_data_size += size;
 	Reassembler::sizes[reassembler->rtype] += size + sizeof(DataBlock);
@@ -113,10 +111,10 @@ DataBlockList::Insert(uint64_t seq, uint64_t upper, const u_char* data,
 	if ( block_map.empty() )
 		return Insert(seq, upper, data, block_map.end());
 
-	auto last = block_map.rbegin()->second;
+	const auto& last = block_map.rbegin()->second;
 
 	// Special check for the common case of appending to the end.
-	if ( seq == last->upper )
+	if ( seq == last.upper )
 		return Insert(seq, upper, data, block_map.end());
 
 	// Find the first block that doesn't come completely before the new data.
@@ -132,44 +130,39 @@ DataBlockList::Insert(uint64_t seq, uint64_t upper, const u_char* data,
 			it = block_map.begin();
 		}
 
-	while ( std::next(it) != block_map.end() && it->second->upper <= seq )
+	while ( std::next(it) != block_map.end() && it->second.upper <= seq )
 		++it;
 
-	DataBlock* b = it->second;
+	const auto& b = it->second;
 
-	if ( b->upper <= seq )
+	if ( b.upper <= seq )
 		// b is the last block, and it comes completely before the new block.
 		return Insert(seq, upper, data, block_map.end());
 
-	if ( upper <= b->seq )
+	if ( upper <= b.seq )
 		// The new block comes completely before b.
 		return Insert(seq, upper, data, it);
 
-	DataBlock* new_b;
 	DataBlockMap::const_iterator rval;
 
 	// The blocks overlap.
-	if ( seq < b->seq )
+	if ( seq < b.seq )
 		{
 		// The new block has a prefix that comes before b.
-		uint64_t prefix_len = b->seq - seq;
+		uint64_t prefix_len = b.seq - seq;
 
 		rval = Insert(seq, seq + prefix_len, data, it);
-		new_b = rval->second;
 
 		data += prefix_len;
 		seq += prefix_len;
 		}
 	else
-		{
 		rval = it;
-		new_b = b;
-		}
 
 	uint64_t overlap_start = seq;
-	uint64_t overlap_offset = overlap_start - b->seq;
+	uint64_t overlap_offset = overlap_start - b.seq;
 	uint64_t new_b_len = upper - seq;
-	uint64_t b_len = b->upper - overlap_start;
+	uint64_t b_len = b.upper - overlap_start;
 	uint64_t overlap_len = min(new_b_len, b_len);
 
 	if ( overlap_len < new_b_len )
@@ -180,7 +173,7 @@ DataBlockList::Insert(uint64_t seq, uint64_t upper, const u_char* data,
 
 		auto r = Insert(seq, upper, data, &it);
 
-		if ( new_b == b )
+		if ( rval == it )
 			rval = r;
 		}
 
@@ -197,11 +190,11 @@ uint64_t DataBlockList::Trim(uint64_t seq, uint64_t max_old,
 
 	if ( ! block_map.empty() )
 		{
-		auto first = block_map.begin()->second;
+		const auto& first = block_map.begin()->second;
 
-		if ( first->seq > reassembler->LastReassemSeq() )
+		if ( first.seq > reassembler->LastReassemSeq() )
 			// An initial hole.
-			num_missing += first->seq - reassembler->LastReassemSeq();
+			num_missing += first.seq - reassembler->LastReassemSeq();
 		}
 	else if ( seq > reassembler->LastReassemSeq() )
 		{
@@ -219,26 +212,25 @@ uint64_t DataBlockList::Trim(uint64_t seq, uint64_t max_old,
 	while ( ! block_map.empty() )
 		{
 		auto first_it = block_map.begin();
-		auto first = first_it->second;
+		const auto& first = first_it->second;
 
-		if ( first->upper > seq )
+		if ( first.upper > seq )
 			break;
 
-		auto next_it = std::next(first_it);
-		auto next = next_it == block_map.end() ? nullptr : next_it->second;
+		auto next = std::next(first_it);
 
-		if ( next && next->seq <= seq )
+		if ( next != block_map.end() && next->second.seq <= seq )
 			{
-			if ( first->upper != next->seq )
-				num_missing += next->seq - first->upper;
+			if ( first.upper != next->second.seq )
+				num_missing += next->second.seq - first.upper;
 			}
 		else
 			{
 			// No more blocks - did this one make it to seq?
 			// Second half of test is for acks of FINs, which
 			// don't get entered into the sequence space.
-			if ( first->upper != seq && first->upper != seq - 1 )
-				num_missing += seq - first->upper;
+			if ( first.upper != seq && first.upper != seq - 1 )
+				num_missing += seq - first.upper;
 			}
 
 		if ( max_old )
@@ -250,12 +242,12 @@ uint64_t DataBlockList::Trim(uint64_t seq, uint64_t max_old,
 	if ( ! block_map.empty() )
 		{
 		auto first_it = block_map.begin();
-		auto first = first_it->second;
+		const auto& first = first_it->second;
 
 		// If we skipped over some undeliverable data, then
 		// it's possible that this block is now deliverable.
 		// Give it a try.
-		if ( first->seq == reassembler->LastReassemSeq() )
+		if ( first.seq == reassembler->LastReassemSeq() )
 			reassembler->BlockInserted(first_it);
 		}
 
@@ -277,9 +269,9 @@ void Reassembler::CheckOverlap(const DataBlockList& list,
 	if ( list.Empty() )
 		return;
 
-	auto last = list.LastBlock();
+	const auto& last = list.LastBlock();
 
-	if ( seq == last->upper )
+	if ( seq == last.upper )
 		// Special case check for common case of appending to the end.
 		return;
 
@@ -292,31 +284,31 @@ void Reassembler::CheckOverlap(const DataBlockList& list,
 
 	for ( ; it != list.End(); ++it )
 		{
-		auto b = it->second;
+		const auto& b = it->second;
 		uint64_t nseq = seq;
 		uint64_t nupper = upper;
 		const u_char* ndata = data;
 
-		if ( nupper <= b->seq )
+		if ( nupper <= b.seq )
 			break;
 
-		if ( nseq >= b->upper )
+		if ( nseq >= b.upper )
 			continue;
 
-		if ( nseq < b->seq )
+		if ( nseq < b.seq )
 			{
-			ndata += (b->seq - seq);
-			nseq = b->seq;
+			ndata += (b.seq - seq);
+			nseq = b.seq;
 			}
 
-		if ( nupper > b->upper )
-			nupper = b->upper;
+		if ( nupper > b.upper )
+			nupper = b.upper;
 
-		uint64_t overlap_offset = (nseq - b->seq);
+		uint64_t overlap_offset = (nseq - b.seq);
 		uint64_t overlap_len = (nupper - nseq);
 
 		if ( overlap_len )
-			Overlap(&b->block[overlap_offset], ndata, overlap_len);
+			Overlap(&b.block[overlap_offset], ndata, overlap_len);
 		}
 	}
 

--- a/src/Reassem.cc
+++ b/src/Reassem.cc
@@ -11,7 +11,7 @@ static const bool DEBUG_reassem = false;
 
 DataBlock::DataBlock(Reassembler* reass, const u_char* data,
                      uint64_t size, uint64_t arg_seq, DataBlock* arg_prev,
-                     DataBlock* arg_next, ReassemblerType reassem_type)
+                     DataBlock* arg_next)
 	{
 	seq = arg_seq;
 	upper = seq + size;
@@ -30,8 +30,7 @@ DataBlock::DataBlock(Reassembler* reass, const u_char* data,
 	reassembler = reass;
 	reassembler->size_of_all_blocks += size;
 
-	rtype = reassem_type;
-	Reassembler::sizes[rtype] += pad_size(size) + padded_sizeof(DataBlock);
+	Reassembler::sizes[reass->rtype] += pad_size(size) + padded_sizeof(DataBlock);
 	Reassembler::total_size += pad_size(size) + padded_sizeof(DataBlock);
 	}
 
@@ -121,7 +120,7 @@ void Reassembler::NewBlock(double t, uint64_t seq, uint64_t len, const u_char* d
 
 	if ( ! blocks )
 		blocks = last_block = start_block =
-			new DataBlock(this, data, len, seq, 0, 0, rtype);
+			new DataBlock(this, data, len, seq, 0, 0);
 	else
 		start_block = AddAndCheck(blocks, seq, upper_seq, data);
 
@@ -281,7 +280,7 @@ DataBlock* Reassembler::AddAndCheck(DataBlock* b, uint64_t seq, uint64_t upper,
 	if ( last_block && seq == last_block->upper )
 		{
 		last_block = new DataBlock(this, data, upper - seq,
-		                           seq, last_block, 0, rtype);
+		                           seq, last_block, 0);
 		return last_block;
 		}
 
@@ -295,7 +294,7 @@ DataBlock* Reassembler::AddAndCheck(DataBlock* b, uint64_t seq, uint64_t upper,
 		// b is the last block, and it comes completely before
 		// the new block.
 		last_block = new DataBlock(this, data, upper - seq,
-		                           seq, b, 0, rtype);
+		                           seq, b, 0);
 		return last_block;
 		}
 
@@ -305,7 +304,7 @@ DataBlock* Reassembler::AddAndCheck(DataBlock* b, uint64_t seq, uint64_t upper,
 		{
 		// The new block comes completely before b.
 		new_b = new DataBlock(this, data, upper - seq, seq,
-		                      b->prev, b, rtype);
+		                      b->prev, b);
 		if ( b == blocks )
 			blocks = new_b;
 		return new_b;
@@ -317,7 +316,7 @@ DataBlock* Reassembler::AddAndCheck(DataBlock* b, uint64_t seq, uint64_t upper,
 		// The new block has a prefix that comes before b.
 		uint64_t prefix_len = b->seq - seq;
 		new_b = new DataBlock(this, data, prefix_len, seq,
-		                      b->prev, b, rtype);
+		                      b->prev, b);
 		if ( b == blocks )
 			blocks = new_b;
 

--- a/src/Reassem.cc
+++ b/src/Reassem.cc
@@ -7,7 +7,8 @@
 
 #include "Reassem.h"
 
-static const bool DEBUG_reassem = false;
+uint64_t Reassembler::total_size = 0;
+uint64_t Reassembler::sizes[REASSEM_NUM];
 
 DataBlock::DataBlock(Reassembler* reass, const u_char* data,
                      uint64_t size, uint64_t arg_seq, DataBlock* arg_prev,
@@ -27,6 +28,8 @@ DataBlock::DataBlock(Reassembler* reass, const u_char* data,
 	if ( next )
 		next->prev = this;
 
+	// TODO: could probably store this pointer and do book-keeping in
+	// DataBlockList instead
 	reassembler = reass;
 	reassembler->size_of_all_blocks += size;
 
@@ -34,28 +37,238 @@ DataBlock::DataBlock(Reassembler* reass, const u_char* data,
 	Reassembler::total_size += pad_size(size) + padded_sizeof(DataBlock);
 	}
 
-uint64_t Reassembler::total_size = 0;
-uint64_t Reassembler::sizes[REASSEM_NUM];
+void DataBlockList::Size(uint64_t seq_cutoff, uint64_t* below, uint64_t* above) const
+	{
+	// TODO: just have book-keeping to track this info and avoid iterating ?
+	for ( auto b = head; b; b = b->next )
+		{
+		if ( b->seq <= seq_cutoff )
+			*above += b->Size();
+		else
+			*below += b->Size();
+		}
+	}
+
+void DataBlockList::Clear()
+	{
+	while ( head )
+		{
+		auto next = head->next;
+		delete head;
+		head = next;
+		}
+	}
+
+void DataBlockList::Add(DataBlock* block, uint64_t limit)
+	{
+	++total_blocks;
+	block->next = nullptr;
+
+	if ( tail )
+		{
+		block->prev = tail;
+		tail->next = block;
+		}
+	else
+		{
+		block->prev = nullptr;
+		head = tail = block;
+		}
+
+	while ( head && total_blocks > limit )
+		{
+		auto next = head->next;
+		delete head;
+		head = next;
+		--total_blocks;
+		}
+	}
+
+DataBlock* DataBlockList::Insert(uint64_t seq, uint64_t upper,
+                                 const u_char* data, Reassembler* reass,
+                                 DataBlock* start)
+    {
+	// TODO: can probably do a lot better at finding the right insertion location
+
+	// Empty list.
+	if ( ! head )
+		{
+		head = tail = new DataBlock(reass, data, upper - seq, seq, 0, 0);
+		++total_blocks;
+		return head;
+		}
+
+	// Special check for the common case of appending to the end.
+	if ( tail && seq == tail->upper )
+		{
+		tail = new DataBlock(reass, data, upper - seq, seq, tail, 0);
+		++total_blocks;
+		return tail;
+		}
+
+	auto b = start ? start : head;
+
+	// Find the first block that doesn't come completely before the
+	// new data.
+	while ( b->next && b->upper <= seq )
+		b = b->next;
+
+	if ( b->upper <= seq )
+		{
+		// b is the last block, and it comes completely before
+		// the new block.
+		tail = new DataBlock(reass, data, upper - seq, seq, b, 0);
+		++total_blocks;
+		return tail;
+		}
+
+	DataBlock* new_b = 0;
+
+	if ( upper <= b->seq )
+		{
+		// The new block comes completely before b.
+		new_b = new DataBlock(reass, data, upper - seq, seq, b->prev, b);
+		++total_blocks;
+
+		if ( b == head )
+			head = new_b;
+
+		return new_b;
+		}
+
+	// The blocks overlap.
+	if ( seq < b->seq )
+		{
+		// The new block has a prefix that comes before b.
+		uint64_t prefix_len = b->seq - seq;
+		new_b = new DataBlock(reass, data, prefix_len, seq, b->prev, b);
+		++total_blocks;
+
+		if ( b == head )
+			head = new_b;
+
+		data += prefix_len;
+		seq += prefix_len;
+		}
+	else
+		new_b = b;
+
+	uint64_t overlap_start = seq;
+	uint64_t overlap_offset = overlap_start - b->seq;
+	uint64_t new_b_len = upper - seq;
+	uint64_t b_len = b->upper - overlap_start;
+	uint64_t overlap_len = min(new_b_len, b_len);
+
+	if ( overlap_len < new_b_len )
+		{
+		// Recurse to resolve remainder of the new data.
+		data += overlap_len;
+		seq += overlap_len;
+
+		if ( new_b == b )
+			new_b = Insert(seq, upper, data, reass, b);
+		else
+			Insert(seq, upper, data, reass, b);
+		}
+
+	if ( new_b->prev == tail )
+		tail = new_b;
+
+	return new_b;
+    }
+
+uint64_t DataBlockList::Trim(uint64_t seq, Reassembler* reass,
+                             uint64_t max_old, DataBlockList* old_list)
+	{
+	uint64_t num_missing = 0;
+
+	// Do this accounting before looking for Undelivered data,
+	// since that will alter last_reassem_seq.
+
+	if ( head )
+		{
+		if ( head->seq > reass->LastReassemSeq() )
+			// An initial hole.
+			num_missing += head->seq - reass->LastReassemSeq();
+		}
+
+	else if ( seq > reass->LastReassemSeq() )
+		{ // Trimming data we never delivered.
+		if ( ! head )
+			// We won't have any accounting based on blocks
+			// for this hole.
+			num_missing += seq - reass->LastReassemSeq();
+		}
+
+	if ( seq > reass->LastReassemSeq() )
+		{
+		// We're trimming data we never delivered.
+		reass->Undelivered(seq);
+		}
+
+	// TODO: better loop ?
+
+	while ( head && head->upper <= seq )
+		{
+		DataBlock* b = head->next;
+
+		if ( b && b->seq <= seq )
+			{
+			if ( head->upper != b->seq )
+				num_missing += b->seq - head->upper;
+			}
+		else
+			{
+			// No more blocks - did this one make it to seq?
+			// Second half of test is for acks of FINs, which
+			// don't get entered into the sequence space.
+			if ( head->upper != seq && head->upper != seq - 1 )
+				num_missing += seq - head->upper;
+			}
+
+		if ( max_old )
+			old_list->Add(head, max_old);
+		else
+			delete head;
+
+		head = b;
+		}
+
+	if ( head )
+		{
+		head->prev = 0;
+
+		// If we skipped over some undeliverable data, then
+		// it's possible that this block is now deliverable.
+		// Give it a try.
+		if ( head->seq == reass->LastReassemSeq() )
+			reass->BlockInserted(head);
+		}
+	else
+		tail = 0;
+
+	reass->SetTrimSeq(seq);
+	return num_missing;
+	}
 
 Reassembler::Reassembler(uint64_t init_seq, ReassemblerType reassem_type)
-	:  blocks(), last_block(), old_blocks(), last_old_block(),
-	  last_reassem_seq(init_seq), trim_seq(init_seq),
-	  max_old_blocks(0), total_old_blocks(0), size_of_all_blocks(0),
+	: last_reassem_seq(init_seq), trim_seq(init_seq),
+	  max_old_blocks(0), size_of_all_blocks(0),
 	  rtype(reassem_type)
 	{
 	}
 
-Reassembler::~Reassembler()
+void Reassembler::CheckOverlap(const DataBlockList& list,
+                               uint64_t seq, uint64_t len,
+                               const u_char* data)
 	{
-	ClearBlocks();
-	ClearOldBlocks();
-	}
-
-void Reassembler::CheckOverlap(DataBlock *head, DataBlock *tail,
-					uint64_t seq, uint64_t len, const u_char* data)
-	{
-	if ( ! head || ! tail )
+	if ( list.Empty() )
 		return;
+
+	auto head = list.Head();
+	auto tail = list.Tail();
+
+	// TODO: better way to iterate ?
 
 	if ( seq == tail->upper )
 		// Special case check for common case of appending to the end.
@@ -63,7 +276,7 @@ void Reassembler::CheckOverlap(DataBlock *head, DataBlock *tail,
 
 	uint64_t upper = (seq + len);
 
-	for ( DataBlock* b = head; b; b = b->next )
+	for ( auto b = head; b; b = b->next )
 		{
 		uint64_t nseq = seq;
 		uint64_t nupper = upper;
@@ -99,13 +312,13 @@ void Reassembler::NewBlock(double t, uint64_t seq, uint64_t len, const u_char* d
 
 	uint64_t upper_seq = seq + len;
 
-	CheckOverlap(old_blocks, last_old_block, seq, len, data);
+	CheckOverlap(old_block_list, seq, len, data);
 
 	if ( upper_seq <= trim_seq )
 		// Old data, don't do any work for it.
 		return;
 
-	CheckOverlap(blocks, last_block, seq, len, data);
+	CheckOverlap(block_list, seq, len, data);
 
 	if ( seq < trim_seq )
 		{ // Partially old data, just keep the good stuff.
@@ -116,139 +329,23 @@ void Reassembler::NewBlock(double t, uint64_t seq, uint64_t len, const u_char* d
 		len -= amount_old;
 		}
 
-	DataBlock* start_block;
-
-	if ( ! blocks )
-		blocks = last_block = start_block =
-			new DataBlock(this, data, len, seq, 0, 0);
-	else
-		start_block = AddAndCheck(blocks, seq, upper_seq, data);
-
+	auto start_block = block_list.Insert(seq, upper_seq, data, this);;
 	BlockInserted(start_block);
 	}
 
 uint64_t Reassembler::TrimToSeq(uint64_t seq)
 	{
-	uint64_t num_missing = 0;
-
-	// Do this accounting before looking for Undelivered data,
-	// since that will alter last_reassem_seq.
-
-	if ( blocks )
-		{
-		if ( blocks->seq > last_reassem_seq )
-			// An initial hole.
-			num_missing += blocks->seq - last_reassem_seq;
-		}
-
-	else if ( seq > last_reassem_seq )
-		{ // Trimming data we never delivered.
-		if ( ! blocks )
-			// We won't have any accounting based on blocks
-			// for this hole.
-			num_missing += seq - last_reassem_seq;
-		}
-
-	if ( seq > last_reassem_seq )
-		{
-		// We're trimming data we never delivered.
-		Undelivered(seq);
-		}
-
-	while ( blocks && blocks->upper <= seq )
-		{
-		DataBlock* b = blocks->next;
-
-		if ( b && b->seq <= seq )
-			{
-			if ( blocks->upper != b->seq )
-				num_missing += b->seq - blocks->upper;
-			}
-		else
-			{
-			// No more blocks - did this one make it to seq?
-			// Second half of test is for acks of FINs, which
-			// don't get entered into the sequence space.
-			if ( blocks->upper != seq && blocks->upper != seq - 1 )
-				num_missing += seq - blocks->upper;
-			}
-
-		if ( max_old_blocks )
-			{
-			// Move block over to old_blocks queue.
-			blocks->next = 0;
-
-			if ( last_old_block )
-				{
-				blocks->prev = last_old_block;
-				last_old_block->next = blocks;
-				}
-			else
-				{
-				blocks->prev = 0;
-				old_blocks = blocks;
-				}
-
-			last_old_block = blocks;
-			total_old_blocks++;
-
-			while ( old_blocks && total_old_blocks > max_old_blocks )
-				{
-				DataBlock* next = old_blocks->next;
-				delete old_blocks;
-				old_blocks = next;
-				total_old_blocks--;
-				}
-			}
-
-		else
-			delete blocks;
-
-		blocks = b;
-		}
-
-	if ( blocks )
-		{
-		blocks->prev = 0;
-
-		// If we skipped over some undeliverable data, then
-		// it's possible that this block is now deliverable.
-		// Give it a try.
-		if ( blocks->seq == last_reassem_seq )
-			BlockInserted(blocks);
-		}
-	else
-		last_block = 0;
-
-	if ( seq > trim_seq )
-		// seq is further ahead in the sequence space.
-		trim_seq = seq;
-
-	return num_missing;
+	return block_list.Trim(seq, this, max_old_blocks, &old_block_list);
 	}
 
 void Reassembler::ClearBlocks()
 	{
-	while ( blocks )
-		{
-		DataBlock* b = blocks->next;
-		delete blocks;
-		blocks = b;
-		}
-
-	last_block = 0;
+	block_list.Clear();
 	}
 
 void Reassembler::ClearOldBlocks()
 	{
-	while ( old_blocks )
-		{
-		DataBlock* b = old_blocks->next;
-		delete old_blocks;
-		old_blocks = b;
-		}
-
-	last_old_block = 0;
+	old_block_list.Clear();
 	}
 
 uint64_t Reassembler::TotalSize() const
@@ -265,89 +362,6 @@ void Reassembler::Undelivered(uint64_t up_to_seq)
 	{
 	// TrimToSeq() expects this.
 	last_reassem_seq = up_to_seq;
-	}
-
-DataBlock* Reassembler::AddAndCheck(DataBlock* b, uint64_t seq, uint64_t upper,
-					const u_char* data)
-	{
-	if ( DEBUG_reassem )
-		{
-		DEBUG_MSG("%.6f Reassembler::AddAndCheck seq=%" PRIu64", upper=%" PRIu64"\n",
-		          network_time, seq, upper);
-		}
-
-	// Special check for the common case of appending to the end.
-	if ( last_block && seq == last_block->upper )
-		{
-		last_block = new DataBlock(this, data, upper - seq,
-		                           seq, last_block, 0);
-		return last_block;
-		}
-
-	// Find the first block that doesn't come completely before the
-	// new data.
-	while ( b->next && b->upper <= seq )
-		b = b->next;
-
-	if ( b->upper <= seq )
-		{
-		// b is the last block, and it comes completely before
-		// the new block.
-		last_block = new DataBlock(this, data, upper - seq,
-		                           seq, b, 0);
-		return last_block;
-		}
-
-	DataBlock* new_b = 0;
-
-	if ( upper <= b->seq )
-		{
-		// The new block comes completely before b.
-		new_b = new DataBlock(this, data, upper - seq, seq,
-		                      b->prev, b);
-		if ( b == blocks )
-			blocks = new_b;
-		return new_b;
-		}
-
-	// The blocks overlap.
-	if ( seq < b->seq )
-		{
-		// The new block has a prefix that comes before b.
-		uint64_t prefix_len = b->seq - seq;
-		new_b = new DataBlock(this, data, prefix_len, seq,
-		                      b->prev, b);
-		if ( b == blocks )
-			blocks = new_b;
-
-		data += prefix_len;
-		seq += prefix_len;
-		}
-	else
-		new_b = b;
-
-	uint64_t overlap_start = seq;
-	uint64_t overlap_offset = overlap_start - b->seq;
-	uint64_t new_b_len = upper - seq;
-	uint64_t b_len = b->upper - overlap_start;
-	uint64_t overlap_len = min(new_b_len, b_len);
-
-	if ( overlap_len < new_b_len )
-		{
-		// Recurse to resolve remainder of the new data.
-		data += overlap_len;
-		seq += overlap_len;
-
-		if ( new_b == b )
-			new_b = AddAndCheck(b, seq, upper, data);
-		else
-			(void) AddAndCheck(b, seq, upper, data);
-		}
-
-	if ( new_b->prev == last_block )
-		last_block = new_b;
-
-	return new_b;
 	}
 
 uint64_t Reassembler::MemoryAllocation(ReassemblerType rtype)

--- a/src/Reassem.cc
+++ b/src/Reassem.cc
@@ -1,7 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
 #include <algorithm>
-#include <vector>
 
 #include "zeek-config.h"
 
@@ -10,39 +9,22 @@
 uint64_t Reassembler::total_size = 0;
 uint64_t Reassembler::sizes[REASSEM_NUM];
 
-DataBlock::DataBlock(DataBlockList* list, DataBlockMap::const_iterator hint,
-                     const u_char* data, uint64_t size, uint64_t arg_seq,
-                     DataBlock* arg_prev, DataBlock* arg_next)
+DataBlock::DataBlock(const u_char* data, uint64_t size, uint64_t arg_seq)
 	{
-	// TODO: make a separate DataBlockList::Insert()
 	seq = arg_seq;
 	upper = seq + size;
 	block = new u_char[size];
-
-	memcpy((void*) block, (const void*) data, size);
-
-	prev = arg_prev;
-	next = arg_next;
-
-	if ( prev )
-		prev->next = this;
-	if ( next )
-		next->prev = this;
-
-	list->block_map.emplace_hint(hint, seq, this);
-	// TODO: no longer need a separate block count since the map can provide that
-	++list->total_blocks;
-	list->total_data_size += size;
-
-	Reassembler::sizes[list->reassembler->rtype] += pad_size(size) + padded_sizeof(DataBlock);
-	Reassembler::total_size += pad_size(size) + padded_sizeof(DataBlock);
+	memcpy(block, data, size);
 	}
 
 void DataBlockList::DataSize(uint64_t seq_cutoff, uint64_t* below, uint64_t* above) const
 	{
-	// TODO: just have book-keeping to track this info and avoid iterating ?
-	for ( auto b = head; b; b = b->next )
+	// TODO: add warnings that this is O(n) and slow
+
+	for ( const auto& e : block_map )
 		{
+		auto b = e.second;
+
 		if ( b->seq <= seq_cutoff )
 			*above += b->Size();
 		else
@@ -50,63 +32,47 @@ void DataBlockList::DataSize(uint64_t seq_cutoff, uint64_t* below, uint64_t* abo
 		}
 	}
 
-void DataBlockList::DeleteBlock(DataBlock* b)
+void DataBlockList::Delete(DataBlockMap::const_iterator it)
 	{
-	// TODO: Separate Remove / Delete ?
+	auto b = it->second;
 	auto size = b->Size();
 
-	--total_blocks;
+	block_map.erase(it);
 	total_data_size -= size;
 
-	Reassembler::total_size -= pad_size(size) + padded_sizeof(DataBlock);
-	Reassembler::sizes[reassembler->rtype] -= pad_size(size) + padded_sizeof(DataBlock);
-
-	// TODO: most of the time we'd better erase via iterator rather than search
-	//block_map.erase(b->seq);
-
 	delete b;
+	Reassembler::total_size -= size + sizeof(DataBlock);
+	Reassembler::sizes[reassembler->rtype] -= size + sizeof(DataBlock);
+	}
+
+DataBlock* DataBlockList::Remove(DataBlockMap::const_iterator it)
+	{
+	auto b = it->second;
+	auto size = b->Size();
+
+	block_map.erase(it);
+	total_data_size -= size;
+
+	return b;
 	}
 
 void DataBlockList::Clear()
 	{
-	// TODO: can be done more efficiently
-	while ( head )
-		{
-		auto next = head->next;
-		DeleteBlock(head);
-		head = next;
-		}
+	// TODO: maybe can just use clear()
+	while ( ! block_map.empty() )
+		Delete(block_map.begin());
 
 	block_map.clear();
-	tail = nullptr;
 	}
 
 void DataBlockList::Append(DataBlock* block, uint64_t limit)
 	{
-	++total_blocks;
 	total_data_size += block->Size();
-	block->next = nullptr;
-
-	if ( tail )
-		{
-		block->prev = tail;
-		tail->next = block;
-		}
-	else
-		{
-		block->prev = nullptr;
-		head = tail = block;
-		}
 
 	block_map.emplace_hint(block_map.end(), block->seq, block);
 
-	while ( head && total_blocks > limit )
-		{
-		auto next = head->next;
-		DeleteBlock(head);
-		block_map.erase(block_map.begin());
-		head = next;
-		}
+	while ( block_map.size() > limit )
+		Delete(block_map.begin());
 	}
 
 DataBlockMap::const_iterator DataBlockList::FindFirstBlockBefore(uint64_t seq) const
@@ -123,23 +89,35 @@ DataBlockMap::const_iterator DataBlockList::FindFirstBlockBefore(uint64_t seq) c
 	return std::prev(it);
 	}
 
-DataBlock* DataBlockList::Insert(uint64_t seq, uint64_t upper,
-                                 const u_char* data,
-                                 DataBlockMap::const_iterator* hint)
-    {
+DataBlockMap::const_iterator
+DataBlockList::Insert(uint64_t seq, uint64_t upper, const u_char* data,
+                      DataBlockMap::const_iterator hint)
+	{
+	auto size = upper - seq;
+	auto db = new DataBlock(data, size, seq);
+
+	auto rval = block_map.emplace_hint(hint, seq, db);
+
+	total_data_size += size;
+	Reassembler::sizes[reassembler->rtype] += size + sizeof(DataBlock);
+	Reassembler::total_size += size + sizeof(DataBlock);
+
+	return rval;
+	}
+
+DataBlockMap::const_iterator
+DataBlockList::Insert(uint64_t seq, uint64_t upper, const u_char* data,
+                      DataBlockMap::const_iterator* hint)
+	{
 	// Empty list.
-	if ( ! head )
-		{
-		head = tail = new DataBlock(this, block_map.end(), data, upper - seq, seq, 0, 0);
-		return head;
-		}
+	if ( block_map.empty() )
+		return Insert(seq, upper, data, block_map.end());
+
+	auto last = block_map.rbegin()->second;
 
 	// Special check for the common case of appending to the end.
-	if ( tail && seq == tail->upper )
-		{
-		tail = new DataBlock(this, block_map.end(), data, upper - seq, seq, tail, 0);
-		return tail;
-		}
+	if ( seq == last->upper )
+		return Insert(seq, upper, data, block_map.end());
 
 	// Find the first block that doesn't come completely before the new data.
 	DataBlockMap::const_iterator it;
@@ -160,40 +138,33 @@ DataBlock* DataBlockList::Insert(uint64_t seq, uint64_t upper,
 	DataBlock* b = it->second;
 
 	if ( b->upper <= seq )
-		{
 		// b is the last block, and it comes completely before the new block.
-		tail = new DataBlock(this, block_map.end(), data, upper - seq, seq, b, 0);
-		return tail;
-		}
-
-	DataBlock* new_b = 0;
+		return Insert(seq, upper, data, block_map.end());
 
 	if ( upper <= b->seq )
-		{
 		// The new block comes completely before b.
-		new_b = new DataBlock(this, it, data, upper - seq, seq, b->prev, b);
+		return Insert(seq, upper, data, it);
 
-		if ( b == head )
-			head = new_b;
-
-		return new_b;
-		}
+	DataBlock* new_b;
+	DataBlockMap::const_iterator rval;
 
 	// The blocks overlap.
 	if ( seq < b->seq )
 		{
 		// The new block has a prefix that comes before b.
 		uint64_t prefix_len = b->seq - seq;
-		new_b = new DataBlock(this, it, data, prefix_len, seq, b->prev, b);
 
-		if ( b == head )
-			head = new_b;
+		rval = Insert(seq, seq + prefix_len, data, it);
+		new_b = rval->second;
 
 		data += prefix_len;
 		seq += prefix_len;
 		}
 	else
+		{
+		rval = it;
 		new_b = b;
+		}
 
 	uint64_t overlap_start = seq;
 	uint64_t overlap_offset = overlap_start - b->seq;
@@ -207,17 +178,14 @@ DataBlock* DataBlockList::Insert(uint64_t seq, uint64_t upper,
 		data += overlap_len;
 		seq += overlap_len;
 
+		auto r = Insert(seq, upper, data, &it);
+
 		if ( new_b == b )
-			new_b = Insert(seq, upper, data, &it);
-		else
-			Insert(seq, upper, data, &it);
+			rval = r;
 		}
 
-	if ( new_b->prev == tail )
-		tail = new_b;
-
-	return new_b;
-    }
+	return rval;
+	}
 
 uint64_t DataBlockList::Trim(uint64_t seq, uint64_t max_old,
                              DataBlockList* old_list)
@@ -227,19 +195,19 @@ uint64_t DataBlockList::Trim(uint64_t seq, uint64_t max_old,
 	// Do this accounting before looking for Undelivered data,
 	// since that will alter last_reassem_seq.
 
-	if ( head )
+	if ( ! block_map.empty() )
 		{
-		if ( head->seq > reassembler->LastReassemSeq() )
-			// An initial hole.
-			num_missing += head->seq - reassembler->LastReassemSeq();
-		}
+		auto first = block_map.begin()->second;
 
+		if ( first->seq > reassembler->LastReassemSeq() )
+			// An initial hole.
+			num_missing += first->seq - reassembler->LastReassemSeq();
+		}
 	else if ( seq > reassembler->LastReassemSeq() )
-		{ // Trimming data we never delivered.
-		if ( ! head )
-			// We won't have any accounting based on blocks
-			// for this hole.
-			num_missing += seq - reassembler->LastReassemSeq();
+		{
+		// Trimming data we never delivered.
+		// We won't have any accounting based on blocks for this hole.
+		num_missing += seq - reassembler->LastReassemSeq();
 		}
 
 	if ( seq > reassembler->LastReassemSeq() )
@@ -248,56 +216,48 @@ uint64_t DataBlockList::Trim(uint64_t seq, uint64_t max_old,
 		reassembler->Undelivered(seq);
 		}
 
-	auto first_removed = head && head->upper <= seq ? block_map.begin() : block_map.end();
-	auto last_removed = first_removed;
-
-	while ( head && head->upper <= seq )
+	while ( ! block_map.empty() )
 		{
-		DataBlock* b = head->next;
+		auto first_it = block_map.begin();
+		auto first = first_it->second;
 
-		if ( b && b->seq <= seq )
+		if ( first->upper > seq )
+			break;
+
+		auto next_it = std::next(first_it);
+		auto next = next_it == block_map.end() ? nullptr : next_it->second;
+
+		if ( next && next->seq <= seq )
 			{
-			if ( head->upper != b->seq )
-				num_missing += b->seq - head->upper;
+			if ( first->upper != next->seq )
+				num_missing += next->seq - first->upper;
 			}
 		else
 			{
 			// No more blocks - did this one make it to seq?
 			// Second half of test is for acks of FINs, which
 			// don't get entered into the sequence space.
-			if ( head->upper != seq && head->upper != seq - 1 )
-				num_missing += seq - head->upper;
+			if ( first->upper != seq && first->upper != seq - 1 )
+				num_missing += seq - first->upper;
 			}
 
-		// NOTE: erasing the node from the map takes place over the full
-		// range getting removed (see below) rather than one node at a time.
 		if ( max_old )
-			{
-			--total_blocks;
-			total_data_size -= head->Size();
-			old_list->Append(head, max_old);
-			}
+			old_list->Append(Remove(first_it), max_old);
 		else
-			DeleteBlock(head);
-
-		++last_removed;
-		head = b;
+			Delete(first_it);
 		}
 
-	block_map.erase(first_removed, last_removed);
-
-	if ( head )
+	if ( ! block_map.empty() )
 		{
-		head->prev = 0;
+		auto first_it = block_map.begin();
+		auto first = first_it->second;
 
 		// If we skipped over some undeliverable data, then
 		// it's possible that this block is now deliverable.
 		// Give it a try.
-		if ( head->seq == reassembler->LastReassemSeq() )
-			reassembler->BlockInserted(head);
+		if ( first->seq == reassembler->LastReassemSeq() )
+			reassembler->BlockInserted(first_it);
 		}
-	else
-		tail = 0;
 
 	reassembler->SetTrimSeq(seq);
 	return num_missing;
@@ -317,25 +277,22 @@ void Reassembler::CheckOverlap(const DataBlockList& list,
 	if ( list.Empty() )
 		return;
 
-	auto head = list.Head();
-	auto tail = list.Tail();
+	auto last = list.LastBlock();
 
-	if ( seq == tail->upper )
+	if ( seq == last->upper )
 		// Special case check for common case of appending to the end.
 		return;
 
 	uint64_t upper = (seq + len);
 
 	auto it = list.FindFirstBlockBefore(seq);
-	const DataBlock* start;
 
-	if ( it == list.block_map.end() )
-		start = head;
-	else
-		start = it->second;
+	if ( it == list.End() )
+		it = list.Begin();
 
-	for ( auto b = start; b; b = b->next )
+	for ( ; it != list.End(); ++it )
 		{
+		auto b = it->second;
 		uint64_t nseq = seq;
 		uint64_t nupper = upper;
 		const u_char* ndata = data;
@@ -387,8 +344,8 @@ void Reassembler::NewBlock(double t, uint64_t seq, uint64_t len, const u_char* d
 		len -= amount_old;
 		}
 
-	auto start_block = block_list.Insert(seq, upper_seq, data);;
-	BlockInserted(start_block);
+	auto it = block_list.Insert(seq, upper_seq, data);;
+	BlockInserted(it);
 	}
 
 uint64_t Reassembler::TrimToSeq(uint64_t seq)

--- a/src/Reassem.h
+++ b/src/Reassem.h
@@ -24,8 +24,7 @@ class DataBlock {
 public:
 	DataBlock(Reassembler* reass, const u_char* data,
 	          uint64_t size, uint64_t seq,
-	          DataBlock* prev, DataBlock* next,
-	          ReassemblerType reassem_type = REASSEM_UNKNOWN);
+	          DataBlock* prev, DataBlock* next);
 
 	~DataBlock();
 
@@ -35,7 +34,6 @@ public:
 	DataBlock* prev;	// previous block with lower seq #
 	uint64_t seq, upper;
 	u_char* block;
-	ReassemblerType rtype;
 
 	Reassembler* reassembler; // Non-owning pointer back to parent.
 };
@@ -108,7 +106,7 @@ inline DataBlock::~DataBlock()
 	{
 	reassembler->size_of_all_blocks -= Size();
 	Reassembler::total_size -= pad_size(upper - seq) + padded_sizeof(DataBlock);
-	Reassembler::sizes[rtype] -= pad_size(upper - seq) + padded_sizeof(DataBlock);
+	Reassembler::sizes[reassembler->rtype] -= pad_size(upper - seq) + padded_sizeof(DataBlock);
 	delete [] block;
 	}
 

--- a/src/Reassem.h
+++ b/src/Reassem.h
@@ -21,25 +21,23 @@ enum ReassemblerType {
 };
 
 class Reassembler;
-class DataBlock;
-class DataBlockList;
-using DataBlockMap = std::map<uint64_t, DataBlock*>;
 
 class DataBlock {
 public:
-	DataBlock(DataBlockList* list, DataBlockMap::const_iterator hint,
-	          const u_char* data, uint64_t size, uint64_t seq,
-	          DataBlock* prev, DataBlock* next);
+	DataBlock(const u_char* data, uint64_t size, uint64_t seq);
 
-	~DataBlock()	{ delete [] block; }
+	~DataBlock()
+		{ delete [] block; }
 
-	uint64_t Size() const	{ return upper - seq; }
+	uint64_t Size() const
+		{ return upper - seq; }
 
-	DataBlock* next;	// next block with higher seq #
-	DataBlock* prev;	// previous block with lower seq #
-	uint64_t seq, upper;
+	uint64_t seq;
+	uint64_t upper;
 	u_char* block;
 };
+
+using DataBlockMap = std::map<uint64_t, DataBlock*>;
 
 // TODO: add comments
 class DataBlockList {
@@ -54,17 +52,23 @@ public:
 	~DataBlockList()
 		{ Clear(); }
 
-	const DataBlock* Head() const
-		{ return head; }
+	DataBlockMap::const_iterator Begin() const
+		{ return block_map.begin(); }
 
-	const DataBlock* Tail() const
-		{ return tail; }
+	DataBlockMap::const_iterator End() const
+		{ return block_map.end(); }
+
+	DataBlock* FirstBlock() const
+		{ return block_map.begin()->second; }
+
+	DataBlock* LastBlock() const
+		{ return block_map.rbegin()->second; }
 
 	bool Empty() const
-		{ return head == nullptr; };
+		{ return block_map.empty(); };
 
 	size_t NumBlocks() const
-		{ return total_blocks; };
+		{ return block_map.size(); };
 
 	size_t DataSize() const
 		{ return total_data_size; }
@@ -73,8 +77,9 @@ public:
 
 	void Clear();
 
-	DataBlock* Insert(uint64_t seq, uint64_t upper, const u_char* data,
-	                  DataBlockMap::const_iterator* hint = nullptr);
+	DataBlockMap::const_iterator
+	Insert(uint64_t seq, uint64_t upper, const u_char* data,
+	       DataBlockMap::const_iterator* hint = nullptr);
 
 	void Append(DataBlock* block, uint64_t limit);
 
@@ -84,15 +89,15 @@ public:
 
 private:
 
-	void DeleteBlock(DataBlock* b);
+	DataBlockMap::const_iterator
+	Insert(uint64_t seq, uint64_t upper, const u_char* data,
+	       DataBlockMap::const_iterator hint);
 
-	friend class DataBlock;
-	friend class Reassembler;
+	void Delete(DataBlockMap::const_iterator it);
+
+	DataBlock* Remove(DataBlockMap::const_iterator it);
 
 	Reassembler* reassembler = nullptr;
-	DataBlock* head = nullptr;
-	DataBlock* tail = nullptr;
-	size_t total_blocks = 0;
 	size_t total_data_size = 0;
 	DataBlockMap block_map;
 };
@@ -138,12 +143,11 @@ public:
 protected:
 	Reassembler()	{ }
 
-	friend class DataBlock;
 	friend class DataBlockList;
 
 	virtual void Undelivered(uint64_t up_to_seq);
 
-	virtual void BlockInserted(const DataBlock* b) = 0;
+	virtual void BlockInserted(DataBlockMap::const_iterator it) = 0;
 	virtual void Overlap(const u_char* b1, const u_char* b2, uint64_t n) = 0;
 
 	void CheckOverlap(const DataBlockList& list,
@@ -152,7 +156,6 @@ protected:
 	DataBlockList block_list;
 	DataBlockList old_block_list;
 
-	// TODO: maybe roll some of these stats into DataBlockList ?
 	uint64_t last_reassem_seq;
 	uint64_t trim_seq;	// how far we've trimmed
 	uint32_t max_old_blocks;

--- a/src/Reassem.h
+++ b/src/Reassem.h
@@ -206,10 +206,11 @@ public:
 
 	/**
 	 * @return an iterator pointing to the first element with a segment whose
-	 * starting sequence number comes before "seq".  If no such element
-	 * exists, returns an iterator denoting one-past the end of the list.
+	 * starting sequence number is less than or equal to "seq".  If no such
+	 * element exists, returns an iterator denoting one-past the end of the
+	 * list.
 	 */
-	DataBlockMap::const_iterator FindFirstBlockBefore(uint64_t seq) const;
+	DataBlockMap::const_iterator FirstBlockAtOrBefore(uint64_t seq) const;
 
 private:
 

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.h
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.h
@@ -162,6 +162,8 @@ public:
 	//
 	// If we're not processing contents, then naturally each of
 	// these is empty.
+	//
+	// WARNING: this is an O(n) operation and potentially very slow.
 	void SizeBufferedData(uint64_t& waiting_on_hole, uint64_t& waiting_on_ack);
 
 	int ValidChecksum(const struct tcphdr* tp, int len) const;

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -80,7 +80,7 @@ void TCP_Reassembler::SizeBufferedData(uint64_t& waiting_on_hole,
 					uint64_t& waiting_on_ack) const
 	{
 	waiting_on_hole = waiting_on_ack = 0;
-	block_list.Size(last_reassem_seq, &waiting_on_ack, &waiting_on_hole);
+	block_list.DataSize(last_reassem_seq, &waiting_on_ack, &waiting_on_hole);
 	}
 
 uint64_t TCP_Reassembler::NumUndeliveredBytes() const
@@ -503,7 +503,7 @@ int TCP_Reassembler::DataSent(double t, uint64_t seq, int len,
 		}
 
 	if ( tcp_excessive_data_without_further_acks &&
-	     size_of_all_blocks > static_cast<uint64_t>(tcp_excessive_data_without_further_acks) )
+	     block_list.DataSize() > static_cast<uint64_t>(tcp_excessive_data_without_further_acks) )
 		{
 		tcp_analyzer->Weird("excessive_data_without_further_acks");
 		ClearBlocks();

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.h
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.h
@@ -90,7 +90,7 @@ private:
 	void RecordBlock(const DataBlock* b, BroFile* f);
 	void RecordGap(uint64_t start_seq, uint64_t upper_seq, BroFile* f);
 
-	void BlockInserted(const DataBlock* b) override;
+	void BlockInserted(DataBlockMap::const_iterator it) override;
 	void Overlap(const u_char* b1, const u_char* b2, uint64_t n) override;
 
 	TCP_Endpoint* endp;

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.h
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.h
@@ -87,7 +87,7 @@ private:
 	void Gap(uint64_t seq, uint64_t len);
 
 	void RecordToSeq(uint64_t start_seq, uint64_t stop_seq, BroFile* f);
-	void RecordBlock(const DataBlock* b, BroFile* f);
+	void RecordBlock(const DataBlock& b, BroFile* f);
 	void RecordGap(uint64_t start_seq, uint64_t upper_seq, BroFile* f);
 
 	void BlockInserted(DataBlockMap::const_iterator it) override;

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.h
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.h
@@ -39,6 +39,8 @@ public:
 	//
 	// If we're not processing contents, then naturally each of
 	// these is empty.
+	//
+	// WARNING: this is an O(n) operation and potentially very slow.
 	void SizeBufferedData(uint64_t& waiting_on_hole, uint64_t& waiting_on_ack) const;
 
 	// How much data is pending delivery since it's not yet reassembled.

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.h
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.h
@@ -44,13 +44,7 @@ public:
 	// How much data is pending delivery since it's not yet reassembled.
 	// Includes the data due to holes (so this value is a bit different
 	// from waiting_on_hole above; and is computed in a different fashion).
-	uint64_t NumUndeliveredBytes() const
-		{
-		if ( last_block )
-			return last_block->upper - last_reassem_seq;
-		else
-			return 0;
-		}
+	uint64_t NumUndeliveredBytes() const;
 
 	void SetContentsFile(BroFile* f);
 	BroFile* GetContentsFile() const	{ return record_contents_file; }
@@ -93,10 +87,10 @@ private:
 	void Gap(uint64_t seq, uint64_t len);
 
 	void RecordToSeq(uint64_t start_seq, uint64_t stop_seq, BroFile* f);
-	void RecordBlock(DataBlock* b, BroFile* f);
+	void RecordBlock(const DataBlock* b, BroFile* f);
 	void RecordGap(uint64_t start_seq, uint64_t upper_seq, BroFile* f);
 
-	void BlockInserted(DataBlock* b) override;
+	void BlockInserted(const DataBlock* b) override;
 	void Overlap(const u_char* b1, const u_char* b2, uint64_t n) override;
 
 	TCP_Endpoint* endp;

--- a/src/file_analysis/FileReassembler.cc
+++ b/src/file_analysis/FileReassembler.cc
@@ -29,11 +29,11 @@ uint64_t FileReassembler::Flush()
 	if ( block_list.Empty() )
 		return 0;
 
-	auto last_block = std::prev(block_list.End())->second;
+	const auto& last_block = std::prev(block_list.End())->second;
 
 	// This is expected to call back into FileReassembler::Undelivered().
 	flushing = true;
-	uint64_t rval = TrimToSeq(last_block->upper);
+	uint64_t rval = TrimToSeq(last_block.upper);
 	flushing = false;
 	return rval;
 	}
@@ -52,24 +52,24 @@ uint64_t FileReassembler::FlushTo(uint64_t sequence)
 
 void FileReassembler::BlockInserted(DataBlockMap::const_iterator it)
 	{
-	auto start_block = it->second;
+	const auto& start_block = it->second;
 
-	if ( start_block->seq > last_reassem_seq ||
-	     start_block->upper <= last_reassem_seq )
+	if ( start_block.seq > last_reassem_seq ||
+	     start_block.upper <= last_reassem_seq )
 		return;
 
 	while ( it != block_list.End() )
 		{
-		auto b = it->second;
+		const auto& b = it->second;
 
-		if ( b->seq > last_reassem_seq )
+		if ( b.seq > last_reassem_seq )
 			break;
 
-		if ( b->seq == last_reassem_seq )
+		if ( b.seq == last_reassem_seq )
 			{ // New stuff.
-			uint64_t len = b->Size();
+			uint64_t len = b.Size();
 			last_reassem_seq += len;
-			the_file->DeliverStream(b->block, len);
+			the_file->DeliverStream(b.block, len);
 			}
 
 		++it;
@@ -86,21 +86,21 @@ void FileReassembler::Undelivered(uint64_t up_to_seq)
 
 	while ( it != block_list.End() )
 		{
-		auto b = it->second;
+		const auto& b = it->second;
 
-		if ( b->seq < last_reassem_seq )
+		if ( b.seq < last_reassem_seq )
 			{
 			// Already delivered this block.
 			++it;
 			continue;
 			}
 
-		if ( b->seq >= up_to_seq )
+		if ( b.seq >= up_to_seq )
 			// Block is beyond what we need to process at this point.
 			break;
 
 		uint64_t gap_at_seq = last_reassem_seq;
-		uint64_t gap_len = b->seq - last_reassem_seq;
+		uint64_t gap_len = b.seq - last_reassem_seq;
 		the_file->Gap(gap_at_seq, gap_len);
 		last_reassem_seq += gap_len;
 		BlockInserted(it);

--- a/src/file_analysis/FileReassembler.h
+++ b/src/file_analysis/FileReassembler.h
@@ -51,7 +51,7 @@ protected:
 	FileReassembler();
 
 	void Undelivered(uint64_t up_to_seq) override;
-	void BlockInserted(DataBlock* b) override;
+	void BlockInserted(const DataBlock* b) override;
 	void Overlap(const u_char* b1, const u_char* b2, uint64_t n) override;
 
 	File* the_file;

--- a/src/file_analysis/FileReassembler.h
+++ b/src/file_analysis/FileReassembler.h
@@ -51,7 +51,7 @@ protected:
 	FileReassembler();
 
 	void Undelivered(uint64_t up_to_seq) override;
-	void BlockInserted(const DataBlock* b) override;
+	void BlockInserted(DataBlockMap::const_iterator it) override;
 	void Overlap(const u_char* b1, const u_char* b2, uint64_t n) override;
 
 	File* the_file;


### PR DESCRIPTION
Fixes #575

Changes the internal reassembly data structure to use `std::map` instead of a linked-list.


# Performance Comparisons Versus `master`

## Common Case
Timings using `2009-M57-day11-18.trace`

- branch / debug build / bare scripts: 3.102
- branch / debug build / full scripts: 10.498
- branch / release build / bare scripts: 0.946
- branch / release build / full scripts: 4.717
- master / debug build / bare scripts: 2.84
- master / debug build / full scripts: 10.125
- master / release build / bare scripts: 0.96
- master / release build / full scripts: 4.664

Additional overhead is noticeable for debug build.  Within 1% overhead for release build.

## Pathological Case

Using `pathological-reassembly-duplicate-segments.pcap`

Master:
```
$ time -f "%e" zeek -b -r pathological-reassembly-duplicate-segments.pcap
15.77
```

Branch:

```
$ time -f "%e" zeek -b -r pathological-reassembly-duplicate-segments.pcap
0.21
```

Way better.

# Questions

## Would `std::vector` perform better than `std::map`

E.g. due to better cache use.

Maybe, I tested it and was overall like 1% better than `std::map` in debug
build, but that's also only testing the common case where 99% if insertions were
at the end of the list.  Safer to just use a map.

## Would a skip-list perform better than `std::map`

Seems like it. Tested in `topic/jsiwek/reassembly-improvements` and could not
tell any difference from the old linked-list implementation using the most naive
skip-list implementation.  Inserting and erasing a node in a tree just always
adds a bit more work.

Reasons not to (initially) use a skip-list:

- Overhead of `std::map` seems minimal, so better to spend our time
  working on other areas

- Skip-list isn't deterministic, so technically it can randomly, with low
  probability, still hit the O(n) worst case.  There's ways to make it
  deterministic, but didn't fully investigate -- initial understanding is that it
  requires periodically iterating over the full list to balance it, so may 
  end up with similar overhead to `std::map` in the end.

- Additional complexity.  Harder to audit correctness.  Additional maintenance
  burden.

## Should we add an option similar to `tcp_excessive_data_without_further_acks`, but instead measured by number of blocks ?

Maybe, but I don't know what number to pick as the default.  The problem is that
we release the reassembly buffer based on ACKs, so it's effected by window size
-- large window, small segments means it's maybe easy to pick a bad default and
skip analyzing more legit connections than we want.