### PR TITLE
Fix for CIDs 1402823 and 1394050.

### DIFF
--- a/src/Frame.h
+++ b/src/Frame.h
@@ -128,7 +128,7 @@ public:
 	/**
 	 * Performs a deep copy of all the values in the current frame. If
 	 * the frame has a closure the returned frame captures that closure
-	 * by reference.. As such, performing a clone operation does not copy
+	 * by reference. As such, performing a clone operation does not copy
 	 * the values in the closure.
 	 *
 	 * @return a copy of this frame.

--- a/src/Trigger.cc
+++ b/src/Trigger.cc
@@ -218,7 +218,21 @@ bool Trigger::Eval()
 	// An alternative approach to copying the frame would be to deep-copy
 	// the expression itself, replacing all references to locals with
 	// constants.
-	Frame* f = frame->Clone();
+
+	Frame* f = nullptr;
+
+	try
+		{
+		f = frame->Clone();
+		}
+	catch ( InterpreterException& )
+		{
+		// Frame contains values that couldn't be cloned. It's
+		// already been reported, disable trigger.
+		Disable();
+		return false;
+		}
+
 	f->SetTrigger(this);
 
 	Val* v = nullptr;


### PR DESCRIPTION
An InterpreterException from clone framing could go uncaught.

Seems reasonable (but not crucial) to merge into 3.0 still.