### PR TITLE
Fix CAF include directories and add convenience alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,9 +366,7 @@ endif ()
 
 # CAF headers aren't necessarily in same location as Broker headers and
 # inclusion of a Broker header may pull in CAF headers.
-include_directories(BEFORE ${CAF_INCLUDE_DIR_CORE})
-include_directories(BEFORE ${CAF_INCLUDE_DIR_IO})
-include_directories(BEFORE ${CAF_INCLUDE_DIR_OPENSSL})
+include_directories(BEFORE ${CAF_INCLUDE_DIRS})
 
 add_subdirectory(aux/paraglob)
 set(zeekdeps ${zeekdeps} paraglob)

--- a/configure
+++ b/configure
@@ -18,6 +18,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
 
   Build Options:
     --builddir=DIR         place build files in directory [build]
+    --build-dir=DIR        alias for --builddir
     --build-type=TYPE      set CMake build type [RelWithDebInfo]:
                              - Debug: optimizations off, debug symbols + flags
                              - MinSizeRel: size optimizations, debugging off
@@ -169,6 +170,9 @@ while [ $# -ne 0 ]; do
             exit 1
             ;;
         --builddir=*)
+            builddir=$optarg
+            ;;
+        --build-dir=*)
             builddir=$optarg
             ;;
         --build-type=*)

--- a/src/logging/CMakeLists.txt
+++ b/src/logging/CMakeLists.txt
@@ -6,8 +6,7 @@ include_directories(BEFORE
                     ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-include_directories(BEFORE ${CAF_INCLUDE_DIR_CORE})
-include_directories(BEFORE ${CAF_INCLUDE_DIR_IO})
+include_directories(BEFORE ${CAF_INCLUDE_DIRS})
 
 add_subdirectory(writers)
 


### PR DESCRIPTION
Calling `find_package(CAF)` puts all include directory paths into the single variable `CAF_INCLUDE_DIRS`. Picking the paths individually is not only error prone and cumbersome, but can also lead to bulid errors. For example, when using a build directory for `CAF_ROOT` then `CAF_INCLUDE_DIRS` will have one extra path to find CAF's `config.hpp` (which is part of the build
directory).

The new alias in the `configure` script makes it easier for tooling that deals with both Zeek and Broker (which uses `--build-dir`). Also, it's one less quirk to remember when working with both repositories.