### PR TITLE
Fix build with external CAF but bundled Broker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,11 +339,17 @@ InstallSymlink("${CMAKE_INSTALL_PREFIX}/bin/zeek-wrapper" "${CMAKE_INSTALL_PREFI
 ########################################################################
 ## Recurse on sub-directories
 
-if ( BROKER_ROOT_DIR )
-  find_package(Broker REQUIRED)
+if ( CAF_ROOT_DIR )
   find_package(CAF COMPONENTS core io openssl REQUIRED)
+endif ()
 
-  set(zeekdeps ${zeekdeps} ${BROKER_LIBRARY} ${CAF_LIBRARIES})
+if ( BROKER_ROOT_DIR )
+  # Avoid calling find_package(CAF) twice.
+  if ( NOT CAF_ROOT_DIR )
+    find_package(CAF COMPONENTS core io openssl REQUIRED)
+  endif ()
+  find_package(Broker REQUIRED)
+  set(zeekdeps ${zeekdeps} ${BROKER_LIBRARY})
   include_directories(BEFORE ${BROKER_INCLUDE_DIR})
 else ()
   set(ENABLE_STATIC_ONLY_SAVED ${ENABLE_STATIC_ONLY})
@@ -364,8 +370,11 @@ else ()
                              ${CMAKE_CURRENT_BINARY_DIR}/aux/broker/include)
 endif ()
 
-# CAF headers aren't necessarily in same location as Broker headers and
-# inclusion of a Broker header may pull in CAF headers.
+# CAF_LIBRARIES and CAF_INCLUDE_DIRS are defined either by calling
+# find_package(CAF) or by calling add_subdirectory(aux/broker). In either case,
+# we have to care about CAF here because Broker headers can pull in CAF
+# headers.
+set(zeekdeps ${zeekdeps} ${CAF_LIBRARIES})
 include_directories(BEFORE ${CAF_INCLUDE_DIRS})
 
 add_subdirectory(aux/paraglob)


### PR DESCRIPTION
If we use both bundled CAF and bundled Broker then `add_subdirectory(aux/broker)` sets `CAF_ROOT_DIR` and `CAF_LIBRARIES` as `CACHE` variables. This seems to propagate them up to the outer CMake scope. However, if Broker's CMake calls `find_package(CAF)` then these variables seem to not "leak" into the parent context. Hence, we need to make sure to call `find_package(CAF)` here as well in all cases where Broker's `CMakeLists.txt` calls it.

Also, if Broker uses the bundled CAF version then it sets `CAF_LIBRARIES` to CMake targets of `IMPORTED` libraries. Imported libraries use directory scope, so we also need to add `GLOBAL`. Hence this PR also requires https://github.com/zeek/broker/pull/62. Previously, we only linked against CAF in some cases. I don't know what's the rationale behind that. Since Broker exposes CAF in its headers its IMO the safe route to always link against CAF.

I didn't find a better solution that avoids touching both repositories and also allows to link against CAF in all cases.

These configurations all compiled for me on CentOS (when also applying https://github.com/zeek/broker/pull/62):

```
./configure --generator=Ninja && ninja -C build
./configure --generator=Ninja --with-caf=/users/neverlord/workspace/bundles/caf && ninja -C build
./configure --generator=Ninja --with-caf=/users/neverlord/workspace/bundles/caf  --with-broker=/users/neverlord/workspace/bundles/broker && ninja -C build
```

With `bundles/caf` containing an installed CAF `master` and `bundles/broker` containing an installed Broker `master` (linked to the CAF bundle) respectively.

Closes #612.