### PR TITLE
Use Ubuntu 18.04 for Travis CI environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: bionic
+
 language: cpp
 
 services:


### PR DESCRIPTION
The `zeek` repo recently started using the new default environment, `xenial`, but for unknown reason, a few btests are now consistently exceeding their timeouts.  For example, this PR shows a stable test results when using `trusty`:

https://travis-ci.com/zeek/zeek/builds/130144103

But upon merging it, we suddenly started using `xenial` and sees test failures:

https://travis-ci.com/zeek/zeek/builds/130784249

If Travis runs this PR  and tests are stable again, we'll jump ahead to `bionic`, else I'll try reverting to `trusty`.