### PR TITLE
Support whitespace at end of line for config reader.

### DIFF
--- a/src/input/readers/config/Config.cc
+++ b/src/input/readers/config/Config.cc
@@ -199,7 +199,7 @@ bool Config::DoUpdate()
 		}
 
 	regex_t re;
-	if ( regcomp(&re, "^([^[:blank:]]+)[[:blank:]]+(.*)$", REG_EXTENDED) )
+	if ( regcomp(&re, "^([^[:blank:]]+)[[:blank:]]+(.*[^[:blank:]])[[:blank:]]*$", REG_EXTENDED) )
 		{
 		Error(Fmt("Failed to compile regex."));
 		return true;

--- a/testing/btest/Baseline/scripts.base.frameworks.config.read_config/zeek.config.log
+++ b/testing/btest/Baseline/scripts.base.frameworks.config.read_config/zeek.config.log
@@ -3,21 +3,22 @@
 #empty_field	(empty)
 #unset_field	-
 #path	config
-#open	2017-10-11-20-47-09
+#open	2019-10-14-15-40-21
 #fields	ts	id	old_value	new_value	location
 #types	time	string	string	string	string
-1507754829.092788	testbool	T	F	../configfile
-1507754829.092788	testcount	0	1	../configfile
-1507754829.092788	testcount	1	2	../configfile
-1507754829.092788	testint	0	-1	../configfile
-1507754829.092788	testenum	SSH::LOG	Conn::LOG	../configfile
-1507754829.092788	testport	42/tcp	45/unknown	../configfile
-1507754829.092788	testaddr	127.0.0.1	127.0.0.1	../configfile
-1507754829.092788	testaddr	127.0.0.1	2607:f8b0:4005:801::200e	../configfile
-1507754829.092788	testinterval	1.0 sec	60.0	../configfile
-1507754829.092788	testtime	0.0	1507321987.0	../configfile
-1507754829.092788	test_set	(empty)	b,c,a,d,erdbeerschnitzel	../configfile
-1507754829.092788	test_vector	(empty)	1,2,3,4,5,6	../configfile
-1507754829.092788	test_set	b,c,a,d,erdbeerschnitzel	(empty)	../configfile
-1507754829.092788	test_set	(empty)	\x2d	../configfile
-#close	2017-10-11-20-47-09
+1571067621.558501	testbool	T	F	../configfile
+1571067621.558501	testcount	0	1	../configfile
+1571067621.558501	testcount	1	2	../configfile
+1571067621.558501	testint	0	-1	../configfile
+1571067621.558501	testenum	SSH::LOG	Conn::LOG	../configfile
+1571067621.558501	testport	42/tcp	45/unknown	../configfile
+1571067621.558501	testaddr	127.0.0.1	127.0.0.1	../configfile
+1571067621.558501	testaddr	127.0.0.1	2607:f8b0:4005:801::200e	../configfile
+1571067621.558501	testinterval	1.0 sec	60.0	../configfile
+1571067621.558501	teststring	a	abc	../configfile
+1571067621.558501	testtime	0.0	1507321987.0	../configfile
+1571067621.558501	test_set	(empty)	b,c,a,d,erdbeerschnitzel	../configfile
+1571067621.558501	test_vector	(empty)	1,2,3,4,5,6	../configfile
+1571067621.558501	test_set	b,c,a,d,erdbeerschnitzel	(empty)	../configfile
+1571067621.558501	test_set	(empty)	\x2d	../configfile
+#close	2019-10-14-15-40-21

--- a/testing/btest/scripts/base/frameworks/config/read_config.zeek
+++ b/testing/btest/scripts/base/frameworks/config/read_config.zeek
@@ -19,6 +19,7 @@ testport 45
 testaddr 127.0.0.1
 testaddr 2607:f8b0:4005:801::200e
 testinterval 60
+teststring abc  
 testtime 1507321987
 test_set a,b,c,d,erdbeerschnitzel
 test_vector 1,2,3,4,5,6


### PR DESCRIPTION
This commit addresses issue #624