### PR TITLE
Skip connection_state_remove for connection attempts

### DIFF
--- a/scripts/base/protocols/conn/main.zeek
+++ b/scripts/base/protocols/conn/main.zeek
@@ -303,3 +303,13 @@ event connection_state_remove(c: connection) &priority=-5
 	Log::write(Conn::LOG, c$conn);
 	}
 
+event connection_attempt(c: connection) &priority=5
+	{
+	set_conn(c, T);
+	}
+
+event connection_attempt(c: connection) &priority=-5
+	{
+	Log::write(Conn::LOG, c$conn);
+	}
+

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -1028,7 +1028,7 @@ Connection* NetSessions::FindConnection(Val* v)
 	return conn;
 	}
 
-void NetSessions::Remove(Connection* c)
+void NetSessions::Remove(Connection* c, bool skip_connection_state_remove_event)
 	{
 	if ( c->IsKeyValid() )
 		{
@@ -1047,7 +1047,7 @@ void NetSessions::Remove(Connection* c)
 
 		c->Done();
 
-		if ( connection_state_remove )
+		if ( !skip_connection_state_remove_event && connection_state_remove )
 			c->Event(connection_state_remove, 0);
 
 		// Zero out c's copy of the key, so that if c has been Ref()'d

--- a/src/Sessions.h
+++ b/src/Sessions.h
@@ -78,7 +78,7 @@ public:
 	// no such connection or the Val is ill-formed.
 	Connection* FindConnection(Val* v);
 
-	void Remove(Connection* c);
+	void Remove(Connection* c, bool skip_connection_state_remove_event=false);
 	void Remove(FragReassembler* f);
 
 	void Insert(Connection* c);

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -1469,7 +1469,7 @@ void TCP_Analyzer::AttemptTimer(double /* t */)
 		is_active = 0;
 
 		// All done with this connection.
-		sessions->Remove(Conn());
+		sessions->Remove(Conn(), true);
 		}
 	}
 


### PR DESCRIPTION
Instead of raising both connection_attempt and connection_state_remove, only raise connection_attempt.