### PR TITLE
Make http::build_url work correctly

### DIFF
--- a/scripts/base/protocols/http/utils.zeek
+++ b/scripts/base/protocols/http/utils.zeek
@@ -55,9 +55,13 @@ function extract_keys(data: string, kv_splitter: pattern): string_vec
 function build_url(rec: Info): string
 	{
 	local uri  = rec?$uri ? rec$uri : "/<missed_request>";
+	if ( strstr(uri, "://") != 0 )
+		return uri;
+
 	local host = rec?$host ? rec$host : addr_to_uri(rec$id$resp_h);
-	if ( rec$id$resp_p != 80/tcp )
-		host = fmt("%s:%s", host, rec$id$resp_p);
+	local resp_p = port_to_count(rec$id$resp_p);
+	if ( resp_p != 80 )
+		host = fmt("%s:%s", host, resp_p);
 	return fmt("%s%s", host, uri);
 	}
 	


### PR DESCRIPTION
The pull request resolves issues of the `HTTP:build_url` function as they are described in the [issue 658](https://github.com/zeek/zeek/issues/658):

- if the `uri` is already an absolute url (contains scheme, `://`): return the uri itself
- casts `resp_p` to `count` in order to avoid `80/tcp` in url

Also a separate function `build_url_http` seems to be redundant in this way as it simply appends `http://` to the return value of `build_url`, which becomes incorrect in case of proxied request