### PR TITLE
Add and use new IntrusivePtr type in Zeek

### DIFF
--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -410,7 +410,7 @@ std::pair<bool, Frame*> Frame::Unserialize(const broker::vector& data)
 			return std::make_pair(false, nullptr);
 			}
 
-		rf->frame[i] = val.release();
+		rf->frame[i] = val.detach();
 		}
 
 	return std::make_pair(true, rf);

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -403,14 +403,14 @@ std::pair<bool, Frame*> Frame::Unserialize(const broker::vector& data)
 		broker::integer g = *has_type;
 		BroType t( static_cast<TypeTag>(g) );
 
-		Val* val = bro_broker::data_to_val(std::move(val_tuple[0]), &t);
+		auto val = bro_broker::data_to_val(std::move(val_tuple[0]), &t);
 		if ( ! val )
 			{
 			Unref(rf);
 			return std::make_pair(false, nullptr);
 			}
 
-		rf->frame[i] = val;
+		rf->frame[i] = val.release();
 		}
 
 	return std::make_pair(true, rf);

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -127,7 +127,7 @@ private:
 
 // Convenience function for creating intrusive pointers.
 template <class T, class... Ts>
-IntrusivePtr<T> makeCounted(Ts&&... args)
+IntrusivePtr<T> make_intrusive(Ts&&... args)
 	{
 	// Assumes that objects start with a reference count of 1!
 	return {new T(std::forward<Ts>(args)...), false};

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -5,15 +5,6 @@
 #include <type_traits>
 #include <utility>
 
-// These forward declarations only exist to enable ADL for the Ref and Unref
-// functions.
-
-struct IntrusivePtrDummy;
-
-void Ref(IntrusivePtrDummy*);
-
-void Unref(IntrusivePtrDummy*);
-
 // An intrusive, reference counting smart pointer implementation.
 template <class T>
 class IntrusivePtr {
@@ -65,7 +56,7 @@ public:
 
 	~IntrusivePtr()
 		{
-		if (ptr_)
+		if ( ptr_ )
 			Unref(ptr_);
 		}
 
@@ -76,10 +67,10 @@ public:
 
 	// Returns the raw pointer without modifying the reference count and sets
 	// this to `nullptr`.
-	pointer release() noexcept
+	pointer detach() noexcept
 		{
 		auto result = ptr_;
-		if (result)
+		if ( result )
 			ptr_ = nullptr;
 		return result;
 		}
@@ -88,7 +79,7 @@ public:
 		{
 		auto old = ptr_;
 		setPtr(new_value, add_ref);
-		if (old)
+		if ( old )
 			Unref(old);
 		}
 

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -1,0 +1,225 @@
+// See the file "COPYING" in the main distribution directory for copyright.
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+// These forward declarations only exist to enable ADL for the Ref and Unref
+// functions.
+
+struct IntrusivePtrDummy;
+
+void Ref(IntrusivePtrDummy*);
+
+void Unref(IntrusivePtrDummy*);
+
+// An intrusive, reference counting smart pointer implementation.
+template <class T>
+class IntrusivePtr {
+public:
+	// -- member types
+
+	using pointer = T*;
+
+	using const_pointer = const T*;
+
+	using element_type = T;
+
+	using reference = T&;
+
+	using const_reference = const T&;
+
+	// -- constructors, destructors, and assignment operators
+
+	constexpr IntrusivePtr() noexcept : ptr_(nullptr)
+		{
+		// nop
+		}
+
+	constexpr IntrusivePtr(std::nullptr_t) noexcept : IntrusivePtr()
+		{
+		// nop
+		}
+
+	IntrusivePtr(pointer raw_ptr, bool add_ref) noexcept
+		{
+		setPtr(raw_ptr, add_ref);
+		}
+
+	IntrusivePtr(IntrusivePtr&& other) noexcept : ptr_(other.detach())
+		{
+		// nop
+		}
+
+	IntrusivePtr(const IntrusivePtr& other) noexcept
+		{
+		setPtr(other.get(), true);
+		}
+
+	template <class U, class = std::enable_if_t<std::is_convertible_v<U*, T*>>>
+	IntrusivePtr(IntrusivePtr<U> other) noexcept : ptr_(other.detach())
+		{
+		// nop
+		}
+
+	~IntrusivePtr()
+		{
+		if (ptr_)
+			Unref(ptr_);
+		}
+
+	void swap(IntrusivePtr& other) noexcept
+		{
+		std::swap(ptr_, other.ptr_);
+		}
+
+	// Returns the raw pointer without modifying the reference count and sets
+	// this to `nullptr`.
+	pointer release() noexcept
+		{
+		auto result = ptr_;
+		if (result)
+			ptr_ = nullptr;
+		return result;
+		}
+
+	void reset(pointer new_value = nullptr, bool add_ref = true) noexcept
+		{
+		auto old = ptr_;
+		setPtr(new_value, add_ref);
+		if (old)
+			Unref(old);
+		}
+
+	IntrusivePtr& operator=(IntrusivePtr other) noexcept
+		{
+		swap(other);
+		return *this;
+		}
+
+	pointer get() const noexcept
+		{
+		return ptr_;
+		}
+
+	pointer operator->() const noexcept
+		{
+		return ptr_;
+		}
+
+	reference operator*() const noexcept
+		{
+		return *ptr_;
+		}
+
+	bool operator!() const noexcept
+		{
+		return !ptr_;
+		}
+
+	explicit operator bool() const noexcept
+		{
+		return ptr_ != nullptr;
+		}
+
+private:
+	void setPtr(pointer raw_ptr, bool add_ref) noexcept
+		{
+		ptr_ = raw_ptr;
+		if ( raw_ptr && add_ref )
+			Ref(raw_ptr);
+		}
+
+	pointer ptr_;
+};
+
+// Convenience function for creating intrusive pointers.
+template <class T, class... Ts>
+IntrusivePtr<T> makeCounted(Ts&&... args)
+	{
+	// Assumes that objects start with a reference count of 1!
+	return {new T(std::forward<Ts>(args)...), false};
+	}
+
+// -- comparison to nullptr ----------------------------------------------------
+
+template <class T>
+bool operator==(const IntrusivePtr<T>& x, std::nullptr_t) {
+  return !x;
+}
+
+template <class T>
+bool operator==(std::nullptr_t, const IntrusivePtr<T>& x) {
+  return !x;
+}
+
+template <class T>
+bool operator!=(const IntrusivePtr<T>& x, std::nullptr_t) {
+  return static_cast<bool>(x);
+}
+
+template <class T>
+bool operator!=(std::nullptr_t, const IntrusivePtr<T>& x) {
+  return static_cast<bool>(x);
+}
+
+// -- comparison to raw pointer ------------------------------------------------
+
+template <class T>
+bool operator==(const IntrusivePtr<T>& x, const T* y) {
+  return x.get() == y;
+}
+
+template <class T>
+bool operator==(const T* x, const IntrusivePtr<T>& y) {
+  return x == y.get();
+}
+
+template <class T>
+bool operator!=(const IntrusivePtr<T>& x, const T* y) {
+  return x.get() != y;
+}
+
+template <class T>
+bool operator!=(const T* x, const IntrusivePtr<T>& y) {
+  return x != y.get();
+}
+
+template <class T>
+bool operator<(const IntrusivePtr<T>& x, const T* y)
+	{
+	return x.get() < y;
+	}
+
+template <class T>
+bool operator<(const T* x, const IntrusivePtr<T>& y)
+	{
+	return x < y.get();
+	}
+
+// -- comparison to intrusive pointer ------------------------------------------
+
+// Using trailing return type and decltype() here removes this function from
+// overload resolution if the two pointers types are not comparable (SFINAE).
+template <class T, class U>
+auto operator==(const IntrusivePtr<T>& x, const IntrusivePtr<U>& y)
+-> decltype(x.get() == y.get())
+	{
+	return x.get() == y.get();
+	}
+
+template <class T, class U>
+auto operator!=(const IntrusivePtr<T>& x, const IntrusivePtr<U>& y)
+-> decltype(x.get() != y.get())
+	{
+	return x.get() != y.get();
+	}
+
+template <class T>
+auto operator<(const IntrusivePtr<T>& x, const IntrusivePtr<T>& y)
+-> decltype(x.get() < y.get())
+	{
+	return x.get() < y.get();
+	}
+

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -3159,7 +3159,7 @@ Val* cast_value_to_type(Val* v, BroType* t)
 		if ( ! dv )
 			return 0;
 
-		return static_cast<bro_broker::DataVal *>(dv)->castTo(t);
+		return static_cast<bro_broker::DataVal *>(dv)->castTo(t).release();
 		}
 
 	return 0;

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -3159,7 +3159,7 @@ Val* cast_value_to_type(Val* v, BroType* t)
 		if ( ! dv )
 			return 0;
 
-		return static_cast<bro_broker::DataVal *>(dv)->castTo(t).release();
+		return static_cast<bro_broker::DataVal *>(dv)->castTo(t).detach();
 		}
 
 	return 0;

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -181,7 +181,7 @@ struct val_converter {
 			return nullptr;
 
 		auto tt = type->AsTableType();
-		auto rval = makeCounted<TableVal>(tt);
+		auto rval = make_intrusive<TableVal>(tt);
 
 		for ( auto& item : a )
 			{
@@ -215,7 +215,7 @@ struct val_converter {
 			     indices->size() )
 				return nullptr;
 
-			auto list_val = makeCounted<ListVal>(TYPE_ANY);
+			auto list_val = make_intrusive<ListVal>(TYPE_ANY);
 
 			for ( auto i = 0u; i < indices->size(); ++i )
 				{
@@ -241,7 +241,7 @@ struct val_converter {
 			return nullptr;
 
 		auto tt = type->AsTableType();
-		auto rval = makeCounted<TableVal>(tt);
+		auto rval = make_intrusive<TableVal>(tt);
 
 		for ( auto& item : a )
 			{
@@ -275,7 +275,7 @@ struct val_converter {
 			     indices->size() )
 				return nullptr;
 
-			auto list_val = makeCounted<ListVal>(TYPE_ANY);
+			auto list_val = make_intrusive<ListVal>(TYPE_ANY);
 
 			for ( auto i = 0u; i < indices->size(); ++i )
 				{
@@ -305,7 +305,7 @@ struct val_converter {
 		if ( type->Tag() == TYPE_VECTOR )
 			{
 			auto vt = type->AsVectorType();
-			auto rval = makeCounted<VectorVal>(vt);
+			auto rval = make_intrusive<VectorVal>(vt);
 
 			for ( auto& item : a )
 				{
@@ -362,7 +362,7 @@ struct val_converter {
 		else if ( type->Tag() == TYPE_RECORD )
 			{
 			auto rt = type->AsRecordType();
-			auto rval = makeCounted<RecordVal>(rt);
+			auto rval = make_intrusive<RecordVal>(rt);
 			auto idx = 0u;
 
 			for ( auto i = 0u; i < static_cast<size_t>(rt->NumFields()); ++i )

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -229,14 +229,14 @@ struct val_converter {
 					return nullptr;
 					}
 
-				list_val->Append(index_val.release());
+				list_val->Append(index_val.detach());
 				}
 
 
 			rval->Assign(list_val.get(), nullptr);
 			}
 
-		return rval.release();
+		return rval.detach();
 		}
 
 	result_type operator()(broker::table& a)
@@ -293,7 +293,7 @@ struct val_converter {
 					return nullptr;
 					}
 
-				list_val->Append(index_val.release());
+				list_val->Append(index_val.detach());
 				}
 
 			auto value_val = bro_broker::data_to_val(move(item.second),
@@ -304,10 +304,10 @@ struct val_converter {
 				return nullptr;
 				}
 
-			rval->Assign(list_val.get(), value_val.release());
+			rval->Assign(list_val.get(), value_val.detach());
 			}
 
-		return rval.release();
+		return rval.detach();
 		}
 
 	result_type operator()(broker::vector& a)
@@ -326,10 +326,10 @@ struct val_converter {
 					return nullptr;
 					}
 
-				rval->Assign(rval->Size(), item_val.release());
+				rval->Assign(rval->Size(), item_val.detach());
 				}
 
-			return rval.release();
+			return rval.detach();
 			}
 		else if ( type->Tag() == TYPE_FUNC )
 			{
@@ -399,11 +399,11 @@ struct val_converter {
 					return nullptr;
 					}
 
-				rval->Assign(i, item_val.release());
+				rval->Assign(i, item_val.detach());
 				++idx;
 				}
 
-			return rval.release();
+			return rval.detach();
 			}
 		else if ( type->Tag() == TYPE_PATTERN )
 			{

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -213,9 +213,7 @@ struct val_converter {
 
 			if ( static_cast<size_t>(expected_index_types->length()) !=
 			     indices->size() )
-				{
 				return nullptr;
-				}
 
 			auto list_val = makeCounted<ListVal>(TYPE_ANY);
 
@@ -225,9 +223,7 @@ struct val_converter {
 				                                         (*expected_index_types)[i]);
 
 				if ( ! index_val )
-					{
 					return nullptr;
-					}
 
 				list_val->Append(index_val.detach());
 				}
@@ -277,9 +273,7 @@ struct val_converter {
 
 			if ( static_cast<size_t>(expected_index_types->length()) !=
 			     indices->size() )
-				{
 				return nullptr;
-				}
 
 			auto list_val = makeCounted<ListVal>(TYPE_ANY);
 
@@ -289,9 +283,7 @@ struct val_converter {
 				                                         (*expected_index_types)[i]);
 
 				if ( ! index_val )
-					{
 					return nullptr;
-					}
 
 				list_val->Append(index_val.detach());
 				}
@@ -300,9 +292,7 @@ struct val_converter {
 			                                         tt->YieldType());
 
 			if ( ! value_val )
-				{
 				return nullptr;
-				}
 
 			rval->Assign(list_val.get(), value_val.detach());
 			}
@@ -322,9 +312,7 @@ struct val_converter {
 				auto item_val = bro_broker::data_to_val(move(item), vt->YieldType());
 
 				if ( ! item_val )
-					{
 					return nullptr;
-					}
 
 				rval->Assign(rval->Size(), item_val.detach());
 				}
@@ -380,9 +368,7 @@ struct val_converter {
 			for ( auto i = 0u; i < static_cast<size_t>(rt->NumFields()); ++i )
 				{
 				if ( idx >= a.size() )
-					{
 					return nullptr;
-					}
 
 				if ( caf::get_if<broker::none>(&a[idx]) != nullptr )
 					{
@@ -395,9 +381,7 @@ struct val_converter {
 				                                        rt->FieldType(i));
 
 				if ( ! item_val )
-					{
 					return nullptr;
-					}
 
 				rval->Assign(i, item_val.detach());
 				++idx;

--- a/src/broker/Data.h
+++ b/src/broker/Data.h
@@ -7,6 +7,7 @@
 #include "Reporter.h"
 #include "Frame.h"
 #include "Expr.h"
+#include "IntrusivePtr.h"
 
 namespace bro_broker {
 
@@ -58,7 +59,7 @@ broker::expected<broker::data> val_to_data(Val* v);
  * @return a pointer to a new Bro value or a nullptr if the conversion was not
  * possible.
  */
-Val* data_to_val(broker::data d, BroType* type);
+IntrusivePtr<Val> data_to_val(broker::data d, BroType* type);
 
 /**
  * Convert a Bro threading::Value to a Broker data value.
@@ -107,7 +108,7 @@ public:
 		d->Add("}");
 		}
 
-	Val* castTo(BroType* t);
+	IntrusivePtr<Val> castTo(BroType* t);
 	bool canCastTo(BroType* t) const;
 
 	// Returns the Bro type that scripts use to represent a Broker data
@@ -181,9 +182,9 @@ struct type_name_getter {
 		{ return "table"; }
 
 	result_type operator()(const broker::vector&)
-		{ 
+		{
 		assert(tag == TYPE_VECTOR || tag == TYPE_RECORD);
-	 	return tag == TYPE_VECTOR ? "vector" : "record";
+		return tag == TYPE_VECTOR ? "vector" : "record";
 		}
 
 	TypeTag tag;

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -1033,7 +1033,7 @@ void Manager::ProcessEvent(const broker::topic& topic, broker::zeek::Event ev)
 		auto val = data_to_val(std::move(args[i]), expected_type);
 
 		if ( val )
-			vl.push_back(val.release());
+			vl.push_back(val.detach());
 		else
 			{
 			auto expected_name = type_name(expected_type->Tag());
@@ -1245,7 +1245,7 @@ bool Manager::ProcessIdentifierUpdate(broker::zeek::IdentifierUpdate iu)
 		return false;
 		}
 
-	id->SetVal(val.release());
+	id->SetVal(val.detach());
 	return true;
 	}
 

--- a/src/option.bif
+++ b/src/option.bif
@@ -90,8 +90,7 @@ function Option::set%(ID: string, val: any, location: string &default=""%): bool
 			return val_mgr->GetBool(0);
 			}
 
-		auto rval = call_option_handlers_and_set_value(ID, i, val_from_data, location);
-		Unref(val_from_data);
+		auto rval = call_option_handlers_and_set_value(ID, i, val_from_data.get(), location);
 		return val_mgr->GetBool(rval);
 		}
 

--- a/src/probabilistic/Topk.cc
+++ b/src/probabilistic/Topk.cc
@@ -505,14 +505,14 @@ bool TopkVal::DoUnserialize(const broker::data& data)
 		for ( uint64_t j = 0; j < *elements_count; j++ )
 			{
 			auto epsilon = caf::get_if<uint64_t>(&(*v)[idx++]);
-			Val* val = bro_broker::data_to_val((*v)[idx++], type);
+			auto val = bro_broker::data_to_val((*v)[idx++], type);
 
 			if ( ! (epsilon && val) )
 				return false;
 
 			Element* e = new Element();
 			e->epsilon = *epsilon;
-			e->value = val;
+			e->value = val.release();
 			e->parent = b;
 
 			b->elements.insert(b->elements.end(), e);

--- a/src/probabilistic/Topk.cc
+++ b/src/probabilistic/Topk.cc
@@ -512,7 +512,7 @@ bool TopkVal::DoUnserialize(const broker::data& data)
 
 			Element* e = new Element();
 			e->epsilon = *epsilon;
-			e->value = val.release();
+			e->value = val.detach();
 			e->parent = b;
 
 			b->elements.insert(b->elements.end(), e);


### PR DESCRIPTION
@timwoj we discussed the use of smart pointers for automated reference counting a while back. This PR takes the first steps towards modernizing the Zeek code base by moving away from C-style manual reference counting.

Manual memory management via Ref/Unref is verbose and prone to error. An intrusive smart pointer automates the reference counting, makes code more robust (in particular w.r.t. to exceptions) and reduces boilerplate code. A big benefit of the intrusive smart pointers for Zeek is that they can co-exist with the manual memory management. Rather than having to port the entire code base at once, we can migrate components one-by-one. In this first step, we add `ValPtr` as an alias for `intrusive_ptr<Val>` and start using it in the Broker Manager. This makes the previous `unref_guard` obsolete.