### PR TITLE
Add initial scaffold for unit testing via doctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ include(cmake/FindClangTidy.cmake)
 ########################################################################
 ## Project/Build Configuration
 
+
+if (ENABLE_ZEEK_UNIT_TESTS)
+    enable_testing()
+else ()
+    add_definitions(-DDOCTEST_CONFIG_DISABLE)
+endif ()
+
 if ( ENABLE_CCACHE )
     find_program(CCACHE_PROGRAM ccache)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ include(cmake/FindClangTidy.cmake)
 
 if (ENABLE_ZEEK_UNIT_TESTS)
     enable_testing()
+    add_definitions(-DDOCTEST_CONFIG_SUPER_FAST_ASSERTS)
 else ()
     add_definitions(-DDOCTEST_CONFIG_DISABLE)
 endif ()

--- a/COPYING.3rdparty
+++ b/COPYING.3rdparty
@@ -583,3 +583,29 @@ The original source file comes with this licensing statement:
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+==============================================================================
+
+%%% src/3rdparty/doctest.h
+
+==============================================================================
+
+Copyright (c) 2016-2019 Viktor Kirilov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/configure
+++ b/configure
@@ -47,6 +47,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --enable-jemalloc      link against jemalloc
     --enable-static-broker build Broker statically (ignored if --with-broker is specified)
     --enable-static-binpac build binpac statically (ignored if --with-binpac is specified)
+    --enable-cpp-tests     build Zeek's C++ unit tests
     --disable-zeekctl      don't install ZeekControl
     --disable-auxtools     don't build or install auxiliary tools
     --disable-python       don't try to build python bindings for Broker
@@ -244,6 +245,9 @@ while [ $# -ne 0 ]; do
             ;;
         --enable-static-binpac)
             append_cache_entry BUILD_STATIC_BINPAC    BOOL    true
+            ;;
+        --enable-cpp-tests)
+            append_cache_entry ENABLE_ZEEK_UNIT_TESTS BOOL    true
             ;;
         --disable-zeekctl)
             append_cache_entry INSTALL_ZEEKCTL       BOOL   false

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -433,3 +433,25 @@ add_clang_tidy_files(${MAIN_SRCS})
 # (*.pac.cc) files, and most of the generated code for BIFs (not including
 # *.bif.register.cc)
 create_clang_tidy_target()
+
+########################################################################
+## CTest setup.
+
+# Scan all .cc files for TEST_CASE macros and generate CTest targets.
+if (ENABLE_ZEEK_UNIT_TESTS)
+    file(GLOB_RECURSE all_cc_files "*.cc")
+    set(test_cases "")
+    foreach (cc_file ${all_cc_files})
+        file (STRINGS ${cc_file} test_case_lines REGEX "TEST_CASE")
+        foreach (line ${test_case_lines})
+            string(REGEX REPLACE "TEST_CASE\\(\"(.+)\"\\)" "\\1" test_case "${line}")
+            list(APPEND test_cases "${test_case}")
+        endforeach ()
+    endforeach ()
+    list(LENGTH test_cases num_test_cases)
+    MESSAGE(STATUS "-- Found ${num_test_cases} test cases for CTest")
+    foreach (test_case ${test_cases})
+        add_test(NAME "\"${test_case}\""
+                 COMMAND zeek --testing "--test-case=${test_case}")
+    endforeach ()
+endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -452,6 +452,6 @@ if (ENABLE_ZEEK_UNIT_TESTS)
     MESSAGE(STATUS "-- Found ${num_test_cases} test cases for CTest")
     foreach (test_case ${test_cases})
         add_test(NAME "\"${test_case}\""
-                 COMMAND zeek --testing "--test-case=${test_case}")
+                 COMMAND zeek --test "--test-case=${test_case}")
     endforeach ()
 endif ()

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -1,5 +1,6 @@
 #include "Data.h"
 #include "File.h"
+#include "3rdparty/doctest.h"
 #include "broker/data.bif.h"
 
 #include <broker/error.hh>
@@ -35,6 +36,16 @@ static broker::port::protocol to_broker_port_proto(TransportProto tp)
 	}
 	}
 
+TEST_CASE("converting Zeek to Broker protocol constants")
+	{
+	CHECK_EQ(to_broker_port_proto(TRANSPORT_TCP), broker::port::protocol::tcp);
+	CHECK_EQ(to_broker_port_proto(TRANSPORT_UDP), broker::port::protocol::udp);
+	CHECK_EQ(to_broker_port_proto(TRANSPORT_ICMP),
+	         broker::port::protocol::icmp);
+	CHECK_EQ(to_broker_port_proto(TRANSPORT_UNKNOWN),
+	         broker::port::protocol::unknown);
+	}
+
 TransportProto bro_broker::to_bro_port_proto(broker::port::protocol tp)
 	{
 	switch ( tp ) {
@@ -48,6 +59,16 @@ TransportProto bro_broker::to_bro_port_proto(broker::port::protocol tp)
 	default:
 		return TRANSPORT_UNKNOWN;
 	}
+	}
+
+TEST_CASE("converting Broker to Zeek protocol constants")
+	{
+	using bro_broker::to_bro_port_proto;
+	CHECK_EQ(to_bro_port_proto(broker::port::protocol::tcp), TRANSPORT_TCP);
+	CHECK_EQ(to_bro_port_proto(broker::port::protocol::udp), TRANSPORT_UDP);
+	CHECK_EQ(to_bro_port_proto(broker::port::protocol::icmp), TRANSPORT_ICMP);
+	CHECK_EQ(to_bro_port_proto(broker::port::protocol::unknown),
+	         TRANSPORT_UNKNOWN);
 	}
 
 struct val_converter {


### PR DESCRIPTION
Now that we switched to object libraries in the repository via #674, I could revisit C++ unit testing via `doctest` (see #643).

What makes `doctest` different from other unit tests is that it merges test code and implementation. There is no separate unit test binary and `doctest` has the concept of running tests before entering the regular `main` code. However, I'm unsure whether this is a good default. I've opted to always return with `return context.run()` from `main` after running any test code, because I think a user either wants to run `zeek` or to run the unit tests.

Also, since this bakes the unit tests into the `zeek` binary, I think explicitly enabling unit testing as opt in makes more sense than an opt out build flag. Otherwise, users might end up accidentally using a `zeek` binary with builtin unit tests in production.

When building `zeek` with unit tests, passing `--testing` as first argument on the command line enters "doctest mode". By default, this runs all test cases. All arguments after `--testing` are passed to `doctest`, to `--testing -h` prints the `doctest`-generated help text. Users also can add regular Zeek arguments by adding `--` after all `doctest` options followed by the `zeek` options. Just in case some part of Zeek accesses `bro_argc`/`bro_argv` (or if we decide to not always stop after running unit tests).

I've added two simple unit tests to make sure everything's working as expected. The CMake scaffold also generates CTest targets, so users can use the familiar CMake work flows. Further, this makes it simple to integrate automatic testing into CI jobs.