### PR TITLE
Add hint to run make distclean if configure fails

### DIFF
--- a/configure
+++ b/configure
@@ -2,6 +2,9 @@
 # Convenience wrapper for easily viewing/setting options that
 # the project's CMake scripts will recognize
 set -e
+
+trap '[ $? -eq 0 ] && exit 0 || echo "Also, before rerunning configure, consider cleaning the cache via: make distclean"' EXIT
+
 command="$0 $*"
 
 usage="\


### PR DESCRIPTION
Added portable [1] hint message if ./configure fails.

[1] https://stackoverflow.com/questions/31313305/portably-trapping-err-in-shell-script