### PR TITLE
add packet_sources() BIF

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -120,6 +120,22 @@ type mime_match: record {
 ## :zeek:see:`file_magic`
 type mime_matches: vector of mime_match;
 
+## Properties of an I/O packet source being read by Zeek.
+type PacketSource: record {
+	## Whether the packet source is a live interface or offline pcap file.
+	live: bool;
+	## The interface name for a live interface or filesystem path of
+	## an offline pcap file.
+	path: string;
+	## The data link-layer type of the packet source.
+	link_type: int;
+	## The netmask assoicated with the source or ``NETMASK_UNKNOWN``.
+	netmask: count;
+};
+
+## A list of packet sources being read by Zeek.
+type PacketSourceList: vector of PacketSource;
+
 ## A connection's transport-layer protocol. Note that Zeek uses the term
 ## "connection" broadly, using flow semantics for ICMP and UDP.
 type transport_proto: enum {

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -23,6 +23,7 @@
 #include "file_analysis/Manager.h"
 #include "iosource/Manager.h"
 #include "iosource/Packet.h"
+#include "IntrusivePtr.h"
 
 using namespace std;
 
@@ -1884,7 +1885,7 @@ function type_name%(t: any%): string
 ##
 ## Returns: True if reading traffic from a network interface.
 ##
-## .. zeek:see:: reading_traces
+## .. zeek:see:: reading_traces packet_sources
 function reading_live_traffic%(%): bool
 	%{
 	return val_mgr->GetBool(reading_live);
@@ -1895,12 +1896,33 @@ function reading_live_traffic%(%): bool
 ##
 ## Returns: True if reading traffic from a network trace.
 ##
-## .. zeek:see:: reading_live_traffic
+## .. zeek:see:: reading_live_traffic packet_sources
 function reading_traces%(%): bool
 	%{
 	return val_mgr->GetBool(reading_traces);
 	%}
 
+## Returns: a list of packet sources being read by Zeek.
+##
+## .. zeek:seek:: reading_live_traffic reading_traces
+function packet_sources%(%): PacketSourceList
+	%{
+	auto ps_type = internal_type("PacketSource")->AsRecordType();
+	auto psl_type = internal_type("PacketSourceList")->AsVectorType();
+	auto rval = make_intrusive<VectorVal>(psl_type);
+
+	for ( const auto& ps : iosource_mgr->GetPktSrcs() )
+		{
+		auto r = make_intrusive<RecordVal>(ps_type);
+		r->Assign(0, val_mgr->GetBool(ps->IsLive()));
+		r->Assign(1, new StringVal(ps->Path()));
+		r->Assign(2, val_mgr->GetInt(ps->LinkType()));
+		r->Assign(3, val_mgr->GetCount(ps->Netmask()));
+		rval->Assign(rval->Size(), r.detach());
+		}
+
+	return rval.detach();
+	%}
 
 ## Generates a table of the size of all global variables. The table index is
 ## the variable name and the value is the variable size in bytes.

--- a/testing/btest/Baseline/bifs.packet_sources/out
+++ b/testing/btest/Baseline/bifs.packet_sources/out
@@ -1,0 +1,1 @@
+[[live=F, path=/Users/jsiwek/pro/zeek/zeek/testing/btest/Traces/http/get.trace, link_type=1, netmask=4294967295]]

--- a/testing/btest/bifs/packet_sources.zeek
+++ b/testing/btest/bifs/packet_sources.zeek
@@ -1,0 +1,7 @@
+# @TEST-EXEC: zeek -b -r $TRACES/http/get.trace %INPUT >out
+# @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff out
+
+event zeek_init()
+	{
+	print packet_sources();
+	}


### PR DESCRIPTION
Provides access to properties of packet sources, like interface or pcap
file name.

Addresses #700

* I might have missed if this info is accessible some other way, but didn't notice any.
* Need to regenerate `zeek-docs` on merge.