### PR TITLE
add zeek_args() BIF

### DIFF
--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -23,6 +23,7 @@
 #include "file_analysis/Manager.h"
 #include "iosource/Manager.h"
 #include "iosource/Packet.h"
+#include "IntrusivePtr.h"
 
 using namespace std;
 
@@ -1875,6 +1876,18 @@ function type_name%(t: any%): string
 	s->SetUseFreeToDelete(true);
 
 	return new StringVal(s);
+	%}
+
+## Returns: list of command-line arguments (``argv``) used to run Zeek.
+function zeek_args%(%): string_vec
+	%{
+	auto sv = internal_type("string_vec")->AsVectorType();
+	auto rval = make_intrusive<VectorVal>(sv);
+
+	for ( auto i = 0; i < bro_argc; ++i )
+		rval->Assign(rval->Size(), new StringVal(bro_argv[i]));
+
+	return rval.detach();
 	%}
 
 ## Checks whether Zeek reads traffic from one or more network interfaces (as

--- a/testing/btest/Baseline/bifs.zeek_args/out
+++ b/testing/btest/Baseline/bifs.zeek_args/out
@@ -1,0 +1,1 @@
+[zeek, -b, -r, /Users/jsiwek/pro/zeek/zeek/testing/btest/Traces/http/get.trace, -e, print zeek_args()]

--- a/testing/btest/bifs/zeek_args.zeek
+++ b/testing/btest/bifs/zeek_args.zeek
@@ -1,0 +1,2 @@
+# @TEST-EXEC: zeek -b -r $TRACES/http/get.trace -e 'print zeek_args()' >out
+# @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff out


### PR DESCRIPTION
Provides access to all zeek command-line arguments ("argv").

Addresses #700

* This is simple enough to add/support, but probably a bit better to generally provide script-layer variables/functions for accessing argument info when we can, like #702 (since otherwise user has to perform the arg-parsing logic themself).
* Need to generate `zeek-docs` on merge.