### PR TITLE
GHI-599: avoid memory leak with default pattern matching and json formatting

### DIFF
--- a/src/Val.cc
+++ b/src/Val.cc
@@ -429,7 +429,7 @@ TableVal* Val::GetRecordFields()
 	}
 
 // This is a static method in this file to avoid including json.hpp in Val.h since it's huge.
-static ZeekJson BuildJSON(Val* val, bool only_loggable=false, RE_Matcher* re=new RE_Matcher("^_"))
+static ZeekJson BuildJSON(Val* val, bool only_loggable=false, RE_Matcher* re=nullptr)
 	{
 	// If the value wasn't set, return a nullptr. This will get turned into a 'null' in the json output.
 	if ( ! val )
@@ -562,7 +562,7 @@ static ZeekJson BuildJSON(Val* val, bool only_loggable=false, RE_Matcher* re=new
 				auto field_name = rt->FieldName(i);
 				std::string key_string;
 
-				if ( re->MatchAnywhere(field_name) != 0 )
+				if ( re && re->MatchAnywhere(field_name) != 0 )
 					{
 					StringVal blank("");
 					StringVal fn_val(field_name);

--- a/src/Val.h
+++ b/src/Val.h
@@ -348,7 +348,7 @@ public:
 
 	TableVal* GetRecordFields();
 
-	StringVal* ToJSON(bool only_loggable=false, RE_Matcher* re=new RE_Matcher("^_"));
+	StringVal* ToJSON(bool only_loggable=false, RE_Matcher* re=nullptr);
 
 protected:
 


### PR DESCRIPTION
Fixes #599 

What it says in the desciption. I opted to go with a default `nullptr` argument here, since not passing one isn't possible due to the `only_loggable` argument having a default argument.