### PR TITLE
Allow Patterns as Table Index

### DIFF
--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -146,6 +146,30 @@ char* CompositeHash::SingleValHash(int type_check, char* kp0,
 			break;
 			}
 
+		case TYPE_PATTERN:
+			{
+			const char* texts[2] = {
+				v->AsPattern()->PatternText(),
+				v->AsPattern()->AnywherePatternText()
+			};
+
+			size_t* kp;
+			for (int i = 0; i < 2; i++)
+				{
+				kp = AlignAndPadType<size_t>(kp0+i);
+				*kp = strlen(texts[i]) + 1;
+				}
+
+			kp1 = reinterpret_cast<char*>(kp+1);
+			for (int i = 0; i < 2; i++)
+				{
+				memcpy(kp1, texts[i], strlen(texts[i]) + 1);
+				kp1 += strlen(texts[i]) + 1;
+				}
+
+			break;
+			}
+
 		case TYPE_RECORD:
 			{
 			char* kp = kp0;
@@ -401,20 +425,19 @@ HashKey* CompositeHash::ComputeSingletonHash(const Val* v, int type_check) const
 		if ( v->Type()->Tag() == TYPE_FUNC )
 			return new HashKey(v->AsFunc()->GetUniqueFuncID());
 
-		if (v->Type()->Tag() == TYPE_PATTERN) {
-			char* texts[2] = {
+		if (v->Type()->Tag() == TYPE_PATTERN) 
+			{
+			const char* texts[2] = {
 				v->AsPattern()->PatternText(),
 				v->AsPattern()->AnywherePatternText()
 			};
-
-			char key [ sizeof(size_t) * 2 + strlen(texts[0]) + strlen(texts[1]) ];
-			std::memcpy(key, strlen(texts[0]), sizeof(size_t));
-			std::memcpy(*(key + sizeof(size_t)), strlen(texts[1]), sizeof(size_t));
-			std::memcpy(key + 2 * sizeof(size_t), texts[0], strlen(texts[0]));
-			std::memcpy(key + 2 * sizeof(size_t) + strlen(texts[0]), texts[1], strlen(texts[1]));
-
-			return new HashKey(key);
-		}
+			int n = strlen(texts[0]) + strlen(texts[1]) + 2; // 2 for null
+			char* key = new char[n];
+			std::memcpy(key, texts[0], strlen(texts[0]) + 1);
+			std::memcpy(key + strlen(texts[0]) + 1, texts[1], strlen(texts[1]) + 1);
+			//std::cout << "Singleton key of " << v->AsPattern()->PatternText() << "; " << key << std::endl;
+			return new HashKey(reinterpret_cast<void*>(key), n);
+			}
 
 		reporter->InternalError("bad index type in CompositeHash::ComputeSingletonHash");
 		return 0;
@@ -474,6 +497,17 @@ int CompositeHash::SingleTypeKeySize(BroType* bt, const Val* v,
 		case TYPE_FUNC:
 			{
 			sz = SizeAlign(sz, sizeof(uint32_t));
+			break;
+			}
+
+		case TYPE_PATTERN:
+			{
+			if ( ! v )
+				return (optional && ! calc_static_size) ? sz : 0;
+
+			sz = SizeAlign(sz, 2 * sizeof(size_t));
+			sz += strlen(v->AsPattern()->PatternText())
+				+ strlen(v->AsPattern()->AnywherePatternText()) + 2; // 2 for null terminators
 			break;
 			}
 
@@ -843,6 +877,28 @@ const char* CompositeHash::RecoverOneVal(const HashKey* k, const char* kp0,
 			else if ( t->Tag() == TYPE_FUNC &&
 				  pval->Type()->Tag() != TYPE_FUNC )
 				reporter->InternalError("inconsistent aggregate Val in CompositeHash::RecoverOneVal()");
+			}
+			break;
+
+		case TYPE_PATTERN:
+			{
+			RE_Matcher* re = nullptr;
+			if ( is_singleton )
+				{
+				kp1 = kp0;
+				int divider = strlen(kp0) + 1;
+				re = new RE_Matcher(kp1, kp1 + divider);
+				kp1 += k->Size();
+				}
+			else
+				{
+				const size_t* const len = AlignType<size_t>(kp0);
+
+				kp1 = reinterpret_cast<const char*>(len+2);
+				re = new RE_Matcher(kp1, kp1 + len[0]);
+				kp1 += len[0] + len[1];
+				}
+			pval = new PatternVal(re);
 			}
 			break;
 

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -401,6 +401,21 @@ HashKey* CompositeHash::ComputeSingletonHash(const Val* v, int type_check) const
 		if ( v->Type()->Tag() == TYPE_FUNC )
 			return new HashKey(v->AsFunc()->GetUniqueFuncID());
 
+		if (v->Type()->Tag() == TYPE_PATTERN) {
+			char* texts[2] = {
+				v->AsPattern()->PatternText(),
+				v->AsPattern()->AnywherePatternText()
+			};
+
+			char key [ sizeof(size_t) * 2 + strlen(texts[0]) + strlen(texts[1]) ];
+			std::memcpy(key, strlen(texts[0]), sizeof(size_t));
+			std::memcpy(*(key + sizeof(size_t)), strlen(texts[1]), sizeof(size_t));
+			std::memcpy(key + 2 * sizeof(size_t), texts[0], strlen(texts[0]));
+			std::memcpy(key + 2 * sizeof(size_t) + strlen(texts[0]), texts[1], strlen(texts[1]));
+
+			return new HashKey(key);
+		}
+
 		reporter->InternalError("bad index type in CompositeHash::ComputeSingletonHash");
 		return 0;
 

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -391,7 +391,7 @@ TableType::TableType(TypeList* ind, BroType* yield)
 		// Allow functions, since they can be compared
 		// for Func* pointer equality.
 		if ( t == TYPE_INTERNAL_OTHER && tli->Tag() != TYPE_FUNC &&
-		     tli->Tag() != TYPE_RECORD )
+		     tli->Tag() != TYPE_RECORD && tli->Tag() != TYPE_PATTERN)
 			{
 			tli->Error("bad index type");
 			SetError();


### PR DESCRIPTION
Added CompHash functions for Pattern, so they can be used in sets and as indexes for Tables. Sample code:

```
event zeek_init () {
	local p1: pattern = /foo|bar/; 
        local p2: pattern = /oob/; 
        local p3: pattern = /^oob/; 
        local p4 = /foo/;
	local p: set[pattern] = {p1, p2, p3, p4};
	local t: table[pattern] of count = {
		[p1] = 0,
		[p2] = 1,
		[p3] = 2,
		[p4] = 3
	};
	local t2: table[pattern, count] of count = {
		[p1,2] = 0,
		[p2,3] = 2,
		[p3,4] = 4,
		[p4,5] = 6
	};
	print p1;
	print p2;
	print p3;
	print p4;
	print "";

	for ( [c1, c2] in t2)
	{
		print(c1);
		print(c2);
	}

	print "";

	for (key in p) {
		print key;
	}

	print "";

	for ( key in t ) 
		{
		print key;
		}

}
```

yields output:

```
/^?(foo|bar)$?/
/^?(oob)$?/
/^?(^oob)$?/
/^?(foo)$?/

/^?(^oob)$?/
4
/^?(oob)$?/
3
/^?(foo)$?/
5
/^?(foo|bar)$?/
2

/^?(foo|bar)$?/
/^?(^oob)$?/
/^?(foo)$?/
/^?(oob)$?/

/^?(foo|bar)$?/
/^?(^oob)$?/
/^?(foo)$?/
/^?(oob)$?/
```