### PR TITLE
Remove uses of bit-fields where fixed types will be more descriptive

### DIFF
--- a/src/BroString.cc
+++ b/src/BroString.cc
@@ -25,52 +25,40 @@ const int BroString::BRO_STRING_LITERAL;
 // arg_final_NUL == 1; when str is a sequence of n bytes, make
 // arg_final_NUL == 0.
 
-BroString::BroString(int arg_final_NUL, byte_vec str, int arg_n)
+BroString::BroString(bool arg_final_NUL, byte_vec str, int arg_n)
 	{
 	b = str;
 	n = arg_n;
 	final_NUL = arg_final_NUL;
-	use_free_to_delete = 0;
+	use_free_to_delete = false;
 	}
 
-BroString::BroString(const u_char* str, int arg_n, int add_NUL)
+BroString::BroString(const u_char* str, int arg_n, bool add_NUL) : BroString()
 	{
-	b = 0;
-	n = 0;
-	use_free_to_delete = 0;
 	Set(str, arg_n, add_NUL);
 	}
 
-BroString::BroString(const char* str)
+BroString::BroString(const char* str) : BroString()
 	{
-	b = 0;
-	n = 0;
-	use_free_to_delete = 0;
 	Set(str);
 	}
 
-BroString::BroString(const string &str)
+BroString::BroString(const string &str) : BroString()
 	{
-	b = 0;
-	n = 0;
-	use_free_to_delete = 0;
 	Set(str);
 	}
 
-BroString::BroString(const BroString& bs)
+BroString::BroString(const BroString& bs) : BroString()
 	{
-	b = 0;
-	n = 0;
-	use_free_to_delete = 0;
 	*this = bs;
 	}
 
 BroString::BroString()
 	{
-	b = 0;
+	b = nullptr;
 	n = 0;
-	final_NUL = 0;
-	use_free_to_delete = 0;
+	final_NUL = false;
+	use_free_to_delete = false;
 	}
 
 void BroString::Reset()
@@ -80,10 +68,10 @@ void BroString::Reset()
 	else
 		delete [] b;
 
-	b = 0;
+	b = nullptr;
 	n = 0;
-	final_NUL = 0;
-	use_free_to_delete = 0;
+	final_NUL = false;
+	use_free_to_delete = false;
 	}
 
 const BroString& BroString::operator=(const BroString &bs)
@@ -95,8 +83,8 @@ const BroString& BroString::operator=(const BroString &bs)
 	memcpy(b, bs.b, n);
 	b[n] = '\0';
 
-	final_NUL = 1;
-	use_free_to_delete = 0;
+	final_NUL = true;
+	use_free_to_delete = false;
 	return *this;
 	}
 
@@ -122,7 +110,7 @@ void BroString::Adopt(byte_vec bytes, int len)
 	n = len - final_NUL;
 	}
 
-void BroString::Set(const u_char* str, int len, int add_NUL)
+void BroString::Set(const u_char* str, int len, bool add_NUL)
 	{
 	Reset();
 
@@ -134,7 +122,7 @@ void BroString::Set(const u_char* str, int len, int add_NUL)
 	if ( add_NUL )
 		b[n] = 0;
 
-	use_free_to_delete = 0;
+	use_free_to_delete = false;
 	}
 
 void BroString::Set(const char* str)
@@ -144,8 +132,8 @@ void BroString::Set(const char* str)
 	n = strlen(str);
 	b = new u_char[n+1];
 	memcpy(b, str, n+1);
-	final_NUL = 1;
-	use_free_to_delete = 0;
+	final_NUL = true;
+	use_free_to_delete = false;
 	}
 
 void BroString::Set(const string& str)
@@ -155,8 +143,8 @@ void BroString::Set(const string& str)
 	n = str.size();
 	b = new u_char[n+1];
 	memcpy(b, str.c_str(), n+1);
-	final_NUL = 1;
-	use_free_to_delete = 0;
+	final_NUL = true;
+	use_free_to_delete = false;
 	}
 
 void BroString::Set(const BroString& str)
@@ -307,7 +295,7 @@ BroString::Vec* BroString::Split(const BroString::IdxVec& indices) const
 	{
 	unsigned int i;
 
-	if ( indices.size() == 0 )
+	if ( indices.empty() )
 		return 0;
 
 	// Copy input, ensuring space for "0":
@@ -453,7 +441,7 @@ BroString* concatenate(std::vector<data_chunk_t>& v)
 
 	*b = '\0';
 
-	return new BroString(1, (byte_vec) data, len);
+	return new BroString(true, (byte_vec) data, len);
 	}
 
 BroString* concatenate(BroString::CVec& v)
@@ -474,7 +462,7 @@ BroString* concatenate(BroString::CVec& v)
 		}
 	*b = '\0';
 
-	return new BroString(1, (byte_vec) data, len);
+	return new BroString(true, (byte_vec) data, len);
 	}
 
 BroString* concatenate(BroString::Vec& v)

--- a/src/BroString.h
+++ b/src/BroString.h
@@ -33,13 +33,13 @@ public:
 	typedef IdxVec::const_iterator IdxVecCIt;
 
 	// Constructors creating internal copies of the data passed in.
-	BroString(const u_char* str, int arg_n, int add_NUL);
+	BroString(const u_char* str, int arg_n, bool add_NUL);
 	explicit BroString(const char* str);
 	explicit BroString(const std::string& str);
 	BroString(const BroString& bs);
 
 	// Constructor that takes owernship of the vector passed in.
-	BroString(int arg_final_NUL, byte_vec str, int arg_n);
+	BroString(bool arg_final_NUL, byte_vec str, int arg_n);
 
 	BroString();
 	~BroString()	{ Reset(); }
@@ -61,7 +61,7 @@ public:
 	// current contents, if any, and then set the string's
 	// contents to a copy of the string given by the arguments.
 	//
-	void Set(const u_char* str, int len, int add_NUL=1);
+	void Set(const u_char* str, int len, bool add_NUL=true);
 	void Set(const char* str);
 	void Set(const std::string& str);
 	void Set(const BroString &str);
@@ -146,8 +146,8 @@ protected:
 
 	byte_vec b;
 	int n;
-	unsigned int final_NUL:1;	// whether we have added a final NUL
-	unsigned int use_free_to_delete:1;	// free() vs. operator delete
+	bool final_NUL;	// whether we have added a final NUL
+	bool use_free_to_delete;	// free() vs. operator delete
 };
 
 // A comparison class that sorts pointers to BroString's according to

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -18,7 +18,7 @@
 #include "analyzer/Manager.h"
 
 void ConnectionTimer::Init(Connection* arg_conn, timer_func arg_timer,
-				int arg_do_expire)
+				bool arg_do_expire)
 	{
 	conn = arg_conn;
 	timer = arg_timer;
@@ -87,8 +87,8 @@ Connection::Connection(NetSessions* s, const ConnIDKey& k, double t, const ConnI
 	vlan = pkt->vlan;
 	inner_vlan = pkt->inner_vlan;
 
-	conn_val = 0;
-	login_conn = 0;
+	conn_val = nullptr;
+	login_conn = nullptr;
 
 	is_active = 1;
 	skip = 0;
@@ -108,8 +108,8 @@ Connection::Connection(NetSessions* s, const ConnIDKey& k, double t, const ConnI
 	hist_seen = 0;
 	history = "";
 
-	root_analyzer = 0;
-	primary_PIA = 0;
+	root_analyzer = nullptr;
+	primary_PIA = nullptr;
 
 	++current_connections;
 	++total_connections;
@@ -172,7 +172,7 @@ void Connection::CheckEncapsulation(const EncapsulationStack* arg_encap)
 		EncapsulationStack empty;
 		Event(tunnel_changed, 0, empty.GetVectorVal());
 		delete encapsulation;
-		encapsulation = 0;
+		encapsulation = nullptr;
 		}
 
 	else if ( arg_encap )
@@ -222,7 +222,7 @@ void Connection::NextPacket(double t, int is_orig,
 		last_time = t;
 
 	current_timestamp = 0;
-	current_pkt = 0;
+	current_pkt = nullptr;
 	}
 
 void Connection::SetLifetime(double lifetime)
@@ -533,7 +533,7 @@ void Connection::Weird(const char* name, const char* addl)
 	reporter->Weird(this, name, addl ? addl : "");
 	}
 
-void Connection::AddTimer(timer_func timer, double t, int do_expire,
+void Connection::AddTimer(timer_func timer, double t, bool do_expire,
 		TimerType type)
 	{
 	if ( timers_canceled )
@@ -609,7 +609,7 @@ void Connection::FlipRoles()
 	orig_flow_label = tmp_flow;
 
 	Unref(conn_val);
-	conn_val = 0;
+	conn_val = nullptr;
 
 	if ( root_analyzer )
 		root_analyzer->FlipRoles();

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -303,7 +303,7 @@ protected:
 	// Add the given timer to expire at time t.  If do_expire
 	// is true, then the timer is also evaluated when Bro terminates,
 	// otherwise not.
-	void AddTimer(timer_func timer, double t, int do_expire,
+	void AddTimer(timer_func timer, double t, bool do_expire,
 			TimerType type);
 
 	void RemoveTimer(Timer* t);
@@ -367,7 +367,7 @@ protected:
 class ConnectionTimer : public Timer {
 public:
 	ConnectionTimer(Connection* arg_conn, timer_func arg_timer,
-			double arg_t, int arg_do_expire, TimerType arg_type)
+			double arg_t, bool arg_do_expire, TimerType arg_type)
 		: Timer(arg_t, arg_type)
 		{ Init(arg_conn, arg_timer, arg_do_expire); }
 	~ConnectionTimer() override;
@@ -377,11 +377,11 @@ public:
 protected:
 	ConnectionTimer()	{}
 
-	void Init(Connection* conn, timer_func timer, int do_expire);
+	void Init(Connection* conn, timer_func timer, bool do_expire);
 
 	Connection* conn;
 	timer_func timer;
-	int do_expire;
+	bool do_expire;
 };
 
 #define ADD_TIMER(timer, t, do_expire, type) \

--- a/src/Timer.h
+++ b/src/Timer.h
@@ -12,7 +12,7 @@ extern "C" {
 }
 
 // If you add a timer here, adjust TimerNames in Timer.cc.
-enum TimerType {
+enum TimerType : uint8_t {
 	TIMER_BACKDOOR,
 	TIMER_BREAKPOINT,
 	TIMER_CONN_DELETE,
@@ -51,8 +51,7 @@ class ODesc;
 
 class Timer : public PQ_Element {
 public:
-	Timer(double t, TimerType arg_type) : PQ_Element(t)
-		{ type = (char) arg_type; }
+	Timer(double t, TimerType arg_type) : PQ_Element(t), type(arg_type) { }
 	~Timer() override { }
 
 	TimerType Type() const	{ return (TimerType) type; }
@@ -66,8 +65,7 @@ public:
 
 protected:
 	Timer()	{}
-
-	unsigned int type:8;
+	TimerType type;
 };
 
 class TimerMgr {

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -15,7 +15,7 @@ using namespace analyzer::ident;
 Ident_Analyzer::Ident_Analyzer(Connection* conn)
 : tcp::TCP_ApplicationAnalyzer("IDENT", conn)
 	{
-	did_bad_reply = did_deliver = 0;
+	did_bad_reply = did_deliver = false;
 
 	orig_ident = new tcp::ContentLine_Analyzer(conn, true, 1000);
 	resp_ident = new tcp::ContentLine_Analyzer(conn, false, 1000);
@@ -89,7 +89,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 			val_mgr->GetPort(remote_port, TRANSPORT_TCP),
 		});
 
-		did_deliver = 1;
+		did_deliver = true;
 		}
 
 	else
@@ -251,6 +251,6 @@ void Ident_Analyzer::BadReply(int length, const char* line)
 		{
 		BroString s((const u_char*)line, length, true);
 		Weird("bad_ident_reply", s.CheckString());
-		did_bad_reply = 1;
+		did_bad_reply = true;
 		}
 	}

--- a/src/analyzer/protocol/ident/Ident.h
+++ b/src/analyzer/protocol/ident/Ident.h
@@ -29,8 +29,8 @@ protected:
 	tcp::ContentLine_Analyzer* orig_ident;
 	tcp::ContentLine_Analyzer* resp_ident;
 
-	unsigned int did_deliver:1;
-	unsigned int did_bad_reply:1;
+	bool did_deliver;
+	bool did_bad_reply;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/netbios/NetbiosSSN.h
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.h
@@ -32,9 +32,9 @@ typedef enum {
 struct NetbiosSSN_RawMsgHdr {
 	NetbiosSSN_RawMsgHdr(const u_char*& data, int& len);
 
-	unsigned int type:8;
-	unsigned int flags:8;
-	unsigned int length:16;
+	uint8_t type;
+	uint8_t flags;
+	uint16_t length;
 };
 
 //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -51,13 +51,13 @@ struct NetbiosSSN_RawMsgHdr {
 struct NetbiosDGM_RawMsgHdr {
 	NetbiosDGM_RawMsgHdr(const u_char*& data, int& len);
 
-	unsigned int type:8;
-	unsigned int flags:8;
-	unsigned int id:16;
-	unsigned int srcip:32;
-	unsigned int srcport:16;
-	unsigned int length:16;
-	unsigned int offset:16;
+	uint8_t type;
+	uint8_t flags;
+	uint16_t id;
+	uint32_t srcip;
+	uint16_t srcport;
+	uint16_t length;
+	uint16_t offset;
 };
 
 

--- a/src/analyzer/protocol/tcp/ContentLine.cc
+++ b/src/analyzer/protocol/tcp/ContentLine.cc
@@ -21,17 +21,17 @@ ContentLine_Analyzer::ContentLine_Analyzer(const char* name, Connection* conn, b
 
 void ContentLine_Analyzer::InitState()
 	{
-	flag_NULs = 0;
+	flag_NULs = false;
 	CR_LF_as_EOL = (CR_as_EOL | LF_as_EOL);
-	skip_deliveries = 0;
-	skip_partial = 0;
+	skip_deliveries = false;
+	skip_partial = false;
 	buf = 0;
 	seq_delivered_in_lines = 0;
 	skip_pending = 0;
 	seq = 0;
 	seq_to_skip = 0;
 	plain_delivery_length = 0;
-	is_plain = 0;
+	is_plain = false;
 	suppress_weirds = false;
 
 	InitBuffer(0);
@@ -70,7 +70,7 @@ ContentLine_Analyzer::~ContentLine_Analyzer()
 	delete [] buf;
 	}
 
-int ContentLine_Analyzer::HasPartialLine() const
+bool ContentLine_Analyzer::HasPartialLine() const
 	{
 	return buf && offset > 0;
 	}
@@ -150,11 +150,11 @@ void ContentLine_Analyzer::DoDeliver(int len, const u_char* data)
 
 			last_char = 0; // clear last_char
 			plain_delivery_length -= deliver_plain;
-			is_plain = 1;
+			is_plain = true;
 
 			ForwardStream(deliver_plain, data, IsOrig());
 
-			is_plain = 0;
+			is_plain = false;
 
 			data += deliver_plain;
 			len -= deliver_plain;
@@ -339,4 +339,3 @@ void ContentLine_Analyzer::SkipBytes(int64_t length)
 	skip_pending = 0;
 	seq_to_skip = SeqDelivered() + length;
 	}
-

--- a/src/analyzer/protocol/tcp/ContentLine.h
+++ b/src/analyzer/protocol/tcp/ContentLine.h
@@ -35,12 +35,12 @@ public:
 	int CRLFAsEOL()
 		{ return CR_LF_as_EOL ; }
 
-	int HasPartialLine() const;
+	bool HasPartialLine() const;
 
 	bool SkipDeliveries() const
 		{ return skip_deliveries; }
 
-	void SetSkipDeliveries(int should_skip)
+	void SetSkipDeliveries(bool should_skip)
 		{ skip_deliveries = should_skip; }
 
 	// We actually have two delivery modes: line delivery and plain
@@ -97,21 +97,21 @@ protected:
 
 	// Remaining bytes to deliver plain.
 	int64_t plain_delivery_length;
-	int is_plain;
+	bool is_plain;
 
 	// Don't deliver further data.
-	int skip_deliveries;
+	bool skip_deliveries;
 
 	bool suppress_weirds;
 
 	// If true, flag (first) line with embedded NUL.
-	unsigned int flag_NULs:1;
+	bool flag_NULs;
 
 	// Whether single CR / LF are considered as EOL.
-	unsigned int CR_LF_as_EOL:2;
+	uint8_t CR_LF_as_EOL:2;
 
 	// Whether to skip partial conns.
-	unsigned int skip_partial:1;
+	bool skip_partial;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -28,9 +28,9 @@ TCP_Reassembler::TCP_Reassembler(analyzer::Analyzer* arg_dst_analyzer,
 	endp = arg_endp;
 	had_gap = false;
 	record_contents_file = 0;
-	deliver_tcp_contents = 0;
-	skip_deliveries = 0;
-	did_EOF = 0;
+	deliver_tcp_contents = false;
+	skip_deliveries = false;
+	did_EOF = false;
 	seq_to_skip = 0;
 	in_delivery = false;
 
@@ -49,7 +49,7 @@ TCP_Reassembler::TCP_Reassembler(analyzer::Analyzer* arg_dst_analyzer,
 		if ( (IsOrig() && tcp_content_deliver_all_orig) ||
 		     (! IsOrig() && tcp_content_deliver_all_resp) ||
 		     (result && result->AsBool()) )
-			deliver_tcp_contents = 1;
+			deliver_tcp_contents = true;
 
 		Unref(dst_port_val);
 		}
@@ -221,7 +221,7 @@ void TCP_Reassembler::Undelivered(uint64_t up_to_seq)
 		// the SYN packet carries data.
 		//
 		// Skip the undelivered part without reporting to the endpoint.
-		skip_deliveries = 1;
+		skip_deliveries = true;
 		}
 	else
 		{
@@ -517,7 +517,7 @@ int TCP_Reassembler::DataSent(double t, uint64_t seq, int len,
 		{
 		tcp_analyzer->Weird("above_hole_data_without_any_acks");
 		ClearBlocks();
-		skip_deliveries = 1;
+		skip_deliveries = true;
 		}
 
 	if ( tcp_excessive_data_without_further_acks &&
@@ -525,7 +525,7 @@ int TCP_Reassembler::DataSent(double t, uint64_t seq, int len,
 		{
 		tcp_analyzer->Weird("excessive_data_without_further_acks");
 		ClearBlocks();
-		skip_deliveries = 1;
+		skip_deliveries = true;
 		}
 
 	return 1;
@@ -592,7 +592,7 @@ void TCP_Reassembler::CheckEOF()
 			          network_time, endp->IsOrig());
 			}
 
-		did_EOF = 1;
+		did_EOF = true;
 		tcp_analyzer->EndpointEOF(this);
 		}
 	}

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.h
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.h
@@ -96,10 +96,10 @@ private:
 
 	TCP_Endpoint* endp;
 
-	unsigned int deliver_tcp_contents:1;
-	unsigned int had_gap:1;
-	unsigned int did_EOF:1;
-	unsigned int skip_deliveries:1;
+	bool deliver_tcp_contents;
+	bool had_gap;
+	bool did_EOF;
+	bool skip_deliveries;
 
 	uint64_t seq_to_skip;
 
@@ -114,4 +114,4 @@ private:
 	Type type;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*


### PR DESCRIPTION
This PR removes a number of uses of bit fields where a fixed type such as uint*_t or bool makes the code more readable. It also includes a bit of code modernization work in BroString to remove redundancy.