### PR TITLE
Fix snprintf compiler warning in hexdump BIF

### DIFF
--- a/src/strings.bif
+++ b/src/strings.bif
@@ -1097,7 +1097,7 @@ function hexdump%(data_str: string%) : string
 			{
 			char offset[5];
 			snprintf(offset, sizeof(offset),
-					"%.4x", data_ptr - data);
+					"%.4tx", data_ptr - data);
 			memcpy(hex_data_ptr, offset, 4);
 			hex_data_ptr += 6;
 			ascii_ptr = hex_data_ptr + 50;


### PR DESCRIPTION
Warning on macOS was:

```
In file included from ../src/Func.cc:750:
strings.bif:1099:14: warning: format specifies type 'unsigned int' but the argument has type 'long' [-Wformat]
                                        "%.4x", data_ptr - data);
                                         ~~~~   ^~~~~~~~~~~~~~~
                                         %.4lx
```