### PR TITLE
Fix build warning in X509 plugin

### DIFF
--- a/src/file_analysis/analyzer/x509/Plugin.cc
+++ b/src/file_analysis/analyzer/x509/Plugin.cc
@@ -11,7 +11,7 @@ namespace Zeek_X509 {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::file_analysis::Component("X509", ::file_analysis::X509::Instantiate));
 		AddComponent(new ::file_analysis::Component("OCSP_REQUEST", ::file_analysis::OCSP::InstantiateRequest));


### PR DESCRIPTION
Fixes a build warning with an overridden method in the X509 plugin.