### PR TITLE
fix NTLM field value access

### DIFF
--- a/scripts/base/protocols/ntlm/main.zeek
+++ b/scripts/base/protocols/ntlm/main.zeek
@@ -65,9 +65,9 @@ event ntlm_challenge(c: connection, challenge: NTLM::Challenge) &priority=5
 	if ( challenge?$target_info )
 		{
 		local ti = challenge$target_info;
-		if ( ti?$nb_domain_name )
+		if ( ti?$nb_computer_name )
 			c$ntlm$server_nb_computer_name = ti$nb_computer_name;
-		if ( ti?$dns_domain_name )
+		if ( ti?$dns_computer_name )
 			c$ntlm$server_dns_computer_name = ti$dns_computer_name;
 		if ( ti?$dns_tree_name )
 			c$ntlm$server_tree_name = ti$dns_tree_name;


### PR DESCRIPTION
The fields being checked for existence were not the same as the fields
being accessed.