### PR TITLE
Fix bug triggered by cloning nested lambdas.

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -4385,6 +4385,11 @@ LambdaExpr::LambdaExpr(std::unique_ptr<function_ingredients> arg_ing,
 	id->SetConst();
 	}
 
+Scope* LambdaExpr::GetScope() const
+	{
+	return ingredients->scope;
+	}
+
 Val* LambdaExpr::Eval(Frame* f) const
 	{
 	::Ref(ingredients->body);

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -963,6 +963,8 @@ public:
 	Val* Eval(Frame* f) const override;
 	TraversalCode Traverse(TraversalCallback* cb) const override;
 
+	Scope* GetScope() const;
+
 protected:
 	void ExprDescribe(ODesc* d) const override;
 

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -465,16 +465,6 @@ void end_func(Stmt* body)
 	{
 	auto ingredients = std::make_unique<function_ingredients>(pop_scope(), body);
 
-	if ( streq(ingredients->id->Name(), "anonymous-function") )
-		{
-		OuterIDBindingFinder cb(ingredients->scope);
-		ingredients->body->Traverse(&cb);
-
-		for ( size_t i = 0; i < cb.outer_id_references.size(); ++i )
-			cb.outer_id_references[i]->Error(
-						"referencing outer function IDs not supported");
-		}
-
 	if ( ingredients->id->HasVal() )
 		ingredients->id->ID_Val()->AsFunc()->AddBody(
 			ingredients->body,


### PR DESCRIPTION
Resolves #725.

Previously, Zeek would leak memory and potentially catch an error if a nested lambda was cloned. This occurred because local variables of nested lambdas were being incorrectly detected as variables in the parent lambdas closure.

This also removes an unneeded check for outer IDs in regular functions that wasn't removed after closures became supported.

I'd appreciate some feedback on how I implemented this. In particular the addition of a new traversal code `TC_SKIPBODY`. That was the most elegant way that I could think of to indicate to inner lambdas that they should skip traversing their bodies, but I understand that adding a new traversal code for that use case only might be less than ideal.

I ran this through leak tests on my machine and it looked fine, but this is my first time using the new system so its possible I missed something there as well.