### PR TITLE
Enable LeakSanitizer for unit tests run via doctest

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -454,6 +454,7 @@ int main(int argc, char** argv)
 #else
 		doctest::Context context;
 		context.applyCommandLine(std::distance(first, separator), argv);
+		ZEEK_LSAN_ENABLE();
 		return context.run();
 #endif
 		}

--- a/src/util.cc
+++ b/src/util.cc
@@ -167,6 +167,7 @@ TEST_CASE("util get_escaped_string")
 		{
 		ODesc* d = get_escaped_string(nullptr, "a bcd\n", 6, false);
 		CHECK(strcmp(d->Description(), "a\\x20bcd\\x0a") == 0);
+		delete d;
 		}
 
 	SUBCASE("provided ODesc")


### PR DESCRIPTION
Seems worthwhile since unit tests have more potential to cover hard-to-reach corners than btests sometimes do.  Can always instrument individual tests to ignore leaks if that's ever needed, but think that shouldn't be often.