### PR TITLE
Fix warning when reading files from non-network sources

### DIFF
--- a/scripts/base/protocols/ssl/files.zeek
+++ b/scripts/base/protocols/ssl/files.zeek
@@ -92,7 +92,7 @@ event zeek_init() &priority=5
 
 event file_sniff(f: fa_file, meta: fa_metadata) &priority=5
 	{
-	if ( |f$conns| != 1 )
+	if ( ! f?$conns || |f$conns| != 1 )
 		return;
 
 	if ( ! f?$info || ! f$info?$mime_type )


### PR DESCRIPTION
If files are being read from non-network sources, there was a warning in the SSL base scripts about missing the f$conns field.