### PR TITLE
Use consistent zeek_init priority for Log::create_stream calls

### DIFF
--- a/scripts/base/frameworks/signatures/main.zeek
+++ b/scripts/base/frameworks/signatures/main.zeek
@@ -140,7 +140,7 @@ global count_per_orig: table[addr, string] of count
 global did_sig_log: set[string] &read_expire = 1 hr;
 
 
-event zeek_init()
+event zeek_init() &priority=5
 	{
 	Log::create_stream(Signatures::LOG, [$columns=Info, $ev=log_signature, $path="signatures"]);
 	}

--- a/scripts/policy/files/x509/log-ocsp.zeek
+++ b/scripts/policy/files/x509/log-ocsp.zeek
@@ -39,7 +39,7 @@ export {
 	global log_ocsp: event(rec: Info);
 }
 
-event zeek_init()
+event zeek_init() &priority=5
 	{
 	Log::create_stream(LOG, [$columns=Info, $ev=log_ocsp, $path="ocsp"]);
 	Files::register_for_mime_type(Files::ANALYZER_OCSP_REPLY, "application/ocsp-response");

--- a/scripts/policy/protocols/conn/known-hosts.zeek
+++ b/scripts/policy/protocols/conn/known-hosts.zeek
@@ -145,7 +145,7 @@ event Known::host_found(info: HostsInfo)
 	event known_host_add(info);
 	}
 
-event zeek_init()
+event zeek_init() &priority=5
 	{
 	Log::create_stream(Known::HOSTS_LOG, [$columns=HostsInfo, $ev=log_known_hosts, $path="known_hosts"]);
 	}


### PR DESCRIPTION
Typically in base scripts, Log::create_stream() is called in zeek_init()
handler with &priority=5 such that it will have already been created
in the default zeek_init() &priority=0.

Pitfall caused by the current inconsistency reported via thread: http://mailman.icsi.berkeley.edu/pipermail/zeek/2020-January/014941.html