### PR TITLE
Topic/frerich/gh 750 uri with empty portnum

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -67,6 +67,11 @@ Changed Functionality
   previously used. Output from the formatters remains nearly
   identical.
 
+- The ``decompose_uri`` function no longer raises an error when parsing
+  URIs with an empty port number (e.g. ``http://example.org:/``). Instead,
+  the ``portnum`` component of the returned ``URI`` value is left
+  uninitialized.
+
 Removed Functionality
 ---------------------
 

--- a/scripts/base/utils/urls.zeek
+++ b/scripts/base/utils/urls.zeek
@@ -119,7 +119,10 @@ function decompose_uri(uri: string): URI
 		# Parse location and port.
 		parts = split_string1(s, /:/);
 		u$netlocation = parts[0];
-		u$portnum = to_count(parts[1]);
+		if ( parts[1] != "" )
+		    {
+		    u$portnum = to_count(parts[1]);
+		    }
 		}
 	else
 		{

--- a/testing/btest/Baseline/scripts.base.utils.urls/output
+++ b/testing/btest/Baseline/scripts.base.utils.urls/output
@@ -6,6 +6,7 @@
 [scheme=http, netlocation=hyphen-example.com, portnum=<uninitialized>, path=/index.asp, file_name=index.asp, file_base=index, file_ext=asp, params={
 [q] = 123
 }]
+[scheme=git, netlocation=git.kernel.org, portnum=<uninitialized>, path=/pub/scm/linux/, file_name=<uninitialized>, file_base=<uninitialized>, file_ext=<uninitialized>, params=<uninitialized>]
 [scheme=<uninitialized>, netlocation=dfasjdfasdfasdf, portnum=<uninitialized>, path=/, file_name=<uninitialized>, file_base=<uninitialized>, file_ext=<uninitialized>, params={
 
 }]

--- a/testing/btest/scripts/base/utils/urls.test
+++ b/testing/btest/scripts/base/utils/urls.test
@@ -8,6 +8,7 @@ print decompose_uri("https://www.example.com/");
 print decompose_uri("http://example.com:99/test//?foo=bar");
 print decompose_uri("ftp://1.2.3.4/pub/files/something.exe");
 print decompose_uri("http://hyphen-example.com/index.asp?q=123");
+print decompose_uri("git://git.kernel.org:/pub/scm/linux/");
 
 # This is mostly undefined behavior but it doesn't give any 
 # reporter messages at least.


### PR DESCRIPTION
`decompose_uri` would raise an error when called with an URI having an empty port number (e.g. `http://example.org:/`). I don't think this is syntactically valid, but it appears that Git accepts it - in fact, there is even a [test for this](https://github.com/git/git/blob/77bd3ea9f54f1584147b594abc04c26ca516d987/t/t0110-urlmatch-normalization.sh#L69) in the Git source code.

The new behaviour is to not raise an error but rather leave the `portnum` component of the `URI` uninitialized.

My first contribution to the project - just a little something to get my feet wet. :-)

Fixes #750 