### PR TITLE
main: drop privileges after initialization

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,6 +230,7 @@ set(MAIN_SRCS
     Dict.cc
     Discard.cc
     DNS_Mgr.cc
+    DropPrivileges.cc
     EquivClass.cc
     Event.cc
     EventHandler.cc

--- a/src/DropPrivileges.cc
+++ b/src/DropPrivileges.cc
@@ -1,0 +1,75 @@
+// See the file "COPYING" in the main distribution directory for copyright.
+
+#include "zeek-config.h"
+#include "DropPrivileges.h"
+
+#include <initializer_list>
+
+#ifdef __linux__
+#include <sched.h>
+#include <sys/mount.h>
+#include <sys/prctl.h>
+
+static void BindRemount(const char *path, unsigned long flags) noexcept
+	{
+	if (mount(path, path, nullptr, MS_BIND, nullptr) == 0)
+		mount(nullptr, path, nullptr, MS_REMOUNT|MS_BIND|flags,
+		      nullptr);
+	}
+
+static void HardenFilesystems() noexcept
+	{
+	/* create a new mount namespace, so the following mounts
+	   affect only this process and nobody else */
+	if (unshare(CLONE_NEWNS) < 0)
+		return;
+
+	/* convert all "shared" mounts to "private" mounts */
+	if (mount(nullptr, "/", nullptr, MS_PRIVATE|MS_REC, nullptr) < 0)
+		return;
+
+	/* we don't need those filesystems */
+	for (const char *path : {"/proc", "/sys", "/dev/pts", "/dev/hugepages", "/dev/mqueue", "/run"})
+		umount2(path, MNT_DETACH);
+
+	/* mount a private tmpfs here so we're not affected by
+	   other processes */
+	for (const char *path : {"/tmp", "/var/tmp", "/dev/shm"})
+		mount("none", path, "tmpfs",
+		      MS_NODEV|MS_NOEXEC|MS_NOSUID,
+		      "size=16M,nr_inodes=256,mode=1777");
+
+	/* remount those paths read-only so we can't do any
+	   harm here */
+	BindRemount("/usr", MS_RDONLY|MS_NODEV|MS_NOSUID);
+	BindRemount("/opt", MS_RDONLY|MS_NODEV|MS_NOSUID);
+	BindRemount("/etc", MS_RDONLY|MS_NODEV|MS_NOEXEC);
+	}
+
+#endif
+
+void DropPrivileges() noexcept
+	{
+#ifdef __linux__
+	HardenFilesystems();
+
+#ifdef PR_SET_NO_NEW_PRIVS
+	/* shut off all ways to regain privileges (suid bits etc.) */
+	prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+#endif
+
+	/* this drops all capabilities and effectively makes this
+	   process unprivileged (even though it's still "root" and
+	   still has access to "root"-owned processes and files), but
+	   this currently fails with errno=EINVAL because the allows
+	   this only if there are no threads yet - to make this work,
+	   we must change our initalization order and move libcaf
+	   initialization to after this call */
+	unshare(CLONE_NEWUSER);
+
+	/* this would isolate our process from the rest, but this
+	   breaks thread creation (need to figure out how to do this
+	   properly) */
+	//unshare(CLONE_NEWPID);
+#endif
+	}

--- a/src/DropPrivileges.h
+++ b/src/DropPrivileges.h
@@ -1,0 +1,5 @@
+// See the file "COPYING" in the main distribution directory for copyright.
+
+#pragma once
+
+void DropPrivileges() noexcept;

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -104,6 +104,7 @@ void zeek::usage(const char* prog, int code)
 	fprintf(stderr, "    -T|--re-level <level>          | set 'RE_level' for rules\n");
 	fprintf(stderr, "    -U|--status-file <file>        | Record process status in file\n");
 	fprintf(stderr, "    -W|--watchdog                  | activate watchdog timer\n");
+	fprintf(stderr, "    -D|--drop-privileges           | drop privileges after initialization\n");
 	fprintf(stderr, "    -X|--zeekygen <cfgfile>        | generate documentation based on config file\n");
 
 #ifdef USE_PERFTOOLS_DEBUG
@@ -210,6 +211,7 @@ zeek::Options zeek::parse_cmdline(int argc, char** argv)
 		{"debug-rules",		no_argument,		0,	'S'},
 		{"re-level",		required_argument,	0,	'T'},
 		{"watchdog",		no_argument,		0,	'W'},
+		{"drop-privileges",	no_argument,		0,	'D'},
 		{"print-id",		required_argument,	0,	'I'},
 		{"status-file",		required_argument,	0,	'U'},
 
@@ -232,7 +234,7 @@ zeek::Options zeek::parse_cmdline(int argc, char** argv)
 	};
 
 	char opts[256];
-	safe_strncpy(opts, "B:e:f:G:H:I:i:j::n:p:r:s:T:t:U:w:X:CFNPQSWabdhv",
+	safe_strncpy(opts, "B:e:f:G:H:I:i:j::n:p:r:s:T:t:U:w:X:CFNPQSWDabdhv",
 	             sizeof(opts));
 
 #ifdef USE_PERFTOOLS_DEBUG
@@ -370,6 +372,9 @@ zeek::Options zeek::parse_cmdline(int argc, char** argv)
 			break;
 		case 'W':
 			rval.use_watchdog = true;
+			break;
+		case 'D':
+			rval.drop_privileges = true;
 			break;
 		case 'X':
 			rval.zeekygen_config_file = optarg;

--- a/src/Options.h
+++ b/src/Options.h
@@ -44,6 +44,7 @@ struct Options {
 	int signature_re_level = 4;
 	bool ignore_checksums = false;
 	bool use_watchdog = false;
+	bool drop_privileges = false;
 	double pseudo_realtime = 0;
 	DNS_MgrMode dns_mode = DNS_DEFAULT;
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -21,6 +21,7 @@ extern "C" {
 #include <openssl/err.h>
 
 #include "Options.h"
+#include "DropPrivileges.h"
 #include "input.h"
 #include "DNS_Mgr.h"
 #include "Frame.h"
@@ -351,6 +352,7 @@ static void bro_new_handler()
 	{
 	out_of_memory("new");
 	}
+
 
 static std::vector<std::string> get_script_signature_files()
 	{
@@ -887,6 +889,9 @@ int main(int argc, char** argv)
 	broker_mgr->ZeekInitDone();
 	reporter->ZeekInitDone();
 	analyzer_mgr->DumpDebug();
+
+	if ( options.drop_privileges )
+		DropPrivileges();
 
 	have_pending_timers = ! reading_traces && timer_mgr->Size() > 0;
 


### PR DESCRIPTION
Zeek is designed to run as root (to be able to capture packets).  This
makes Zeek itself a huge surface for attackers.  Zeek parses and
evaluates malicious data, after all.

As a proactive countermeasure, this patch drops unneeded privileges to
reduce the damage from a hack:

- create a new mount namespace, unmount various filesystems and
  remount others read-only
- mount a private tmpfs on /tmp, /var/tmp and /dev/shm
- set the "NO_NEW_PRIVS" process flag

All of this is Linux specific.  Other operating systems have other
knobs which may be interesting for Zeek.

Though much more needs to be done to make Zeek more secure, for
example:

- create a user namespace (see code comment)
- change to a different uid/gid
- install a seccomp filter to create a whitelist of allowed system
  calls
- run Zeek in an empty network namespace so attackers cannot
  communicate with the internet
- make more parts of the filesystem unavailable, e.g. /var, /opt, /etc
  or better: run Zeek in an empty VFS where just the output directory
  is bind-mounted
- run the dangerous packet evaluation code in a dedicated process
  which has a socket to the main process and nothing else, no
  filesystem, no network, a tiny system call whitelist (Privilege
  Separation)

You can't be paranoid enough with software like Zeek!