### PR TITLE
Update Cirrus CI config to use macOS Catalina

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -94,7 +94,7 @@ ubuntu16_task:
 # image is available.
 macos_task:
   osx_instance:
-    image: mojave-base
+    image: catalina-base
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   env:


### PR DESCRIPTION
This should be a no-op since Cirrus claims to already auto-upgrade requests for the Mojave image to Catalina instead, but may as well be explicit.  I can merge myself once I see for sure the change still works fine.