### PR TITLE
threading/Queue: lock mutex before notifying the condition_variable

### DIFF
--- a/src/threading/Queue.h
+++ b/src/threading/Queue.h
@@ -255,7 +255,10 @@ template<typename T>
 inline void Queue<T>::WakeUp()
 	{
 	for ( int i = 0; i < NUM_QUEUES; i++ )
+		{
+		auto lock = acquire_lock(mutex[i]);
 		has_data[i].notify_all();
+		}
 	}
 
 }


### PR DESCRIPTION
Locking the associated mutex is not strictly mandatory, but not doing
so can easily create race conditions and lockups.