### PR TITLE
Change packet source fields of Options to std::optional

### DIFF
--- a/src/Net.cc
+++ b/src/Net.cc
@@ -145,34 +145,34 @@ void net_update_time(double new_network_time)
 	PLUGIN_HOOK_VOID(HOOK_UPDATE_NETWORK_TIME, HookUpdateNetworkTime(new_network_time));
 	}
 
-void net_init(const std::string& interface,
-              const std::string& pcap_input_file,
+void net_init(const std::optional<std::string>& interface,
+              const std::optional<std::string>& pcap_input_file,
               const std::optional<std::string>& pcap_output_file,
               bool do_watchdog)
 	{
-	if ( ! pcap_input_file.empty() )
+	if ( pcap_input_file )
 		{
 		reading_live = pseudo_realtime > 0.0;
 		reading_traces = true;
 
-		iosource::PktSrc* ps = iosource_mgr->OpenPktSrc(pcap_input_file, false);
+		iosource::PktSrc* ps = iosource_mgr->OpenPktSrc(*pcap_input_file, false);
 		assert(ps);
 
 		if ( ! ps->IsOpen() )
 			reporter->FatalError("problem with trace file %s (%s)",
-				pcap_input_file.c_str(), ps->ErrorMsg());
+				pcap_input_file->c_str(), ps->ErrorMsg());
 		}
-	else if ( ! interface.empty() )
+	else if ( interface )
 		{
 		reading_live = true;
 		reading_traces = false;
 
-		iosource::PktSrc* ps = iosource_mgr->OpenPktSrc(interface, true);
+		iosource::PktSrc* ps = iosource_mgr->OpenPktSrc(*interface, true);
 		assert(ps);
 
 		if ( ! ps->IsOpen() )
 			reporter->FatalError("problem with interface %s (%s)",
-				interface.c_str(), ps->ErrorMsg());
+				interface->c_str(), ps->ErrorMsg());
 		}
 
 	else

--- a/src/Net.h
+++ b/src/Net.h
@@ -19,8 +19,8 @@ namespace iosource {
 
 class Packet;
 
-extern void net_init(const std::string& interfaces,
-                     const std::string& pcap_input_file,
+extern void net_init(const std::optional<std::string>& interfaces,
+                     const std::optional<std::string>& pcap_input_file,
                      const std::optional<std::string>& pcap_output_file,
                      bool do_watchdog);
 extern void net_run();

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -268,12 +268,13 @@ zeek::Options zeek::parse_cmdline(int argc, char** argv)
 			rval.print_usage = true;
 			break;
 		case 'i':
-			if ( ! rval.interface.empty() )
+			if ( rval.interface )
 				{
 				fprintf(stderr, "ERROR: Only a single interface option (-i) is allowed.\n");
 				exit(1);
 				}
-			else if ( ! rval.pcap_file.empty() )
+
+			if ( rval.pcap_file )
 				{
 				fprintf(stderr, "ERROR: Using -i is not allow when reading a pcap file.\n");
 				exit(1);
@@ -294,16 +295,18 @@ zeek::Options zeek::parse_cmdline(int argc, char** argv)
 			rval.script_prefixes.emplace_back(optarg);
 			break;
 		case 'r':
-			if ( ! rval.pcap_file.empty() )
+			if ( rval.pcap_file )
 				{
 				fprintf(stderr, "ERROR: Only a single readfile option (-r) is allowed.\n");
 				exit(1);
 				}
-			else if ( ! rval.interface.empty() )
+
+			if ( rval.interface )
 				{
 				fprintf(stderr, "Using -r is not allowed when reading a live interface.\n");
 				exit(1);
 				}
+
 			rval.pcap_file = optarg;
 			break;
 		case 's':

--- a/src/Options.h
+++ b/src/Options.h
@@ -58,8 +58,8 @@ struct Options {
 	std::vector<std::string> doctest_args;
 
 	std::optional<std::string> pcap_filter;
-	std::string interface;
-	std::string pcap_file;
+	std::optional<std::string> interface;
+	std::optional<std::string> pcap_file;
 	std::vector<std::string> signature_files;
 
 	std::optional<std::string> pcap_output_file;

--- a/src/main.cc
+++ b/src/main.cc
@@ -565,8 +565,7 @@ int main(int argc, char** argv)
 
 	if ( options.plugins_to_load.empty() && options.scripts_to_load.empty() &&
 	     options.script_options_to_set.empty() &&
-		 options.pcap_file.empty() &&
-		 options.interface.empty() &&
+		 ! options.pcap_file && ! options.interface &&
 	     ! options.identifier_to_print &&
 	     ! command_line_policy && ! options.print_plugins &&
 	     ! options.supervisor_mode && ! zeek::Supervisor::ThisNode() )
@@ -596,7 +595,7 @@ int main(int argc, char** argv)
 	log_mgr = new logging::Manager();
 	input_mgr = new input::Manager();
 	file_mgr = new file_analysis::Manager();
-	broker_mgr = new bro_broker::Manager(! options.pcap_file.empty());
+	broker_mgr = new bro_broker::Manager(options.pcap_file.has_value());
 	trigger_mgr = new trigger::Manager();
 
 	plugin_mgr->InitPreScript();
@@ -745,7 +744,7 @@ int main(int argc, char** argv)
 		// ### Add support for debug command file.
 		dbg_init_debugger(0);
 
-	if ( options.pcap_file.empty() && options.interface.empty() )
+	if ( ! options.pcap_file && ! options.interface )
 		{
 		Val* interfaces_val = internal_val("interfaces");
 		if ( interfaces_val )


### PR DESCRIPTION
Use of `std::optional` better expresses the optionality of the, um, options.