### PR TITLE
CMakeLists.txt: fix cross-compilation with binpac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,8 +178,7 @@ FindRequiredPackage(OpenSSL)
 FindRequiredPackage(BIND)
 FindRequiredPackage(ZLIB)
 
-if (NOT BINPAC_EXE_PATH AND
-    EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/aux/binpac/CMakeLists.txt)
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/aux/binpac/CMakeLists.txt)
 
     set(ENABLE_STATIC_ONLY_SAVED ${ENABLE_STATIC_ONLY})
 


### PR DESCRIPTION
When cross-compiling, `BINPAC_EXE_PATH` will be set by the user to the host binpac binary which is fine however aux/binpac won't be built which will raise a build failure as target binpac (headers, library) won't be installed or built

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>