### PR TITLE
A few follow-up changes for the IOSource code

### DIFF
--- a/src/iosource/Manager.cc
+++ b/src/iosource/Manager.cc
@@ -255,11 +255,11 @@ void Manager::Register(IOSource* src, bool dont_count)
 	{
 	// First see if we already have registered that source. If so, just
 	// adjust dont_count.
-	for ( SourceList::iterator i = sources.begin(); i != sources.end(); ++i )
+	for ( const auto& iosrc : sources )
 		{
-		if ( (*i)->src == src )
+		if ( iosrc->src == src )
 			{
-			if ( (*i)->dont_count != dont_count )
+			if ( iosrc->dont_count != dont_count )
 				// Adjust the global counter.
 				dont_counts += (dont_count ? 1 : -1);
 
@@ -323,12 +323,8 @@ PktSrc* Manager::OpenPktSrc(const std::string& path, bool is_live)
 	PktSrcComponent* component = 0;
 
 	std::list<PktSrcComponent*> all_components = plugin_mgr->Components<PktSrcComponent>();
-
-	for ( std::list<PktSrcComponent*>::const_iterator i = all_components.begin();
-	      i != all_components.end(); i++ )
+	for ( const auto& c : all_components )
 		{
-		PktSrcComponent* c = *i;
-
 		if ( c->HandlesPrefix(prefix) &&
 		     ((  is_live && c->DoesLive() ) ||
 		      (! is_live && c->DoesTrace())) )
@@ -369,13 +365,11 @@ PktDumper* Manager::OpenPktDumper(const string& path, bool append)
 	PktDumperComponent* component = 0;
 
 	std::list<PktDumperComponent*> all_components = plugin_mgr->Components<PktDumperComponent>();
-
-	for ( std::list<PktDumperComponent*>::const_iterator i = all_components.begin();
-	      i != all_components.end(); i++ )
+	for ( const auto& c : all_components )
 		{
-		if ( (*i)->HandlesPrefix(prefix) )
+		if ( c->HandlesPrefix(prefix) )
 			{
-			component = (*i);
+			component = c;
 			break;
 			}
 		}

--- a/src/iosource/Manager.cc
+++ b/src/iosource/Manager.cc
@@ -1,7 +1,7 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include <sys/event.h>
 #include <sys/types.h>
+#include <sys/event.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <assert.h>

--- a/src/iosource/PktSrc.cc
+++ b/src/iosource/PktSrc.cc
@@ -335,10 +335,10 @@ double PktSrc::GetNextTimeout()
 	// If there's no file descriptor for the source, which is the case for some interfaces like
 	// myricom, we can't rely on the polling mechanism to wait for data to be available. As gross
 	// as it is, just spin with a short timeout here so that it will continually poll the
-	// interface. The old IOSource code had a 20ns timeout between calls to select() so just
-	// use that.
+	// interface. The old IOSource code had a 20 microsecond timeout between calls to select()
+	// so just use that.
 	if ( props.selectable_fd == -1 )
-		return 0.00000002;
+		return 0.00002;
 
 	// If we're live we want poll to do what it has to with the file descriptor. If we're not live
 	// but we're not in pseudo-realtime mode, let the loop just spin as fast as it can. If we're


### PR DESCRIPTION
- Fix build on FreeBSD 11, which required the includes in `iosource/Manager.cc` in a specific order to avoid some errors about missing types in `sys/event.h`
- Use ranged-for loops in the `Open` methods in `iosource/Manager.cc`. This is just a code-cleanup change.
- Set the timeout for live interfaces without file descriptors back to 20 microseconds, which is the value the old code used to use for the timeout for `select()`. Benchmarking against a 600Mbps stream shows no additional packet loss and uses 2-3% less CPU over a 5-minute run.