### PR TITLE
Use 2 btest retries for CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,6 @@
 cpus: &CPUS 8
 btest_jobs: &BTEST_JOBS 8
+btest_retries: &BTEST_RETRIES 2
 memory: &MEMORY 6GB
 
 config: &CONFIG --build-type=release --enable-cpp-tests
@@ -46,6 +47,7 @@ env:
   CIRRUS_WORKING_DIR: /zeek
   ZEEK_CI_CPUS: *CPUS
   ZEEK_CI_BTEST_JOBS: *BTEST_JOBS
+  ZEEK_CI_BTEST_RETRIES: *BTEST_RETRIES
   ZEEK_CI_CONFIGURE_FLAGS: *CONFIG
   # This is a single-purpose, read-only GitHub deploy key (SSH private key) for
   # the zeek-testing-private repository.

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -13,6 +13,7 @@ if [[ -z "${CIRRUS_CI}" ]]; then
     [[ $(which nproc) ]] && ZEEK_CI_CPUS=$(nproc)
     [[ -n "${1}" ]] && ZEEK_CI_CPUS=${1}
     ZEEK_CI_BTEST_JOBS=${ZEEK_CI_CPUS}
+    ZEEK_CI_BTEST_RETRIES=2
 fi
 
 function pushd
@@ -56,7 +57,7 @@ function run_btests
     banner "Running baseline tests: zeek"
 
     pushd testing/btest
-    ${BTEST} -d -b -x btest-results.xml -j ${ZEEK_CI_BTEST_JOBS} || result=1
+    ${BTEST} -z ${ZEEK_CI_BTEST_RETRIES} -d -b -x btest-results.xml -j ${ZEEK_CI_BTEST_JOBS} || result=1
     make coverage
     prep_artifacts
     popd

--- a/ci/travis-job
+++ b/ci/travis-job
@@ -10,6 +10,7 @@
 
 LEAK_TEST_DISTRO="ubuntu_18.04_leaktest"
 COVERITY_DISTRO="ubuntu_18.04"
+BTEST_RETRIES=2
 
 usage() {
     echo "usage: $0 CMD DISTRO"
@@ -229,7 +230,7 @@ run() {
 
     set +e
     # Must specify a value for "-j" option, otherwise Travis uses a huge value.
-    ../../aux/btest/btest -j 4 -d
+    ../../aux/btest/btest -z ${BTEST_RETRIES} -j 4 -d
 
     if [ $? -ne 0 ]; then
         ret=1


### PR DESCRIPTION
This depends on https://github.com/zeek/btest/pull/19 first getting reviewed/accepted.  Ultimately, I would like to see this in 3.1.0, even if it means updating `btest` during the beta.