### PR TITLE
Refactor/modernize BroObj, BroType and Val

### DIFF
--- a/src/Obj.cc
+++ b/src/Obj.cc
@@ -10,7 +10,6 @@
 #include "File.h"
 #include "plugin/Manager.h"
 
-Location no_location("<no location>", 0, 0, 0, 0);
 Location start_location("<start uninitialized>", 0, 0, 0, 0);
 Location end_location("<end uninitialized>", 0, 0, 0, 0);
 

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -73,6 +73,10 @@ public:
 
 	virtual ~BroObj();
 
+	/* disallow copying */
+	BroObj(const BroObj &) = delete;
+	BroObj &operator=(const BroObj &) = delete;
+
 	// Report user warnings/errors.  If obj2 is given, then it's
 	// included in the message, though if pinpoint_only is non-zero,
 	// then obj2 is only used to pinpoint the location.

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -53,9 +53,6 @@ class BroObj {
 public:
 	BroObj()
 		{
-		ref_cnt = 1;
-		notify_plugins = false;
-
 		// A bit of a hack.  We'd like to associate location
 		// information with every object created when parsing,
 		// since for them, the location is generally well-defined.
@@ -141,8 +138,8 @@ private:
 	friend inline void Ref(BroObj* o);
 	friend inline void Unref(BroObj* o);
 
-	bool notify_plugins;
-	int ref_cnt;
+	bool notify_plugins = false;
+	int ref_cnt = 1;
 
 	// If non-zero, do not print runtime errors.  Useful for
 	// speculative evaluation.

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -31,7 +31,7 @@ typedef Location yyltype;
 YYLTYPE GetCurrentLocation();
 
 // Used to mean "no location associated with this object".
-extern Location no_location;
+inline constexpr Location no_location("<no location>", 0, 0, 0, 0);
 
 // Current start/end location.
 extern Location start_location;

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -63,68 +63,9 @@ const char* type_name(TypeTag t)
 BroType::BroType(TypeTag t, bool arg_base_type)
 	{
 	tag = t;
-	is_network_order = 0;
+	is_network_order = ::is_network_order(t);
 	base_type = arg_base_type;
-
-	switch ( tag ) {
-	case TYPE_VOID:
-		internal_tag = TYPE_INTERNAL_VOID;
-		break;
-
-	case TYPE_BOOL:
-	case TYPE_INT:
-	case TYPE_ENUM:
-		internal_tag = TYPE_INTERNAL_INT;
-		break;
-
-	case TYPE_COUNT:
-	case TYPE_COUNTER:
-		internal_tag = TYPE_INTERNAL_UNSIGNED;
-		break;
-
-	case TYPE_PORT:
-		internal_tag = TYPE_INTERNAL_UNSIGNED;
-		is_network_order = 1;
-		break;
-
-	case TYPE_DOUBLE:
-	case TYPE_TIME:
-	case TYPE_INTERVAL:
-		internal_tag = TYPE_INTERNAL_DOUBLE;
-		break;
-
-	case TYPE_STRING:
-		internal_tag = TYPE_INTERNAL_STRING;
-		break;
-
-	case TYPE_ADDR:
-		internal_tag = TYPE_INTERNAL_ADDR;
-		break;
-
-	case TYPE_SUBNET:
-		internal_tag = TYPE_INTERNAL_SUBNET;
-		break;
-
-	case TYPE_PATTERN:
-	case TYPE_TIMER:
-	case TYPE_ANY:
-	case TYPE_TABLE:
-	case TYPE_UNION:
-	case TYPE_RECORD:
-	case TYPE_LIST:
-	case TYPE_FUNC:
-	case TYPE_FILE:
-	case TYPE_OPAQUE:
-	case TYPE_VECTOR:
-	case TYPE_TYPE:
-		internal_tag = TYPE_INTERNAL_OTHER;
-		break;
-
-	case TYPE_ERROR:
-		internal_tag = TYPE_INTERNAL_ERROR;
-		break;
-	}
-
+	internal_tag = to_internal_type_tag(tag);
 	}
 
 BroType* BroType::ShallowClone()

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -61,11 +61,10 @@ const char* type_name(TypeTag t)
 	}
 
 BroType::BroType(TypeTag t, bool arg_base_type)
+	:tag(t), internal_tag(to_internal_type_tag(tag)),
+	 is_network_order(::is_network_order(t)),
+	 base_type(arg_base_type)
 	{
-	tag = t;
-	is_network_order = ::is_network_order(t);
-	base_type = arg_base_type;
-	internal_tag = to_internal_type_tag(tag);
 	}
 
 BroType* BroType::ShallowClone()

--- a/src/Type.h
+++ b/src/Type.h
@@ -83,7 +83,6 @@ const int MATCHES_INDEX_VECTOR = 2;
 class BroType : public BroObj {
 public:
 	explicit BroType(TypeTag tag, bool base_type = false);
-	~BroType() override { }
 
 	// Performs a shallow clone operation of the Bro type.
 	// This especially means that especially for tables the types

--- a/src/Type.h
+++ b/src/Type.h
@@ -14,7 +14,7 @@
 
 // BRO types.
 
-typedef enum {
+enum TypeTag {
 	TYPE_VOID,      // 0
 	TYPE_BOOL,      // 1
 	TYPE_INT,       // 2
@@ -42,25 +42,25 @@ typedef enum {
 	TYPE_TYPE,      // 24
 	TYPE_ERROR      // 25
 #define NUM_TYPES (int(TYPE_ERROR) + 1)
-} TypeTag;
+};
 
 constexpr bool is_network_order(TypeTag tag) noexcept
 	{
 	return tag == TYPE_PORT;
 	}
 
-typedef enum {
+enum function_flavor {
 	FUNC_FLAVOR_FUNCTION,
 	FUNC_FLAVOR_EVENT,
 	FUNC_FLAVOR_HOOK
-} function_flavor;
+};
 
-typedef enum {
+enum InternalTypeTag {
 	TYPE_INTERNAL_VOID,
 	TYPE_INTERNAL_INT, TYPE_INTERNAL_UNSIGNED, TYPE_INTERNAL_DOUBLE,
 	TYPE_INTERNAL_STRING, TYPE_INTERNAL_ADDR, TYPE_INTERNAL_SUBNET,
 	TYPE_INTERNAL_OTHER, TYPE_INTERNAL_ERROR
-} InternalTypeTag;
+};
 
 constexpr InternalTypeTag to_internal_type_tag(TypeTag tag) noexcept
 	{

--- a/src/Type.h
+++ b/src/Type.h
@@ -44,6 +44,11 @@ typedef enum {
 #define NUM_TYPES (int(TYPE_ERROR) + 1)
 } TypeTag;
 
+constexpr bool is_network_order(TypeTag tag) noexcept
+	{
+	return tag == TYPE_PORT;
+	}
+
 typedef enum {
 	FUNC_FLAVOR_FUNCTION,
 	FUNC_FLAVOR_EVENT,
@@ -56,6 +61,60 @@ typedef enum {
 	TYPE_INTERNAL_STRING, TYPE_INTERNAL_ADDR, TYPE_INTERNAL_SUBNET,
 	TYPE_INTERNAL_OTHER, TYPE_INTERNAL_ERROR
 } InternalTypeTag;
+
+constexpr InternalTypeTag to_internal_type_tag(TypeTag tag) noexcept
+	{
+	switch ( tag ) {
+	case TYPE_VOID:
+		return TYPE_INTERNAL_VOID;
+
+	case TYPE_BOOL:
+	case TYPE_INT:
+	case TYPE_ENUM:
+		return TYPE_INTERNAL_INT;
+
+	case TYPE_COUNT:
+	case TYPE_COUNTER:
+		return TYPE_INTERNAL_UNSIGNED;
+
+	case TYPE_PORT:
+		return TYPE_INTERNAL_UNSIGNED;
+
+	case TYPE_DOUBLE:
+	case TYPE_TIME:
+	case TYPE_INTERVAL:
+		return TYPE_INTERNAL_DOUBLE;
+
+	case TYPE_STRING:
+		return TYPE_INTERNAL_STRING;
+
+	case TYPE_ADDR:
+		return TYPE_INTERNAL_ADDR;
+
+	case TYPE_SUBNET:
+		return TYPE_INTERNAL_SUBNET;
+
+	case TYPE_PATTERN:
+	case TYPE_TIMER:
+	case TYPE_ANY:
+	case TYPE_TABLE:
+	case TYPE_UNION:
+	case TYPE_RECORD:
+	case TYPE_LIST:
+	case TYPE_FUNC:
+	case TYPE_FILE:
+	case TYPE_OPAQUE:
+	case TYPE_VECTOR:
+	case TYPE_TYPE:
+		return TYPE_INTERNAL_OTHER;
+
+	case TYPE_ERROR:
+		return TYPE_INTERNAL_ERROR;
+	}
+
+	/* this should be unreachable */
+	return TYPE_INTERNAL_VOID;
+	}
 
 // Returns the name of the type.
 extern const char* type_name(TypeTag t);

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -38,28 +38,23 @@
 #include "threading/formatters/JSON.h"
 
 Val::Val(Func* f)
-	:val(f)
+	:val(f), type(f->FType()->Ref())
 	{
 	::Ref(val.func_val);
-	type = f->FType()->Ref();
-#ifdef DEBUG
-	bound_id = 0;
-#endif
 	}
 
-Val::Val(BroFile* f)
-	:val(f)
+static FileType *GetStringFileType() noexcept
 	{
 	static FileType* string_file_type = 0;
 	if ( ! string_file_type )
 		string_file_type = new FileType(base_type(TYPE_STRING));
+	return string_file_type;
+	}
 
+Val::Val(BroFile* f)
+	:val(f), type(GetStringFileType()->Ref())
+	{
 	assert(f->FType()->Tag() == TYPE_STRING);
-	type = string_file_type->Ref();
-
-#ifdef DEBUG
-	bound_id = 0;
-#endif
 	}
 
 Val::~Val()

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -828,9 +828,8 @@ AddrVal::AddrVal(const char* text) : Val(TYPE_ADDR)
 	val.addr_val = new IPAddr(text);
 	}
 
-AddrVal::AddrVal(const std::string& text) : Val(TYPE_ADDR)
+AddrVal::AddrVal(const std::string& text) : AddrVal(text.c_str())
 	{
-	val.addr_val = new IPAddr(text);
 	}
 
 AddrVal::AddrVal(uint32_t addr) : Val(TYPE_ADDR)
@@ -886,16 +885,12 @@ SubNetVal::SubNetVal(const char* text, int width) : Val(TYPE_SUBNET)
 	val.subnet_val = new IPPrefix(text, width);
 	}
 
-SubNetVal::SubNetVal(uint32_t addr, int width) : Val(TYPE_SUBNET)
+SubNetVal::SubNetVal(uint32_t addr, int width) : SubNetVal(IPAddr{IPv4, &addr, IPAddr::Network}, width)
 	{
-	IPAddr a(IPv4, &addr, IPAddr::Network);
-	val.subnet_val = new IPPrefix(a, width);
 	}
 
-SubNetVal::SubNetVal(const uint32_t* addr, int width) : Val(TYPE_SUBNET)
+SubNetVal::SubNetVal(const uint32_t* addr, int width) : SubNetVal(IPAddr{IPv6, addr, IPAddr::Network}, width)
 	{
-	IPAddr a(IPv6, addr, IPAddr::Network);
-	val.subnet_val = new IPPrefix(a, width);
 	}
 
 SubNetVal::SubNetVal(const IPAddr& addr, int width) : Val(TYPE_SUBNET)
@@ -984,20 +979,17 @@ StringVal::StringVal(BroString* s) : Val(TYPE_STRING)
 	val.string_val = s;
 	}
 
-StringVal::StringVal(int length, const char* s) : Val(TYPE_STRING)
+// The following adds a NUL at the end.
+StringVal::StringVal(int length, const char* s) : StringVal(new BroString((const u_char*)  s, length, 1))
 	{
-	// The following adds a NUL at the end.
-	val.string_val = new BroString((const u_char*)  s, length, 1);
 	}
 
-StringVal::StringVal(const char* s) : Val(TYPE_STRING)
+StringVal::StringVal(const char* s) : StringVal(new BroString(s))
 	{
-	val.string_val = new BroString(s);
 	}
 
-StringVal::StringVal(const string& s) : Val(TYPE_STRING)
+StringVal::StringVal(const string& s) : StringVal(s.length(), s.data())
 	{
-	val.string_val = new BroString(reinterpret_cast<const u_char*>(s.data()), s.length(), 1);
 	}
 
 Val* StringVal::SizeVal() const

--- a/src/Val.h
+++ b/src/Val.h
@@ -61,7 +61,7 @@ class TableEntryVal;
 
 class RE_Matcher;
 
-typedef union {
+union BroValUnion {
 	// Used for bool, int, enum.
 	bro_int_t int_val;
 
@@ -86,7 +86,7 @@ typedef union {
 
 	vector<Val*>* vector_val;
 
-} BroValUnion;
+};
 
 class Val : public BroObj {
 public:

--- a/src/Val.h
+++ b/src/Val.h
@@ -128,12 +128,8 @@ union BroValUnion {
 class Val : public BroObj {
 public:
 	Val(double d, TypeTag t)
-		:val(d)
+		:val(d), type(base_type(t))
 		{
-		type = base_type(t);
-#ifdef DEBUG
-		bound_id = 0;
-#endif
 		}
 
 	explicit Val(Func* f);
@@ -143,20 +139,13 @@ public:
 	explicit Val(BroFile* f);
 
 	Val(BroType* t, bool type_type) // Extra arg to differentiate from protected version.
+		:type(new TypeType(t->Ref()))
 		{
-		type = new TypeType(t->Ref());
-#ifdef DEBUG
-		bound_id = 0;
-#endif
 		}
 
 	Val()
-		:val(bro_int_t(0))
+		:val(bro_int_t(0)), type(base_type(TYPE_ERROR))
 		{
-		type = base_type(TYPE_ERROR);
-#ifdef DEBUG
-		bound_id = 0;
-#endif
 		}
 
 	~Val() override;
@@ -364,30 +353,19 @@ protected:
 
 	template<typename V>
 	Val(V &&v, TypeTag t) noexcept
-		:val(std::forward<V>(v))
+		:val(std::forward<V>(v)), type(base_type(t))
 		{
-		type = base_type(t);
-#ifdef DEBUG
-		bound_id = 0;
-#endif
 		}
 
 	template<typename V>
 	Val(V &&v, BroType* t) noexcept
-		:val(std::forward<V>(v))
+		:val(std::forward<V>(v)), type(t->Ref())
 		{
-		type = t->Ref();
-#ifdef DEBUG
-		bound_id = 0;
-#endif
 		}
 
 	explicit Val(BroType* t)
+		:type(t->Ref())
 		{
-		type = t->Ref();
-#ifdef DEBUG
-		bound_id = 0;
-#endif
 		}
 
 	ACCESSOR(TYPE_TABLE, PDict<TableEntryVal>*, table_val, AsNonConstTable)
@@ -415,7 +393,7 @@ protected:
 
 #ifdef DEBUG
 	// For debugging, we keep the name of the ID to which a Val is bound.
-	const char* bound_id;
+	const char* bound_id = nullptr;
 #endif
 
 };

--- a/src/Val.h
+++ b/src/Val.h
@@ -479,9 +479,7 @@ public:
 	static uint32_t Mask(uint32_t port_num, TransportProto port_type);
 
 protected:
-	friend class Val;
 	friend class ValManager;
-	PortVal()	{}
 	PortVal(uint32_t p);
 
 	void ValDescribe(ODesc* d) const override;
@@ -504,11 +502,6 @@ public:
 	unsigned int MemoryAllocation() const override;
 
 protected:
-	friend class Val;
-	AddrVal()	{}
-	explicit AddrVal(TypeTag t) : Val(t)	{ }
-	explicit AddrVal(BroType* t) : Val(t)	{ }
-
 	Val* DoClone(CloneState* state) override;
 };
 
@@ -533,9 +526,6 @@ public:
 	unsigned int MemoryAllocation() const override;
 
 protected:
-	friend class Val;
-	SubNetVal()	{}
-
 	void ValDescribe(ODesc* d) const override;
 	Val* DoClone(CloneState* state) override;
 };
@@ -566,9 +556,6 @@ public:
 	Val* Substitute(RE_Matcher* re, StringVal* repl, bool do_all);
 
 protected:
-	friend class Val;
-	StringVal()	{}
-
 	void ValDescribe(ODesc* d) const override;
 	Val* DoClone(CloneState* state) override;
 };
@@ -585,9 +572,6 @@ public:
 	unsigned int MemoryAllocation() const override;
 
 protected:
-	friend class Val;
-	PatternVal()	{}
-
 	void ValDescribe(ODesc* d) const override;
 	Val* DoClone(CloneState* state) override;
 };
@@ -630,9 +614,6 @@ public:
 	unsigned int MemoryAllocation() const override;
 
 protected:
-	friend class Val;
-	ListVal()	{}
-
 	Val* DoClone(CloneState* state) override;
 
 	val_list vals;
@@ -819,9 +800,6 @@ public:
 	notifier::Modifiable* Modifiable() override	{ return this; }
 
 protected:
-	friend class Val;
-	TableVal()	{}
-
 	void Init(TableType* t);
 
 	void CheckExpireAttr(attr_tag at);
@@ -925,9 +903,6 @@ public:
 	static void ResizeParseTimeRecords();
 
 protected:
-	friend class Val;
-	RecordVal()	{}
-
 	Val* DoClone(CloneState* state) override;
 
 	BroObj* origin;
@@ -947,8 +922,6 @@ protected:
 		{
 		val.int_val = i;
 		}
-
-	EnumVal()	{}
 
 	void ValDescribe(ODesc* d) const override;
 	Val* DoClone(CloneState* state) override;
@@ -1012,9 +985,6 @@ public:
 	bool Remove(unsigned int index);
 
 protected:
-	friend class Val;
-	VectorVal()	{ }
-
 	void ValDescribe(ODesc* d) const override;
 	Val* DoClone(CloneState* state) override;
 


### PR DESCRIPTION
This PR prepares for a few ideas I have to optimize Zeek: I want the classes named above to be constexpr-initializable so things like:
https://github.com/zeek/zeek/blob/6c72b09bf538b9a1f4d57d5235f8df4067525248/src/Val.cc#L3297-L3309
.. can be done at compile time, to eliminate runtime overhead completely. But this will require a few more rounds of refactoring; there are obstacles like `BroType::name` which is a `std::string` and thus cannot be `constexpr`. This field needs to be decoupled by using different classes for "basic" types and "user" types.