### PR TITLE
Replace most uses of varargs/va_list with variadic templates

### DIFF
--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -71,21 +71,6 @@ bool StmtLocMapping::StartsAfter(const StmtLocMapping* m2)
 		 loc.first_column > m2->loc.first_column);
 	}
 
-
-// Generic debug message output.
-int debug_msg(const char* fmt, ...)
-	{
-	va_list args;
-	int retval;
-
-	va_start(args, fmt);
-	retval = vfprintf(stderr, fmt, args);
-	va_end(args);
-
-	return retval;
-	}
-
-
 // Trace message output
 
 FILE* TraceState::SetTraceFile(const char* filename)
@@ -123,23 +108,17 @@ void TraceState::TraceOff()
 	dbgtrace = false;
 	}
 
-int TraceState::LogTrace(const char* fmt, ...)
+void TraceState::LogTraceHelper()
 	{
-	va_list args;
-	int retval;
-
-	va_start(args, fmt);
-
 	// Prefix includes timestamp and file/line info.
 	fprintf(trace_file, "%.6f ", network_time);
 
-	const Stmt* stmt;
 	Location loc;
 	loc.filename = 0;
 
 	if ( g_frame_stack.size() > 0 && g_frame_stack.back() )
 		{
-		stmt = g_frame_stack.back()->GetNextStmt();
+		const Stmt* stmt = g_frame_stack.back()->GetNextStmt();
 		if ( stmt )
 			loc = *stmt->GetLocationInfo();
 		else
@@ -161,13 +140,6 @@ int TraceState::LogTrace(const char* fmt, ...)
 	// Each stack frame is indented.
 	for ( int i = 0; i < int(g_frame_stack.size()); ++i )
 		fprintf(trace_file, "\t");
-
-	retval = vfprintf(trace_file, fmt, args);
-
-	fflush(trace_file);
-	va_end(args);
-
-	return retval;
 	}
 
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -47,11 +47,30 @@ public:
 	void TraceOn();
 	void TraceOff();
 
-	int LogTrace(const char* fmt, ...) __attribute__((format(printf, 2, 3)));;
+	template <typename... Args>
+	int LogTrace(const char* fmt, Args&&... args)
+		{
+		int retval;
+
+		LogTraceHelper();
+
+		if constexpr ( sizeof...(args) > 0 )
+			return fprintf(trace_file, fmt, std::forward<Args>(args)...);
+		else
+			return fprintf(trace_file, "%s", fmt);
+
+		fflush(trace_file);
+
+		return retval;
+		}
 
 protected:
 	bool dbgtrace;		// print an execution trace
 	FILE* trace_file;
+
+private:
+
+	void LogTraceHelper();
 };
 
 extern TraceState g_trace_state;
@@ -174,4 +193,11 @@ extern Frame* g_dbg_locals;	// variables created within debugger context
 extern std::map<std::string, Filemap*> g_dbgfilemaps; // filename => filemap
 
 // Perhaps add a code/priority argument to do selective output.
-int debug_msg(const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
+template <typename... Args>
+int debug_msg(const char* fmt, Args&&... args)
+	{
+	if constexpr ( sizeof...(args) > 0 )
+		return fprintf(stderr, fmt, std::forward<Args>(args)...);
+	else
+		return fprintf(stderr, "%s", fmt);
+	}

--- a/src/DebugLogger.cc
+++ b/src/DebugLogger.cc
@@ -141,46 +141,10 @@ next:
 	delete [] tmp;
 	}
 
-void DebugLogger::Log(DebugStream stream, const char* fmt, ...)
+std::string DebugLogger::GetPluginName(const plugin::Plugin& plugin)
 	{
-	Stream* g = &streams[int(stream)];
-
-	if ( ! g->enabled )
-		return;
-
-	fprintf(file, "%17.06f/%17.06f [%s] ",
-			network_time, current_time(true), g->prefix);
-
-	for ( int i = g->indent; i > 0; --i )
-		fputs("   ", file);
-
-	va_list ap;
-	va_start(ap, fmt);
-	vfprintf(file, fmt, ap);
-	va_end(ap);
-
-	fputc('\n', file);
-	fflush(file);
+	return plugin.Name();
 	}
 
-void DebugLogger::Log(const plugin::Plugin& plugin, const char* fmt, ...)
-	{
-	string tok = string("plugin-") + plugin.Name();
-	tok = strreplace(tok, "::", "-");
-
-	if ( enabled_streams.find(tok) == enabled_streams.end() )
-		return;
-
-	fprintf(file, "%17.06f/%17.06f [plugin %s] ",
-			network_time, current_time(true), plugin.Name().c_str());
-
-	va_list ap;
-	va_start(ap, fmt);
-	vfprintf(file, fmt, ap);
-	va_end(ap);
-
-	fputc('\n', file);
-	fflush(file);
-	}
 
 #endif

--- a/src/DebugLogger.h
+++ b/src/DebugLogger.h
@@ -9,6 +9,8 @@
 #include <string>
 #include <set>
 
+#include "util.h"
+
 // To add a new debugging stream, add a constant here as well as
 // an entry to DebugLogger::streams in DebugLogger.cc.
 
@@ -55,8 +57,49 @@ public:
 
 	void OpenDebugLog(const char* filename = 0);
 
-	void Log(DebugStream stream, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
-	void Log(const plugin::Plugin& plugin, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
+	template <typename... Args>
+	void Log(DebugStream stream, const char* fmt, Args&&... args)
+		{
+		Stream* g = &streams[int(stream)];
+
+		if ( ! g->enabled )
+			return;
+
+		fprintf(file, "%17.06f/%17.06f [%s] ",
+			network_time, current_time(true), g->prefix);
+
+		for ( int i = g->indent; i > 0; --i )
+			fputs("   ", file);
+
+		if constexpr ( sizeof...(args) > 0 )
+			fprintf(file, fmt, std::forward<Args>(args)...);
+		else
+			fprintf(file, "%s", fmt);
+
+		fputc('\n', file);
+		fflush(file);
+		}
+
+	template <typename... Args>
+	void Log(const plugin::Plugin& plugin, const char* fmt, Args&&... args)
+		{
+		std::string tok = std::string("plugin-") + GetPluginName(plugin);
+		tok = strreplace(tok, "::", "-");
+
+		if ( enabled_streams.find(tok) == enabled_streams.end() )
+			return;
+
+		fprintf(file, "%17.06f/%17.06f [plugin %s] ",
+			network_time, current_time(true), GetPluginName(plugin).c_str());
+
+		if constexpr ( sizeof...(args) > 0 )
+			fprintf(file, fmt, std::forward<Args>(args)...);
+		else
+			fprintf(file, "%s", fmt);
+
+		fputc('\n', file);
+		fflush(file);
+		}
 
 	void PushIndent(DebugStream stream)
 		{ ++streams[int(stream)].indent; }
@@ -92,6 +135,8 @@ private:
 	std::set<std::string> enabled_streams;
 
 	static Stream streams[NUM_DBGS];
+
+	std::string GetPluginName(const plugin::Plugin& plugin);
 };
 
 extern DebugLogger debug_logger;

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -621,19 +621,6 @@ size_t Manager::FlushLogBuffers()
 	return rval;
 	}
 
-void Manager::Error(const char* format, ...)
-	{
-	va_list args;
-	va_start(args, format);
-	auto msg = fmt(format, args);
-	va_end(args);
-
-	if ( script_scope )
-		builtin_error(msg);
-	else
-		reporter->Error("%s", msg);
-	}
-
 bool Manager::AutoPublishEvent(string topic, Val* event)
 	{
 	if ( event->Type()->Tag() != TYPE_FUNC )

--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -343,8 +343,20 @@ private:
 	void ProcessStoreResponse(StoreHandleVal*, broker::store::response response);
 	void FlushPendingQueries();
 
-	void Error(const char* format, ...)
-		__attribute__((format (printf, 2, 3)));
+	template <typename... Args>
+	void Error(const char* format, Args&&... args)
+		{
+		const char* msg;
+		if constexpr ( sizeof...(args) > 0 )
+			msg = fmt(format, args...);
+		else
+			msg = fmt("%s", format);
+
+		if ( script_scope )
+			builtin_error(msg);
+		else
+			reporter->Error("%s", msg);
+		}
 
 	// IOSource interface overrides:
 	void Process() override;

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -57,29 +57,6 @@ static void input_hash_delete_func(void* val)
 	delete h;
 	}
 
-/**
- * Base stuff that every stream can do.
- */
-class Manager::Stream {
-public:
-	string name;
-	bool removed;
-
-	StreamType stream_type; // to distinguish between event and table streams
-
-	EnumVal* type;
-	ReaderFrontend* reader;
-	TableVal* config;
-	EventHandlerPtr error_event;
-
-	RecordVal* description;
-
-	virtual ~Stream();
-
-protected:
-	Stream(StreamType t);
-};
-
 Manager::Stream::Stream(StreamType t)
     : name(), removed(), stream_type(t), type(), reader(), config(),
       error_event(), description()
@@ -1832,28 +1809,6 @@ bool Manager::Delete(ReaderFrontend* reader, Value* *vals)
 	return success;
 	}
 
-bool Manager::CallPred(Func* pred_func, const int numvals, ...) const
-	{
-	bool result = false;
-	val_list vl(numvals);
-
-	va_list lP;
-	va_start(lP, numvals);
-	for ( int i = 0; i < numvals; i++ )
-		vl.push_back( va_arg(lP, Val*) );
-
-	va_end(lP);
-
-	Val* v = pred_func->Call(&vl);
-	if ( v )
-		{
-		result = v->AsBool();
-		Unref(v);
-		}
-
-	return result;
-	}
-
 // Raise everything in here as warnings so it is passed to scriptland without
 // looking "fatal". In addition to these warnings, ReaderBackend will queue
 // one reporter message.
@@ -1918,25 +1873,6 @@ bool Manager::SendEvent(ReaderFrontend* reader, const string& name, const int nu
 
 	return true;
 }
-
-void Manager::SendEvent(EventHandlerPtr ev, const int numvals, ...) const
-	{
-	val_list vl(numvals);
-
-#ifdef DEBUG
-	DBG_LOG(DBG_INPUT, "SendEvent with %d vals",
-		numvals);
-#endif
-
-	va_list lP;
-	va_start(lP, numvals);
-	for ( int i = 0; i < numvals; i++ )
-		vl.push_back( va_arg(lP, Val*) );
-
-	va_end(lP);
-
-	mgr.QueueEvent(ev, std::move(vl), SOURCE_LOCAL);
-	}
 
 void Manager::SendEvent(EventHandlerPtr ev, list<Val*> events) const
 	{
@@ -2723,49 +2659,8 @@ void Manager::Error(ReaderFrontend* reader, const char* msg) const
 	ErrorHandler(i, ErrorType::ERROR, false, "%s", msg);
 	}
 
-void Manager::Info(const Stream* i, const char* fmt, ...) const
+void Manager::DoErrorHandler(const Stream* i, ErrorType et, bool reporter_send, const char* buf) const
 	{
-	va_list ap;
-	va_start(ap, fmt);
-	ErrorHandler(i, ErrorType::INFO, true, fmt, ap);
-	va_end(ap);
-	}
-
-void Manager::Warning(const Stream* i, const char* fmt, ...) const
-	{
-	va_list ap;
-	va_start(ap, fmt);
-	ErrorHandler(i, ErrorType::WARNING, true, fmt, ap);
-	va_end(ap);
-	}
-
-void Manager::Error(const Stream* i, const char* fmt, ...) const
-	{
-	va_list ap;
-	va_start(ap, fmt);
-	ErrorHandler(i, ErrorType::ERROR, true, fmt, ap);
-	va_end(ap);
-	}
-
-void Manager::ErrorHandler(const Stream* i, ErrorType et, bool reporter_send, const char* fmt, ...) const
-	{
-	va_list ap;
-	va_start(ap, fmt);
-	ErrorHandler(i, et, reporter_send, fmt, ap);
-	va_end(ap);
-	}
-
-void Manager::ErrorHandler(const Stream* i, ErrorType et, bool reporter_send, const char* fmt, va_list ap) const
-	{
-	char* buf;
-
-	int n = vasprintf(&buf, fmt, ap);
-	if ( n < 0 || buf == nullptr )
-		{
-		reporter->InternalError("Could not format error message %s for stream %s", fmt, i->name.c_str());
-		return;
-		}
-
 	// send our script level error event
 	if ( i->error_event )
 		{
@@ -2785,7 +2680,7 @@ void Manager::ErrorHandler(const Stream* i, ErrorType et, bool reporter_send, co
 				break;
 
 			default:
-				reporter->InternalError("Unknown error type while trying to report input error %s", fmt);
+				reporter->InternalError("Unknown error type while trying to report input error %s", buf);
 				__builtin_unreachable();
 			}
 
@@ -2810,9 +2705,7 @@ void Manager::ErrorHandler(const Stream* i, ErrorType et, bool reporter_send, co
 				break;
 
 			default:
-				reporter->InternalError("Unknown error type while trying to report input error %s", fmt);
+				reporter->InternalError("Unknown error type while trying to report input error %s", buf);
 			}
 		}
-
-	free(buf);
 	}

--- a/src/input/Manager.h
+++ b/src/input/Manager.h
@@ -4,13 +4,17 @@
 
 #pragma once
 
-#include "Component.h"
-#include "EventHandler.h"
-#include "plugin/ComponentManager.h"
-#include "threading/SerialTypes.h"
-#include "Tag.h"
-
+#include <stdio.h>
 #include <map>
+#include <utility>
+
+#include "BroString.h"
+#include "EventHandler.h"
+#include "Val.h"
+#include "Scope.h"
+#include "Tag.h"
+#include "plugin/ComponentManager.h"
+#include "Func.h"
 
 class RecordVal;
 
@@ -24,6 +28,7 @@ class ReaderBackend;
  */
 class Manager : public plugin::ComponentManager<Tag, Component> {
 public:
+
 	/**
 	 * Constructor.
 	 */
@@ -208,14 +213,35 @@ private:
 	bool UnrollRecordType(vector<threading::Field*> *fields, const RecordType *rec, const string& nameprepend, bool allow_file_func) const;
 
 	// Send events
-	void SendEvent(EventHandlerPtr ev, const int numvals, ...) const;
 	void SendEvent(EventHandlerPtr ev, list<Val*> events) const;
+
+	// Variadiac version of SendEvents. The numvals argument is intentionally not used to maintain
+	// the API from when this used stdargs.
+	template<typename... Args>
+	void SendEvent(EventHandlerPtr ev, const int numvals, Args&&... args) const
+		{
+		list<Val*> vals({args...});
+		SendEvent(ev, vals);
+		}
 
 	// Implementation of SendEndOfData (send end_of_data event).
 	void SendEndOfData(const Stream *i);
 
 	// Call predicate function and return result.
-	bool CallPred(Func* pred_func, const int numvals, ...) const;
+	template<typename... Args>
+	bool CallPred(Func* pred_func, const int numvals, Args&&... args) const
+		{
+		bool result = false;
+		val_list vl({args...});
+
+		if ( Val* v = pred_func->Call(&vl) )
+			{
+			result = v->AsBool();
+			Unref(v);
+			}
+
+		return result;
+		}
 
 	// Get a hashkey for a set of threading::Values.
 	HashKey* HashValues(const int num_elements, const threading::Value* const *vals) const;
@@ -247,20 +273,78 @@ private:
 	// Converts a Bro ListVal to a RecordVal given the record type.
 	RecordVal* ListValToRecordVal(ListVal* list, RecordType *request_type, int* position) const;
 
+	enum class ErrorType { INFO, WARNING, ERROR };
+
 	// Internally signal errors, warnings, etc.
 	// These are sent on to input scriptland and reporter.log
-	void Info(const Stream* i, const char* fmt, ...) const __attribute__((format(printf, 3, 4)));
-	void Warning(const Stream* i, const char* fmt, ...) const __attribute__((format(printf, 3, 4)));
-	void Error(const Stream* i, const char* fmt, ...) const __attribute__((format(printf, 3, 4)));
+	template<typename... Args>
+	void Info(const Stream* i, const char* fmt, Args&&... args) const
+		{
+		ErrorHandler(i, ErrorType::INFO, true, fmt, args...);
+		}
 
-	enum class ErrorType { INFO, WARNING, ERROR };
-	void ErrorHandler(const Stream* i, ErrorType et, bool reporter_send, const char* fmt, ...) const __attribute__((format(printf, 5, 6)));
-	void ErrorHandler(const Stream* i, ErrorType et, bool reporter_send, const char* fmt, va_list ap) const __attribute__((format(printf, 5, 0)));
+	template<typename... Args>
+	void Warning(const Stream* i, const char* fmt, Args&&... args) const
+		{
+		ErrorHandler(i, ErrorType::WARNING, true, fmt, args...);
+		}
+
+	template<typename... Args>
+	void Error(const Stream* i, const char* fmt, Args&&... args) const
+		{
+		ErrorHandler(i, ErrorType::ERROR, true, fmt, args...);
+		}
+
+	template<typename... Args>
+	void ErrorHandler(const Stream* i, ErrorType et, bool reporter_send, const char* fmt, Args&&... args) const
+		{
+		char* buf;
+		int n;
+
+		if constexpr ( sizeof...(args) > 0 )
+			n = asprintf(&buf, fmt, std::forward<Args>(args)...);
+		else
+			n = asprintf(&buf, "%s", fmt);
+
+		if ( n < 0 || buf == nullptr )
+			{
+			reporter->InternalError("Could not format error message %s for stream %s", fmt, i->name.c_str());
+			return;
+			}
+
+		DoErrorHandler(i, et, reporter_send, buf);
+		free(buf);
+		}
+
+	void DoErrorHandler(const Stream* i, ErrorType et, bool reporter_send, const char* buf) const;
 
 	Stream* FindStream(const string &name) const;
 	Stream* FindStream(ReaderFrontend* reader) const;
 
 	enum StreamType { TABLE_STREAM, EVENT_STREAM, ANALYSIS_STREAM };
+
+	/**
+	 * Base stuff that every stream can do.
+	 */
+	class Stream {
+	public:
+		string name;
+		bool removed;
+
+		StreamType stream_type; // to distinguish between event and table streams
+
+		EnumVal* type;
+		ReaderFrontend* reader;
+		TableVal* config;
+		EventHandlerPtr error_event;
+
+		RecordVal* description;
+
+		virtual ~Stream();
+
+	protected:
+		Stream(StreamType t);
+	};
 
 	map<ReaderFrontend*, Stream*> readers;
 
@@ -271,4 +355,3 @@ private:
 }
 
 extern input::Manager* input_mgr;
-

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -71,11 +71,33 @@ struct Stem {
 
 	void ReportStatus(const Supervisor::Node& node) const;
 
-	void Log(std::string_view type, const char* format, va_list args) const;
+	template <typename... Args>
+	void Log(std::string_view type, const char* format, Args&&... args) const
+		{
+		const char* raw_msg;
+		if constexpr ( sizeof...(args) > 0 )
+			raw_msg = fmt(format, std::forward<Args>(args)...);
+		else
+			raw_msg = fmt("%s", format);
 
-	void LogDebug(const char* format, ...) const __attribute__((format(printf, 2, 3)));
+		if ( getenv("ZEEK_DEBUG_STEM_STDERR") )
+			{
+			// Useful when debugging a breaking change to the IPC mechanism itself.
+			fprintf(stderr, "%s\n", raw_msg);
+			return;
+			}
 
-	void LogError(const char* format, ...) const __attribute__((format(printf, 2, 3)));
+		std::string msg{type.data(), type.size()};
+		msg += " ";
+		msg += raw_msg;
+		safe_write(pipe->OutFD(), msg.data(), msg.size() + 1);
+		}
+
+	template <typename... Args>
+	void LogDebug(const char* format, Args&&... args) const	{ Log("debug", format, args...); }
+
+	template <typename... Args>
+	void LogError(const char* format, Args&&... args) const	{ Log("error", format, args...); }
 
 	pid_t parent_pid;
 	int last_signal = -1;
@@ -716,39 +738,6 @@ void Stem::ReportStatus(const Supervisor::Node& node) const
 	{
 	std::string msg = fmt("status %s %d", node.Name().data(), node.pid);
 	safe_write(pipe->OutFD(), msg.data(), msg.size() + 1);
-	}
-
-void Stem::Log(std::string_view type, const char* format, va_list args) const
-	{
-	auto raw_msg = fmt(format, args);
-
-	if ( getenv("ZEEK_DEBUG_STEM_STDERR") )
-		{
-		// Useful when debugging a breaking change to the IPC mechanism itself.
-		fprintf(stderr, "%s\n", raw_msg);
-		return;
-		}
-
-	std::string msg{type.data(), type.size()};
-	msg += " ";
-	msg += raw_msg;
-	safe_write(pipe->OutFD(), msg.data(), msg.size() + 1);
-	}
-
-void Stem::LogDebug(const char* format, ...) const
-	{
-	va_list args;
-	va_start(args, format);
-	Log("debug", format, args);
-	va_end(args);
-	}
-
-void Stem::LogError(const char* format, ...) const
-	{
-	va_list args;
-	va_start(args, format);
-	Log("error", format, args);
-	va_end(args);
 	}
 
 Supervisor::SupervisedNode Stem::Run()

--- a/src/threading/BasicThread.cc
+++ b/src/threading/BasicThread.cc
@@ -50,34 +50,6 @@ void BasicThread::SetOSName(const char* arg_name)
 	zeek::set_thread_name(arg_name, thread.native_handle());
 	}
 
-const char* BasicThread::Fmt(const char* format, ...)
-	{
-	if ( buf_len > 10 * STD_FMT_BUF_LEN )
-		{
-		// Shrink back to normal.
-		buf = (char*) safe_realloc(buf, STD_FMT_BUF_LEN);
-		buf_len = STD_FMT_BUF_LEN;
-		}
-
-	va_list al;
-	va_start(al, format);
-	int n = vsnprintf(buf, buf_len, format, al);
-	va_end(al);
-
-	if ( (unsigned int) n >= buf_len )
-		{ // Not enough room, grow the buffer.
-		buf_len = n + 32;
-		buf = (char*) safe_realloc(buf, buf_len);
-
-		// Is it portable to restart?
-		va_start(al, format);
-		n = vsnprintf(buf, buf_len, format, al);
-		va_end(al);
-		}
-
-	return buf;
-	}
-
 const char* BasicThread::Strerror(int err)
 	{
 	if ( ! strerr_buffer )

--- a/src/util.cc
+++ b/src/util.cc
@@ -961,14 +961,11 @@ string strreplace(const string& s, const string& o, const string& n)
 	{
 	string r = s;
 
-	while ( true )
+	size_t i = r.find(o);
+	while ( i != std::string::npos )
 		{
-		size_t i = r.find(o);
-
-		if ( i == std::string::npos )
-			break;
-
 		r.replace(i, o.size(), n);
+		i = r.find(o, i);
 		}
 
 	return r;
@@ -1786,7 +1783,8 @@ FILE* rotate_file(const char* name, RecordVal* rotate_info)
 	// Build file names.
 	const int buflen = strlen(name) + 128;
 
-	char newname[buflen], tmpname[buflen+4];
+	char* newname = new char[buflen];
+	char* tmpname = new char[buflen+4];
 
 	snprintf(newname, buflen, "%s.%d.%.06f.tmp",
 			name, getpid(), network_time);
@@ -1799,6 +1797,8 @@ FILE* rotate_file(const char* name, RecordVal* rotate_info)
 	if ( ! newf )
 		{
 		reporter->Error("rotate_file: can't open %s: %s", tmpname, strerror(errno));
+		delete [] newname;
+		delete [] tmpname;
 		return 0;
 		}
 
@@ -1811,6 +1811,8 @@ FILE* rotate_file(const char* name, RecordVal* rotate_info)
 		fclose(newf);
 		unlink(newname);
 		unlink(tmpname);
+		delete [] newname;
+		delete [] tmpname;
 		return 0;
 		}
 
@@ -1818,6 +1820,8 @@ FILE* rotate_file(const char* name, RecordVal* rotate_info)
 	if ( unlink(name) < 0 || link(tmpname, name) < 0 || unlink(tmpname) < 0 )
 		{
 		reporter->Error("rotate_file: can't move %s to %s: %s", tmpname, name, strerror(errno));
+		delete [] newname;
+		delete [] tmpname;
 		exit(1);	// hard to fix, but shouldn't happen anyway...
 		}
 
@@ -1829,6 +1833,9 @@ FILE* rotate_file(const char* name, RecordVal* rotate_info)
 		rotate_info->Assign(2, new Val(network_time, TYPE_TIME));
 		rotate_info->Assign(3, new Val(network_time, TYPE_TIME));
 		}
+
+	delete [] newname;
+	delete [] tmpname;
 
 	return newf;
 	}


### PR DESCRIPTION
This is a branch that's been sitting in my queue for a while that I'm finally getting around to making a PR for. This converts most uses of varargs with variadic templates. The reasoning for this is a possible future move to libfmt/std::format, which doesn't play as nicely with varargs.

I held onto this for a couple of reasons:
1. It removes the printf-format compiler attributes from all of the methods that were using them, which makes the code a little less concise.
2. It moves a fairly large amount of code out of cc files and into headers, because the templates require it to be like that.

This PR is not important for 3.1 and can be held until after that's branched.