### PR TITLE
analyzer/protocol/ssh: fix crash vulnerability after duplicate KEX packet

### DIFF
--- a/src/analyzer/protocol/ssh/ssh-protocol.pac
+++ b/src/analyzer/protocol/ssh/ssh-protocol.pac
@@ -398,6 +398,7 @@ refine connection SSH_Conn += {
 				{
 				if ( *(client_list->Lookup(i)->AsStringVal()->AsString()) == *(server_list->Lookup(j)->AsStringVal()->AsString()) )
 					{
+					kex_algorithm_.free();
 					kex_algorithm_.init((const uint8 *) client_list->Lookup(i)->AsStringVal()->Bytes(),
 						client_list->Lookup(i)->AsStringVal()->Len());
 


### PR DESCRIPTION
An attacker can make Zeek crash by posting the KEX packet twice, which
will result in an assertion failure in binpac::datastring::init():

```
 #0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
 #1  0x00007ffff5196535 in __GI_abort () at abort.c:79
 #2  0x00007ffff519640f in __assert_fail_base (fmt=0x7ffff52f86e0 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x1d33530 "!data_",
     file=0x1d33537 "aux/binpac/lib/binpac_bytestring.h", line=108, function=<optimized out>) at assert.c:92
 #3  0x00007ffff51a3b92 in __GI___assert_fail (assertion=0x1d33530 "!data_", file=0x1d33537 "aux/binpac/lib/binpac_bytestring.h",
     line=108, function=0x1d3356c "void binpac::datastring<unsigned char>::init(const T *, int) [T = unsigned char]") at assert.c:101
 #4  0x0000000000c1e970 in binpac::datastring<unsigned char>::init (this=0x608000d609d0, begin=0x603001bdd1d0 "diffie-hellman-group16-sha512", length=29)
     at aux/binpac/lib/binpac_bytestring.h:108
 #5  0x0000000000e9ab60 in binpac::SSH::SSH_Conn::update_kex (this=0x608000d609a0, algs=..., orig=true) at src/analyzer/protocol/ssh/ssh_pac.cc:205
 #6  0x0000000000ea0d06 in binpac::SSH::SSH2_KEXINIT::Parse (this=0x60b000734680,
     t_begin_of_data=0x621000004753 "\200\275\a%\223\023Y8\204t\235\363!\031I.", t_end_of_data=0x621000004b85 "ޭ\276", <incomplete sequence \357>,
     t_context=0x603001bdcc90, t_byteorder=0) at src/analyzer/protocol/ssh/ssh_pac.cc:1598
 #7  0x0000000000e9f8f4 in binpac::SSH::SSH2_Message::Parse (this=0x608000d60ea0,
     t_begin_of_data=0x621000004753 "\200\275\a%\223\023Y8\204t\235\363!\031I.", t_end_of_data=0x621000004b85 "ޭ\276", <incomplete sequence \357>,
     t_context=0x603001bdcc90, t_byteorder=0) at src/analyzer/protocol/ssh/ssh_pac.cc:1326
 #8  0x0000000000e9d7e1 in binpac::SSH::SSH2_Key_Exchange::Parse (this=0x604001779850,
     t_begin_of_data=0x621000004751 "\006\024\200\275\a%\223\023Y8\204t\235\363!\031I.", t_end_of_data=0x621000004b85 "ޭ\276", <incomplete sequence \357>,
     t_context=0x603001bdcc90, t_byteorder=0) at src/analyzer/protocol/ssh/ssh_pac.cc:1210
 #9  0x0000000000e9c981 in binpac::SSH::SSH_Key_Exchange::ParseBuffer (this=0x603001bdccc0, t_flow_buffer=0x608000d60a20, t_context=0x603001bdcc90,
     t_byteorder=0) at src/analyzer/protocol/ssh/ssh_pac.cc:628
 #10 0x0000000000e9c26c in binpac::SSH::SSH_PDU::ParseBuffer (this=0x604001779810, t_flow_buffer=0x608000d60a20, t_context=0x603001bdcc90)
     at src/analyzer/protocol/ssh/ssh_pac.cc:446
 #11 0x0000000000ea6f04 in binpac::SSH::SSH_Flow::NewData (this=0x604001774690, t_begin_of_data=0x62100000474d "",
     t_end_of_data=0x621000004b85 "ޭ\276", <incomplete sequence \357>) at src/analyzer/protocol/ssh/ssh_pac.cc:3071
 #12 0x0000000000e9a38f in binpac::SSH::SSH_Conn::NewData (this=0x608000d609a0, is_orig=true, begin=0x62100000474d "",
     end=0x621000004b85 "ޭ\276", <incomplete sequence \357>) at src/analyzer/protocol/ssh/ssh_pac.cc:63
 #13 0x0000000000e98335 in analyzer::SSH::SSH_Analyzer::DeliverStream (this=0x7fffffffdd40, len=1080, data=0x62100000474d "", orig=true)
     at src/analyzer/protocol/ssh/SSH.cc:68
```

With assertions turned off, this would "only" be a memory leak.

This commit fixes the vulnerability by freeing and clearing the
`binpac::datastring` before assigning a new value.