### PR TITLE
Leaky leak-leak!

### DIFF
--- a/src/DbgBreakpoint.cc
+++ b/src/DbgBreakpoint.cc
@@ -260,6 +260,7 @@ BreakCode DbgBreakpoint::HasHit()
 		if ( ! IsIntegral(yes->Type()->Tag()) &&
 		     ! IsBool(yes->Type()->Tag()) )
 			{
+			Unref(yes);
 			PrintHitMsg();
 			debug_msg("Breakpoint condition should return an integral type");
 			return bcHitAndDelete;
@@ -267,7 +268,12 @@ BreakCode DbgBreakpoint::HasHit()
 
 		yes->CoerceToInt();
 		if ( yes->IsZero() )
+			{
+			Unref(yes);
 			return bcNoHit;
+			}
+
+		Unref(yes);
 		}
 
 	int repcount = GetRepeatCount();

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -570,6 +570,7 @@ int dbg_cmd_print(DebugCmd cmd, const vector<string>& args)
 		{
 		ODesc d;
 		val->Describe(&d);
+		Unref(val);
 		debug_msg("%s\n", d.Description());
 		}
 	else

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -494,6 +494,8 @@ Val* BinaryExpr::Eval(Frame* f) const
 
 		if ( v_op1->Size() != v_op2->Size() )
 			{
+			Unref(v1);
+			Unref(v2);
 			RuntimeError("vector operands are of different sizes");
 			return 0;
 			}

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -1631,7 +1631,10 @@ Val* BoolExpr::Eval(Frame* f) const
 			}
 
 		if ( ! scalar_v || ! vector_v )
+			{
+			Unref(v1);
 			return 0;
+			}
 
 		VectorVal* result = 0;
 
@@ -1657,13 +1660,18 @@ Val* BoolExpr::Eval(Frame* f) const
 	// Only case remaining: both are vectors.
 	Val* v2 = op2->Eval(f);
 	if ( ! v2 )
+		{
+		Unref(v1);
 		return 0;
+		}
 
 	VectorVal* vec_v1 = v1->AsVectorVal();
 	VectorVal* vec_v2 = v2->AsVectorVal();
 
 	if ( vec_v1->Size() != vec_v2->Size() )
 		{
+		Unref(v1);
+		Unref(v2);
 		RuntimeError("vector operands have different sizes");
 		return 0;
 		}

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -101,8 +101,9 @@ void Expr::EvalIntoAggregate(const BroType* /* t */, Val* /* aggr */,
 	Internal("Expr::EvalIntoAggregate called");
 	}
 
-void Expr::Assign(Frame* /* f */, Val* /* v */)
+void Expr::Assign(Frame* /* f */, Val* v)
 	{
+	Unref(v);
 	Internal("Expr::Assign called");
 	}
 
@@ -2787,11 +2788,17 @@ Val* IndexExpr::Fold(Val* v1, Val* v2) const
 void IndexExpr::Assign(Frame* f, Val* v)
 	{
 	if ( IsError() )
+		{
+		Unref(v);
 		return;
+		}
 
 	Val* v1 = op1->Eval(f);
 	if ( ! v1 )
+		{
+		Unref(v);
 		return;
+		}
 
 	Val* v2 = op2->Eval(f);
 
@@ -2799,6 +2806,7 @@ void IndexExpr::Assign(Frame* f, Val* v)
 		{
 		Unref(v1);
 		Unref(v2);
+		Unref(v);
 		return;
 		}
 
@@ -2873,6 +2881,7 @@ void IndexExpr::Assign(Frame* f, Val* v)
 
 	Unref(v1);
 	Unref(v2);
+	Unref(v);
 	}
 
 void IndexExpr::ExprDescribe(ODesc* d) const
@@ -2949,7 +2958,10 @@ int FieldExpr::CanDel() const
 void FieldExpr::Assign(Frame* f, Val* v)
 	{
 	if ( IsError() )
+		{
+		Unref(v);
 		return;
+		}
 
 	Val* op_v = op->Eval(f);
 	if ( op_v )
@@ -2958,6 +2970,8 @@ void FieldExpr::Assign(Frame* f, Val* v)
 		r->Assign(field, v);
 		Unref(r);
 		}
+	else
+		Unref(v);
 	}
 
 void FieldExpr::Delete(Frame* f)
@@ -4889,6 +4903,7 @@ void ListExpr::Assign(Frame* f, Val* v)
 		exprs[i]->Assign(f, (*lv->Vals())[i]->Ref());
 
 	Unref(lv);
+	Unref(v);
 	}
 
 TraversalCode ListExpr::Traverse(TraversalCallback* cb) const

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -1995,11 +1995,18 @@ Val* CondExpr::Eval(Frame* f) const
 
 	Val* v2 = op2->Eval(f);
 	if ( ! v2 )
+		{
+		Unref(v1);
 		return 0;
+		}
 
 	Val* v3 = op3->Eval(f);
 	if ( ! v3 )
+		{
+		Unref(v1);
+		Unref(v2);
 		return 0;
+		}
 
 	VectorVal* cond = v1->AsVectorVal();
 	VectorVal* a = v2->AsVectorVal();
@@ -2007,6 +2014,9 @@ Val* CondExpr::Eval(Frame* f) const
 
 	if ( cond->Size() != a->Size() || a->Size() != b->Size() )
 		{
+		Unref(v1);
+		Unref(v2);
+		Unref(v3);
 		RuntimeError("vectors in conditional expression have different sizes");
 		return 0;
 		}
@@ -2018,12 +2028,18 @@ Val* CondExpr::Eval(Frame* f) const
 		{
 		Val* local_cond = cond->Lookup(i);
 		if ( local_cond )
-			result->Assign(i,
-				       local_cond->IsZero() ?
-					       b->Lookup(i) : a->Lookup(i));
+			{
+			Val *v = local_cond->IsZero() ? b->Lookup(i) : a->Lookup(i);
+			::Ref(v);
+			result->Assign(i, v);
+			}
 		else
 			result->Assign(i, 0);
 		}
+
+	Unref(v1);
+	Unref(v2);
+	Unref(v3);
 
 	return result;
 	}

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -3142,12 +3142,10 @@ Val* RecordConstructorExpr::InitVal(const BroType* t, Val* aggr) const
 		{
 		RecordVal* rv = v->AsRecordVal();
 		RecordVal* ar = rv->CoerceTo(t->AsRecordType(), aggr);
+		Unref(rv);
 
 		if ( ar )
-			{
-			Unref(rv);
 			return ar;
-			}
 		}
 
 	Error("bad record initializer");

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -2404,7 +2404,11 @@ void AssignExpr::EvalIntoAggregate(const BroType* t, Val* aggr, Frame* f) const
 	Val* index = op1->Eval(f);
 	Val* v = check_and_promote(op2->Eval(f), t->YieldType(), 1);
 	if ( ! index || ! v )
+		{
+		Unref(index);
+		Unref(v);
 		return;
+		}
 
 	if ( ! tv->Assign(index, v) )
 		RuntimeError("type clash in table assignment");

--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -855,6 +855,7 @@ BloomFilterVal* BloomFilterVal::Merge(const BloomFilterVal* x,
 
 	if ( ! copy->Merge(y->bloom_filter) )
 		{
+		delete copy;
 		reporter->Error("failed to merge Bloom filter");
 		return 0;
 		}
@@ -863,6 +864,7 @@ BloomFilterVal* BloomFilterVal::Merge(const BloomFilterVal* x,
 
 	if ( x->Type() && ! merged->Typify(x->Type()) )
 		{
+		Unref(merged);
 		reporter->Error("failed to set type on merged Bloom filter");
 		return 0;
 		}

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -1264,13 +1264,13 @@ int HTTP_Analyzer::HTTP_RequestLine(const char* line, const char* end_of_line)
 	if ( rest == end_of_method )
 		goto error;
 
-	request_method = new StringVal(end_of_method - line, line);
-
 	if ( ! ParseRequest(rest, end_of_line) )
 		{
 		reporter->AnalyzerError(this, "HTTP ParseRequest failed");
 		return -1;
 		}
+
+	request_method = new StringVal(end_of_method - line, line);
 
 	Conn()->Match(Rule::HTTP_REQUEST,
 			(const u_char*) unescaped_URI->AsString()->Bytes(),

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -973,6 +973,7 @@ bool Manager::UnrollRecordType(vector<Field*> *fields, const RecordType *rec,
 			{
 			string name = nameprepend + rec->FieldName(i);
 			const char* secondary = 0;
+			Val* c = nullptr;
 			TypeTag ty = rec->FieldType(i)->Tag();
 			TypeTag st = TYPE_VOID;
 			bool optional = false;
@@ -988,7 +989,7 @@ bool Manager::UnrollRecordType(vector<Field*> *fields, const RecordType *rec,
 				{
 				// we have an annotation for the second column
 
-				Val* c = rec->FieldDecl(i)->FindAttr(ATTR_TYPE_COLUMN)->AttrExpr()->Eval(0);
+				c = rec->FieldDecl(i)->FindAttr(ATTR_TYPE_COLUMN)->AttrExpr()->Eval(0);
 
 				assert(c);
 				assert(c->Type()->Tag() == TYPE_STRING);
@@ -1000,6 +1001,7 @@ bool Manager::UnrollRecordType(vector<Field*> *fields, const RecordType *rec,
 				optional = true;
 
 			Field* field = new Field(name.c_str(), secondary, ty, st, optional);
+			Unref(c);
 			fields->push_back(field);
 			}
 		}

--- a/src/scan.l
+++ b/src/scan.l
@@ -762,6 +762,8 @@ void do_atif(Expr* expr)
 		if_stack.push_back(current_depth);
 		BEGIN(IGNORE);
 		}
+
+	Unref(val);
 	}
 
 void do_atifdef(const char* id)


### PR DESCRIPTION
During my attempts to make Zeek use smart pointers (see https://github.com/zeek/zeek/pull/800), I found dozens of memory leaks. This is *bad*!

Please review carefully. The rules for adopting/returning references are completely undocumented in the code, and I had to make an educated guess based on reading some of the implementations. This is still very fragile, because the whole idea of managing references manually is fragile!

Instead of fixing those numerous leaks based on my best guesses, I'd prefer to just use smart pointers, which would not only fix those leaks automatically, but also document reference ownership and would make the compiler enforce it. But @jsiwek [wanted to separate out the bug fixes first](https://github.com/zeek/zeek/pull/800#issuecomment-587748425), so here you are!