### PR TITLE
Expr: add missing reference in AssignExpr::InitVal()

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -2459,6 +2459,7 @@ Val* AssignExpr::InitVal(const BroType* t, Val* aggr) const
 		if ( ! v )
 			return 0;
 
+		::Ref(v);
 		aggr_r->Assign(field, v);
 		return v;
 		}


### PR DESCRIPTION
The one reference returned by `op2->InitVal()` is given to
`aggr_r->Assign()` and returned to the caller, which may result in a
use-after-free crash bug.  This patch adds the missing reference.

Closes https://github.com/zeek/zeek/issues/805