### PR TITLE
Memory leak fixes, again!

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -3804,8 +3804,7 @@ Val* RecordCoerceExpr::Fold(Val* v) const
 				if ( def )
 					rhs = def->AttrExpr()->Eval(0);
 				}
-
-			if ( rhs )
+			else
 				rhs = rhs->Ref();
 
 			assert(rhs || Type()->AsRecordType()->FieldDecl(i)->FindAttr(ATTR_OPTIONAL));

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -3776,12 +3776,10 @@ Val* RecordCoerceExpr::InitVal(const BroType* t, Val* aggr) const
 		{
 		RecordVal* rv = v->AsRecordVal();
 		RecordVal* ar = rv->CoerceTo(t->AsRecordType(), aggr);
+		Unref(rv);
 
 		if ( ar )
-			{
-			Unref(rv);
 			return ar;
-			}
 		}
 
 	Error("bad record initializer");

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -2480,7 +2480,11 @@ Val* AssignExpr::InitVal(const BroType* t, Val* aggr) const
 		Val* index = op1->InitVal(tt->Indices(), 0);
 		Val* v = op2->InitVal(yt, 0);
 		if ( ! index || ! v )
+			{
+			Unref(index);
+			Unref(tv);
 			return 0;
+			}
 
 		if ( ! tv->ExpandAndInit(index, v) )
 			{

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -828,6 +828,7 @@ bool check_built_in_call(BuiltinFunc* f, CallExpr* call)
 
 			if ( ! *fmt_str )
 				{
+				Unref(fmt_str_val);
 				call->Error("format string ends with bare '%'");
 				return false;
 				}
@@ -839,11 +840,13 @@ bool check_built_in_call(BuiltinFunc* f, CallExpr* call)
 
 		if ( args.length() != num_fmt + 1 )
 			{
+			Unref(fmt_str_val);
 			call->Error("mismatch between format string to fmt() and number of arguments passed");
 			return false;
 			}
 		}
 
+	Unref(fmt_str_val);
 	return true;
 	}
 

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -876,11 +876,13 @@ static int get_func_priority(const attr_list& attrs)
 
 		if ( ! IsIntegral(v->Type()->Tag()) )
 			{
+			Unref(v);
 			a->Error("expression is not of integral type");
 			continue;
 			}
 
 		priority = v->InternalInt();
+		Unref(v);
 		}
 
 	return priority;

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -130,7 +130,10 @@ RuleHdrTest::~RuleHdrTest()
 	for ( int i = 0; i < Rule::TYPES; ++i )
 		{
 		for ( auto pset : psets[i] )
+			{
 			delete pset->re;
+			delete pset;
+			}
 		}
 
 	delete ruleset;

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -2100,7 +2100,19 @@ BroType* init_type(Expr* init)
 
 	BroType* t = e0->InitType();
 	if ( t )
+		{
+		BroType *old_t = t;
 		t = reduce_type(t);
+		/* reduce_type() does not return a referenced pointer,
+		   but we want to own a reference, so create one
+		   here */
+		if (t)
+			Ref(t);
+		/* reduce_type() does not adopt our reference passed
+		   as parameter, so we need to release it (after the
+		   Ref() call above) */
+		Unref(old_t);
+		}
 	if ( ! t )
 		return 0;
 

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -235,6 +235,8 @@ void add_global(ID* id, BroType* t, init_class c, Expr* init,
 Stmt* add_local(ID* id, BroType* t, init_class c, Expr* init,
 		attr_list* attr, decl_type dt)
 	{
+	if (init)
+		Ref(init);
 	make_var(id, t, c, init, attr, dt, 0);
 
 	if ( init )
@@ -262,6 +264,7 @@ Stmt* add_local(ID* id, BroType* t, init_class c, Expr* init,
 
 extern Expr* add_and_assign_local(ID* id, Expr* init, Val* val)
 	{
+	Ref(init);
 	make_var(id, 0, INIT_FULL, init, 0, VAR_REGULAR, 0);
 	Ref(id);
 	return new AssignExpr(new NameExpr(id), init, 0, val);

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -42,6 +42,7 @@ static void make_var(ID* id, BroType* t, init_class c, Expr* init,
 		else if ( dt != VAR_REDEF || init || ! attr )
 			{
 			id->Error("already defined", init);
+			Unref(init);
 			return;
 			}
 		}
@@ -51,6 +52,7 @@ static void make_var(ID* id, BroType* t, init_class c, Expr* init,
 		if ( ! id->Type() )
 			{
 			id->Error("\"redef\" used but not previously defined");
+			Unref(init);
 			return;
 			}
 
@@ -64,6 +66,7 @@ static void make_var(ID* id, BroType* t, init_class c, Expr* init,
 		     (! init || ! do_init || (! t && ! (t = init_type(init)))) )
 			{
 			id->Error("already defined", init);
+			Unref(init);
 			return;
 			}
 
@@ -71,6 +74,7 @@ static void make_var(ID* id, BroType* t, init_class c, Expr* init,
 		if ( ! same_type(t, id->Type()) )
 			{
 			id->Error("redefinition changes type", init);
+			Unref(init);
 			return;
 			}
 		}
@@ -85,6 +89,7 @@ static void make_var(ID* id, BroType* t, init_class c, Expr* init,
 			if ( init )
 				{
 				id->Error("double initialization", init);
+				Unref(init);
 				return;
 				}
 
@@ -98,6 +103,7 @@ static void make_var(ID* id, BroType* t, init_class c, Expr* init,
 		if ( ! init )
 			{
 			id->Error("no type given");
+			Unref(init);
 			return;
 			}
 
@@ -105,6 +111,7 @@ static void make_var(ID* id, BroType* t, init_class c, Expr* init,
 		if ( ! t )
 			{
 			id->SetType(error_type());
+			Unref(init);
 			return;
 			}
 		}
@@ -185,7 +192,10 @@ static void make_var(ID* id, BroType* t, init_class c, Expr* init,
 				{
 				v = init_val(init, t, aggr);
 				if ( ! v )
+					{
+					Unref(init);
 					return;
+					}
 				}
 
 			if ( aggr )
@@ -210,6 +220,8 @@ static void make_var(ID* id, BroType* t, init_class c, Expr* init,
 
 		id->SetOption();
 		}
+
+	Unref(init);
 
 	id->UpdateValAttrs();
 

--- a/src/option.bif
+++ b/src/option.bif
@@ -205,6 +205,8 @@ function Option::set_change_handler%(ID: string, on_change: any, priority: int &
 		return val_mgr->GetBool(0);
 		}
 
-	i->AddOptionHandler(on_change->Ref()->AsFunc(), -priority);
+	auto* func = on_change->AsFunc();
+	Ref(func);
+	i->AddOptionHandler(func, -priority);
 	return val_mgr->GetBool(1);
 	%}

--- a/src/parse.y
+++ b/src/parse.y
@@ -1363,6 +1363,7 @@ attr:
 				{
 				ODesc d;
 				$3->Describe(&d);
+				Unref($3);
 				reporter->Error("'&deprecated=%s' must use a string literal",
 				                d.Description());
 				$$ = new Attr(ATTR_DEPRECATED);

--- a/src/parse.y
+++ b/src/parse.y
@@ -688,6 +688,7 @@ expr:
 					{
 					id->Error("undeclared variable");
 					id->SetType(error_type());
+					Ref(id);
 					$$ = new NameExpr(id);
 					}
 
@@ -701,10 +702,14 @@ expr:
 					$$ = new ConstExpr(t->GetVal(intval));
 					}
 				else
+					{
+					Ref(id);
 					$$ = new NameExpr(id);
+					}
 
 				if ( id->IsDeprecated() )
 					reporter->Warning("%s", id->GetDeprecationWarning().c_str());
+				Unref(id);
 				}
 			}
 
@@ -1581,6 +1586,7 @@ event:
 					}
 				if ( id->IsDeprecated() )
 					reporter->Warning("%s", id->GetDeprecationWarning().c_str());
+				Unref(id);
 				}
 
 			$$ = new EventExpr($1, $3);
@@ -1632,7 +1638,10 @@ case_type:
 			if ( case_var && case_var->IsGlobal() )
 				case_var->Error("already a global identifier");
 			else
+				{
+				Unref(case_var);
 				case_var = install_ID(name, current_module.c_str(), false, false);
+				}
 
 			add_local(case_var, type, INIT_NONE, 0, 0, VAR_REGULAR);
 			$$ = case_var;
@@ -1656,8 +1665,11 @@ for_head:
 				}
 
 			else
+				{
+				Unref(loop_var);
 				loop_var = install_ID($3, current_module.c_str(),
 						      false, false);
+				}
 
 			id_list* loop_vars = new id_list;
 			loop_vars->push_back(loop_var);

--- a/src/parse.y
+++ b/src/parse.y
@@ -1304,7 +1304,7 @@ index_slice:
 			{
 			set_location(@1, @6);
 			Expr* low = $3 ? $3 : new ConstExpr(val_mgr->GetCount(0));
-			Expr* high = $5 ? $5 : new SizeExpr($1);
+			Expr* high = $5 ? $5 : new SizeExpr($1->Ref());
 
 			if ( ! IsIntegral(low->Type()->Tag()) || ! IsIntegral(high->Type()->Tag()) )
 				reporter->Error("slice notation must have integral values as indexes");

--- a/src/parse.y
+++ b/src/parse.y
@@ -1099,8 +1099,11 @@ decl:
 
 	|	TOK_REDEF global_id opt_type init_class opt_init opt_attr ';'
 			{
+			if ($5)
+				Ref($5);
 			add_global($2, $3, $4, $5, $6, VAR_REDEF);
 			zeekygen_mgr->Redef($2, ::filename, $4, $5);
+			Unref($5);
 			}
 
 	|	TOK_REDEF TOK_ENUM global_id TOK_ADD_TO '{'

--- a/src/parse.y
+++ b/src/parse.y
@@ -514,7 +514,8 @@ expr:
 			}
 		 func_body
 			{
-			$$ = new FieldAssignExpr($2, new ConstExpr(func_id->ID_Val()));
+			$$ = new FieldAssignExpr($2, new ConstExpr(func_id->ID_Val()->Ref()));
+			Unref(func_id);
 			}
 
 	|	expr TOK_IN expr

--- a/src/zeekygen/IdentifierInfo.cc
+++ b/src/zeekygen/IdentifierInfo.cc
@@ -165,6 +165,8 @@ IdentifierInfo::Redefinition::operator=(const IdentifierInfo::Redefinition& othe
 	if ( &other == this )
 		return *this;
 
+	Unref(init_expr);
+
 	from_script = other.from_script;
 	ic = other.ic;
 	init_expr = other.init_expr;


### PR DESCRIPTION
Another big bunch of memory leak fixes, and several wrong/missing references which could make Zeek crash. These crashes never occurred because Zeek never happens to actually free those objects, due to the numerous memory leaks which keep those objects referenced. The more memory leaks we fix, the more likely will those missing references cause real crashes...