### PR TITLE
Add [[noreturn]] attributes

### DIFF
--- a/src/Flare.cc
+++ b/src/Flare.cc
@@ -13,6 +13,7 @@ Flare::Flare()
 	{
 	}
 
+[[noreturn]]
 static void bad_pipe_op(const char* which, bool signal_safe)
 	{
 	if ( signal_safe )

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -93,6 +93,7 @@ public:
 		BadTag(text, tag_to_text_func(t1), tag_to_text_func(t2)); \
 	}
 
+	[[noreturn]]
 	void Internal(const char* msg) const;
 	void InternalWarning(const char* msg) const;
 
@@ -152,7 +153,7 @@ private:
 // Prints obj to stderr, primarily for debugging.
 extern void print(const BroObj* obj);
 
-extern void bad_ref(int type);
+[[noreturn]] extern void bad_ref(int type);
 
 // Sometimes useful when dealing with BroObj subclasses that have their
 // own (protected) versions of Error.

--- a/src/Reporter.h
+++ b/src/Reporter.h
@@ -66,11 +66,11 @@ public:
 
 	// Report a fatal error. Bro will terminate after the message has been
 	// reported.
-	void FatalError(const char* fmt, ...) FMT_ATTR;
+	[[noreturn]] void FatalError(const char* fmt, ...) FMT_ATTR;
 
 	// Report a fatal error. Bro will terminate after the message has been
 	// reported and always generate a core dump.
-	void FatalErrorWithCore(const char* fmt, ...) FMT_ATTR;
+	[[noreturn]] void FatalErrorWithCore(const char* fmt, ...) FMT_ATTR;
 
 	// Report a runtime error in evaluating a Bro script expression. This
 	// function will not return but raise an InterpreterException.
@@ -97,7 +97,7 @@ public:
 
 	// Report an internal program error. Bro will terminate with a core
 	// dump after the message has been reported.
-	void InternalError(const char* fmt, ...) FMT_ATTR;
+	[[noreturn]] void InternalError(const char* fmt, ...) FMT_ATTR;
 
 	// Report an analyzer error. That analyzer will be set to not process
 	// any further input, but Bro otherwise continues normally.

--- a/src/threading/MsgThread.h
+++ b/src/threading/MsgThread.h
@@ -144,6 +144,7 @@ public:
 	 *
 	 * @param msg  The message. It will be prefixed with the thread's name.
 	 */
+	[[noreturn]]
 	void InternalError(const char* msg);
 
 #ifdef DEBUG


### PR DESCRIPTION
Fixes compiler warnings and allows more optimizations.