### PR TITLE
Add ZEEK_VERSION_NUMBER definition to zeek-config.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,14 @@ execute_process(COMMAND grep "^#define  *BRO_PLUGIN_API_VERSION"
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 string(REGEX REPLACE "^#define.*VERSION *" "" API_VERSION "${API_VERSION}")
 
-string(REPLACE "." " " version_numbers ${VERSION})
+string(REGEX REPLACE "[.-]" " " version_numbers ${VERSION})
 separate_arguments(version_numbers)
 list(GET version_numbers 0 VERSION_MAJOR)
 list(GET version_numbers 1 VERSION_MINOR)
+list(GET version_numbers 2 VERSION_PATCH)
 set(VERSION_MAJ_MIN "${VERSION_MAJOR}.${VERSION_MINOR}")
+math(EXPR ZEEK_VERSION_NUMBER
+     "${VERSION_MAJOR} * 10000 + ${VERSION_MINOR} * 100 + ${VERSION_PATCH}")
 
 set(VERSION_C_IDENT "${VERSION}_plugin_${API_VERSION}")
 string(REGEX REPLACE "-[0-9]*$" "_git" VERSION_C_IDENT "${VERSION_C_IDENT}")

--- a/zeek-config.h.in
+++ b/zeek-config.h.in
@@ -131,6 +131,11 @@
 /* Version number of package */
 #define VERSION "@VERSION@"
 
+// Zeek version number.
+// This is the result of (major * 10000 + minor * 100 + patch)
+// For example, 3.1.2 becomes 30102.
+#define ZEEK_VERSION_NUMBER @ZEEK_VERSION_NUMBER@
+
 /* whether words are stored with the most significant byte first */
 #cmakedefine WORDS_BIGENDIAN
 


### PR DESCRIPTION
Fixes #808

If this gets review/merge on/before Monday, I'll push into the 3.1 branch.

It's a bit late to push into the 3.0 branch since it won't help much anyway -- people can't avoid doing a `#ifndef ZEEK_VERSION_NUMBER` since 3.0.0 and 3.0.1 already don't define it and always possible for a user to be at that version.