### PR TITLE
Val: pass IntrusivePtr<> to TableVal::ExpandAndInit()

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -2477,19 +2477,17 @@ Val* AssignExpr::InitVal(const BroType* t, Val* aggr) const
 		TableVal* tv = aggr->AsTableVal();
 		const TableType* tt = tv->Type()->AsTableType();
 		const BroType* yt = tv->Type()->YieldType();
-		Val* index = op1->InitVal(tt->Indices(), 0);
-		Val* v = op2->InitVal(yt, 0);
+		IntrusivePtr<Val> index{AdoptRef{}, op1->InitVal(tt->Indices(), 0)};
+		IntrusivePtr<Val> v{AdoptRef{}, op2->InitVal(yt, 0)};
 		if ( ! index || ! v )
 			return 0;
 
-		if ( ! tv->ExpandAndInit(index, v) )
+		if ( ! tv->ExpandAndInit(std::move(index), std::move(v)) )
 			{
-			Unref(index);
 			Unref(tv);
 			return 0;
 			}
 
-		Unref(index);
 		return tv;
 		}
 
@@ -4899,14 +4897,12 @@ Val* ListExpr::AddSetInit(const BroType* t, Val* aggr) const
 		if ( ! element )
 			return 0;
 
-		if ( ! tv->ExpandAndInit(element, 0) )
+		if ( ! tv->ExpandAndInit({AdoptRef{}, element}, 0) )
 			{
-			Unref(element);
 			Unref(tv);
 			return 0;
 			}
 
-		Unref(element);
 		}
 
 	return tv;

--- a/src/Val.h
+++ b/src/Val.h
@@ -27,6 +27,7 @@ using std::string;
 #define UDP_PORT_MASK	0x20000
 #define ICMP_PORT_MASK	0x30000
 
+template <class T> class IntrusivePtr;
 template<typename T> class PDict;
 class IterCookie;
 
@@ -754,7 +755,7 @@ public:
 
 	// Expands any lists in the index into multiple initializations.
 	// Returns true if the initializations typecheck, false if not.
-	int ExpandAndInit(Val* index, Val* new_val);
+	int ExpandAndInit(IntrusivePtr<Val> index, IntrusivePtr<Val> new_val);
 
 	// Returns the element's value if it exists in the table,
 	// nil otherwise.  Note, "index" is not const because we
@@ -825,8 +826,8 @@ protected:
 	void Init(TableType* t);
 
 	void CheckExpireAttr(attr_tag at);
-	int ExpandCompoundAndInit(val_list* vl, int k, Val* new_val);
-	int CheckAndAssign(Val* index, Val* new_val);
+	int ExpandCompoundAndInit(val_list* vl, int k, IntrusivePtr<Val> new_val);
+	int CheckAndAssign(Val* index, IntrusivePtr<Val> new_val);
 
 	// Calculates default value for index.  Returns 0 if none.
 	Val* Default(Val* index);


### PR DESCRIPTION
Clarifies ownership and fixes memory leaks.

Closes https://github.com/zeek/zeek/issues/811