### PR TITLE
Add a faster siphash24 implementation than the reference one

### DIFF
--- a/src/siphash24.h
+++ b/src/siphash24.h
@@ -1,15 +1,13 @@
-
 #pragma once
 
 #define SIPHASH_KEYLEN 16
-#define SIPHASH_HASHLEN 8
 
 extern "C" {
-int _siphash(uint8_t *out, const uint8_t *in, uint64_t inlen, const uint8_t *k);
+	uint64_t siphash24(const void *src, unsigned long src_sz, const uint64_t* key);
 }
 
 // [Bro] Wrapper for better type-safety.
 inline void siphash(uint64_t* digest, const uint8_t *in, uint64_t inlen, const uint8_t* key)
 	{
-	_siphash((uint8_t*)digest, in, inlen, key);
+	*digest = siphash24(in, inlen, (const uint64_t*)key);
 	}


### PR DESCRIPTION
- Average of 10 runs of 2009-M57-day11-18.trace (release build at -O3):
  - Master: 6.027s  93650 bytes max RSS
  - Commit: 5.950s  93271 bytes max RSS

- Hashing a fixed 32-byte payload 10 million times with a fixed key:
  - Master: 1.397411s
  - Commit: 0.998211s