### PR TITLE
Type: fix double free bug in SetType::ShallowClone()

### DIFF
--- a/src/Type.cc
+++ b/src/Type.cc
@@ -438,13 +438,11 @@ SetType::SetType(TypeList* ind, ListExpr* arg_elements) : TableType(ind, 0)
 
 SetType* SetType::ShallowClone()
 	{
-	// constructor only consumes indices when elements
-	// is set
-	if ( elements && indices )
-		{
+	if ( elements )
 		elements->Ref();
+
+	if ( indices )
 		indices->Ref();
-		}
 
 	return new SetType(indices, elements);
 	}


### PR DESCRIPTION
The type declaration `addr_set` happens to result in a `SetType` with
`elements`, but no `indices`, and so ShallowClone() does not increment
any reference counter.  However, the `SetType` constructor passed
ownership of a non-existing reference to `TableType`, resulting in a
double free bug (and Zeek crash).

At first, I tried to fix this by obeying the code comment in
SetType::ShallowClone() and pass `indices=nullptr`, but that led to a
crash inside IndexType::IsSubNetIndex().  So this patch attempts to
make the symptom go away by pretending the code comment is simply
wrong, and only corrects the reference counters.