### PR TITLE
Pop global frame stack on exception

### DIFF
--- a/src/Func.cc
+++ b/src/Func.cc
@@ -395,6 +395,7 @@ Val* BroFunc::Call(val_list* args, Frame* parent) const
 			// Already reported, but now determine whether to unwind further.
 			if ( Flavor() == FUNC_FLAVOR_FUNCTION )
 				{
+				g_frame_stack.pop_back();
 				Unref(f);
 				// Result not set b/c exception was thrown
 				throw;


### PR DESCRIPTION
When changing this code for 3.0.0, the code-flow changed significantly.
One of the changes lead to exception being re-thrown from Call - which
leads to the function cleanup not always being run. While the Unref of
the framepointer was (correctly) moved into the catch block, the global
frame stack was not cleaned up - and contains an invalid pointer after
encountering an interpreter exception.

This small commit pops the stack and removes the framepointer that was
pushed onto it before re-throwing the exception.

I also think that this change (re-throwing the exception) breaks the
Zeek debugger in significant ways (you cannot debug a script that causes
a Runtime error anymore).