### PR TITLE
Add ability for plugins to use hardware checksum offloading

### DIFF
--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -251,7 +251,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 	if ( packet_filter && packet_filter->Match(ip_hdr, len, caplen) )
 		 return;
 
-	if ( ! ignore_checksums && ip4 &&
+	if ( ! pkt->l2_checksummed && ! ignore_checksums && ip4 &&
 	     ones_complement_checksum((void*) ip4, ip_hdr_len, 0) != 0xffff )
 		{
 		Weird("bad_IP_checksum", pkt, encapsulation);

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -333,7 +333,7 @@ RecordVal* ICMP_Analyzer::ExtractICMP4Context(int len, const u_char*& data)
 		{
 		bad_hdr_len = 0;
 		ip_len = ip_hdr->TotalLen();
-		bad_checksum = (ones_complement_checksum((void*) ip_hdr->IP4_Hdr(), ip_hdr_len, 0) != 0xffff);
+		bad_checksum = ! current_pkt->l3_checksummed && (ones_complement_checksum((void*) ip_hdr->IP4_Hdr(), ip_hdr_len, 0) != 0xffff);
 
 		src_addr = ip_hdr->SrcAddr();
 		dst_addr = ip_hdr->DstAddr();

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -275,7 +275,7 @@ const struct tcphdr* TCP_Analyzer::ExtractTCP_Header(const u_char*& data,
 bool TCP_Analyzer::ValidateChecksum(const struct tcphdr* tp,
 				TCP_Endpoint* endpoint, int len, int caplen)
 	{
-	if ( ! ignore_checksums && caplen >= len &&
+	if ( ! current_pkt->l3_checksummed && ! ignore_checksums && caplen >= len &&
 	     ! endpoint->ValidChecksum(tp, len) )
 		{
 		Weird("bad_TCP_checksum");

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -62,7 +62,7 @@ void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 
 	int chksum = up->uh_sum;
 
-	auto validate_checksum = ! ignore_checksums && caplen >=len;
+	auto validate_checksum = ! current_pkt->l3_checksummed && ! ignore_checksums && caplen >=len;
 	constexpr auto vxlan_len = 8;
 	constexpr auto eth_len = 14;
 

--- a/src/iosource/Packet.cc
+++ b/src/iosource/Packet.cc
@@ -52,6 +52,9 @@ void Packet::Init(int arg_link_type, pkt_timeval *arg_ts, uint32_t arg_caplen,
 
 	l2_valid = false;
 
+	l2_checksummed = false;
+	l3_checksummed = false;
+
 	if ( data && cap_len < hdr_size )
 		{
 		Weird("truncated_link_header");
@@ -677,4 +680,3 @@ void Packet::Describe(ODesc* d) const
 	d->Add("->");
 	d->Add(ip.DstAddr());
 	}
-

--- a/src/iosource/Packet.cc
+++ b/src/iosource/Packet.cc
@@ -43,16 +43,16 @@ void Packet::Init(int arg_link_type, pkt_timeval *arg_ts, uint32_t arg_caplen,
 
 	time = ts.tv_sec + double(ts.tv_usec) / 1e6;
 	hdr_size = GetLinkHeaderSize(arg_link_type);
-	l3_proto = L3_UNKNOWN;
 	eth_type = 0;
 	vlan = 0;
 	inner_vlan = 0;
-	l2_src = 0;
-	l2_dst = 0;
 
+	l2_src = nullptr;
+	l2_dst = nullptr;
 	l2_valid = false;
-
 	l2_checksummed = false;
+
+	l3_proto = L3_UNKNOWN;
 	l3_checksummed = false;
 
 	if ( data && cap_len < hdr_size )

--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -199,6 +199,18 @@ public:
 	 */
 	uint32_t inner_vlan;
 
+	/**
+	 * Indicates whether the layer 2 checksum was validated by the
+	 * hardware/kernel before being received by zeek.
+	 */
+	bool l2_checksummed;
+
+	/**
+	 * Indicates whether the layer 3 checksum was validated by the
+	 * hardware/kernel before being received by zeek.
+	 */
+	bool l3_checksummed;
+
 private:
 	// Calculate layer 2 attributes. Sets
 	void ProcessLayer2();

--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -19,12 +19,14 @@ class RecordVal;
 
 /**
  * The Layer 3 type of a packet, as determined by the parsing code in Packet.
+ * This enum is sized as an int32_t to make the Packet structure align
+ * correctly.
  */
-enum Layer3Proto {
+enum Layer3Proto : int32_t {
 	L3_UNKNOWN = -1,	/// Layer 3 type could not be determined.
-	L3_IPV4 = 1,	/// Layer 3 is IPv4.
-	L3_IPV6 = 2,	/// Layer 3 is IPv6.
-	L3_ARP = 3,	/// Layer 3 is ARP.
+	L3_IPV4 = 1,		/// Layer 3 is IPv4.
+	L3_IPV6 = 2,		/// Layer 3 is IPv6.
+	L3_ARP = 3,			/// Layer 3 is ARP.
 };
 
 /**
@@ -110,7 +112,7 @@ public:
 	 * Returns true if parsing the layer 2 fields failed, including when
 	 * no data was passed into the constructor in the first place.
 	 */
-	bool Layer2Valid()
+	bool Layer2Valid() const
 		{
 		return l2_valid;
 		}
@@ -212,14 +214,14 @@ public:
 	bool l3_checksummed;
 
 private:
-	// Calculate layer 2 attributes. Sets
+	// Calculate layer 2 attributes.
 	void ProcessLayer2();
 
 	// Wrapper to generate a packet-level weird.
 	void Weird(const char* name);
 
 	// Renders an MAC address into its ASCII representation.
-	Val *FmtEUI48(const u_char *mac) const;
+	Val* FmtEUI48(const u_char *mac) const;
 
 	// True if we need to delete associated packet memory upon
 	// destruction.


### PR DESCRIPTION
This adds a little bit of code to Packet to set whether a packet's checksum is valid or not. This allows packet source plugins to use the hardware checksum offload features of their drivers and avoid lots of repeated calls into `ones_complement_checksum` if the hardware can just verify the checksums externally.

A proof-of-concept for af_packet is on https://github.com/timwoj/zeek-af_packet-plugin/commit/646ca5796e6a67f1d0f4d421880c0eaac16179ec