### PR TITLE
Zeek v3.0.1 defer processing for unseen segments

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -1044,6 +1044,22 @@ const tcp_content_deliver_all_orig = F &redef;
 ##    udp_content_deliver_all_resp tcp_contents
 const tcp_content_deliver_all_resp = F &redef;
 
+## Defer TCP ack for segments not seen from peer.
+##
+## In some environments, it's possible for packets to get reordered and we
+## may see client sending acks for segments the server hasn't sent.
+## In such cases, Bro advances peer ack-seq and raise an Undelivered event.
+## This flag changes the default behavior. The misordered packets are
+## enqueueued and replayed in the when the corresponding peer packet
+## is received.
+## NOTE: Couple of caveats when using this flag.
+##  - This flag only addresses re-order issues between client and server
+##    packets i.e. if client pkt is received before server pkt or vice-versa.
+##  - The flag only addresses re-order issues after client and server move
+##    to established state. This flag does not address re-order issues for
+##    non-established connections.
+const tcp_defer_unseen_segments = F &redef;
+
 ## Defines UDP destination ports for which the contents of the originator stream
 ## should be delivered via :zeek:see:`udp_contents`.
 ##

--- a/src/NetVar.cc
+++ b/src/NetVar.cc
@@ -75,6 +75,7 @@ TableVal* udp_content_delivery_ports_orig;
 TableVal* udp_content_delivery_ports_resp;
 bool udp_content_deliver_all_orig;
 bool udp_content_deliver_all_resp;
+bool tcp_defer_unseen_segments;
 
 double dns_session_timeout;
 double rpc_timeout;

--- a/src/NetVar.h
+++ b/src/NetVar.h
@@ -73,6 +73,7 @@ extern TableVal* tcp_content_delivery_ports_orig;
 extern TableVal* tcp_content_delivery_ports_resp;
 extern bool tcp_content_deliver_all_orig;
 extern bool tcp_content_deliver_all_resp;
+extern bool tcp_defer_unseen_segments;
 
 extern TableVal* udp_content_delivery_ports_orig;
 extern TableVal* udp_content_delivery_ports_resp;

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.h
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.h
@@ -119,6 +119,6 @@ private:
 	Type type;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*
 
 #endif


### PR DESCRIPTION
Defer TCP ack for segments not seen from the peer.

When sourcing traffic from span ports, it is possible for the client and server packets to get re-ordered. An example is where Wireshark shows `TCP ACKed unseen segment` errors. This change defers the packet processing for a TCP packet in such cases. Deferred packets are processed again when processing packets from the peer.  

Addresses the following narrow case:
- Only addresses re-order issues between client and server packets i.e. a client acks a segment not seen from the server or vice-versa.
- Only addresses re-order issues after the client and server have moved to the established state. Other cases could be more involved and hence not tackled here.

Change is disabled by default.  The flag `tcp_defer_unseen_segments` must be enabled in init-bark.zeek file.