### PR TITLE
Duplicate smb2_negotiate_response events defined.

### DIFF
--- a/scripts/base/protocols/smb/smb2-main.zeek
+++ b/scripts/base/protocols/smb/smb2-main.zeek
@@ -98,11 +98,6 @@ event smb2_negotiate_response(c: connection, hdr: SMB2::Header, response: SMB2::
 		}
 	}
 
-event smb2_negotiate_response(c: connection, hdr: SMB2::Header, response: SMB2::NegotiateResponse) &priority=5
-	{
-	# No behavior yet.
-	}
-
 event smb2_tree_connect_request(c: connection, hdr: SMB2::Header, path: string) &priority=5
 	{
 	c$smb_state$current_tree$path = path;


### PR DESCRIPTION
In looking at scripting some SMBv3 traffic, noticed there were two events defined for responses.