### PR TITLE
The Great Embooleanating

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,12 @@ Changed Functionality
   detected and used at configuration-time.  Use the ``--enable-rocksdb`` and
   ``--with-rocksdb=`` flags to opt-in.
 
+- A large number of functions had return values and/or arguments changed
+  to use ``bool`` types instead of ``int``. This includes some virtual
+  methods, which may cause build failures in plugins that were overriding
+  those methods. Those plugins will need to be updated to match these API
+  changes.
+
 Removed Functionality
 ---------------------
 

--- a/src/Anon.cc
+++ b/src/Anon.cc
@@ -69,13 +69,13 @@ ipaddr32_t AnonymizeIPAddr::Anonymize(ipaddr32_t addr)
 	}
 
 // Keep the specified prefix unchanged.
-int AnonymizeIPAddr::PreservePrefix(ipaddr32_t /* input */, int /* num_bits */)
+bool AnonymizeIPAddr::PreservePrefix(ipaddr32_t /* input */, int /* num_bits */)
 	{
 	reporter->InternalError("prefix preserving is not supported for the anonymizer");
-	return 0;
+	return false;
 	}
 
-int AnonymizeIPAddr::PreserveNet(ipaddr32_t input)
+bool AnonymizeIPAddr::PreserveNet(ipaddr32_t input)
 	{
 	switch ( addr_to_class(ntohl(input)) ) {
 	case 'A':
@@ -85,7 +85,7 @@ int AnonymizeIPAddr::PreserveNet(ipaddr32_t input)
 	case 'C':
 		return PreservePrefix(input, 24);
 	default:
-		return 0;
+		return false;
 	}
 	}
 
@@ -160,7 +160,7 @@ void AnonymizeIPAddr_A50::init()
 	new_mapping = 0;
 	}
 
-int AnonymizeIPAddr_A50::PreservePrefix(ipaddr32_t input, int num_bits)
+bool AnonymizeIPAddr_A50::PreservePrefix(ipaddr32_t input, int num_bits)
 	{
 	DEBUG_MSG("%s/%d\n",
 			IPAddr(IPv4, &input, IPAddr::Network).AsString().c_str(),
@@ -169,7 +169,7 @@ int AnonymizeIPAddr_A50::PreservePrefix(ipaddr32_t input, int num_bits)
 	if ( ! before_anonymization )
 		{
 		reporter->Error("prefix perservation specified after anonymization begun");
-		return 0;
+		return false;
 		}
 
 	input = ntohl(input);
@@ -191,7 +191,7 @@ int AnonymizeIPAddr_A50::PreservePrefix(ipaddr32_t input, int num_bits)
 		n->output = (input & prefix_mask) | (rand32() & suffix_mask);
 		}
 
-	return 1;
+	return true;
 	}
 
 ipaddr32_t AnonymizeIPAddr_A50::anonymize(ipaddr32_t a)

--- a/src/Anon.h
+++ b/src/Anon.h
@@ -44,11 +44,11 @@ public:
 
 	ipaddr32_t Anonymize(ipaddr32_t addr);
 
-	virtual int PreservePrefix(ipaddr32_t input, int num_bits);
+	virtual bool PreservePrefix(ipaddr32_t input, int num_bits);
 
 	virtual ipaddr32_t anonymize(ipaddr32_t addr) = 0;
-	
-	int PreserveNet(ipaddr32_t input);
+
+	bool PreserveNet(ipaddr32_t input);
 
 protected:
 	map<ipaddr32_t, ipaddr32_t> mapping;
@@ -85,7 +85,7 @@ public:
 	~AnonymizeIPAddr_A50() override;
 
 	ipaddr32_t anonymize(ipaddr32_t addr) override;
-	int PreservePrefix(ipaddr32_t input, int num_bits) override;
+	bool PreservePrefix(ipaddr32_t input, int num_bits) override;
 
 protected:
 	struct Node {

--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -104,7 +104,7 @@ void Attr::DescribeReST(ODesc* d, bool shorten) const
 		else if ( expr->Tag() == EXPR_CONST )
 			{
 			ODesc dd;
-			dd.SetQuotes(1);
+			dd.SetQuotes(true);
 			expr->Describe(&dd);
 			string s = dd.Description();
 			add_long_expr_string(d, s, shorten);
@@ -260,7 +260,7 @@ void Attributes::CheckAttr(Attr* a)
 	case ATTR_ADD_FUNC:
 	case ATTR_DEL_FUNC:
 		{
-		int is_add = a->Tag() == ATTR_ADD_FUNC;
+		bool is_add = a->Tag() == ATTR_ADD_FUNC;
 
 		BroType* at = a->AttrExpr()->Type();
 		if ( at->Tag() != TYPE_FUNC )
@@ -635,4 +635,3 @@ bool Attributes::operator==(const Attributes& other) const
 
 	return true;
 	}
-

--- a/src/Base64.cc
+++ b/src/Base64.cc
@@ -138,7 +138,7 @@ int Base64Converter::Decode(int len, const char* data, int* pblen, char** pbuf)
 
 	int dlen = 0;
 
-	while ( 1 )
+	while ( true )
 		{
 		if ( base64_group_next == 4 )
 			{
@@ -255,7 +255,7 @@ BroString* decode_base64(const BroString* s, const BroString* a, Connection* con
 	rlen += rlen2;
 
 	rbuf[rlen] = '\0';
-	return new BroString(1, (u_char*) rbuf, rlen);
+	return new BroString(true, (u_char*) rbuf, rlen);
 
 err:
 	delete [] rbuf;
@@ -276,5 +276,5 @@ BroString* encode_base64(const BroString* s, const BroString* a, Connection* con
 	Base64Converter enc(conn, a ? a->CheckString() : "");
 	enc.Encode(s->Len(), (const unsigned char*) s->Bytes(), &outlen, &outbuf);
 
-	return new BroString(1, (u_char*)outbuf, outlen);
+	return new BroString(true, (u_char*)outbuf, outlen);
 	}

--- a/src/Base64.h
+++ b/src/Base64.h
@@ -32,7 +32,7 @@ public:
 	void Encode(int len, const unsigned char* data, int* blen, char** buf);
 
 	int Done(int* pblen, char** pbuf);
-	int HasData() const { return base64_group_next != 0; }
+	bool HasData() const { return base64_group_next != 0; }
 
 	// True if an error has occurred.
 	int Errored() const	{ return errored; }

--- a/src/BroString.cc
+++ b/src/BroString.cc
@@ -107,7 +107,7 @@ void BroString::Adopt(byte_vec bytes, int len)
 
 	// Check if the string ends with a NUL.  If so, mark it as having
 	// a final NUL and adjust the length accordingly.
-	final_NUL = (b[len-1] == '\0') ? 1 : 0;
+	final_NUL = (b[len-1] == '\0');
 	n = len - final_NUL;
 	}
 
@@ -289,7 +289,7 @@ BroString* BroString::GetSubstring(int start, int len) const
 	if ( len < 0 || len > n - start )
 		len = n - start;
 
-	return new BroString(&b[start], len, 1);
+	return new BroString(&b[start], len, true);
 	}
 
 int BroString::FindSubstring(const BroString* s) const

--- a/src/CCL.h
+++ b/src/CCL.h
@@ -15,7 +15,7 @@ public:
 
 	void Add(int sym);
 	void Negate();
-	int IsNegated()		{ return negated; }
+	bool IsNegated()		{ return negated != 0; }
 	int Index()		{ return index; }
 
 	void Sort();

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -25,20 +25,20 @@ CompositeHash::CompositeHash(IntrusivePtr<TypeList> composite_type)
 		{
 		if ( (*type->Types())[0]->Tag() == TYPE_RECORD )
 			{
-			is_complex_type = 1;
-			is_singleton = 0;
+			is_complex_type = true;
+			is_singleton = false;
 			}
 		else
 			{
-			is_complex_type = 0;
-			is_singleton = 1;
+			is_complex_type = false;
+			is_singleton = true;
 			}
 		}
 
 	else
 		{
-		is_singleton = 0;
-		is_complex_type = 0;
+		is_singleton = false;
+		is_complex_type = false;
 		}
 
 	if ( is_singleton )
@@ -52,7 +52,7 @@ CompositeHash::CompositeHash(IntrusivePtr<TypeList> composite_type)
 
 	else
 		{
-		size = ComputeKeySize(0, 1, true);
+		size = ComputeKeySize(0, true, true);
 
 		if ( size > 0 )
 			// Fixed size.  Make sure what we get is fully aligned.
@@ -69,7 +69,7 @@ CompositeHash::~CompositeHash()
 	}
 
 // Computes the piece of the hash for Val*, returning the new kp.
-char* CompositeHash::SingleValHash(int type_check, char* kp0,
+char* CompositeHash::SingleValHash(bool type_check, char* kp0,
 				   BroType* bt, Val* v, bool optional) const
 	{
 	char* kp1 = 0;
@@ -333,7 +333,7 @@ char* CompositeHash::SingleValHash(int type_check, char* kp0,
 	}
 
 
-HashKey* CompositeHash::ComputeHash(const Val* v, int type_check) const
+HashKey* CompositeHash::ComputeHash(const Val* v, bool type_check) const
 	{
 	if ( ! v )
 		reporter->InternalError("null value given to CompositeHash::ComputeHash");
@@ -364,7 +364,7 @@ HashKey* CompositeHash::ComputeHash(const Val* v, int type_check) const
 			return 0;
 
 		k = reinterpret_cast<char*>(new double[sz/sizeof(double) + 1]);
-		type_check = 0;	// no need to type-check again.
+		type_check = false;	// no need to type-check again.
 		}
 
 	const type_list* tl = type->Types();
@@ -387,7 +387,7 @@ HashKey* CompositeHash::ComputeHash(const Val* v, int type_check) const
 	return new HashKey((k == key), (void*) k, kp - k);
 	}
 
-HashKey* CompositeHash::ComputeSingletonHash(const Val* v, int type_check) const
+HashKey* CompositeHash::ComputeSingletonHash(const Val* v, bool type_check) const
 	{
 	if ( v->Type()->Tag() == TYPE_LIST )
 		{
@@ -449,7 +449,7 @@ HashKey* CompositeHash::ComputeSingletonHash(const Val* v, int type_check) const
 	}
 
 int CompositeHash::SingleTypeKeySize(BroType* bt, const Val* v,
-				     int type_check, int sz, bool optional,
+				     bool type_check, int sz, bool optional,
 				     bool calc_static_size) const
 	{
 	InternalTypeTag t = bt->InternalType();
@@ -629,7 +629,7 @@ int CompositeHash::SingleTypeKeySize(BroType* bt, const Val* v,
 	return sz;
 	}
 
-int CompositeHash::ComputeKeySize(const Val* v, int type_check, bool calc_static_size) const
+int CompositeHash::ComputeKeySize(const Val* v, bool type_check, bool calc_static_size) const
 	{
 	const type_list* tl = type->Types();
 	const val_list* vl = 0;
@@ -1044,7 +1044,7 @@ const char* CompositeHash::RecoverOneVal(const HashKey* k, const char* kp0,
 			kp1 = reinterpret_cast<const char*>(kp+1);
 			}
 
-		*pval = make_intrusive<StringVal>(new BroString((const byte_vec) kp1, n, 1));
+		*pval = make_intrusive<StringVal>(new BroString((const byte_vec) kp1, n, true));
 		kp1 += n;
 		}
 		break;

--- a/src/CompHash.h
+++ b/src/CompHash.h
@@ -15,7 +15,7 @@ public:
 
 	// Compute the hash corresponding to the given index val,
 	// or 0 if it fails to typecheck.
-	HashKey* ComputeHash(const Val* v, int type_check) const;
+	HashKey* ComputeHash(const Val* v, bool type_check) const;
 
 	// Given a hash key, recover the values used to create it.
 	IntrusivePtr<ListVal> RecoverVals(const HashKey* k) const;
@@ -23,11 +23,11 @@ public:
 	unsigned int MemoryAllocation() const { return padded_sizeof(*this) + pad_size(size); }
 
 protected:
-	HashKey* ComputeSingletonHash(const Val* v, int type_check) const;
+	HashKey* ComputeSingletonHash(const Val* v, bool type_check) const;
 
 	// Computes the piece of the hash for Val*, returning the new kp.
 	// Used as a helper for ComputeHash in the non-singleton case.
-	char* SingleValHash(int type_check, char* kp, BroType* bt, Val* v,
+	char* SingleValHash(bool type_check, char* kp, BroType* bt, Val* v,
 			    bool optional) const;
 
 	// Recovers just one Val of possibly many; called from RecoverVals.
@@ -72,20 +72,20 @@ protected:
 	// the value is computed for the particular list of values.
 	// Returns 0 if the key has an indeterminant size (if v not given),
 	// or if v doesn't match the index type (if given).
-	int ComputeKeySize(const Val* v, int type_check,
+	int ComputeKeySize(const Val* v, bool type_check,
 			   bool calc_static_size) const;
 
 	int SingleTypeKeySize(BroType*, const Val*,
-			      int type_check, int sz, bool optional,
+			      bool type_check, int sz, bool optional,
 			      bool calc_static_size) const;
 
 	IntrusivePtr<TypeList> type;
 	char* key;	// space for composite key
 	int size;
-	int is_singleton;	// if just one type in index
+	bool is_singleton;	// if just one type in index
 
 	// If one type, but not normal "singleton", e.g. record.
-	int is_complex_type;
+	bool is_complex_type;
 
 	InternalTypeTag singleton_tag;
 };

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -39,7 +39,7 @@ ConnectionTimer::~ConnectionTimer()
 	Unref(conn);
 	}
 
-void ConnectionTimer::Dispatch(double t, int is_expire)
+void ConnectionTimer::Dispatch(double t, bool is_expire)
 	{
 	if ( is_expire && ! do_expire )
 		return;
@@ -177,7 +177,7 @@ void Connection::Done()
 		root_analyzer->Done();
 	}
 
-void Connection::NextPacket(double t, int is_orig,
+void Connection::NextPacket(double t, bool is_orig,
 			const IP_Hdr* ip, int len, int caplen,
 			const u_char*& data,
 			int& record_packet, int& record_content,

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -87,7 +87,7 @@ public:
 	// If record_content is true, then its entire contents should
 	// be recorded, otherwise just up through the transport header.
 	// Both are assumed set to true when called.
-	void NextPacket(double t, int is_orig,
+	void NextPacket(double t, bool is_orig,
 			const IP_Hdr* ip, int len, int caplen,
 			const u_char*& data,
 			int& record_packet, int& record_content,
@@ -126,27 +126,27 @@ public:
 	// True if we should record subsequent packets (either headers or
 	// in their entirety, depending on record_contents).  We still
 	// record subsequent SYN/FIN/RST, regardless of how this is set.
-	int RecordPackets() const		{ return record_packets; }
-	void SetRecordPackets(int do_record)	{ record_packets = do_record; }
+	bool RecordPackets() const		{ return record_packets; }
+	void SetRecordPackets(bool do_record)	{ record_packets = do_record ? 1 : 0; }
 
 	// True if we should record full packets for this connection,
 	// false if we should just record headers.
-	int RecordContents() const		{ return record_contents; }
-	void SetRecordContents(int do_record)	{ record_contents = do_record; }
+	bool RecordContents() const		{ return record_contents; }
+	void SetRecordContents(bool do_record)	{ record_contents = do_record ? 1 : 0; }
 
 	// Set whether to record *current* packet header/full.
-	void SetRecordCurrentPacket(int do_record)
-		{ record_current_packet = do_record; }
-	void SetRecordCurrentContent(int do_record)
-		{ record_current_content = do_record; }
+	void SetRecordCurrentPacket(bool do_record)
+		{ record_current_packet = do_record ? 1 : 0; }
+	void SetRecordCurrentContent(bool do_record)
+		{ record_current_content = do_record ? 1 : 0; }
 
 	// FIXME: Now this is in Analyzer and should eventually be removed here.
 	//
 	// If true, skip processing of remainder of connection.  Note
 	// that this does not in itself imply that record_packets is false;
 	// we might want instead to process the connection off-line.
-	void SetSkip(int do_skip)		{ skip = do_skip; }
-	int Skipping() const			{ return skip; }
+	void SetSkip(bool do_skip)		{ skip = do_skip ? 1 : 0; }
+	bool Skipping() const			{ return skip; }
 
 	// Arrange for the connection to expire after the given amount of time.
 	void SetLifetime(double lifetime);
@@ -237,16 +237,16 @@ public:
 	// Cancel all associated timers.
 	void CancelTimers();
 
-	inline int FlagEvent(ConnEventToFlag e)
+	inline bool FlagEvent(ConnEventToFlag e)
 		{
 		if ( e >= 0 && e < NUM_EVENTS_TO_FLAG )
 			{
 			if ( suppress_event & (1 << e) )
-				return 0;
+				return false;
 			suppress_event |= 1 << e;
 			}
 
-		return 1;
+		return true;
 		}
 
 	void Describe(ODesc* d) const override;
@@ -264,7 +264,7 @@ public:
 		{ return current_connections; }
 
 	// Returns true if the history was already seen, false otherwise.
-	int CheckHistory(uint32_t mask, char code)
+	bool CheckHistory(uint32_t mask, char code)
 		{
 		if ( (hist_seen & mask) == 0 )
 			{
@@ -387,7 +387,7 @@ public:
 		{ Init(arg_conn, arg_timer, arg_do_expire); }
 	~ConnectionTimer() override;
 
-	void Dispatch(double t, int is_expire) override;
+	void Dispatch(double t, bool is_expire) override;
 
 protected:
 	ConnectionTimer()	{}

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -107,8 +107,8 @@ public:
 	DNS_Mapping(const IPAddr& addr, struct hostent* h, uint32_t ttl);
 	DNS_Mapping(FILE* f);
 
-	int NoMapping() const		{ return no_mapping; }
-	int InitFailed() const		{ return init_failed; }
+	bool NoMapping() const		{ return no_mapping; }
+	bool InitFailed() const		{ return init_failed; }
 
 	~DNS_Mapping();
 
@@ -128,8 +128,8 @@ public:
 
 	void Save(FILE* f) const;
 
-	int Failed() const		{ return failed; }
-	int Valid() const		{ return ! failed; }
+	bool Failed() const		{ return failed; }
+	bool Valid() const		{ return ! failed; }
 
 	bool Expired() const
 		{
@@ -147,9 +147,6 @@ protected:
 	void Init(struct hostent* h);
 	void Clear();
 
-	int no_mapping;	// when initializing from a file, immediately hit EOF
-	int init_failed;
-
 	char* req_host;
 	IPAddr req_addr;
 	uint32_t req_ttl;
@@ -162,9 +159,11 @@ protected:
 	IPAddr* addrs;
 	IntrusivePtr<ListVal> addrs_val;
 
-	int failed;
 	double creation_time;
 	int map_type;
+	bool no_mapping;	// when initializing from a file, immediately hit EOF
+	bool init_failed;
+	bool failed;
 };
 
 void DNS_Mgr_mapping_delete_func(void* v)
@@ -202,7 +201,7 @@ DNS_Mapping::DNS_Mapping(const IPAddr& addr, struct hostent* h, uint32_t ttl)
 DNS_Mapping::DNS_Mapping(FILE* f)
 	{
 	Clear();
-	init_failed = 1;
+	init_failed = true;
 
 	req_host = 0;
 	req_ttl = 0;
@@ -212,17 +211,20 @@ DNS_Mapping::DNS_Mapping(FILE* f)
 
 	if ( ! fgets(buf, sizeof(buf), f) )
 		{
-		no_mapping = 1;
+		no_mapping = true;
 		return;
 		}
 
 	char req_buf[512+1], name_buf[512+1];
 	int is_req_host;
+	int failed_local;
 
 	if ( sscanf(buf, "%lf %d %512s %d %512s %d %d %" PRIu32, &creation_time,
-	     &is_req_host, req_buf, &failed, name_buf, &map_type, &num_addrs,
+	     &is_req_host, req_buf, &failed_local, name_buf, &map_type, &num_addrs,
 	     &req_ttl) != 8 )
 		return;
+
+	failed = static_cast<bool>(failed_local);
 
 	if ( is_req_host )
 		req_host = copy_string(req_buf);
@@ -255,7 +257,7 @@ DNS_Mapping::DNS_Mapping(FILE* f)
 	else
 		addrs = 0;
 
-	init_failed = 0;
+	init_failed = false;
 	}
 
 DNS_Mapping::~DNS_Mapping()
@@ -310,8 +312,8 @@ IntrusivePtr<StringVal> DNS_Mapping::Host()
 
 void DNS_Mapping::Init(struct hostent* h)
 	{
-	no_mapping = 0;
-	init_failed = 0;
+	no_mapping = false;
+	init_failed = false;
 	creation_time = current_time();
 	host_val = 0;
 	addrs_val = 0;
@@ -344,7 +346,7 @@ void DNS_Mapping::Init(struct hostent* h)
 	else
 		addrs = 0;
 
-	failed = 0;
+	failed = false;
 	}
 
 void DNS_Mapping::Clear()
@@ -354,9 +356,9 @@ void DNS_Mapping::Clear()
 	addrs = 0;
 	host_val = 0;
 	addrs_val = 0;
-	no_mapping = 0;
+	no_mapping = false;
 	map_type = 0;
-	failed = 1;
+	failed = true;
 	}
 
 void DNS_Mapping::Save(FILE* f) const
@@ -373,7 +375,7 @@ void DNS_Mapping::Save(FILE* f) const
 
 DNS_Mgr::DNS_Mgr(DNS_MgrMode arg_mode)
 	{
-	did_init = 0;
+	did_init = false;
 
 	mode = arg_mode;
 
@@ -680,15 +682,15 @@ void DNS_Mgr::Resolve()
 		delete requests.remove_nth(i);
 	}
 
-int DNS_Mgr::Save()
+bool DNS_Mgr::Save()
 	{
 	if ( ! cache_name )
-		return 0;
+		return false;
 
 	FILE* f = fopen(cache_name, "w");
 
 	if ( ! f )
-		return 0;
+		return false;
 
 	Save(f, host_mappings);
 	Save(f, addr_mappings);
@@ -696,7 +698,7 @@ int DNS_Mgr::Save()
 
 	fclose(f);
 
-	return 1;
+	return true;
 	}
 
 void DNS_Mgr::Event(EventHandlerPtr e, DNS_Mapping* dm)

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -57,7 +57,7 @@ public:
 
 	void Verify();
 	void Resolve();
-	int Save();
+	bool Save();
 
 	const char* LookupAddrInCache(const IPAddr& addr);
 	IntrusivePtr<TableVal> LookupNameInCache(const string& name);
@@ -147,7 +147,7 @@ protected:
 	char* cache_name;
 	char* dir;	// directory in which cache_name resides
 
-	int did_init;
+	bool did_init;
 
 	// DNS-related events.
 	EventHandlerPtr dns_mapping_valid;
@@ -171,7 +171,7 @@ protected:
 
 		AsyncRequest() : time(0.0), is_txt(false), processed(false) { }
 
-		bool IsAddrReq() const	{ return name.length() == 0; }
+		bool IsAddrReq() const	{ return name.empty(); }
 
 		void Resolved(const char* name)
 			{

--- a/src/DbgBreakpoint.cc
+++ b/src/DbgBreakpoint.cc
@@ -27,13 +27,13 @@ public:
 		: Timer(arg_t, TIMER_BREAKPOINT)
 			{ bp = arg_bp; }
 
-	void Dispatch(double t, int is_expire);
+	void Dispatch(double t, bool is_expire) override;
 
 protected:
 	DbgBreakpoint* bp;
 };
 
-void BreakpointTimer::Dispatch(double t, int is_expire)
+void BreakpointTimer::Dispatch(double t, bool is_expire)
 	{
 	if ( is_expire )
 		return;

--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -237,7 +237,7 @@ static void parse_function_name(vector<ParseLocationRec>& result,
 		body = bodies[0].stmts.get();
 	else
 		{
-		while ( 1 )
+		while ( true )
 			{
 			debug_msg("There are multiple definitions of that event handler.\n"
 				 "Please choose one of the following options:\n");
@@ -600,7 +600,7 @@ int dbg_execute_command(const char* cmd)
 		{
 		/* The prototype for add_history(), at least under MacOS,
 		 * has it taking a char* rather than a const char*.
-		 * But documentation at 
+		 * But documentation at
 		 * http://tiswww.case.edu/php/chet/readline/history.html
 		 * suggests that it's safe to assume it's really const char*.
 		 */

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -77,7 +77,7 @@ void choose_global_symbols_regex(const string& regex, vector<ID*>& choices,
 	if ( choices.size() <= 1 )
 		return;
 
-	while ( 1 )
+	while ( true )
 		{
 		debug_msg("There were multiple matches, please choose:\n");
 

--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -35,10 +35,10 @@ ODesc::ODesc(desc_type t, BroFile* arg_f)
 		}
 
 	indent_level = 0;
-	is_short = 0;
-	want_quotes = 0;
-	do_flush = 1;
-	include_stats = 0;
+	is_short = false;
+	want_quotes = false;
+	do_flush = true;
+	include_stats = false;
 	indent_with_spaces = 0;
 	escape = false;
 	utf8 = false;

--- a/src/Desc.h
+++ b/src/Desc.h
@@ -33,27 +33,27 @@ public:
 
 	~ODesc();
 
-	int IsReadable() const		{ return type == DESC_READABLE; }
-	int IsPortable() const		{ return type == DESC_PORTABLE; }
-	int IsBinary() const		{ return type == DESC_BINARY; }
+	bool IsReadable() const		{ return type == DESC_READABLE; }
+	bool IsPortable() const		{ return type == DESC_PORTABLE; }
+	bool IsBinary() const		{ return type == DESC_BINARY; }
 
-	int IsShort() const		{ return is_short; }
-	void SetShort()			{ is_short = 1; }
-	void SetShort(int s)		{ is_short = s; }
+	bool IsShort() const		{ return is_short; }
+	void SetShort()			{ is_short = true; }
+	void SetShort(bool s)		{ is_short = s; }
 
 	// Whether we want to have quotes around strings.
-	int WantQuotes() const	{ return want_quotes; }
-	void SetQuotes(int q)	{ want_quotes = q; }
+	bool WantQuotes() const	{ return want_quotes; }
+	void SetQuotes(bool q)	{ want_quotes = q; }
 
 	// Whether we want to print statistics like access time and execution
 	// count where available.
-	int IncludeStats() const	{ return include_stats; }
-	void SetIncludeStats(int s)	{ include_stats = s; }
+	bool IncludeStats() const	{ return include_stats; }
+	void SetIncludeStats(bool s)	{ include_stats = s; }
 
 	desc_style Style() const	{ return style; }
 	void SetStyle(desc_style s)	{ style = s; }
 
-	void SetFlush(int arg_do_flush)	{ do_flush = arg_do_flush; }
+	void SetFlush(bool arg_do_flush)	{ do_flush = arg_do_flush; }
 
 	void EnableEscaping();
 	void EnableUTF8();
@@ -196,11 +196,11 @@ protected:
 	BroFile* f;	// or the file we're using.
 
 	int indent_level;
-	int is_short;
-	int want_quotes;
-	int do_flush;
-	int include_stats;
 	int indent_with_spaces;
+	bool is_short;
+	bool want_quotes;
+	bool do_flush;
+	bool include_stats;
 
 	std::set<const BroType*> encountered_types;
 };

--- a/src/Dict.cc
+++ b/src/Dict.cc
@@ -284,7 +284,7 @@ void* Dictionary::Lookup(const void* key, int key_size, hash_t hash) const
 	}
 
 void* Dictionary::Insert(void* key, int key_size, hash_t hash, void* val,
-				int copy_key)
+				bool copy_key)
 	{
 	if ( ! tbl )
 		Init(DEFAULT_DICT_SIZE);
@@ -524,7 +524,7 @@ void Dictionary::Init2(int size)
 	}
 
 // private
-void* Dictionary::Insert(DictEntry* new_entry, int copy_key)
+void* Dictionary::Insert(DictEntry* new_entry, bool copy_key)
 	{
 	if ( ! tbl )
 		Init(DEFAULT_DICT_SIZE);
@@ -623,13 +623,13 @@ int Dictionary::NextPrime(int n) const
 	return n;
 	}
 
-int Dictionary::IsPrime(int n) const
+bool Dictionary::IsPrime(int n) const
 	{
 	for ( int j = 3; j * j <= n; ++j )
 		if ( n % j == 0 )
-			return 0;
+			return false;
 
-	return 1;
+	return true;
 	}
 
 void Dictionary::StartChangeSize(int new_size)
@@ -669,7 +669,7 @@ void Dictionary::MoveChains()
 
 		for ( int j = 0; j < chain->length(); ++j )
 			{
-			Insert((*chain)[j], 0);
+			Insert((*chain)[j], false);
 			--num_entries;
 			--num;
 			}

--- a/src/Dict.h
+++ b/src/Dict.h
@@ -42,7 +42,7 @@ public:
 	// that it's a heap pointer that now belongs to the Dictionary to
 	// manage as needed.
 	void* Insert(void* key, int key_size, hash_t hash, void* val,
-			int copy_key);
+			bool copy_key);
 
 	// Removes the given element.  Returns a pointer to the element in
 	// case it needs to be deleted.  Returns 0 if no such element exists.
@@ -125,13 +125,13 @@ private:
 	void DeInit();
 
 	// Internal version of Insert().
-	void* Insert(DictEntry* entry, int copy_key);
+	void* Insert(DictEntry* entry, bool copy_key);
 
 	void* DoRemove(DictEntry* entry, hash_t h,
 			PList<DictEntry>* chain, int chain_offset);
 
 	int NextPrime(int n) const;
-	int IsPrime(int n) const;
+	bool IsPrime(int n) const;
 	void StartChangeSize(int new_size);
 	void FinishChangeSize();
 	void MoveChains();

--- a/src/Discard.h
+++ b/src/Discard.h
@@ -4,14 +4,8 @@
 
 #include <sys/types.h> // for u_char
 
-struct ip;
-struct tcphdr;
-struct udphdr;
-struct icmp;
-
 class IP_Hdr;
 class Val;
-class RecordType;
 class Func;
 
 class Discarder {
@@ -19,9 +13,9 @@ public:
 	Discarder();
 	~Discarder();
 
-	int IsActive();
+	bool IsActive();
 
-	int NextPacket(const IP_Hdr* ip, int len, int caplen);
+	bool NextPacket(const IP_Hdr* ip, int len, int caplen);
 
 protected:
 	Val* BuildData(const u_char* data, int hdrlen, int len, int caplen);

--- a/src/EquivClass.h
+++ b/src/EquivClass.h
@@ -20,7 +20,7 @@ public:
 
 	void ConvertCCL(CCL* ccl);
 
-	int IsRep(int sym) const		{ return rep[sym] == sym; }
+	bool IsRep(int sym) const		{ return rep[sym] == sym; }
 	int EquivRep(int sym) const		{ return rep[sym]; }
 	int SymEquivClass(int sym) const	{ return equiv_class[sym]; }
 	int* EquivClasses() const		{ return equiv_class; }

--- a/src/Event.cc
+++ b/src/Event.cc
@@ -36,9 +36,7 @@ void Event::Describe(ODesc* d) const
 	if ( d->IsReadable() )
 		d->AddSP("event");
 
-	int s = d->IsShort();
-	d->SetShort();
-//	handler->Describe(d);
+	bool s = d->IsShort();
 	d->SetShort(s);
 
 	if ( ! d->IsBinary() )
@@ -80,7 +78,7 @@ EventMgr::EventMgr()
 	current_src = SOURCE_LOCAL;
 	current_aid = 0;
 	src_val = 0;
-	draining = 0;
+	draining = false;
 	}
 
 EventMgr::~EventMgr()

--- a/src/Event.h
+++ b/src/Event.h
@@ -117,7 +117,7 @@ public:
 	void Drain();
 	bool IsDraining() const	{ return draining; }
 
-	int HasEvents() const	{ return head != 0; }
+	bool HasEvents() const	{ return head != 0; }
 
 	// Returns the source ID of last raised event.
 	SourceID CurrentSource() const	{ return current_src; }

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -331,7 +331,7 @@ protected:
 	virtual IntrusivePtr<Val> AddrFold(Val* v1, Val* v2) const;
 	virtual IntrusivePtr<Val> SubNetFold(Val* v1, Val* v2) const;
 
-	int BothConst() const	{ return op1->IsConst() && op2->IsConst(); }
+	bool BothConst() const	{ return op1->IsConst() && op2->IsConst(); }
 
 	// Exchange op1 and op2.
 	void SwapOps();
@@ -511,7 +511,7 @@ class AssignExpr : public BinaryExpr {
 public:
 	// If val is given, evaluating this expression will always yield the val
 	// yet still perform the assignment.  Used for triggers.
-	AssignExpr(IntrusivePtr<Expr> op1, IntrusivePtr<Expr> op2, int is_init,
+	AssignExpr(IntrusivePtr<Expr> op1, IntrusivePtr<Expr> op2, bool is_init,
 	           IntrusivePtr<Val> val = nullptr, attr_list* attrs = nullptr);
 
 	IntrusivePtr<Val> Eval(Frame* f) const override;
@@ -525,14 +525,14 @@ protected:
 	bool TypeCheck(attr_list* attrs = 0);
 	bool TypeCheckArithmetics(TypeTag bt1, TypeTag bt2);
 
-	int is_init;
+	bool is_init;
 	IntrusivePtr<Val> val;	// optional
 };
 
 class IndexSliceAssignExpr : public AssignExpr {
 public:
 	IndexSliceAssignExpr(IntrusivePtr<Expr> op1,
-	                     IntrusivePtr<Expr> op2, int is_init);
+	                     IntrusivePtr<Expr> op2, bool is_init);
 	IntrusivePtr<Val> Eval(Frame* f) const override;
 };
 
@@ -744,7 +744,7 @@ public:
 	ScheduleTimer(const EventHandlerPtr& event, zeek::Args args, double t);
 	~ScheduleTimer() override;
 
-	void Dispatch(double t, int is_expire) override;
+	void Dispatch(double t, bool is_expire) override;
 
 protected:
 	EventHandlerPtr event;
@@ -879,7 +879,7 @@ protected:
 
 class RecordAssignExpr : public ListExpr {
 public:
-	RecordAssignExpr(const IntrusivePtr<Expr>& record, const IntrusivePtr<Expr>& init_list, int is_init);
+	RecordAssignExpr(const IntrusivePtr<Expr>& record, const IntrusivePtr<Expr>& init_list, bool is_init);
 };
 
 class CastExpr : public UnaryExpr {
@@ -912,7 +912,7 @@ inline Val* Expr::ExprVal() const
 
 // Decides whether to return an AssignExpr or a RecordAssignExpr.
 IntrusivePtr<Expr> get_assign_expr(IntrusivePtr<Expr> op1,
-                                   IntrusivePtr<Expr> op2, int is_init);
+                                   IntrusivePtr<Expr> op2, bool is_init);
 
 // Type-check the given expression(s) against the given type(s).  Complain
 // if the expression cannot match the given type, returning 0.  If it can
@@ -931,9 +931,9 @@ IntrusivePtr<Expr> get_assign_expr(IntrusivePtr<Expr> op1,
  */
 extern IntrusivePtr<Expr> check_and_promote_expr(Expr* e, BroType* t);
 
-extern int check_and_promote_exprs(ListExpr* elements, TypeList* types);
-extern int check_and_promote_args(ListExpr* args, RecordType* types);
-extern int check_and_promote_exprs_to_type(ListExpr* elements, BroType* type);
+extern bool check_and_promote_exprs(ListExpr* elements, TypeList* types);
+extern bool check_and_promote_args(ListExpr* args, RecordType* types);
+extern bool check_and_promote_exprs_to_type(ListExpr* elements, BroType* type);
 
 // Returns a ListExpr simplified down to a list a values, or nil
 // if they couldn't all be reduced.

--- a/src/File.cc
+++ b/src/File.cc
@@ -87,12 +87,12 @@ BroFile::BroFile(const char* arg_name, const char* arg_access)
 		f = stderr;
 
 	if ( f )
-		is_open = 1;
+		is_open = true;
 
 	else if ( ! Open() )
 		{
 		reporter->Error("cannot open %s: %s", name, strerror(errno));
-		is_open = 0;
+		is_open = false;
 		}
 	}
 
@@ -139,11 +139,11 @@ bool BroFile::Open(FILE* file, const char* mode)
 
 	if ( ! f )
 		{
-		is_open = 0;
+		is_open = false;
 		return false;
 		}
 
-	is_open = 1;
+	is_open = true;
 	open_files.emplace_back(std::make_pair(name, this));
 
 	RaiseOpenEvent();
@@ -166,7 +166,8 @@ BroFile::~BroFile()
 
 void BroFile::Init()
 	{
-	open_time = is_open = 0;
+	open_time = 0;
+	is_open = false;
 	attrs = 0;
 	buffered = true;
 	raw_output = false;
@@ -203,25 +204,26 @@ void BroFile::SetBuf(bool arg_buffered)
 	buffered = arg_buffered;
 	}
 
-int BroFile::Close()
+bool BroFile::Close()
 	{
 	if ( ! is_open )
-		return 1;
+		return true;
 
 	// Do not close stdin/stdout/stderr.
 	if ( f == stdin || f == stdout || f == stderr )
-		return 0;
+		return false;
 
 	if ( ! f )
-		return 0;
+		return false;
 
 	fclose(f);
 	f = nullptr;
-	open_time = is_open = 0;
+	open_time = 0;
+	is_open = false;
 
 	Unlink();
 
-	return 1;
+	return true;
 	}
 
 void BroFile::Unlink()
@@ -305,10 +307,10 @@ void BroFile::CloseOpenFiles()
 		}
 	}
 
-int BroFile::Write(const char* data, int len)
+bool BroFile::Write(const char* data, int len)
 	{
 	if ( ! is_open )
-		return 0;
+		return false;
 
 	if ( ! len )
 		len = strlen(data);
@@ -355,4 +357,3 @@ BroFile* BroFile::GetFile(const char* name)
 
 	return new BroFile(name, "w");
 	}
-

--- a/src/File.h
+++ b/src/File.h
@@ -29,7 +29,7 @@ public:
 	const char* Name() const;
 
 	// Returns false if an error occured.
-	int Write(const char* data, int len = 0);
+	bool Write(const char* data, int len = 0);
 
 	void Flush()	{ fflush(f); }
 
@@ -42,11 +42,11 @@ public:
 	// Whether the file is open in a general sense; it might
 	// not be open as a Unix file due to our management of
 	// a finite number of FDs.
-	int IsOpen() const	{ return is_open; }
+	bool IsOpen() const	{ return is_open; }
 
 	// Returns true if the close made sense, false if it was already
 	// closed, not active, or whatever.
-	int Close();
+	bool Close();
 
 	void Describe(ODesc* d) const override;
 
@@ -97,10 +97,10 @@ protected:
 	IntrusivePtr<BroType> t;
 	char* name;
 	char* access;
-	int is_open;	// whether the file is open in a general sense
 	Attributes* attrs;
-	bool buffered;
 	double open_time;
+	bool is_open;	// whether the file is open in a general sense
+	bool buffered;
 	bool raw_output;
 
 	static const int MIN_BUFFER_SIZE = 1024;

--- a/src/Frag.cc
+++ b/src/Frag.cc
@@ -18,7 +18,7 @@ FragTimer::~FragTimer()
 		f->ClearTimer();
 	}
 
-void FragTimer::Dispatch(double t, int /* is_expire */)
+void FragTimer::Dispatch(double t, bool /* is_expire */)
 	{
 	if ( f )
 		f->Expire(t);

--- a/src/Frag.h
+++ b/src/Frag.h
@@ -60,7 +60,7 @@ public:
 			{ f = arg_f; }
 	~FragTimer() override;
 
-	void Dispatch(double t, int is_expire) override;
+	void Dispatch(double t, bool is_expire) override;
 
 	// Break the association between this timer and its creator.
 	void ClearReassembler()	{ f = 0; }

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -289,7 +289,7 @@ BroFunc::~BroFunc()
 		Unref(closure);
 	}
 
-int BroFunc::IsPure() const
+bool BroFunc::IsPure() const
 	{
 	return std::all_of(bodies.begin(), bodies.end(),
 		[](const Body& b) { return b.stmts->IsPure(); });
@@ -575,7 +575,7 @@ IntrusivePtr<Stmt> BroFunc::AddInits(IntrusivePtr<Stmt> body, id_list* inits)
 	}
 
 BuiltinFunc::BuiltinFunc(built_in_func arg_func, const char* arg_name,
-			int arg_is_pure)
+			bool arg_is_pure)
 : Func(BUILTIN_FUNC)
 	{
 	func = arg_func;
@@ -596,7 +596,7 @@ BuiltinFunc::~BuiltinFunc()
 	{
 	}
 
-int BuiltinFunc::IsPure() const
+bool BuiltinFunc::IsPure() const
 	{
 	return is_pure;
 	}

--- a/src/Func.h
+++ b/src/Func.h
@@ -39,7 +39,7 @@ public:
 
 	~Func() override;
 
-	virtual int IsPure() const = 0;
+	virtual bool IsPure() const = 0;
 	function_flavor Flavor() const	{ return FType()->Flavor(); }
 
 	struct Body {
@@ -123,7 +123,7 @@ public:
 	BroFunc(ID* id, IntrusivePtr<Stmt> body, id_list* inits, size_t frame_size, int priority);
 	~BroFunc() override;
 
-	int IsPure() const override;
+	bool IsPure() const override;
 	IntrusivePtr<Val> Call(const zeek::Args& args, Frame* parent) const override;
 
 	/**
@@ -195,10 +195,10 @@ using built_in_func = Val* (*)(Frame* frame, const zeek::Args* args);
 
 class BuiltinFunc : public Func {
 public:
-	BuiltinFunc(built_in_func func, const char* name, int is_pure);
+	BuiltinFunc(built_in_func func, const char* name, bool is_pure);
 	~BuiltinFunc() override;
 
-	int IsPure() const override;
+	bool IsPure() const override;
 	IntrusivePtr<Val> Call(const zeek::Args& args, Frame* parent) const override;
 	built_in_func TheFunc() const	{ return func; }
 
@@ -208,7 +208,7 @@ protected:
 	BuiltinFunc()	{ func = 0; is_pure = 0; }
 
 	built_in_func func;
-	int is_pure;
+	bool is_pure;
 };
 
 

--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -36,7 +36,6 @@ HashKey::HashKey(bro_int_t i)
 	key = (void*) &key_u;
 	size = sizeof(i);
 	hash = HashBytes(key, size);
-	is_our_dynamic = 0;
 	}
 
 HashKey::HashKey(bro_uint_t u)
@@ -45,7 +44,6 @@ HashKey::HashKey(bro_uint_t u)
 	key = (void*) &key_u;
 	size = sizeof(u);
 	hash = HashBytes(key, size);
-	is_our_dynamic = 0;
 	}
 
 HashKey::HashKey(uint32_t u)
@@ -54,7 +52,6 @@ HashKey::HashKey(uint32_t u)
 	key = (void*) &key_u;
 	size = sizeof(u);
 	hash = HashBytes(key, size);
-	is_our_dynamic = 0;
 	}
 
 HashKey::HashKey(const uint32_t u[], int n)
@@ -62,7 +59,6 @@ HashKey::HashKey(const uint32_t u[], int n)
 	size = n * sizeof(u[0]);
 	key = (void*) u;
 	hash = HashBytes(key, size);
-	is_our_dynamic = 0;
 	}
 
 HashKey::HashKey(double d)
@@ -76,7 +72,6 @@ HashKey::HashKey(double d)
 	key = (void*) &key_u;
 	size = sizeof(d);
 	hash = HashBytes(key, size);
-	is_our_dynamic = 0;
 	}
 
 HashKey::HashKey(const void* p)
@@ -85,7 +80,6 @@ HashKey::HashKey(const void* p)
 	key = (void*) &key_u;
 	size = sizeof(p);
 	hash = HashBytes(key, size);
-	is_our_dynamic = 0;
 	}
 
 HashKey::HashKey(const char* s)
@@ -93,7 +87,6 @@ HashKey::HashKey(const char* s)
 	size = strlen(s);	// note - skip final \0
 	key = (void*) s;
 	hash = HashBytes(key, size);
-	is_our_dynamic = 0;
 	}
 
 HashKey::HashKey(const BroString* s)
@@ -101,13 +94,12 @@ HashKey::HashKey(const BroString* s)
 	size = s->Len();
 	key = (void*) s->Bytes();
 	hash = HashBytes(key, size);
-	is_our_dynamic = 0;
 	}
 
 HashKey::HashKey(int copy_key, void* arg_key, int arg_size)
 	{
 	size = arg_size;
-	is_our_dynamic = 1;
+	is_our_dynamic = true;
 
 	if ( copy_key )
 		{
@@ -125,7 +117,7 @@ HashKey::HashKey(const void* arg_key, int arg_size, hash_t arg_hash)
 	size = arg_size;
 	hash = arg_hash;
 	key = CopyKey(arg_key, size);
-	is_our_dynamic = 1;
+	is_our_dynamic = true;
 	}
 
 HashKey::HashKey(const void* arg_key, int arg_size, hash_t arg_hash,
@@ -134,7 +126,6 @@ HashKey::HashKey(const void* arg_key, int arg_size, hash_t arg_hash,
 	size = arg_size;
 	hash = arg_hash;
 	key = const_cast<void*>(arg_key);
-	is_our_dynamic = 0;
 	}
 
 HashKey::HashKey(const void* bytes, int arg_size)
@@ -142,14 +133,14 @@ HashKey::HashKey(const void* bytes, int arg_size)
 	size = arg_size;
 	key = CopyKey(bytes, size);
 	hash = HashBytes(key, size);
-	is_our_dynamic = 1;
+	is_our_dynamic = true;
 	}
 
 void* HashKey::TakeKey()
 	{
 	if ( is_our_dynamic )
 		{
-		is_our_dynamic = 0;
+		is_our_dynamic = false;
 		return key;
 		}
 	else

--- a/src/Hash.h
+++ b/src/Hash.h
@@ -81,9 +81,9 @@ protected:
 	} key_u;
 
 	void* key;
-	int is_our_dynamic;
-	int size;
 	hash_t hash;
+	int size;
+	bool is_our_dynamic = false;
 };
 
 extern void init_hash_function();

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -125,7 +125,7 @@ void ID::SetVal(IntrusivePtr<Val> v, init_class c)
 				return;
 				}
 			else
-				v->AddTo(val, 0);
+				v->AddTo(val, false);
 			}
 		else
 			{
@@ -313,7 +313,7 @@ TraversalCode ID::Traverse(TraversalCallback* cb) const
 
 void ID::Error(const char* msg, const BroObj* o2)
 	{
-	BroObj::Error(msg, o2, 1);
+	BroObj::Error(msg, o2, true);
 	SetType(error_type());
 	}
 

--- a/src/IP.cc
+++ b/src/IP.cc
@@ -66,7 +66,7 @@ static VectorVal* BuildOptionsVal(const u_char* data, int len)
 			uint16_t off = 2 * sizeof(uint8_t);
 			rv->Assign(1, val_mgr->GetCount(opt->ip6o_len));
 			rv->Assign(2, make_intrusive<StringVal>(
-			        new BroString(data + off, opt->ip6o_len, 1)));
+			        new BroString(data + off, opt->ip6o_len, true)));
 			data += opt->ip6o_len + off;
 			len -= opt->ip6o_len + off;
 			}
@@ -132,7 +132,7 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		rv->Assign(2, val_mgr->GetCount(rt->ip6r_type));
 		rv->Assign(3, val_mgr->GetCount(rt->ip6r_segleft));
 		uint16_t off = 4 * sizeof(uint8_t);
-		rv->Assign(4, make_intrusive<StringVal>(new BroString(data + off, Length() - off, 1)));
+		rv->Assign(4, make_intrusive<StringVal>(new BroString(data + off, Length() - off, true)));
 		}
 		break;
 
@@ -163,7 +163,7 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 			// Payload Len was non-zero for this header.
 			rv->Assign(4, val_mgr->GetCount(ntohl(((uint32_t*)data)[2])));
 			uint16_t off = 3 * sizeof(uint32_t);
-			rv->Assign(5, make_intrusive<StringVal>(new BroString(data + off, Length() - off, 1)));
+			rv->Assign(5, make_intrusive<StringVal>(new BroString(data + off, Length() - off, true)));
 			}
 		}
 		break;

--- a/src/List.h
+++ b/src/List.h
@@ -136,6 +136,7 @@ public:
 		}
 
 	bool empty() const noexcept { return num_entries == 0; }
+	size_t size() const noexcept { return num_entries; }
 
 	int length() const	{ return num_entries; }
 	int max() const		{ return max_entries; }

--- a/src/Obj.cc
+++ b/src/Obj.cc
@@ -58,7 +58,7 @@ BroObj::~BroObj()
 	delete location;
 	}
 
-void BroObj::Warn(const char* msg, const BroObj* obj2, int pinpoint_only, const Location* expr_location) const
+void BroObj::Warn(const char* msg, const BroObj* obj2, bool pinpoint_only, const Location* expr_location) const
 	{
 	ODesc d;
 	DoMsg(&d, msg, obj2, pinpoint_only, expr_location);
@@ -66,7 +66,7 @@ void BroObj::Warn(const char* msg, const BroObj* obj2, int pinpoint_only, const 
 	reporter->PopLocation();
 	}
 
-void BroObj::Error(const char* msg, const BroObj* obj2, int pinpoint_only, const Location* expr_location) const
+void BroObj::Error(const char* msg, const BroObj* obj2, bool pinpoint_only, const Location* expr_location) const
 	{
 	if ( suppress_errors )
 		return;
@@ -158,7 +158,7 @@ void BroObj::UpdateLocationEndInfo(const Location& end)
 	}
 
 void BroObj::DoMsg(ODesc* d, const char s1[], const BroObj* obj2,
-			int pinpoint_only, const Location* expr_location) const
+			bool pinpoint_only, const Location* expr_location) const
 	{
 	d->SetShort();
 
@@ -175,7 +175,7 @@ void BroObj::DoMsg(ODesc* d, const char s1[], const BroObj* obj2,
 	reporter->PushLocation(GetLocationInfo(), loc2);
 	}
 
-void BroObj::PinPoint(ODesc* d, const BroObj* obj2, int pinpoint_only) const
+void BroObj::PinPoint(ODesc* d, const BroObj* obj2, bool pinpoint_only) const
 	{
 	d->Add(" (");
 	Describe(d);

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -81,9 +81,9 @@ public:
 	// included in the message, though if pinpoint_only is non-zero,
 	// then obj2 is only used to pinpoint the location.
 	void Warn(const char* msg, const BroObj* obj2 = 0,
-			int pinpoint_only = 0, const Location* expr_location = 0) const;
+			bool pinpoint_only = false, const Location* expr_location = 0) const;
 	void Error(const char* msg, const BroObj* obj2 = 0,
-			int pinpoint_only = 0, const Location* expr_location = 0) const;
+			bool pinpoint_only = false, const Location* expr_location = 0) const;
 
 	// Report internal errors.
 	void BadTag(const char* msg, const char* t1 = 0,
@@ -135,9 +135,9 @@ private:
 	friend class SuppressErrors;
 
 	void DoMsg(ODesc* d, const char s1[], const BroObj* obj2 = 0,
-			int pinpoint_only = 0, const Location* expr_location = 0) const;
+			bool pinpoint_only = false, const Location* expr_location = 0) const;
 	void PinPoint(ODesc* d, const BroObj* obj2 = 0,
-			int pinpoint_only = 0) const;
+			bool pinpoint_only = false) const;
 
 	friend inline void Ref(BroObj* o);
 	friend inline void Unref(BroObj* o);

--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -754,14 +754,14 @@ BroType* BloomFilterVal::Type() const
 
 void BloomFilterVal::Add(const Val* val)
 	{
-	HashKey* key = hash->ComputeHash(val, 1);
+	HashKey* key = hash->ComputeHash(val, true);
 	bloom_filter->Add(key);
 	delete key;
 	}
 
 size_t BloomFilterVal::Count(const Val* val) const
 	{
-	HashKey* key = hash->ComputeHash(val, 1);
+	HashKey* key = hash->ComputeHash(val, true);
 	size_t cnt = bloom_filter->Count(key);
 	delete key;
 	return cnt;
@@ -924,7 +924,7 @@ BroType* CardinalityVal::Type() const
 
 void CardinalityVal::Add(const Val* val)
 	{
-	HashKey* key = hash->ComputeHash(val, 1);
+	HashKey* key = hash->ComputeHash(val, true);
 	c->AddElement(key->Hash());
 	delete key;
 	}

--- a/src/PrefixTable.cc
+++ b/src/PrefixTable.cc
@@ -16,7 +16,7 @@ prefix_t* PrefixTable::MakePrefix(const IPAddr& addr, int width)
 
 IPPrefix PrefixTable::PrefixToIPPrefix(prefix_t* prefix)
 	{
-	return IPPrefix(IPAddr(IPv6, reinterpret_cast<const uint32_t*>(&prefix->add.sin6), IPAddr::Network), prefix->bitlen, 1);
+	return IPPrefix(IPAddr(IPv6, reinterpret_cast<const uint32_t*>(&prefix->add.sin6), IPAddr::Network), prefix->bitlen, true);
 	}
 
 void* PrefixTable::Insert(const IPAddr& addr, int width, void* data)
@@ -173,7 +173,7 @@ PrefixTable::iterator PrefixTable::InitIterator()
 
 void* PrefixTable::GetNext(iterator* i)
 	{
-	while ( 1 )
+	while ( true )
 		{
 		i->Xnode = i->Xrn;
 		if ( ! i->Xnode )

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -116,10 +116,10 @@ void Specific_RE_Matcher::MakeCaseInsensitive()
 	pattern_text = s;
 	}
 
-int Specific_RE_Matcher::Compile(int lazy)
+bool Specific_RE_Matcher::Compile(bool lazy)
 	{
 	if ( ! pattern_text )
-		return 0;
+		return false;
 
 	rem = this;
 	RE_set_input(pattern_text);
@@ -132,7 +132,7 @@ int Specific_RE_Matcher::Compile(int lazy)
 		reporter->Error("error compiling pattern /%s/", pattern_text);
 		Unref(nfa);
 		nfa = 0;
-		return 0;
+		return false;
 		}
 
 	EC()->BuildECs();
@@ -140,15 +140,15 @@ int Specific_RE_Matcher::Compile(int lazy)
 
 	dfa = new DFA_Machine(nfa, EC());
 
-	Unref(nfa); 
+	Unref(nfa);
 	nfa = 0;
 
 	ecs = EC()->EquivClasses();
 
-	return 1;
+	return true;
 	}
 
-int Specific_RE_Matcher::CompileSet(const string_list& set, const int_list& idx)
+bool Specific_RE_Matcher::CompileSet(const string_list& set, const int_list& idx)
 	{
 	if ( (size_t)set.length() != idx.size() )
 		reporter->InternalError("compileset: lengths of sets differ");
@@ -173,7 +173,7 @@ int Specific_RE_Matcher::CompileSet(const string_list& set, const int_list& idx)
 				Unref(nfa);
 
 			nfa = 0;
-			return 0;
+			return false;
 			}
 
 		nfa->FinalState()->SetAccept(idx[i]);
@@ -192,7 +192,7 @@ int Specific_RE_Matcher::CompileSet(const string_list& set, const int_list& idx)
 	dfa = new DFA_Machine(nfa, EC());
 	ecs = EC()->EquivClasses();
 
-	return 1;
+	return true;
 	}
 
 string Specific_RE_Matcher::LookupDef(const string& def)
@@ -204,12 +204,12 @@ string Specific_RE_Matcher::LookupDef(const string& def)
 	return string();
 	}
 
-int Specific_RE_Matcher::MatchAll(const char* s)
+bool Specific_RE_Matcher::MatchAll(const char* s)
 	{
 	return MatchAll((const u_char*)(s), strlen(s));
 	}
 
-int Specific_RE_Matcher::MatchAll(const BroString* s)
+bool Specific_RE_Matcher::MatchAll(const BroString* s)
 	{
 	// s->Len() does not include '\0'.
 	return MatchAll(s->Bytes(), s->Len());
@@ -235,7 +235,7 @@ int Specific_RE_Matcher::LongestMatch(const BroString* s)
 	return LongestMatch(s->Bytes(), s->Len());
 	}
 
-int Specific_RE_Matcher::MatchAll(const u_char* bv, int n)
+bool Specific_RE_Matcher::MatchAll(const u_char* bv, int n)
 	{
 	if ( ! dfa )
 		// An empty pattern matches "all" iff what's being
@@ -480,7 +480,7 @@ void RE_Matcher::MakeCaseInsensitive()
 	re_exact->MakeCaseInsensitive();
 	}
 
-int RE_Matcher::Compile(int lazy)
+bool RE_Matcher::Compile(bool lazy)
 	{
 	return re_anywhere->Compile(lazy) && re_exact->Compile(lazy);
 	}

--- a/src/RE.h
+++ b/src/RE.h
@@ -54,7 +54,7 @@ public:
 
 	void SetPat(const char* pat)	{ pattern_text = copy_string(pat); }
 
-	int Compile(int lazy = 0);
+	bool Compile(bool lazy = false);
 
 	// The following is vestigial from flex's use of "{name}" definitions.
 	// It's here because at some point we may want to support such
@@ -80,14 +80,14 @@ public:
 
 	void ConvertCCLs();
 
-	int MatchAll(const char* s);
-	int MatchAll(const BroString* s);
+	bool MatchAll(const char* s);
+	bool MatchAll(const BroString* s);
 
 	// Compiles a set of regular expressions simultaniously.
 	// 'idx' contains indizes associated with the expressions.
 	// On matching, the set of indizes is returned which correspond
 	// to the matching expressions.  (idx must not contain zeros).
-	int CompileSet(const string_list& set, const int_list& idx);
+	bool CompileSet(const string_list& set, const int_list& idx);
 
 	// Returns the position in s just beyond where the first match
 	// occurs, or 0 if there is no such position in s.  Note that
@@ -119,7 +119,7 @@ protected:
 	// appending to an existing pattern_text.
 	void AddPat(const char* pat, const char* orig_fmt, const char* app_fmt);
 
-	int MatchAll(const u_char* bv, int n);
+	bool MatchAll(const u_char* bv, int n);
 	int Match(const u_char* bv, int n);
 
 	match_type mt;
@@ -186,12 +186,12 @@ public:
 	// Makes the matcher as specified to date case-insensitive.
 	void MakeCaseInsensitive();
 
-	int Compile(int lazy = 0);
+	bool Compile(bool lazy = false);
 
 	// Returns true if s exactly matches the pattern, false otherwise.
-	int MatchExactly(const char* s)
+	bool MatchExactly(const char* s)
 		{ return re_exact->MatchAll(s); }
-	int MatchExactly(const BroString* s)
+	bool MatchExactly(const BroString* s)
 		{ return re_exact->MatchAll(s); }
 
 	// Returns the position in s just beyond where the first match

--- a/src/Reassem.h
+++ b/src/Reassem.h
@@ -265,7 +265,7 @@ public:
 	void ClearBlocks();
 	void ClearOldBlocks();
 
-	int HasBlocks() const
+	bool HasBlocks() const
 		{ return ! block_list.Empty(); }
 
 	uint64_t LastReassemSeq() const	{ return last_reassem_seq; }

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -244,7 +244,7 @@ public:
 	: Timer(t + timeout, TIMER_NET_WEIRD_EXPIRE), weird_name(name)
 		{}
 
-	void Dispatch(double t, int is_expire) override
+	void Dispatch(double t, bool is_expire) override
 		{ reporter->ResetNetWeird(weird_name); }
 
 	std::string weird_name;
@@ -258,7 +258,7 @@ public:
 		: Timer(t + timeout, TIMER_FLOW_WEIRD_EXPIRE), endpoints(std::move(p))
 		{}
 
-	void Dispatch(double t, int is_expire) override
+	void Dispatch(double t, bool is_expire) override
 		{ reporter->ResetFlowWeird(endpoints.first, endpoints.second); }
 
 	IPPair endpoints;

--- a/src/RuleCondition.cc
+++ b/src/RuleCondition.cc
@@ -195,4 +195,3 @@ void RuleConditionEval::PrintDebug()
 	{
 	fprintf(stderr, "	RuleConditionEval: %s\n", id->Name());
 	}
-

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -758,8 +758,8 @@ RuleEndpointState* RuleMatcher::InitEndpoint(analyzer::Analyzer* analyzer,
 		// Evaluate all rules on this node which don't contain
 		// any patterns.
 		for ( Rule* r = hdr_test->pure_rules; r; r = r->next )
-			if ( EvalRuleConditions(r, state, 0, 0, 0) )
-				ExecRuleActions(r, state, 0, 0, 0);
+			if ( EvalRuleConditions(r, state, 0, 0, false) )
+				ExecRuleActions(r, state, 0, 0, false);
 
 		// If we're on or above the RE_level, we may have some
 		// pattern matching to do.
@@ -953,17 +953,17 @@ void RuleMatcher::Match(RuleEndpointState* state, Rule::PatternType type,
 			if ( ! state->matched_by_patterns.is_member(r) )
 				{
 				state->matched_by_patterns.push_back(r);
-				BroString* s = new BroString(data, data_len, 0);
+				BroString* s = new BroString(data, data_len, false);
 				state->matched_text.push_back(s);
 				}
 
 			DBG_LOG(DBG_RULES, "And has not already fired");
 			// Eval additional conditions.
-			if ( ! EvalRuleConditions(r, state, data, data_len, 0) )
+			if ( ! EvalRuleConditions(r, state, data, data_len, false) )
 				continue;
 
 			// Found a match.
-			ExecRuleActions(r, state, data, data_len, 0);
+			ExecRuleActions(r, state, data, data_len, false);
 			}
 		}
 	}
@@ -977,11 +977,11 @@ void RuleMatcher::FinishEndpoint(RuleEndpointState* state)
 	// although they have not matched at the beginning. So, we have
 	// to test the candidates here.
 
-	ExecPureRules(state, 1);
+	ExecPureRules(state, true);
 
 	loop_over_list(state->matched_by_patterns, i)
 		ExecRulePurely(state->matched_by_patterns[i],
-				state->matched_text[i], state, 1);
+				state->matched_text[i], state, true);
 	}
 
 void RuleMatcher::ExecPureRules(RuleEndpointState* state, bool eos)
@@ -1115,7 +1115,7 @@ void RuleMatcher::ExecRule(Rule* rule, RuleEndpointState* state, bool eos)
 
 void RuleMatcher::ClearEndpointState(RuleEndpointState* state)
 	{
-	ExecPureRules(state, 1);
+	ExecPureRules(state, true);
 
 	state->payload_size = -1;
 

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -43,7 +43,7 @@ enum NetBIOS_Service {
 
 NetSessions* sessions;
 
-void IPTunnelTimer::Dispatch(double t, int is_expire)
+void IPTunnelTimer::Dispatch(double t, bool is_expire)
 	{
 	NetSessions::IPTunnelMap::const_iterator it =
 			sessions->ip_tunnels.find(tunnel_idx);
@@ -360,7 +360,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 		const struct tcphdr* tp = (const struct tcphdr *) data;
 		id.src_port = tp->th_sport;
 		id.dst_port = tp->th_dport;
-		id.is_one_way = 0;
+		id.is_one_way = false;
 		d = &tcp_conns;
 		break;
 		}
@@ -370,7 +370,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 		const struct udphdr* up = (const struct udphdr *) data;
 		id.src_port = up->uh_sport;
 		id.dst_port = up->uh_dport;
-		id.is_one_way = 0;
+		id.is_one_way = false;
 		d = &udp_conns;
 		break;
 		}
@@ -681,7 +681,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 	int record_packet = 1;	// whether to record the packet at all
 	int record_content = 1;	// whether to record its data
 
-	int is_orig = (id.src_addr == conn->OrigAddr()) &&
+	bool is_orig = (id.src_addr == conn->OrigAddr()) &&
 			(id.src_port == conn->OrigPort());
 
 	conn->CheckFlowLabel(is_orig, ip_hdr->FlowLabel());
@@ -951,7 +951,7 @@ Connection* NetSessions::FindConnection(Val* v)
 	id.src_port = htons((unsigned short) orig_portv->Port());
 	id.dst_port = htons((unsigned short) resp_portv->Port());
 
-	id.is_one_way = 0;	// ### incorrect for ICMP connections
+	id.is_one_way = false;	// ### incorrect for ICMP connections
 
 	ConnIDKey key = BuildConnIDKey(id);
 	ConnectionMap* d;

--- a/src/Sessions.h
+++ b/src/Sessions.h
@@ -245,7 +245,7 @@ public:
 
 	~IPTunnelTimer() override {}
 
-	void Dispatch(double t, int is_expire) override;
+	void Dispatch(double t, bool is_expire) override;
 
 protected:
 	NetSessions::IPPair tunnel_idx;

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -31,14 +31,14 @@ public:
 		interval = i;
 		}
 
-	void Dispatch(double t, int is_expire);
+	void Dispatch(double t, bool is_expire) override;
 
 protected:
 	double interval;
 	ProfileLogger* logger;
 };
 
-void ProfileTimer::Dispatch(double t, int is_expire)
+void ProfileTimer::Dispatch(double t, bool is_expire)
 	{
 	logger->Log();
 

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -35,7 +35,7 @@ public:
 	bool SetLocationInfo(const Location* start, const Location* end) override;
 
 	// True if the statement has no side effects, false otherwise.
-	virtual int IsPure() const;
+	virtual bool IsPure() const;
 
 	StmtList* AsStmtList()
 		{
@@ -131,7 +131,7 @@ protected:
 
 	virtual IntrusivePtr<Val> DoExec(Frame* f, Val* v, stmt_flow_type& flow) const;
 
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	IntrusivePtr<Expr> e;
 };
@@ -150,7 +150,7 @@ public:
 
 protected:
 	IntrusivePtr<Val> DoExec(Frame* f, Val* v, stmt_flow_type& flow) const override;
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	IntrusivePtr<Stmt> s1;
 	IntrusivePtr<Stmt> s2;
@@ -195,7 +195,7 @@ public:
 
 protected:
 	IntrusivePtr<Val> DoExec(Frame* f, Val* v, stmt_flow_type& flow) const override;
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	// Initialize composite hash and case label map.
 	void Init();
@@ -227,7 +227,7 @@ class AddStmt : public ExprStmt {
 public:
 	explicit AddStmt(IntrusivePtr<Expr> e);
 
-	int IsPure() const override;
+	bool IsPure() const override;
 	IntrusivePtr<Val> Exec(Frame* f, stmt_flow_type& flow) const override;
 
 	TraversalCode Traverse(TraversalCallback* cb) const override;
@@ -237,7 +237,7 @@ class DelStmt : public ExprStmt {
 public:
 	explicit DelStmt(IntrusivePtr<Expr> e);
 
-	int IsPure() const override;
+	bool IsPure() const override;
 	IntrusivePtr<Val> Exec(Frame* f, stmt_flow_type& flow) const override;
 
 	TraversalCode Traverse(TraversalCallback* cb) const override;
@@ -261,7 +261,7 @@ public:
 	WhileStmt(IntrusivePtr<Expr> loop_condition, IntrusivePtr<Stmt> body);
 	~WhileStmt() override;
 
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	void Describe(ODesc* d) const override;
 
@@ -287,7 +287,7 @@ public:
 	const Expr* LoopExpr() const	{ return e.get(); }
 	const Stmt* LoopBody() const	{ return body.get(); }
 
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	void Describe(ODesc* d) const override;
 
@@ -308,7 +308,7 @@ public:
 	NextStmt() : Stmt(STMT_NEXT)	{ }
 
 	IntrusivePtr<Val> Exec(Frame* f, stmt_flow_type& flow) const override;
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	void Describe(ODesc* d) const override;
 
@@ -322,7 +322,7 @@ public:
 	BreakStmt() : Stmt(STMT_BREAK)	{ }
 
 	IntrusivePtr<Val> Exec(Frame* f, stmt_flow_type& flow) const override;
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	void Describe(ODesc* d) const override;
 
@@ -336,7 +336,7 @@ public:
 	FallthroughStmt() : Stmt(STMT_FALLTHROUGH)	{ }
 
 	IntrusivePtr<Val> Exec(Frame* f, stmt_flow_type& flow) const override;
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	void Describe(ODesc* d) const override;
 
@@ -369,7 +369,7 @@ public:
 	TraversalCode Traverse(TraversalCallback* cb) const override;
 
 protected:
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	stmt_list stmts;
 };
@@ -414,7 +414,7 @@ public:
 	NullStmt() : Stmt(STMT_NULL)	{ }
 
 	IntrusivePtr<Val> Exec(Frame* f, stmt_flow_type& flow) const override;
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	void Describe(ODesc* d) const override;
 
@@ -430,7 +430,7 @@ public:
 	~WhenStmt() override;
 
 	IntrusivePtr<Val> Exec(Frame* f, stmt_flow_type& flow) const override;
-	int IsPure() const override;
+	bool IsPure() const override;
 
 	const Expr* Cond() const	{ return cond.get(); }
 	const Stmt* Body() const	{ return s1.get(); }

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -139,7 +139,7 @@ void PQ_TimerMgr::Expire()
 		{
 		DBG_LOG(DBG_TM, "Dispatching timer %s (%p)",
 		        timer_type_to_string(timer->Type()), timer);
-		timer->Dispatch(t, 1);
+		timer->Dispatch(t, true);
 		--current_timers[timer->Type()];
 		delete timer;
 		}
@@ -161,7 +161,7 @@ int PQ_TimerMgr::DoAdvance(double new_t, int max_expire)
 
 		DBG_LOG(DBG_TM, "Dispatching timer %s (%p)",
 		        timer_type_to_string(timer->Type()), timer);
-		timer->Dispatch(new_t, 0);
+		timer->Dispatch(new_t, false);
 		delete timer;
 
 		timer = Top();

--- a/src/Timer.h
+++ b/src/Timer.h
@@ -57,7 +57,7 @@ public:
 	// t gives the dispatch time.  is_expire is true if the
 	// timer is being dispatched because we're expiring all
 	// pending timers.
-	virtual void Dispatch(double t, int is_expire) = 0;
+	virtual void Dispatch(double t, bool is_expire) = 0;
 
 	void Describe(ODesc* d) const;
 

--- a/src/Trigger.cc
+++ b/src/Trigger.cc
@@ -98,7 +98,7 @@ public:
 	~TriggerTimer()
 		{ Unref(trigger); }
 
-	void Dispatch(double t, int is_expire)
+	void Dispatch(double t, bool is_expire) override
 		{
 		// The network_time may still have been zero when the
 		// timer was instantiated.  In this case, it fires

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -112,9 +112,9 @@ BroType* BroType::YieldType()
 	return nullptr;
 	}
 
-int BroType::HasField(const char* /* field */) const
+bool BroType::HasField(const char* /* field */) const
 	{
-	return 0;
+	return false;
 	}
 
 BroType* BroType::FieldType(const char* /* field */) const
@@ -157,12 +157,12 @@ TypeList::~TypeList()
 		Unref(type);
 	}
 
-int TypeList::AllMatch(const BroType* t, int is_init) const
+bool TypeList::AllMatch(const BroType* t, bool is_init) const
 	{
 	for ( const auto& type : types )
 		if ( ! same_type(type, t, is_init) )
-			return 0;
-	return 1;
+			return false;
+	return true;
 	}
 
 void TypeList::Append(IntrusivePtr<BroType> t)
@@ -498,7 +498,7 @@ int FuncType::MatchesIndex(ListExpr* const index) const
 			MATCHES_INDEX_SCALAR : DOES_NOT_MATCH_INDEX;
 	}
 
-int FuncType::CheckArgs(const type_list* args, bool is_init) const
+bool FuncType::CheckArgs(const type_list* args, bool is_init) const
 	{
 	const type_list* my_args = arg_types->Types();
 
@@ -506,17 +506,17 @@ int FuncType::CheckArgs(const type_list* args, bool is_init) const
 		{
 		Warn(fmt("Wrong number of arguments for function. Expected %d, got %d.",
 			args->length(), my_args->length()));
-		return 0;
+		return false;
 		}
 
-	int success = 1;
+	bool success = true;
 
 	for ( int i = 0; i < my_args->length(); ++i )
 		if ( ! same_type((*args)[i], (*my_args)[i], is_init) )
 			{
 			Warn(fmt("Type mismatch in function argument #%d. Expected %s, got %s.",
 				i, type_name((*args)[i]->Tag()), type_name((*my_args)[i]->Tag())));
-			success = 0;
+			success = false;
 			}
 
 	return success;
@@ -640,7 +640,7 @@ RecordType::~RecordType()
 		}
 	}
 
-int RecordType::HasField(const char* field) const
+bool RecordType::HasField(const char* field) const
 	{
 	return FieldOffset(field) >= 0;
 	}
@@ -1410,40 +1410,40 @@ BroType* base_type_no_ref(TypeTag tag)
 // false otherwise.  Assumes that t1's tag is different from t2's.  Note
 // that the test is in only one direction - we don't check whether t2 is
 // initialization-compatible with t1.
-static int is_init_compat(const BroType* t1, const BroType* t2)
+static bool is_init_compat(const BroType* t1, const BroType* t2)
 	{
 	if ( t1->Tag() == TYPE_LIST )
 		{
 		if ( t2->Tag() == TYPE_RECORD )
-			return 1;
+			return true;
 		else
-			return t1->AsTypeList()->AllMatch(t2, 1);
+			return t1->AsTypeList()->AllMatch(t2, true);
 		}
 
 	if ( t1->IsSet() )
-		return same_type(t1->AsSetType()->Indices(), t2, 1);
+		return same_type(t1->AsSetType()->Indices(), t2, true);
 
-	return 0;
+	return false;
 	}
 
-int same_type(const BroType* t1, const BroType* t2, int is_init, bool match_record_field_names)
+bool same_type(const BroType* t1, const BroType* t2, bool is_init, bool match_record_field_names)
 	{
 	if ( t1 == t2 ||
 	     t1->Tag() == TYPE_ANY ||
 	     t2->Tag() == TYPE_ANY )
-		return 1;
+		return true;
 
 	t1 = flatten_type(t1);
 	t2 = flatten_type(t2);
 	if ( t1 == t2 )
-		return 1;
+		return true;
 
 	if ( t1->Tag() != t2->Tag() )
 		{
 		if ( is_init )
 			return is_init_compat(t1, t2) || is_init_compat(t2, t1);
 
-		return 0;
+		return false;
 		}
 
 	switch ( t1->Tag() ) {
@@ -1463,14 +1463,14 @@ int same_type(const BroType* t1, const BroType* t2, int is_init, bool match_reco
 	case TYPE_SUBNET:
 	case TYPE_ANY:
 	case TYPE_ERROR:
-		return 1;
+		return true;
 
 	case TYPE_ENUM:
 		// We should probably check to see whether all of the
 		// enumerations are present and in the same location.
 		// FIXME: Yes, but perhaps we should better return
 		// true per default?
-		return 1;
+		return true;
 
 	case TYPE_TABLE:
 		{
@@ -1483,7 +1483,7 @@ int same_type(const BroType* t1, const BroType* t2, int is_init, bool match_reco
 		if ( tl1 || tl2 )
 			{
 			if ( ! tl1 || ! tl2 || ! same_type(tl1, tl2, is_init, match_record_field_names) )
-				return 0;
+				return false;
 			}
 
 		const BroType* y1 = t1->YieldType();
@@ -1492,10 +1492,10 @@ int same_type(const BroType* t1, const BroType* t2, int is_init, bool match_reco
 		if ( y1 || y2 )
 			{
 			if ( ! y1 || ! y2 || ! same_type(y1, y2, is_init, match_record_field_names) )
-				return 0;
+				return false;
 			}
 
-		return 1;
+		return true;
 		}
 
 	case TYPE_FUNC:
@@ -1504,13 +1504,13 @@ int same_type(const BroType* t1, const BroType* t2, int is_init, bool match_reco
 		const FuncType* ft2 = (const FuncType*) t2;
 
 		if ( ft1->Flavor() != ft2->Flavor() )
-			return 0;
+			return false;
 
 		if ( t1->YieldType() || t2->YieldType() )
 			{
 			if ( ! t1->YieldType() || ! t2->YieldType() ||
 			     ! same_type(t1->YieldType(), t2->YieldType(), is_init, match_record_field_names) )
-				return 0;
+				return false;
 			}
 
 		return ft1->CheckArgs(ft2->ArgTypes()->Types(), is_init);
@@ -1522,7 +1522,7 @@ int same_type(const BroType* t1, const BroType* t2, int is_init, bool match_reco
 		const RecordType* rt2 = (const RecordType*) t2;
 
 		if ( rt1->NumFields() != rt2->NumFields() )
-			return 0;
+			return false;
 
 		for ( int i = 0; i < rt1->NumFields(); ++i )
 			{
@@ -1531,10 +1531,10 @@ int same_type(const BroType* t1, const BroType* t2, int is_init, bool match_reco
 
 			if ( (match_record_field_names && ! streq(td1->id, td2->id)) ||
 			     ! same_type(td1->type.get(), td2->type.get(), is_init, match_record_field_names) )
-				return 0;
+				return false;
 			}
 
-		return 1;
+		return true;
 		}
 
 	case TYPE_LIST:
@@ -1543,13 +1543,13 @@ int same_type(const BroType* t1, const BroType* t2, int is_init, bool match_reco
 		const type_list* tl2 = t2->AsTypeList()->Types();
 
 		if ( tl1->length() != tl2->length() )
-			return 0;
+			return false;
 
 		loop_over_list(*tl1, i)
 			if ( ! same_type((*tl1)[i], (*tl2)[i], is_init, match_record_field_names) )
-				return 0;
+				return false;
 
-		return 1;
+		return true;
 		}
 
 	case TYPE_VECTOR:
@@ -1560,7 +1560,7 @@ int same_type(const BroType* t1, const BroType* t2, int is_init, bool match_reco
 		{
 		const OpaqueType* ot1 = (const OpaqueType*) t1;
 		const OpaqueType* ot2 = (const OpaqueType*) t2;
-		return ot1->Name() == ot2->Name() ? 1 : 0;
+		return ot1->Name() == ot2->Name();
 		}
 
 	case TYPE_TYPE:
@@ -1569,10 +1569,10 @@ int same_type(const BroType* t1, const BroType* t2, int is_init, bool match_reco
 	case TYPE_UNION:
 		reporter->Error("union type in same_type()");
 	}
-	return 0;
+	return false;
 	}
 
-int same_attrs(const Attributes* a1, const Attributes* a2)
+bool same_attrs(const Attributes* a1, const Attributes* a2)
 	{
 	if ( ! a1 )
 		return (a2 == 0);
@@ -1583,7 +1583,7 @@ int same_attrs(const Attributes* a1, const Attributes* a2)
 	return (*a1 == *a2);
 	}
 
-int record_promotion_compatible(const RecordType* super_rec,
+bool record_promotion_compatible(const RecordType* super_rec,
 				const RecordType* sub_rec)
 	{
 	for ( int i = 0; i < sub_rec->NumFields(); ++i )
@@ -1601,17 +1601,17 @@ int record_promotion_compatible(const RecordType* super_rec,
 			continue;
 
 		if ( sub_field_type->Tag() != TYPE_RECORD )
-			return 0;
+			return false;
 
 		if ( super_field_type->Tag() != TYPE_RECORD )
-			return 0;
+			return false;
 
 		if ( ! record_promotion_compatible(super_field_type->AsRecordType(),
 		                                   sub_field_type->AsRecordType()) )
-			return 0;
+			return false;
 		}
 
-	return 1;
+	return true;
 	}
 
 const BroType* flatten_type(const BroType* t)
@@ -1630,7 +1630,7 @@ const BroType* flatten_type(const BroType* t)
 		reporter->InternalError("empty type list in flatten_type");
 
 	const BroType* ft = (*types)[0];
-	if ( types->length() == 1 || tl->AllMatch(ft, 0) )
+	if ( types->length() == 1 || tl->AllMatch(ft, false) )
 		return ft;
 
 	return t;
@@ -1641,7 +1641,7 @@ BroType* flatten_type(BroType* t)
 	return (BroType*) flatten_type((const BroType*) t);
 	}
 
-int is_assignable(BroType* t)
+bool is_assignable(BroType* t)
 	{
 	switch ( t->Tag() ) {
 	case TYPE_BOOL:
@@ -1663,23 +1663,23 @@ int is_assignable(BroType* t)
 	case TYPE_ANY:
 	case TYPE_ERROR:
 	case TYPE_LIST:
-		return 1;
+		return true;
 
 	case TYPE_VECTOR:
 	case TYPE_FILE:
 	case TYPE_OPAQUE:
 	case TYPE_TABLE:
 	case TYPE_TYPE:
-		return 1;
+		return true;
 
 	case TYPE_VOID:
-		return 0;
+		return false;
 
 	case TYPE_UNION:
 		reporter->Error("union type in is_assignable()");
 	}
 
-	return 0;
+	return false;
 	}
 
 #define CHECK_TYPE(t) \

--- a/src/Type.h
+++ b/src/Type.h
@@ -156,7 +156,7 @@ public:
 	InternalTypeTag InternalType() const	{ return internal_tag; }
 
 	// Whether it's stored in network order.
-	int IsNetworkOrder() const	{ return is_network_order; }
+	bool IsNetworkOrder() const	{ return is_network_order; }
 
 	// Type-checks the given expression list, returning
 	// MATCHES_INDEX_SCALAR = 1 if it matches this type's index
@@ -176,7 +176,7 @@ public:
 
 	// Returns true if this type is a record and contains the
 	// given field, false otherwise.
-	virtual int HasField(const char* field) const;
+	virtual bool HasField(const char* field) const;
 
 	// Returns the type of the given field, or nil if no such field.
 	virtual BroType* FieldType(const char* field) const;
@@ -357,7 +357,7 @@ public:
 	const type_list* Types() const	{ return &types; }
 	type_list* Types()		{ return &types; }
 
-	int IsPure() const		{ return pure_type != 0; }
+	bool IsPure() const		{ return pure_type != 0; }
 
 	// Returns the underlying pure type, or nil if the list
 	// is not pure or is empty.
@@ -367,7 +367,7 @@ public:
 	// True if all of the types match t, false otherwise.  If
 	// is_init is true, then the matching is done in the context
 	// of an initialization.
-	int AllMatch(const BroType* t, int is_init) const;
+	bool AllMatch(const BroType* t, bool is_init) const;
 
 	void Append(IntrusivePtr<BroType> t);
 	void AppendEvenIfNotPure(IntrusivePtr<BroType> t);
@@ -457,7 +457,7 @@ public:
 		{ yield = nullptr; flavor = arg_flav; }
 
 	int MatchesIndex(ListExpr* index) const override;
-	int CheckArgs(const type_list* args, bool is_init = false) const;
+	bool CheckArgs(const type_list* args, bool is_init = false) const;
 
 	TypeList* ArgTypes() const	{ return arg_types.get(); }
 
@@ -508,7 +508,7 @@ public:
 
 	~RecordType() override;
 
-	int HasField(const char* field) const override;
+	bool HasField(const char* field) const override;
 	BroType* FieldType(const char* field) const override;
 	BroType* FieldType(int field) const;
 	IntrusivePtr<Val> FieldDefault(int field) const;
@@ -702,14 +702,14 @@ inline IntrusivePtr<BroType> error_type()	{ return base_type(TYPE_ERROR); }
 // True if the two types are equivalent.  If is_init is true then the test is
 // done in the context of an initialization. If match_record_field_names is
 // true then for record types the field names have to match, too.
-extern int same_type(const BroType* t1, const BroType* t2, int is_init=0, bool match_record_field_names=true);
+extern bool same_type(const BroType* t1, const BroType* t2, bool is_init=false, bool match_record_field_names=true);
 
 // True if the two attribute lists are equivalent.
-extern int same_attrs(const Attributes* a1, const Attributes* a2);
+extern bool same_attrs(const Attributes* a1, const Attributes* a2);
 
 // Returns true if the record sub_rec can be promoted to the record
 // super_rec.
-extern int record_promotion_compatible(const RecordType* super_rec,
+extern bool record_promotion_compatible(const RecordType* super_rec,
 					const RecordType* sub_rec);
 
 // If the given BroType is a TypeList with just one element, returns
@@ -737,7 +737,7 @@ IntrusivePtr<BroType> init_type(Expr* init);
 bool is_atomic_type(const BroType* t);
 
 // True if the given type tag corresponds to type that can be assigned to.
-extern int is_assignable(BroType* t);
+extern bool is_assignable(BroType* t);
 
 // True if the given type tag corresponds to an integral type.
 inline bool IsIntegral(TypeTag t) { return (t == TYPE_INT || t == TYPE_COUNT || t == TYPE_COUNTER); }

--- a/src/Val.h
+++ b/src/Val.h
@@ -155,8 +155,8 @@ public:
 	Val* Ref()			{ ::Ref(this); return this; }
 	IntrusivePtr<Val> Clone();
 
-	int IsZero() const;
-	int IsOne() const;
+	bool IsZero() const;
+	bool IsOne() const;
 
 	bro_int_t InternalInt() const;
 	bro_uint_t InternalUnsigned() const;
@@ -177,10 +177,10 @@ public:
 	// Returns true if succcessful.  is_first_init is true only if
 	// this is the *first* initialization of the value, not
 	// if it's a subsequent += initialization.
-	virtual int AddTo(Val* v, int is_first_init) const;
+	virtual bool AddTo(Val* v, bool is_first_init) const;
 
 	// Remove this value from the given value (if appropriate).
-	virtual int RemoveFrom(Val* v) const;
+	virtual bool RemoveFrom(Val* v) const;
 
 	BroType* Type()			{ return type; }
 	const BroType* Type() const	{ return type; }
@@ -478,9 +478,9 @@ public:
 	string Protocol() const;
 
 	// Tests for protocol types.
-	int IsTCP() const;
-	int IsUDP() const;
-	int IsICMP() const;
+	bool IsTCP() const;
+	bool IsUDP() const;
+	bool IsICMP() const;
 
 	TransportProto PortType() const
 		{
@@ -584,7 +584,7 @@ public:
 	explicit PatternVal(RE_Matcher* re);
 	~PatternVal() override;
 
-	int AddTo(Val* v, int is_first_init) const override;
+	bool AddTo(Val* v, bool is_first_init) const override;
 
 	void SetMatcher(RE_Matcher* re);
 
@@ -679,7 +679,7 @@ public:
 	TableValTimer(TableVal* val, double t);
 	~TableValTimer() override;
 
-	void Dispatch(double t, int is_expire) override;
+	void Dispatch(double t, bool is_expire) override;
 
 	TableVal* Table()	{ return table; }
 
@@ -701,10 +701,10 @@ public:
 	// version takes a HashKey and Unref()'s it when done. If we're a
 	// set, new_val has to be nil. If we aren't a set, index may be nil
 	// in the second version.
-	int Assign(Val* index, IntrusivePtr<Val> new_val);
-	int Assign(Val* index, Val* new_val);
-	int Assign(Val* index, HashKey* k, IntrusivePtr<Val> new_val);
-	int Assign(Val* index, HashKey* k, Val* new_val);
+	bool Assign(Val* index, IntrusivePtr<Val> new_val);
+	bool Assign(Val* index, Val* new_val);
+	bool Assign(Val* index, HashKey* k, IntrusivePtr<Val> new_val);
+	bool Assign(Val* index, HashKey* k, Val* new_val);
 
 	IntrusivePtr<Val> SizeVal() const override;
 
@@ -713,10 +713,10 @@ public:
 	// Returns true if the addition typechecked, false if not.
 	// If is_first_init is true, then this is the *first* initialization
 	// (and so should be strictly adding new elements).
-	int AddTo(Val* v, int is_first_init) const override;
+	bool AddTo(Val* v, bool is_first_init) const override;
 
 	// Same but allows suppression of state operations.
-	int AddTo(Val* v, int is_first_init, bool propagate_ops) const;
+	bool AddTo(Val* v, bool is_first_init, bool propagate_ops) const;
 
 	// Remove the entire contents.
 	void RemoveAll();
@@ -724,7 +724,7 @@ public:
 	// Remove the entire contents of the table from the given value.
 	// which must also be a TableVal.
 	// Returns true if the addition typechecked, false if not.
-	int RemoveFrom(Val* v) const override;
+	bool RemoveFrom(Val* v) const override;
 
 	// Returns a new table that is the intersection of this
 	// table and the given table.  Intersection is just done
@@ -744,7 +744,7 @@ public:
 
 	// Expands any lists in the index into multiple initializations.
 	// Returns true if the initializations typecheck, false if not.
-	int ExpandAndInit(IntrusivePtr<Val> index, IntrusivePtr<Val> new_val);
+	bool ExpandAndInit(IntrusivePtr<Val> index, IntrusivePtr<Val> new_val);
 
 	// Returns the element's value if it exists in the table,
 	// nil otherwise.  Note, "index" is not const because we
@@ -836,8 +836,8 @@ protected:
 	void RebuildTable(ParseTimeTableState ptts);
 
 	void CheckExpireAttr(attr_tag at);
-	int ExpandCompoundAndInit(val_list* vl, int k, IntrusivePtr<Val> new_val);
-	int CheckAndAssign(Val* index, IntrusivePtr<Val> new_val);
+	bool ExpandCompoundAndInit(val_list* vl, int k, IntrusivePtr<Val> new_val);
+	bool CheckAndAssign(Val* index, IntrusivePtr<Val> new_val);
 
 	// Calculates default value for index.  Returns 0 if none.
 	IntrusivePtr<Val> Default(Val* index);
@@ -993,7 +993,7 @@ public:
 
 	// Add this value to the given value (if appropriate).
 	// Returns true if succcessful.
-	int AddTo(Val* v, int is_first_init) const override;
+	bool AddTo(Val* v, bool is_first_init) const override;
 
 	// Returns nil if no element was at that value.
 	// Lookup does NOT grow the vector to this size.
@@ -1035,11 +1035,11 @@ protected:
 // and returns nil, also Unref()'ing v.  If is_init is true, then
 // the checking is done in the context of an initialization.
 extern IntrusivePtr<Val> check_and_promote(IntrusivePtr<Val> v,
-                                           const BroType* t, int is_init,
+                                           const BroType* t, bool is_init,
                                            const Location* expr_location = nullptr);
 
-extern int same_val(const Val* v1, const Val* v2);
-extern int same_atomic_val(const Val* v1, const Val* v2);
+extern bool same_val(const Val* v1, const Val* v2);
+extern bool same_atomic_val(const Val* v1, const Val* v2);
 extern bool is_atomic_val(const Val* v);
 extern void describe_vals(const val_list* vals, ODesc* d, int offset=0);
 extern void describe_vals(const std::vector<IntrusivePtr<Val>>& vals,

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -31,7 +31,7 @@ static IntrusivePtr<Val> init_val(Expr* init, const BroType* t,
 
 static void make_var(ID* id, IntrusivePtr<BroType> t, init_class c,
                      IntrusivePtr<Expr> init, attr_list* attr, decl_type dt,
-                     int do_init)
+                     bool do_init)
 	{
 	if ( id->Type() )
 		{
@@ -39,7 +39,7 @@ static void make_var(ID* id, IntrusivePtr<BroType> t, init_class c,
 			{
 			BroObj* redef_obj = init ? (BroObj*) init.get() : (BroObj*) t.get();
 			if ( dt != VAR_REDEF )
-				id->Warn("redefinition requires \"redef\"", redef_obj, 1);
+				id->Warn("redefinition requires \"redef\"", redef_obj, true);
 			}
 
 		else if ( dt != VAR_REDEF || init || ! attr )
@@ -225,14 +225,14 @@ static void make_var(ID* id, IntrusivePtr<BroType> t, init_class c,
 void add_global(ID* id, IntrusivePtr<BroType> t, init_class c,
                 IntrusivePtr<Expr> init, attr_list* attr, decl_type dt)
 	{
-	make_var(id, std::move(t), c, std::move(init), attr, dt, 1);
+	make_var(id, std::move(t), c, std::move(init), attr, dt, true);
 	}
 
 IntrusivePtr<Stmt> add_local(IntrusivePtr<ID> id, IntrusivePtr<BroType> t,
                              init_class c, IntrusivePtr<Expr> init,
                              attr_list* attr, decl_type dt)
 	{
-	make_var(id.get(), std::move(t), c, init, attr, dt, 0);
+	make_var(id.get(), std::move(t), c, init, attr, dt, false);
 
 	if ( init )
 		{
@@ -264,10 +264,10 @@ extern IntrusivePtr<Expr> add_and_assign_local(IntrusivePtr<ID> id,
                                                IntrusivePtr<Expr> init,
                                                IntrusivePtr<Val> val)
 	{
-	make_var(id.get(), 0, INIT_FULL, init, 0, VAR_REGULAR, 0);
+	make_var(id.get(), nullptr, INIT_FULL, init, nullptr, VAR_REGULAR, false);
 	auto name_expr = make_intrusive<NameExpr>(std::move(id));
 	return make_intrusive<AssignExpr>(std::move(name_expr), std::move(init),
-	                                  0, std::move(val));
+	                                  false, std::move(val));
 	}
 
 void add_type(ID* id, IntrusivePtr<BroType> t, attr_list* attr)
@@ -339,7 +339,7 @@ static bool has_attr(const attr_list* al, attr_tag tag)
 	}
 
 void begin_func(ID* id, const char* module_name, function_flavor flavor,
-                int is_redef, IntrusivePtr<FuncType> t, attr_list* attrs)
+                bool is_redef, IntrusivePtr<FuncType> t, attr_list* attrs)
 	{
 	if ( flavor == FUNC_FLAVOR_EVENT )
 		{

--- a/src/Var.h
+++ b/src/Var.h
@@ -32,7 +32,7 @@ extern IntrusivePtr<Expr> add_and_assign_local(IntrusivePtr<ID> id,
 extern void add_type(ID* id, IntrusivePtr<BroType> t, attr_list* attr);
 
 extern void begin_func(ID* id, const char* module_name, function_flavor flavor,
-                       int is_redef, IntrusivePtr<FuncType> t,
+                       bool is_redef, IntrusivePtr<FuncType> t,
                        attr_list* attrs = nullptr);
 
 extern void end_func(IntrusivePtr<Stmt> body);

--- a/src/WeirdState.h
+++ b/src/WeirdState.h
@@ -6,7 +6,7 @@
 #include <unordered_map>
 
 struct WeirdState {
-	WeirdState() { count = 0; sampling_start_time = 0; }
+	WeirdState() = default;
 	uint64_t count = 0;
 	double sampling_start_time = 0;
 };

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -19,7 +19,7 @@ public:
 
 	virtual ~AnalyzerTimer();
 
-	void Dispatch(double t, int is_expire);
+	void Dispatch(double t, bool is_expire) override;
 
 protected:
 	AnalyzerTimer() : analyzer(), timer(), do_expire()	{}
@@ -48,7 +48,7 @@ AnalyzerTimer::~AnalyzerTimer()
 	Unref(analyzer->Conn());
 	}
 
-void AnalyzerTimer::Dispatch(double t, int is_expire)
+void AnalyzerTimer::Dispatch(double t, bool is_expire)
 	{
 	if ( is_expire && ! do_expire )
 		return;
@@ -725,7 +725,7 @@ void Analyzer::ProtocolViolation(const char* reason, const char* data, int len)
 	}
 
 void Analyzer::AddTimer(analyzer_timer_func timer, double t,
-			int do_expire, TimerType type)
+			bool do_expire, TimerType type)
 	{
 	Timer* analyzer_timer = new
 		AnalyzerTimer(this, timer, t, do_expire, type);
@@ -752,7 +752,7 @@ void Analyzer::CancelTimers()
 	for ( auto timer : tmp )
 		timer_mgr->Cancel(timer);
 
-	timers_canceled = 1;
+	timers_canceled = true;
 	timers.clear();
 	}
 
@@ -929,7 +929,7 @@ void TransportLayerAnalyzer::PacketContents(const u_char* data, int len)
 	{
 	if ( packet_contents && len > 0 )
 		{
-		BroString* cbs = new BroString(data, len, 1);
+		BroString* cbs = new BroString(data, len, true);
 		Val* contents = new StringVal(cbs);
 		Event(packet_contents, contents);
 		}

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -648,7 +648,7 @@ protected:
 	 *
 	 * @param type The timer's type.
 	 */
-	void AddTimer(analyzer_timer_func timer, double t, int do_expire,
+	void AddTimer(analyzer_timer_func timer, double t, bool do_expire,
 			TimerType type);
 
 	/**

--- a/src/analyzer/protocol/conn-size/functions.bif
+++ b/src/analyzer/protocol/conn-size/functions.bif
@@ -35,11 +35,11 @@ function set_current_conn_bytes_threshold%(cid: conn_id, threshold: count, is_or
 	%{
 	analyzer::Analyzer* a = GetConnsizeAnalyzer(cid);
 	if ( ! a )
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 
-	static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->SetByteAndPacketThreshold(threshold, 1, is_orig);
+	static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->SetByteAndPacketThreshold(threshold, true, is_orig);
 
-	return val_mgr->GetBool(1);
+	return val_mgr->GetTrue();
 	%}
 
 ## Sets a threshold for connection packets, overwtiting any potential old thresholds.
@@ -59,11 +59,11 @@ function set_current_conn_packets_threshold%(cid: conn_id, threshold: count, is_
 	%{
 	analyzer::Analyzer* a = GetConnsizeAnalyzer(cid);
 	if ( ! a )
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 
-	static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->SetByteAndPacketThreshold(threshold, 0, is_orig);
+	static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->SetByteAndPacketThreshold(threshold, false, is_orig);
 
-	return val_mgr->GetBool(1);
+	return val_mgr->GetTrue();
 	%}
 
 ## Sets the current duration threshold for connection, overwriting any potential old
@@ -81,11 +81,11 @@ function set_current_conn_duration_threshold%(cid: conn_id, threshold: interval%
 	%{
 	analyzer::Analyzer* a = GetConnsizeAnalyzer(cid);
 	if ( ! a )
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 
 	static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->SetDurationThreshold(threshold);
 
-	return val_mgr->GetBool(1);
+	return val_mgr->GetTrue();
 	%}
 
 # Gets the current byte threshold size for a connection.
@@ -105,7 +105,7 @@ function get_current_conn_bytes_threshold%(cid: conn_id, is_orig: bool%): count
 	if ( ! a )
 		return val_mgr->GetCount(0);
 
-	return val_mgr->GetCount(static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->GetByteAndPacketThreshold(1, is_orig));
+	return val_mgr->GetCount(static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->GetByteAndPacketThreshold(true, is_orig));
 	%}
 
 ## Gets the current packet threshold size for a connection.
@@ -124,7 +124,7 @@ function get_current_conn_packets_threshold%(cid: conn_id, is_orig: bool%): coun
 	if ( ! a )
 		return val_mgr->GetCount(0);
 
-	return val_mgr->GetCount(static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->GetByteAndPacketThreshold(0, is_orig));
+	return val_mgr->GetCount(static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->GetByteAndPacketThreshold(false, is_orig));
 	%}
 
 ## Gets the current duration threshold size for a connection.

--- a/src/analyzer/protocol/dce-rpc/dce_rpc-protocol.pac
+++ b/src/analyzer/protocol/dce-rpc/dce_rpc-protocol.pac
@@ -98,7 +98,7 @@ type DCE_RPC_Bind = record {
 	max_xmit_frag  : uint16;
 	max_recv_frag  : uint16;
 	assoc_group_id : uint32;
-	context_list   : ContextList(1, DCE_RPC_BIND);
+	context_list   : ContextList(true, DCE_RPC_BIND);
 };
 
 type DCE_RPC_Bind_Ack = record {
@@ -108,7 +108,7 @@ type DCE_RPC_Bind_Ack = record {
 	sec_addr_length : uint16;
 	sec_addr        : bytestring &length=sec_addr_length;
 	pad             : padding align 4;
-	contexts        : ContextList(0, DCE_RPC_BIND_ACK);
+	contexts        : ContextList(false, DCE_RPC_BIND_ACK);
 };
 
 type DCE_RPC_Request(h: DCE_RPC_Header) = record {
@@ -136,7 +136,7 @@ type DCE_RPC_AlterContext = record {
 	max_xmit_frag  : uint16;
 	max_recv_frag  : uint16;
 	assoc_group_id : uint32;
-	context_list   : ContextList(1, DCE_RPC_ALTER_CONTEXT);
+	context_list   : ContextList(true, DCE_RPC_ALTER_CONTEXT);
 };
 
 type DCE_RPC_AlterContext_Resp = record {
@@ -146,7 +146,7 @@ type DCE_RPC_AlterContext_Resp = record {
 	sec_addr_length : uint16;
 	sec_addr        : bytestring &length=sec_addr_length;
 	pad             : padding align 4;
-	contexts        : ContextList(0, DCE_RPC_ALTER_CONTEXT_RESP);
+	contexts        : ContextList(false, DCE_RPC_ALTER_CONTEXT_RESP);
 };
 
 type DCE_RPC_Body(header: DCE_RPC_Header) = case header.PTYPE of {

--- a/src/analyzer/protocol/dnp3/DNP3.cc
+++ b/src/analyzer/protocol/dnp3/DNP3.cc
@@ -409,12 +409,12 @@ void DNP3_TCP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	try
 		{
 		if ( ! ProcessData(len, data, orig) )
-			SetSkip(1);
+			SetSkip(true);
 		}
 
 	catch ( const binpac::Exception& e )
 		{
-		SetSkip(1);
+		SetSkip(true);
 		throw;
 		}
 	}
@@ -447,13 +447,12 @@ void DNP3_UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, ui
 	try
 		{
 		if ( ! ProcessData(len, data, orig) )
-			SetSkip(1);
+			SetSkip(true);
 		}
 
 	catch ( const binpac::Exception& e )
 		{
-		SetSkip(1);
+		SetSkip(true);
 		throw;
 		}
 	}
-

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -25,14 +25,14 @@ DNS_Interpreter::DNS_Interpreter(analyzer::Analyzer* arg_analyzer)
 	first_message = true;
 	}
 
-int DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
+void DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
 	{
 	int hdr_len = sizeof(DNS_RawMsgHdr);
 
 	if ( len < hdr_len )
 		{
 		analyzer->Weird("DNS_truncated_len_lt_hdr_len");
-		return 0;
+		return;
 		}
 
 	DNS_MsgInfo msg((DNS_RawMsgHdr*) data, is_query);
@@ -62,7 +62,7 @@ int DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
 		analyzer->ProtocolViolation("DNS_Conn_count_too_large");
 		analyzer->Weird("DNS_Conn_count_too_large");
 		EndMessage(&msg);
-		return 0;
+		return;
 		}
 
 	const u_char* msg_start = data;	// needed for interpreting compression
@@ -73,14 +73,14 @@ int DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
 	if ( ! ParseQuestions(&msg, data, len, msg_start) )
 		{
 		EndMessage(&msg);
-		return 0;
+		return;
 		}
 
 	if ( ! ParseAnswers(&msg, msg.ancount, DNS_ANSWER,
 				data, len, msg_start) )
 		{
 		EndMessage(&msg);
-		return 0;
+		return;
 		}
 
 	analyzer->ProtocolConfirmation();
@@ -101,7 +101,7 @@ int DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
 		{
 		// No point doing further work parsing the message.
 		EndMessage(&msg);
-		return 1;
+		return;
 		}
 
 	msg.skip_event = skip_auth;
@@ -109,14 +109,14 @@ int DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
 				data, len, msg_start) )
 		{
 		EndMessage(&msg);
-		return 0;
+		return;
 		}
 
 	if ( skip_addl )
 		{
 		// No point doing further work parsing the message.
 		EndMessage(&msg);
-		return 1;
+		return;
 		}
 
 	msg.skip_event = skip_addl;
@@ -124,25 +124,22 @@ int DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
 				data, len, msg_start) )
 		{
 		EndMessage(&msg);
-		return 0;
+		return;
 		}
 
 	EndMessage(&msg);
-	return 1;
 	}
 
-int DNS_Interpreter::EndMessage(DNS_MsgInfo* msg)
+void DNS_Interpreter::EndMessage(DNS_MsgInfo* msg)
 	{
 	if ( dns_end )
 		analyzer->EnqueueConnEvent(dns_end,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()}
 		);
-
-	return 1;
 	}
 
-int DNS_Interpreter::ParseQuestions(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseQuestions(DNS_MsgInfo* msg,
 				const u_char*& data, int& len,
 				const u_char* msg_start)
 	{
@@ -153,7 +150,7 @@ int DNS_Interpreter::ParseQuestions(DNS_MsgInfo* msg,
 	return n == 0;
 	}
 
-int DNS_Interpreter::ParseAnswers(DNS_MsgInfo* msg, int n, DNS_AnswerType atype,
+bool DNS_Interpreter::ParseAnswers(DNS_MsgInfo* msg, int n, DNS_AnswerType atype,
 				const u_char*& data, int& len,
 				const u_char* msg_start)
 	{
@@ -165,7 +162,7 @@ int DNS_Interpreter::ParseAnswers(DNS_MsgInfo* msg, int n, DNS_AnswerType atype,
 	return n == 0;
 	}
 
-int DNS_Interpreter::ParseQuestion(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseQuestion(DNS_MsgInfo* msg,
 				const u_char*& data, int& len,
 				const u_char* msg_start)
 	{
@@ -174,12 +171,12 @@ int DNS_Interpreter::ParseQuestion(DNS_MsgInfo* msg,
 
 	u_char* name_end = ExtractName(data, len, name, name_len, msg_start);
 	if ( ! name_end )
-		return 0;
+		return false;
 
 	if ( len < int(sizeof(short)) * 2 )
 		{
 		analyzer->Weird("DNS_truncated_quest_too_short");
-		return 0;
+		return false;
 		}
 
 	EventHandlerPtr dns_event = nullptr;
@@ -198,7 +195,7 @@ int DNS_Interpreter::ParseQuestion(DNS_MsgInfo* msg,
 	if ( dns_event && ! msg->skip_event )
 		{
 		BroString* question_name =
-			new BroString(name, name_end - name, 1);
+			new BroString(name, name_end - name, true);
 		SendReplyOrRejectEvent(msg, dns_event, data, len, question_name);
 		}
 	else
@@ -208,10 +205,10 @@ int DNS_Interpreter::ParseQuestion(DNS_MsgInfo* msg,
 		(void) ExtractShort(data, len);
 		}
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseAnswer(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseAnswer(DNS_MsgInfo* msg,
 				const u_char*& data, int& len,
 				const u_char* msg_start)
 	{
@@ -221,19 +218,19 @@ int DNS_Interpreter::ParseAnswer(DNS_MsgInfo* msg,
 	u_char* name_end = ExtractName(data, len, name, name_len, msg_start);
 
 	if ( ! name_end )
-		return 0;
+		return false;
 
 	if ( len < int(sizeof(short)) * 2 )
 		{
 		analyzer->Weird("DNS_truncated_ans_too_short");
-		return 0;
+		return false;
 		}
 
 	// Note that the exact meaning of some of these fields will be
 	// re-interpreted by other, more adventurous RR types.
 
 	Unref(msg->query_name);
-	msg->query_name = new StringVal(new BroString(name, name_end - name, 1));
+	msg->query_name = new StringVal(new BroString(name, name_end - name, true));
 	msg->atype = RR_Type(ExtractShort(data, len));
 	msg->aclass = ExtractShort(data, len);
 	msg->ttl = ExtractLong(data, len);
@@ -242,10 +239,10 @@ int DNS_Interpreter::ParseAnswer(DNS_MsgInfo* msg,
 	if ( rdlength > len )
 		{
 		analyzer->Weird("DNS_truncated_RR_rdlength_lt_len");
-		return 0;
+		return false;
 		}
 
-	int status;
+	bool status;
 	switch ( msg->atype ) {
 		case TYPE_A:
 			status = ParseRR_A(msg, data, len, rdlength);
@@ -301,7 +298,7 @@ int DNS_Interpreter::ParseAnswer(DNS_MsgInfo* msg,
 				// The SRV RFC reused the value that was already being
 				// used for this.
 				// We aren't parsing this yet.
-				status = 1;
+				status = true;
 				}
 			else
 				status = ParseRR_SRV(msg, data, len, rdlength, msg_start);
@@ -348,7 +345,7 @@ int DNS_Interpreter::ParseAnswer(DNS_MsgInfo* msg,
 			analyzer->Weird("DNS_RR_unknown_type", fmt("%d", msg->atype));
 			data += rdlength;
 			len -= rdlength;
-			status = 1;
+			status = true;
 			break;
 	}
 
@@ -384,12 +381,12 @@ u_char* DNS_Interpreter::ExtractName(const u_char*& data, int& len,
 	return name;
 	}
 
-int DNS_Interpreter::ExtractLabel(const u_char*& data, int& len,
+bool DNS_Interpreter::ExtractLabel(const u_char*& data, int& len,
 				u_char*& name, int& name_len,
 				const u_char* msg_start)
 	{
 	if ( len <= 0 )
-		return 0;
+		return false;
 
 	const u_char* orig_data = data;
 	int label_len = data[0];
@@ -398,11 +395,11 @@ int DNS_Interpreter::ExtractLabel(const u_char*& data, int& len,
 	--len;
 
 	if ( len <= 0 )
-		return 0;
+		return false;
 
 	if ( label_len == 0 )
 		// Found terminating label.
-		return 0;
+		return false;
 
 	if ( (label_len & 0xc0) == 0xc0 )
 		{
@@ -424,7 +421,7 @@ int DNS_Interpreter::ExtractLabel(const u_char*& data, int& len,
 			//  sometimes compression points to compression.)
 
 			analyzer->Weird("DNS_label_forward_compress_offset");
-			return 0;
+			return false;
 			}
 
 		// Recursively resolve name.
@@ -437,7 +434,7 @@ int DNS_Interpreter::ExtractLabel(const u_char*& data, int& len,
 		name_len -= name_end - name;
 		name = name_end;
 
-		return 0;
+		return false;
 		}
 
 	if ( label_len > len )
@@ -445,7 +442,7 @@ int DNS_Interpreter::ExtractLabel(const u_char*& data, int& len,
 		analyzer->Weird("DNS_label_len_gt_pkt");
 		data += len;	// consume the rest of the packet
 		len = 0;
-		return 0;
+		return false;
 		}
 
 	if ( label_len > 63 &&
@@ -453,13 +450,13 @@ int DNS_Interpreter::ExtractLabel(const u_char*& data, int& len,
 		ntohs(analyzer->Conn()->RespPort()) != 137 )
 		{
 		analyzer->Weird("DNS_label_too_long");
-		return 0;
+		return false;
 		}
 
 	if ( label_len >= name_len )
 		{
 		analyzer->Weird("DNS_label_len_gt_name_len");
-		return 0;
+		return false;
 		}
 
 	memcpy(name, data, label_len);
@@ -471,7 +468,7 @@ int DNS_Interpreter::ExtractLabel(const u_char*& data, int& len,
 	data += label_len;
 	len -= label_len;
 
-	return 1;
+	return true;
 	}
 
 uint16_t DNS_Interpreter::ExtractShort(const u_char*& data, int& len)
@@ -512,7 +509,7 @@ uint32_t DNS_Interpreter::ExtractLong(const u_char*& data, int& len)
 	return val;
 	}
 
-int DNS_Interpreter::ParseRR_Name(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_Name(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -523,7 +520,7 @@ int DNS_Interpreter::ParseRR_Name(DNS_MsgInfo* msg,
 
 	u_char* name_end = ExtractName(data, len, name, name_len, msg_start);
 	if ( ! name_end )
-		return 0;
+		return false;
 
 	if ( data - data_start != rdlength )
 		{
@@ -556,13 +553,13 @@ int DNS_Interpreter::ParseRR_Name(DNS_MsgInfo* msg,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
-			make_intrusive<StringVal>(new BroString(name, name_end - name, 1))
+			make_intrusive<StringVal>(new BroString(name, name_end - name, true))
 		);
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_SOA(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_SOA(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -573,17 +570,17 @@ int DNS_Interpreter::ParseRR_SOA(DNS_MsgInfo* msg,
 
 	u_char* mname_end = ExtractName(data, len, mname, mname_len, msg_start);
 	if ( ! mname_end )
-		return 0;
+		return false;
 
 	u_char rname[513];
 	int rname_len = sizeof(rname) - 1;
 
 	u_char* rname_end = ExtractName(data, len, rname, rname_len, msg_start);
 	if ( ! rname_end )
-		return 0;
+		return false;
 
 	if ( len < 20 )
-		return 0;
+		return false;
 
 	uint32_t serial = ExtractLong(data, len);
 	uint32_t refresh = ExtractLong(data, len);
@@ -597,8 +594,8 @@ int DNS_Interpreter::ParseRR_SOA(DNS_MsgInfo* msg,
 	if ( dns_SOA_reply && ! msg->skip_event )
 		{
 		auto r = make_intrusive<RecordVal>(dns_soa);
-		r->Assign(0, make_intrusive<StringVal>(new BroString(mname, mname_end - mname, 1)));
-		r->Assign(1, make_intrusive<StringVal>(new BroString(rname, rname_end - rname, 1)));
+		r->Assign(0, make_intrusive<StringVal>(new BroString(mname, mname_end - mname, true)));
+		r->Assign(1, make_intrusive<StringVal>(new BroString(rname, rname_end - rname, true)));
 		r->Assign(2, val_mgr->GetCount(serial));
 		r->Assign(3, make_intrusive<IntervalVal>(double(refresh), Seconds));
 		r->Assign(4, make_intrusive<IntervalVal>(double(retry), Seconds));
@@ -613,10 +610,10 @@ int DNS_Interpreter::ParseRR_SOA(DNS_MsgInfo* msg,
 		);
 		}
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_MX(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_MX(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -629,7 +626,7 @@ int DNS_Interpreter::ParseRR_MX(DNS_MsgInfo* msg,
 
 	u_char* name_end = ExtractName(data, len, name, name_len, msg_start);
 	if ( ! name_end )
-		return 0;
+		return false;
 
 	if ( data - data_start != rdlength )
 		analyzer->Weird("DNS_RR_length_mismatch");
@@ -639,23 +636,23 @@ int DNS_Interpreter::ParseRR_MX(DNS_MsgInfo* msg,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
-			make_intrusive<StringVal>(new BroString(name, name_end - name, 1)),
+			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(preference)}
 		);
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_NBS(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_NBS(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
 	data += rdlength;
 	len -= rdlength;
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_SRV(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_SRV(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -670,7 +667,7 @@ int DNS_Interpreter::ParseRR_SRV(DNS_MsgInfo* msg,
 
 	u_char* name_end = ExtractName(data, len, name, name_len, msg_start);
 	if ( ! name_end )
-		return 0;
+		return false;
 
 	if ( data - data_start != rdlength )
 		analyzer->Weird("DNS_RR_length_mismatch");
@@ -680,16 +677,16 @@ int DNS_Interpreter::ParseRR_SRV(DNS_MsgInfo* msg,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
-			make_intrusive<StringVal>(new BroString(name, name_end - name, 1)),
+			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(priority)},
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(weight)},
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(port)}
 		);
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_EDNS(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_EDNS(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -712,7 +709,7 @@ int DNS_Interpreter::ParseRR_EDNS(DNS_MsgInfo* msg,
 		len -= rdlength;
 		}
 
-	return 1;
+	return true;
 	}
 
 void DNS_Interpreter::ExtractOctets(const u_char*& data, int& len,
@@ -722,7 +719,7 @@ void DNS_Interpreter::ExtractOctets(const u_char*& data, int& len,
 	dlen = min(len, static_cast<int>(dlen));
 
 	if ( p )
-		*p = new BroString(data, dlen, 0);
+		*p = new BroString(data, dlen, false);
 
 	data += dlen;
 	len -= dlen;
@@ -732,14 +729,14 @@ BroString* DNS_Interpreter::ExtractStream(const u_char*& data, int& len, int l)
 	{
 	l = max(l, 0);
 	int dlen = min(len, l); // Len in bytes of the algorithm use
-	auto rval = new BroString(data, dlen, 0);
+	auto rval = new BroString(data, dlen, false);
 
 	data += dlen;
 	len -= dlen;
 	return rval;
 	}
 
-int DNS_Interpreter::ParseRR_TSIG(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_TSIG(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -751,7 +748,7 @@ int DNS_Interpreter::ParseRR_TSIG(DNS_MsgInfo* msg,
 		ExtractName(data, len, alg_name, alg_name_len, msg_start);
 
 	if ( ! alg_name_end )
-		return 0;
+		return false;
 
 	uint32_t sign_time_sec = ExtractLong(data, len);
 	unsigned int sign_time_msec = ExtractShort(data, len);
@@ -766,7 +763,7 @@ int DNS_Interpreter::ParseRR_TSIG(DNS_MsgInfo* msg,
 		{
 		TSIG_DATA tsig;
 		tsig.alg_name =
-			new BroString(alg_name, alg_name_end - alg_name, 1);
+			new BroString(alg_name, alg_name_end - alg_name, true);
 		tsig.sig = request_MAC;
 		tsig.time_s = sign_time_sec;
 		tsig.time_ms = sign_time_msec;
@@ -781,10 +778,10 @@ int DNS_Interpreter::ParseRR_TSIG(DNS_MsgInfo* msg,
 		);
 		}
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_RRSIG(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_RRSIG(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -792,11 +789,11 @@ int DNS_Interpreter::ParseRR_RRSIG(DNS_MsgInfo* msg,
 		{
 		data += rdlength;
 		len -= rdlength;
-		return 1;
+		return true;
 		}
 
 	if ( len < 18 )
-		return 0;
+		return false;
 
 	unsigned int type_covered = ExtractShort(data, len);
 	// split the two bytes for algo and labels extraction
@@ -816,7 +813,7 @@ int DNS_Interpreter::ParseRR_RRSIG(DNS_MsgInfo* msg,
 
 	u_char* name_end = ExtractName(data, len, name, name_len, msg_start);
 	if ( ! name_end )
-		return 0;
+		return false;
 
 	int sig_len = rdlength - ((data - data_start) + 18);
 	DNSSEC_Algo dsa = DNSSEC_Algo(algo);
@@ -872,7 +869,7 @@ int DNS_Interpreter::ParseRR_RRSIG(DNS_MsgInfo* msg,
 		rrsig.sig_exp = sign_exp;
 		rrsig.sig_incep = sign_incp;
 		rrsig.key_tag = key_tag;
-		rrsig.signer_name = new BroString(name, name_end - name, 1);
+		rrsig.signer_name = new BroString(name, name_end - name, true);
 		rrsig.signature = sign;
 
 		analyzer->EnqueueConnEvent(dns_RRSIG,
@@ -883,10 +880,10 @@ int DNS_Interpreter::ParseRR_RRSIG(DNS_MsgInfo* msg,
 		);
 		}
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_DNSKEY(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_DNSKEY(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -894,11 +891,11 @@ int DNS_Interpreter::ParseRR_DNSKEY(DNS_MsgInfo* msg,
 		{
 		data += rdlength;
 		len -= rdlength;
-		return 1;
+		return true;
 		}
 
 	if ( len < 4 )
-		return 0;
+		return false;
 
 	auto dflags = ExtractShort(data, len);
 	// split the two bytes for protocol and algorithm extraction
@@ -978,10 +975,10 @@ int DNS_Interpreter::ParseRR_DNSKEY(DNS_MsgInfo* msg,
 		);
 		}
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_NSEC(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_NSEC(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -989,7 +986,7 @@ int DNS_Interpreter::ParseRR_NSEC(DNS_MsgInfo* msg,
 		{
 		data += rdlength;
 		len -= rdlength;
-		return 1;
+		return true;
 		}
 
 	const u_char* data_start = data;
@@ -998,7 +995,7 @@ int DNS_Interpreter::ParseRR_NSEC(DNS_MsgInfo* msg,
 
 	u_char* name_end = ExtractName(data, len, name, name_len, msg_start);
 	if ( ! name_end )
-		return 0;
+		return false;
 
 	int typebitmaps_len = rdlength - (data - data_start);
 
@@ -1026,14 +1023,14 @@ int DNS_Interpreter::ParseRR_NSEC(DNS_MsgInfo* msg,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
-			make_intrusive<StringVal>(new BroString(name, name_end - name, 1)),
+			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
 			std::move(char_strings)
 		);
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_NSEC3(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_NSEC3(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -1041,11 +1038,11 @@ int DNS_Interpreter::ParseRR_NSEC3(DNS_MsgInfo* msg,
 		{
 		data += rdlength;
 		len -= rdlength;
-		return 1;
+		return true;
 		}
 
 	if ( len < 6 )
-		return 0;
+		return false;
 
 	const u_char* data_start = data;
 	uint32_t halgo_flags = ExtractShort(data, len);
@@ -1118,10 +1115,10 @@ int DNS_Interpreter::ParseRR_NSEC3(DNS_MsgInfo* msg,
 	else
 		Unref(char_strings);
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_DS(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_DS(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -1129,11 +1126,11 @@ int DNS_Interpreter::ParseRR_DS(DNS_MsgInfo* msg,
 		{
 		data += rdlength;
 		len -= rdlength;
-		return 1;
+		return true;
 		}
 
 	if ( len < 4 )
-		return 0;
+		return false;
 
 	unsigned int ds_key_tag = ExtractShort(data, len);
 	// split the two bytes for algorithm and digest type extraction
@@ -1176,16 +1173,16 @@ int DNS_Interpreter::ParseRR_DS(DNS_MsgInfo* msg,
 		);
 		}
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_A(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_A(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength)
 	{
 	if ( rdlength != 4 )
 		{
 		analyzer->Weird("DNS_RR_bad_length");
-		return 0;
+		return false;
 		}
 
 	uint32_t addr = ExtractLong(data, len);
@@ -1198,10 +1195,10 @@ int DNS_Interpreter::ParseRR_A(DNS_MsgInfo* msg,
 			make_intrusive<AddrVal>(htonl(addr))
 		);
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_AAAA(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_AAAA(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength)
 	{
 	uint32_t addr[4];
@@ -1216,7 +1213,7 @@ int DNS_Interpreter::ParseRR_AAAA(DNS_MsgInfo* msg,
 				analyzer->Weird("DNS_AAAA_neg_length");
 			else
 				analyzer->Weird("DNS_A6_neg_length");
-			return 0;
+			return false;
 			}
 		}
 
@@ -1234,25 +1231,25 @@ int DNS_Interpreter::ParseRR_AAAA(DNS_MsgInfo* msg,
 			make_intrusive<AddrVal>(addr)
 		);
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_WKS(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_WKS(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength)
 	{
 	data += rdlength;
 	len -= rdlength;
 
-	return 1;
+	return true;
 	}
 
-int DNS_Interpreter::ParseRR_HINFO(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_HINFO(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength)
 	{
 	data += rdlength;
 	len -= rdlength;
 
-	return 1;
+	return true;
 	}
 
 static StringVal* extract_char_string(analyzer::Analyzer* analyzer,
@@ -1283,7 +1280,7 @@ static StringVal* extract_char_string(analyzer::Analyzer* analyzer,
 	return rval;
 	}
 
-int DNS_Interpreter::ParseRR_TXT(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_TXT(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -1291,7 +1288,7 @@ int DNS_Interpreter::ParseRR_TXT(DNS_MsgInfo* msg,
 		{
 		data += rdlength;
 		len -= rdlength;
-		return 1;
+		return true;
 		}
 
 	auto char_strings = make_intrusive<VectorVal>(string_vec);
@@ -1311,7 +1308,7 @@ int DNS_Interpreter::ParseRR_TXT(DNS_MsgInfo* msg,
 	return rdlength == 0;
 	}
 
-int DNS_Interpreter::ParseRR_SPF(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_SPF(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -1319,7 +1316,7 @@ int DNS_Interpreter::ParseRR_SPF(DNS_MsgInfo* msg,
 		{
 		data += rdlength;
 		len -= rdlength;
-		return 1;
+		return true;
 		}
 
 	auto char_strings = make_intrusive<VectorVal>(string_vec);
@@ -1339,7 +1336,7 @@ int DNS_Interpreter::ParseRR_SPF(DNS_MsgInfo* msg,
 	return rdlength == 0;
 	}
 
-int DNS_Interpreter::ParseRR_CAA(DNS_MsgInfo* msg,
+bool DNS_Interpreter::ParseRR_CAA(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start)
 	{
@@ -1347,7 +1344,7 @@ int DNS_Interpreter::ParseRR_CAA(DNS_MsgInfo* msg,
 		{
 		data += rdlength;
 		len -= rdlength;
-		return 1;
+		return true;
 		}
 
 	unsigned int flags = ExtractShort(data, len);
@@ -1357,13 +1354,13 @@ int DNS_Interpreter::ParseRR_CAA(DNS_MsgInfo* msg,
 	if ( (int) tagLen >= rdlength )
 		{
 		analyzer->Weird("DNS_CAA_char_str_past_rdlen");
-		return 0;
+		return false;
 		}
-	BroString* tag = new BroString(data, tagLen, 1);
+	BroString* tag = new BroString(data, tagLen, true);
 	len -= tagLen;
 	data += tagLen;
 	rdlength -= tagLen;
-	BroString* value = new BroString(data, rdlength, 0);
+	BroString* value = new BroString(data, rdlength, false);
 
 	len -= value->Len();
 	data += value->Len();
@@ -1703,7 +1700,6 @@ DNS_Analyzer::DNS_Analyzer(Connection* conn)
 	{
 	interp = new DNS_Interpreter(this);
 	contents_dns_orig = contents_dns_resp = 0;
-	did_session_done = 0;
 
 	if ( Conn()->ConnTransport() == TRANSPORT_TCP )
 		{
@@ -1715,7 +1711,7 @@ DNS_Analyzer::DNS_Analyzer(Connection* conn)
 	else
 		{
 		ADD_ANALYZER_TIMER(&DNS_Analyzer::ExpireTimer,
-					network_time + dns_session_timeout, 1,
+					network_time + dns_session_timeout, true,
 					TIMER_DNS_EXPIRE);
 		}
 	}
@@ -1733,7 +1729,7 @@ void DNS_Analyzer::Done()
 	{
 	tcp::TCP_ApplicationAnalyzer::Done();
 
-	if ( Conn()->ConnTransport() == TRANSPORT_UDP && ! did_session_done )
+	if ( Conn()->ConnTransport() == TRANSPORT_UDP )
 		Event(udp_session_done);
 	else
 		interp->Timeout();
@@ -1743,12 +1739,12 @@ void DNS_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 					uint64_t seq, const IP_Hdr* ip, int caplen)
 	{
 	tcp::TCP_ApplicationAnalyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
-	interp->ParseMessage(data, len, orig);
+	interp->ParseMessage(data, len, orig ? 1 : 0);
 	}
 
 
 void DNS_Analyzer::ConnectionClosed(tcp::TCP_Endpoint* endpoint, tcp::TCP_Endpoint* peer,
-					int gen_event)
+					bool gen_event)
 	{
 	tcp::TCP_ApplicationAnalyzer::ConnectionClosed(endpoint, peer, gen_event);
 
@@ -1769,5 +1765,5 @@ void DNS_Analyzer::ExpireTimer(double t)
 		}
 	else
 		ADD_ANALYZER_TIMER(&DNS_Analyzer::ExpireTimer,
-				t + dns_session_timeout, 1, TIMER_DNS_EXPIRE);
+				t + dns_session_timeout, true, TIMER_DNS_EXPIRE);
 	}

--- a/src/analyzer/protocol/dns/DNS.h
+++ b/src/analyzer/protocol/dns/DNS.h
@@ -222,29 +222,29 @@ class DNS_Interpreter {
 public:
 	explicit DNS_Interpreter(analyzer::Analyzer* analyzer);
 
-	int ParseMessage(const u_char* data, int len, int is_query);
+	void ParseMessage(const u_char* data, int len, int is_query);
 
 	void Timeout()	{ }
 
 protected:
-	int EndMessage(DNS_MsgInfo* msg);
+	void EndMessage(DNS_MsgInfo* msg);
 
-	int ParseQuestions(DNS_MsgInfo* msg,
+	bool ParseQuestions(DNS_MsgInfo* msg,
 				const u_char*& data, int& len,
 				const u_char* start);
-	int ParseAnswers(DNS_MsgInfo* msg, int n, DNS_AnswerType answer_type,
+	bool ParseAnswers(DNS_MsgInfo* msg, int n, DNS_AnswerType answer_type,
 				const u_char*& data, int& len,
 				const u_char* start);
 
-	int ParseQuestion(DNS_MsgInfo* msg,
+	bool ParseQuestion(DNS_MsgInfo* msg,
 			const u_char*& data, int& len, const u_char* start);
-	int ParseAnswer(DNS_MsgInfo* msg,
+	bool ParseAnswer(DNS_MsgInfo* msg,
 			const u_char*& data, int& len, const u_char* start);
 
 	u_char* ExtractName(const u_char*& data, int& len,
 				u_char* label, int label_len,
 				const u_char* msg_start);
-	int ExtractLabel(const u_char*& data, int& len,
+	bool ExtractLabel(const u_char*& data, int& len,
 			 u_char*& label, int& label_len,
 			 const u_char* msg_start);
 
@@ -254,57 +254,57 @@ protected:
 
 	BroString* ExtractStream(const u_char*& data, int& len, int sig_len);
 
-	int ParseRR_Name(DNS_MsgInfo* msg,
+	bool ParseRR_Name(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_SOA(DNS_MsgInfo* msg,
+	bool ParseRR_SOA(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_MX(DNS_MsgInfo* msg,
+	bool ParseRR_MX(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_NBS(DNS_MsgInfo* msg,
+	bool ParseRR_NBS(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_SRV(DNS_MsgInfo* msg,
+	bool ParseRR_SRV(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_EDNS(DNS_MsgInfo* msg,
+	bool ParseRR_EDNS(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_A(DNS_MsgInfo* msg,
+	bool ParseRR_A(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength);
-	int ParseRR_AAAA(DNS_MsgInfo* msg,
+	bool ParseRR_AAAA(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength);
-	int ParseRR_WKS(DNS_MsgInfo* msg,
+	bool ParseRR_WKS(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength);
-	int ParseRR_HINFO(DNS_MsgInfo* msg,
+	bool ParseRR_HINFO(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength);
-	int ParseRR_TXT(DNS_MsgInfo* msg,
+	bool ParseRR_TXT(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_SPF(DNS_MsgInfo* msg,
+	bool ParseRR_SPF(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_CAA(DNS_MsgInfo* msg,
+	bool ParseRR_CAA(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_TSIG(DNS_MsgInfo* msg,
+	bool ParseRR_TSIG(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_RRSIG(DNS_MsgInfo* msg,
+	bool ParseRR_RRSIG(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_DNSKEY(DNS_MsgInfo* msg,
+	bool ParseRR_DNSKEY(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_NSEC(DNS_MsgInfo* msg,
+	bool ParseRR_NSEC(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_NSEC3(DNS_MsgInfo* msg,
+	bool ParseRR_NSEC3(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
-	int ParseRR_DS(DNS_MsgInfo* msg,
+	bool ParseRR_DS(DNS_MsgInfo* msg,
 				const u_char*& data, int& len, int rdlength,
 				const u_char* msg_start);
 	void SendReplyOrRejectEvent(DNS_MsgInfo* msg, EventHandlerPtr event,
@@ -357,7 +357,7 @@ public:
 	void Init() override;
 	void Done() override;
 	void ConnectionClosed(tcp::TCP_Endpoint* endpoint,
-					tcp::TCP_Endpoint* peer, int gen_event) override;
+					tcp::TCP_Endpoint* peer, bool gen_event) override;
 	void ExpireTimer(double t);
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
@@ -367,10 +367,6 @@ protected:
 	DNS_Interpreter* interp;
 	Contents_DNS* contents_dns_orig;
 	Contents_DNS* contents_dns_resp;
-	int did_session_done;
 };
 
-// FIXME: Doesn't really fit into new analyzer structure. What to do?
-int IsReuse(double t, const u_char* pkt);
-
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/finger/Finger.cc
+++ b/src/analyzer/protocol/finger/Finger.cc
@@ -75,7 +75,7 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 			);
 
 		Conn()->Match(Rule::FINGER, (const u_char *) line,
-			  end_of_line - line, true, true, 1, true);
+			  end_of_line - line, true, true, true, true);
 
 		did_deliver = 1;
 		}

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -111,7 +111,7 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 
 		if ( rule_matcher )
 			Conn()->Match(Rule::FTP, (const u_char *) cmd,
-				end_of_line - cmd, true, true, 1, true);
+				end_of_line - cmd, true, true, true, true);
 		}
 	else
 		{

--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -41,7 +41,7 @@ static Val* parse_port(const char* line)
 		{
 		r->Assign(0, make_intrusive<AddrVal>(uint32_t(0)));
 		r->Assign(1, val_mgr->GetPort(0, TRANSPORT_TCP));
-		r->Assign(2, val_mgr->GetBool(0));
+		r->Assign(2, val_mgr->GetFalse());
 		}
 
 	return r;
@@ -218,4 +218,3 @@ function fmt_ftp_port%(a: addr, p: port%): string
 		return val_mgr->GetEmptyString();
 		}
 	%}
-

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -85,13 +85,13 @@ void Gnutella_Analyzer::Done()
 	}
 
 
-int Gnutella_Analyzer::NextLine(const u_char* data, int len)
+bool Gnutella_Analyzer::NextLine(const u_char* data, int len)
 	{
 	if ( ! ms )
-		return 0;
+		return false;
 
 	if ( Established() || ms->current_offset >= len )
-		return 0;
+		return false;
 
 	for ( ; ms->current_offset < len; ++ms->current_offset )
 		{
@@ -102,20 +102,20 @@ int Gnutella_Analyzer::NextLine(const u_char* data, int len)
 			{
 			ms->got_CR = 0;
 			++ms->current_offset;
-			return 1;
+			return true;
 			}
 		else
 			ms->buffer += data[ms->current_offset];
 		}
 
-	return 0;
+	return false;
 	}
 
 
-int Gnutella_Analyzer::IsHTTP(string header)
+bool Gnutella_Analyzer::IsHTTP(string header)
 	{
 	if ( header.find(" HTTP/1.") == string::npos )
-		return 0;
+		return false;
 
 	if ( gnutella_http_notify )
 		EnqueueConnEvent(gnutella_http_notify, IntrusivePtr{AdoptRef{}, BuildConnVal()});
@@ -135,20 +135,20 @@ int Gnutella_Analyzer::IsHTTP(string header)
 		Parent()->RemoveChildAnalyzer(this);
 		}
 
-	return 1;
+	return true;
 	}
 
 
-int Gnutella_Analyzer::GnutellaOK(string header)
+bool Gnutella_Analyzer::GnutellaOK(string header)
 	{
 	if ( strncmp("GNUTELLA", header.data(), 8) )
-		return 0;
+		return false;
 
 	int codepos = header.find(' ') + 1;
 	if ( ! strncmp("200", header.data() + codepos, 3) )
-		return 1;
+		return true;
 
-	return 0;
+	return false;
 	}
 
 
@@ -320,4 +320,3 @@ void Gnutella_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	else if ( gnutella_binary_msg )
 		DeliverMessages(len, data, orig);
 	}
-

--- a/src/analyzer/protocol/gnutella/Gnutella.h
+++ b/src/analyzer/protocol/gnutella/Gnutella.h
@@ -45,12 +45,12 @@ public:
 		{ return new Gnutella_Analyzer(conn); }
 
 private:
-	int NextLine(const u_char* data, int len);
+	bool NextLine(const u_char* data, int len);
 
-	int GnutellaOK(string header);
-	int IsHTTP(string header);
+	bool GnutellaOK(string header);
+	bool IsHTTP(string header);
 
-	int Established() const	{ return state == (ORIG_OK | RESP_OK); }
+	bool Established() const	{ return state == (ORIG_OK | RESP_OK); }
 
 	void DeliverLines(int len, const u_char* data, bool orig);
 
@@ -68,4 +68,4 @@ private:
 	GnutellaMsgState* ms;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/gtpv1/gtpv1-analyzer.pac
+++ b/src/analyzer/protocol/gtpv1/gtpv1-analyzer.pac
@@ -106,7 +106,7 @@ Val* BuildEndUserAddr(const InformationElement* ie)
 			break;
 		default:
 			ev->Assign(3, make_intrusive<StringVal>(
-			  new BroString((const u_char*) d, len, 0)));
+			  new BroString((const u_char*) d, len, false)));
 			break;
 		}
 		}
@@ -117,7 +117,7 @@ Val* BuildEndUserAddr(const InformationElement* ie)
 Val* BuildAccessPointName(const InformationElement* ie)
 	{
 	BroString* bs = new BroString((const u_char*) ie->ap_name()->value().data(),
-	                              ie->ap_name()->value().length(), 0);
+	                              ie->ap_name()->value().length(), false);
 	return new StringVal(bs);
 	}
 
@@ -125,7 +125,7 @@ Val* BuildProtoConfigOptions(const InformationElement* ie)
 	{
 	const u_char* d = (const u_char*) ie->proto_config_opts()->value().data();
 	int len = ie->proto_config_opts()->value().length();
-	return new StringVal(new BroString(d, len, 0));
+	return new StringVal(new BroString(d, len, false));
 	}
 
 Val* BuildGSN_Addr(const InformationElement* ie)
@@ -142,7 +142,7 @@ Val* BuildGSN_Addr(const InformationElement* ie)
 		ev->Assign(0, make_intrusive<AddrVal>(
 		  IPAddr(IPv6, (const uint32*) d, IPAddr::Network)));
 	else
-		ev->Assign(1, make_intrusive<StringVal>(new BroString((const u_char*) d, len, 0)));
+		ev->Assign(1, make_intrusive<StringVal>(new BroString((const u_char*) d, len, false)));
 
 	return ev;
 	}
@@ -151,7 +151,7 @@ Val* BuildMSISDN(const InformationElement* ie)
 	{
 	const u_char* d = (const u_char*) ie->msisdn()->value().data();
 	int len = ie->msisdn()->value().length();
-	return new StringVal(new BroString(d, len, 0));
+	return new StringVal(new BroString(d, len, false));
 	}
 
 Val* BuildQoS_Profile(const InformationElement* ie)
@@ -162,7 +162,7 @@ Val* BuildQoS_Profile(const InformationElement* ie)
 	int len = ie->qos_profile()->data().length();
 
 	ev->Assign(0, val_mgr->GetCount(ie->qos_profile()->alloc_retention_priority()));
-	ev->Assign(1, make_intrusive<StringVal>(new BroString(d, len, 0)));
+	ev->Assign(1, make_intrusive<StringVal>(new BroString(d, len, false)));
 
 	return ev;
 	}
@@ -171,21 +171,21 @@ Val* BuildTrafficFlowTemplate(const InformationElement* ie)
 	{
 	const uint8* d = ie->traffic_flow_template()->value().data();
 	int len = ie->traffic_flow_template()->value().length();
-	return new StringVal(new BroString((const u_char*) d, len, 0));
+	return new StringVal(new BroString((const u_char*) d, len, false));
 	}
 
 Val* BuildTriggerID(const InformationElement* ie)
 	{
 	const uint8* d = ie->trigger_id()->value().data();
 	int len = ie->trigger_id()->value().length();
-	return new StringVal(new BroString((const u_char*) d, len, 0));
+	return new StringVal(new BroString((const u_char*) d, len, false));
 	}
 
 Val* BuildOMC_ID(const InformationElement* ie)
 	{
 	const uint8* d = ie->omc_id()->value().data();
 	int len = ie->omc_id()->value().length();
-	return new StringVal(new BroString((const u_char*) d, len, 0));
+	return new StringVal(new BroString((const u_char*) d, len, false));
 	}
 
 Val* BuildPrivateExt(const InformationElement* ie)
@@ -196,7 +196,7 @@ Val* BuildPrivateExt(const InformationElement* ie)
 	int len = ie->private_ext()->value().length();
 
 	ev->Assign(0, val_mgr->GetCount(ie->private_ext()->id()));
-	ev->Assign(1, make_intrusive<StringVal>(new BroString((const u_char*) d, len, 0)));
+	ev->Assign(1, make_intrusive<StringVal>(new BroString((const u_char*) d, len, false)));
 
 	return ev;
 	}
@@ -771,4 +771,3 @@ flow GTPv1_Flow(is_orig: bool)
 	};
 
 refine typeattr GTPv1_Header += &let { proc_gtpv1 = $context.flow.process_gtpv1(this); };
-

--- a/src/analyzer/protocol/http/HTTP.h
+++ b/src/analyzer/protocol/http/HTTP.h
@@ -38,8 +38,8 @@ public:
 		}
 
 	void EndOfData() override;
-	void Deliver(int len, const char* data, int trailing_CRLF) override;
-	int Undelivered(int64_t len);
+	void Deliver(int len, const char* data, bool trailing_CRLF) override;
+	bool Undelivered(int64_t len);
 	int64_t BodyLength() const 		{ return body_length; }
 	int64_t HeaderLength() const 	{ return header_length; }
 	void SkipBody() 		{ deliver_body = 0; }
@@ -57,9 +57,9 @@ protected:
 	int expect_body;
 	int64_t body_length;
 	int64_t header_length;
-	int deliver_body;
 	enum { IDENTITY, GZIP, COMPRESS, DEFLATE } encoding;
 	zip::ZIP_Analyzer* zip;
+	bool deliver_body;
 	bool is_partial_content;
 	uint64_t offset;
 	int64_t instance_length; // total length indicated by content-range
@@ -68,8 +68,8 @@ protected:
 
 	MIME_Entity* NewChildEntity() override { return new HTTP_Entity(http_message, this, 1); }
 
-	void DeliverBody(int len, const char* data, int trailing_CRLF);
-	void DeliverBodyClear(int len, const char* data, int trailing_CRLF);
+	void DeliverBody(int len, const char* data, bool trailing_CRLF);
+	void DeliverBodyClear(int len, const char* data, bool trailing_CRLF);
 
 	void SubmitData(int len, const char* buf) override;
 
@@ -103,17 +103,17 @@ public:
 	HTTP_Message(HTTP_Analyzer* analyzer, tcp::ContentLine_Analyzer* cl,
 			 bool is_orig, int expect_body, int64_t init_header_length);
 	~HTTP_Message() override;
-	void Done(const int interrupted, const char* msg);
-	void Done() override { Done(0, "message ends normally"); }
+	void Done(bool interrupted, const char* msg);
+	void Done() override { Done(false, "message ends normally"); }
 
-	int Undelivered(int64_t len);
+	bool Undelivered(int64_t len);
 
 	void BeginEntity(mime::MIME_Entity* /* entity */) override;
 	void EndEntity(mime::MIME_Entity* entity) override;
 	void SubmitHeader(mime::MIME_Header* h) override;
 	void SubmitAllHeaders(mime::MIME_HeaderList& /* hlist */) override;
 	void SubmitData(int len, const char* buf) override;
-	int RequestBuffer(int* plen, char** pbuf) override;
+	bool RequestBuffer(int* plen, char** pbuf) override;
 	void SubmitAllData();
 	void SubmitEvent(int event_type, const char* detail) override;
 
@@ -145,7 +145,7 @@ protected:
 
 	HTTP_Entity* current_entity;
 
-	Val* BuildMessageStat(const int interrupted, const char* msg);
+	Val* BuildMessageStat(bool interrupted, const char* msg);
 };
 
 class HTTP_Analyzer : public tcp::TCP_ApplicationAnalyzer {
@@ -153,15 +153,15 @@ public:
 	HTTP_Analyzer(Connection* conn);
 	~HTTP_Analyzer() override;
 
-	void HTTP_Header(int is_orig, mime::MIME_Header* h);
-	void HTTP_EntityData(int is_orig, BroString* entity_data);
-	void HTTP_MessageDone(int is_orig, HTTP_Message* message);
+	void HTTP_Header(bool is_orig, mime::MIME_Header* h);
+	void HTTP_EntityData(bool is_orig, BroString* entity_data);
+	void HTTP_MessageDone(bool is_orig, HTTP_Message* message);
 	void HTTP_Event(const char* category, const char* detail);
 	void HTTP_Event(const char* category, StringVal *detail);
 
-	void SkipEntityData(int is_orig);
+	void SkipEntityData(bool is_orig);
 
-	int IsConnectionClose()		{ return connection_close; }
+	bool IsConnectionClose()		{ return connection_close; }
 	int HTTP_ReplyCode() const { return reply_code; };
 
 	// Overriden from Analyzer.
@@ -171,7 +171,7 @@ public:
 
 	// Overriden from tcp::TCP_ApplicationAnalyzer
 	void EndpointEOF(bool is_orig) override;
-	void ConnectionFinished(int half_finished) override;
+	void ConnectionFinished(bool half_finished) override;
 	void ConnectionReset() override;
 	void PacketWithRST() override;
 
@@ -219,18 +219,18 @@ protected:
 	const char* PrefixWordMatch(const char* line, const char* end_of_line,
 				const char* prefix);
 
-	int ParseRequest(const char* line, const char* end_of_line);
+	bool ParseRequest(const char* line, const char* end_of_line);
 	HTTP_VersionNumber HTTP_Version(int len, const char* data);
 
 	void SetVersion(HTTP_VersionNumber* version, HTTP_VersionNumber new_version);
 
-	int RequestExpected() const { return num_requests == 0 || keep_alive; }
+	bool RequestExpected() const { return num_requests == 0 || keep_alive; }
 
 	void HTTP_Request();
 	void HTTP_Reply();
 
-	void RequestMade(const int interrupted, const char* msg);
-	void ReplyMade(const int interrupted, const char* msg);
+	void RequestMade(bool interrupted, const char* msg);
+	void ReplyMade(bool interrupted, const char* msg);
 	void RequestClash(Val* clash_val);
 
 	const BroString* UnansweredRequestMethod();
@@ -279,10 +279,10 @@ protected:
 	HTTP_Message* reply_message;
 };
 
-extern int is_reserved_URI_char(unsigned char ch);
-extern int is_unreserved_URI_char(unsigned char ch);
+extern bool is_reserved_URI_char(unsigned char ch);
+extern bool is_unreserved_URI_char(unsigned char ch);
 extern void escape_URI_char(unsigned char ch, unsigned char*& p);
 extern BroString* unescape_URI(const u_char* line, const u_char* line_end,
 				analyzer::Analyzer* analyzer);
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/icmp/ICMP.h
+++ b/src/analyzer/protocol/icmp/ICMP.h
@@ -84,7 +84,7 @@ protected:
 	RuleMatcherState matcher_state;
 
 private:
-	void UpdateEndpointVal(RecordVal* endp, int is_orig);
+	void UpdateEndpointVal(RecordVal* endp, bool is_orig);
 };
 
 // Returns the counterpart type to the given type (e.g., the counterpart
@@ -92,4 +92,4 @@ private:
 extern int ICMP4_counterpart(int icmp_type, int icmp_code, bool& is_one_way);
 extern int ICMP6_counterpart(int icmp_type, int icmp_code, bool& is_one_way);
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -174,7 +174,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 
 			BroString* sys_type_s =
 				new BroString((const u_char*) sys_type,
-						sys_end - sys_type + 1, 1);
+						sys_end - sys_type + 1, true);
 
 			line = skip_whitespace(colon + 1, end_of_line);
 

--- a/src/analyzer/protocol/login/Login.h
+++ b/src/analyzer/protocol/login/Login.h
@@ -38,28 +38,28 @@ protected:
 	void NewLine(bool orig, char* line);
 	void AuthenticationDialog(bool orig, char* line);
 
-	void LoginEvent(EventHandlerPtr f, const char* line, int no_user_okay=0);
+	void LoginEvent(EventHandlerPtr f, const char* line, bool no_user_okay=false);
 	const char* GetUsername(const char* line) const;
 	void LineEvent(EventHandlerPtr f, const char* line);
 	void Confused(const char* msg, const char* addl);
 	void ConfusionText(const char* line);
 
-	int IsPloy(const char* line);
-	int IsSkipAuthentication(const char* line) const;
+	bool IsPloy(const char* line);
+	bool IsSkipAuthentication(const char* line) const;
 	const char* IsLoginPrompt(const char* line) const;	// nil if not
-	int IsDirectLoginPrompt(const char* line) const;
-	int IsFailureMsg(const char* line) const;
-	int IsSuccessMsg(const char* line) const;
-	int IsTimeout(const char* line) const;
-	int IsEmpty(const char* line) const;
+	bool IsDirectLoginPrompt(const char* line) const;
+	bool IsFailureMsg(const char* line) const;
+	bool IsSuccessMsg(const char* line) const;
+	bool IsTimeout(const char* line) const;
+	bool IsEmpty(const char* line) const;
 
 	void AddUserText(const char* line);	// complains on overflow
 	char* PeekUserText();	// internal warning on underflow
 	char* PopUserText();		// internal warning on underflow
 	Val* PopUserTextVal();
 
-	int MatchesTypeahead(const char* line) const;
-	int HaveTypeahead() const	{ return num_user_text > 0; }
+	bool MatchesTypeahead(const char* line) const;
+	bool HaveTypeahead() const	{ return num_user_text > 0; }
 	void FlushEmptyTypeahead();
 
 // If we have more user text than this unprocessed, we complain about
@@ -79,8 +79,8 @@ protected:
 	int login_prompt_line;
 	int failure_line;
 
-	int is_VMS;
-	int saw_ploy;
+	bool is_VMS;
+	bool saw_ploy;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/login/NVT.h
+++ b/src/analyzer/protocol/login/NVT.h
@@ -28,12 +28,12 @@ public:
 
 	unsigned int Code() const	{ return code; }
 
-	int IsActive() const		{ return active; }
+	bool IsActive() const		{ return active; }
 
-	int SaidWill() const	{ return flags & OPT_SAID_WILL; }
-	int SaidWont() const	{ return flags & OPT_SAID_WONT; }
-	int SaidDo() const	{ return flags & OPT_SAID_DO; }
-	int SaidDont() const	{ return flags & OPT_SAID_DONT; }
+	bool SaidWill() const	{ return flags & OPT_SAID_WILL; }
+	bool SaidWont() const	{ return flags & OPT_SAID_WONT; }
+	bool SaidDo() const	{ return flags & OPT_SAID_DO; }
+	bool SaidDont() const	{ return flags & OPT_SAID_DONT; }
 
 	void SetWill()	{ flags |= OPT_SAID_WILL; }
 	void SetWont()	{ flags |= OPT_SAID_WONT; }
@@ -43,7 +43,7 @@ public:
 	void RecvOption(unsigned int type);
 	virtual void RecvSubOption(u_char* data, int len);
 
-	virtual void SetActive(int is_active);
+	virtual void SetActive(bool is_active);
 
 	const NVT_Analyzer* Endpoint() const	{ return endp; }
 
@@ -116,7 +116,7 @@ public:
 		: TelnetOption(arg_endp, TELNET_OPTION_BINARY)
 			{ }
 
-	void SetActive(int is_active) override;
+	void SetActive(bool is_active) override;
 
 protected:
 	void InconsistentOption(unsigned int type) override;
@@ -154,19 +154,20 @@ protected:
 	virtual void BadOptionTermination(unsigned int code);
 	const char* PeerAuthName() const;
 
-	NVT_Analyzer* peer;
+	NVT_Analyzer* peer = nullptr;
 
-	int pending_IAC;	// true if we're working on an option/IAC
-	int IAC_pos;		// where the IAC was seen
-	int is_suboption;	// true if current option is suboption
-	int last_was_IAC;	// for scanning suboptions
+	int IAC_pos = 0;		// where the IAC was seen
+	bool pending_IAC = false;	// true if we're working on an option/IAC
+	bool is_suboption = false;	// true if current option is suboption
+	bool last_was_IAC = false;	// for scanning suboptions
+	bool authentication_has_been_accepted = false;	// if true, we accepted peer's authentication
 
-	int binary_mode, encrypting_mode;
-	int authentication_has_been_accepted;	// if true, we accepted peer's authentication
-	char* auth_name;
+	int binary_mode = 0;
+	int encrypting_mode = 0;
+	char* auth_name = nullptr;
 
 	TelnetOption* options[NUM_TELNET_OPTIONS];
-	int num_options;
+	int num_options = 0;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/login/functions.bif
+++ b/src/analyzer/protocol/login/functions.bif
@@ -28,11 +28,11 @@ function get_login_state%(cid: conn_id%): count
 	%{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 
 	analyzer::Analyzer* la = c->FindAnalyzer("Login");
 	if ( ! la )
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 
 	return val_mgr->GetCount(int(static_cast<analyzer::login::Login_Analyzer*>(la)->LoginState()));
 	%}
@@ -52,12 +52,12 @@ function set_login_state%(cid: conn_id, new_state: count%): bool
 	%{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 
 	analyzer::Analyzer* la = c->FindAnalyzer("Login");
 	if ( ! la )
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 
 	static_cast<analyzer::login::Login_Analyzer*>(la)->SetLoginState(analyzer::login::login_state(new_state));
-	return val_mgr->GetBool(1);
+	return val_mgr->GetTrue();
 	%}

--- a/src/analyzer/protocol/mime/MIME.h
+++ b/src/analyzer/protocol/mime/MIME.h
@@ -93,7 +93,7 @@ public:
 	MIME_Entity(MIME_Message* output_message, MIME_Entity* parent_entity);
 	virtual ~MIME_Entity();
 
-	virtual void Deliver(int len, const char* data, int trailing_CRLF);
+	virtual void Deliver(int len, const char* data, bool trailing_CRLF);
 	virtual void EndOfData();
 
 	MIME_Entity* Parent() const { return parent; }
@@ -112,25 +112,25 @@ protected:
 
 	void ParseMIMEHeader(MIME_Header* h);
 	int LookupMIMEHeaderName(data_chunk_t name);
-	int ParseContentTypeField(MIME_Header* h);
-	int ParseContentEncodingField(MIME_Header* h);
-	int ParseFieldParameters(int len, const char* data);
+	bool ParseContentTypeField(MIME_Header* h);
+	bool ParseContentEncodingField(MIME_Header* h);
+	bool ParseFieldParameters(int len, const char* data);
 
 	void ParseContentType(data_chunk_t type, data_chunk_t sub_type);
 	void ParseContentEncoding(data_chunk_t encoding_mechanism);
 
 	void BeginBody();
-	void NewDataLine(int len, const char* data, int trailing_CRLF);
+	void NewDataLine(int len, const char* data, bool trailing_CRLF);
 
 	int CheckBoundaryDelimiter(int len, const char* data);
-	void DecodeDataLine(int len, const char* data, int trailing_CRLF);
-	void DecodeBinary(int len, const char* data, int trailing_CRLF);
+	void DecodeDataLine(int len, const char* data, bool trailing_CRLF);
+	void DecodeBinary(int len, const char* data, bool trailing_CRLF);
 	void DecodeQuotedPrintable(int len, const char* data);
 	void DecodeBase64(int len, const char* data);
 	void StartDecodeBase64();
 	void FinishDecodeBase64();
 
-	int GetDataBuffer();
+	bool GetDataBuffer();
 	void DataOctet(char ch);
 	void DataOctets(int len, const char* data);
 	void FlushData();
@@ -189,7 +189,7 @@ public:
 		// not know its type yet (MIME_Entity / MIME_Mail /
 		// etc.).
 		top_level = 0;
-		finished = 0;
+		finished = false;
 		analyzer = arg_analyzer;
 		}
 
@@ -200,11 +200,11 @@ public:
 			  "missing MIME_Message::Done() call");
 		}
 
-	virtual void Done()	{ finished = 1; }
+	virtual void Done()	{ finished = true; }
 
-	int Finished() const	{ return finished; }
+	bool Finished() const	{ return finished; }
 
-	virtual void Deliver(int len, const char* data, int trailing_CRLF)
+	virtual void Deliver(int len, const char* data, bool trailing_CRLF)
 		{
 		top_level->Deliver(len, data, trailing_CRLF);
 		}
@@ -217,14 +217,14 @@ public:
 	virtual void SubmitHeader(MIME_Header* h) = 0;
 	virtual void SubmitAllHeaders(MIME_HeaderList& hlist) = 0;
 	virtual void SubmitData(int len, const char* buf) = 0;
-	virtual int RequestBuffer(int* plen, char** pbuf) = 0;
+	virtual bool RequestBuffer(int* plen, char** pbuf) = 0;
 	virtual void SubmitEvent(int event_type, const char* detail) = 0;
 
 protected:
 	analyzer::Analyzer* analyzer;
 
 	MIME_Entity* top_level;
-	int finished;
+	bool finished;
 
 	RecordVal* BuildHeaderVal(MIME_Header* h);
 	TableVal* BuildHeaderTable(MIME_HeaderList& hlist);
@@ -241,7 +241,7 @@ public:
 	void SubmitHeader(MIME_Header* h) override;
 	void SubmitAllHeaders(MIME_HeaderList& hlist) override;
 	void SubmitData(int len, const char* buf) override;
-	int RequestBuffer(int* plen, char** pbuf) override;
+	bool RequestBuffer(int* plen, char** pbuf) override;
 	void SubmitAllData();
 	void SubmitEvent(int event_type, const char* detail) override;
 	void Undelivered(int len);
@@ -265,14 +265,14 @@ protected:
 };
 
 
-extern int is_null_data_chunk(data_chunk_t b);
+extern bool is_null_data_chunk(data_chunk_t b);
 extern StringVal* new_string_val(int length, const char* data);
 extern StringVal* new_string_val(const char* data, const char* end_of_data);
 extern StringVal* new_string_val(const data_chunk_t buf);
 extern int fputs(data_chunk_t b, FILE* fp);
 extern bool istrequal(data_chunk_t s, const char* t);
-extern int is_lws(char ch);
-extern int MIME_is_field_name_char(char ch);
+extern bool is_lws(char ch);
+extern bool MIME_is_field_name_char(char ch);
 extern int MIME_count_leading_lws(int len, const char* data);
 extern int MIME_count_trailing_lws(int len, const char* data);
 extern int MIME_skip_comments(int len, const char* data);

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -30,7 +30,7 @@ NCP_Session::NCP_Session(analyzer::Analyzer* a)
 	req_func = 0;
 	}
 
-void NCP_Session::Deliver(int is_orig, int len, const u_char* data)
+void NCP_Session::Deliver(bool is_orig, int len, const u_char* data)
 	{
 	try
 		{
@@ -258,4 +258,3 @@ NCP_Analyzer::~NCP_Analyzer()
 	{
 	delete session;
 	}
-

--- a/src/analyzer/protocol/ncp/NCP.h
+++ b/src/analyzer/protocol/ncp/NCP.h
@@ -31,9 +31,8 @@ namespace analyzer { namespace ncp {
 class NCP_Session {
 public:
 	explicit NCP_Session(analyzer::Analyzer* analyzer);
-	virtual ~NCP_Session() {}
 
-	virtual void Deliver(int is_orig, int len, const u_char* data);
+	void Deliver(bool is_orig, int len, const u_char* data);
 
 	static bool any_ncp_event()
 		{
@@ -115,4 +114,4 @@ protected:
 	Contents_NCP_Analyzer * r_ncp;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -55,8 +55,8 @@ NetbiosSSN_Interpreter::NetbiosSSN_Interpreter(Analyzer* arg_analyzer)
 	//smb_session = arg_smb_session;
 	}
 
-int NetbiosSSN_Interpreter::ParseMessage(unsigned int type, unsigned int flags,
-				const u_char* data, int len, int is_query)
+void NetbiosSSN_Interpreter::ParseMessage(unsigned int type, unsigned int flags,
+				const u_char* data, int len, bool is_query)
 	{
 	if ( netbios_session_message )
 		analyzer->EnqueueConnEvent(netbios_session_message,
@@ -68,54 +68,59 @@ int NetbiosSSN_Interpreter::ParseMessage(unsigned int type, unsigned int flags,
 
 	switch ( type ) {
 	case NETBIOS_SSN_MSG:
-		return ParseSessionMsg(data, len, is_query);
+		ParseSessionMsg(data, len, is_query);
+		break;
 
 	case NETBIOS_SSN_REQ:
-		return ParseSessionReq(data, len, is_query);
+		ParseSessionReq(data, len, is_query);
+		break;
 
 	case NETBIOS_SSN_POS_RESP:
-		return ParseSessionPosResp(data, len, is_query);
+		ParseSessionPosResp(data, len, is_query);
+		break;
 
 	case NETBIOS_SSN_NEG_RESP:
-		return ParseSessionNegResp(data, len, is_query);
+		ParseSessionNegResp(data, len, is_query);
+		break;
 
 	case NETBIOS_SSN_RETARG_RESP:
-		return ParseRetArgResp(data, len, is_query);
+		ParseRetArgResp(data, len, is_query);
+		break;
 
 	case NETBIOS_SSN_KEEP_ALIVE:
-		return ParseKeepAlive(data, len, is_query);
+		ParseKeepAlive(data, len, is_query);
+		break;
 
 	case NETBIOS_DGM_DIRECT_UNIQUE:
 	case NETBIOS_DGM_DIRECT_GROUP:
 	case NETBIOS_DGM_BROADCAST:
-		return ParseBroadcast(data, len, is_query);
+		ParseBroadcast(data, len, is_query);
+		break;
 
 	case NETBIOS_DGM_ERROR:
 	case NETBIOS_DGG_QUERY_REQ:
 	case NETBIOS_DGM_POS_RESP:
 	case NETBIOS_DGM_NEG_RESP:
-		return ParseDatagram(data, len, is_query);
+		ParseDatagram(data, len, is_query);
+		break;
 
  	default:
 		analyzer->Weird("unknown_netbios_type", fmt("0x%x", type));
- 		return 1;
+		break;
 	}
 	}
 
-int NetbiosSSN_Interpreter::ParseDatagram(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseDatagram(const u_char* data, int len,
+						bool is_query)
 	{
 	//if ( smb_session )
 	//	{
 	//	smb_session->Deliver(is_query, len, data);
-	//	return 0;
 	//	}
-
-	return 0;
  	}
 
-int NetbiosSSN_Interpreter::ParseBroadcast(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseBroadcast(const u_char* data, int len,
+						bool is_query)
  	{
 	// FIND THE NUL-TERMINATED NAME STRINGS HERE!
 	// Not sure what's in them, so we don't keep them currently.
@@ -133,12 +138,10 @@ int NetbiosSSN_Interpreter::ParseBroadcast(const u_char* data, int len,
 
 	//if ( smb_session )
 	//	smb_session->Deliver(is_query, len, data);
-
-	return 0;
 	}
 
-int NetbiosSSN_Interpreter::ParseMessageTCP(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseMessageTCP(const u_char* data, int len,
+						bool is_query)
 	{
 	NetbiosSSN_RawMsgHdr hdr(data, len);
 
@@ -152,11 +155,11 @@ int NetbiosSSN_Interpreter::ParseMessageTCP(const u_char* data, int len,
 		len = hdr.length;
 		}
 
-	return ParseMessage(hdr.type, hdr.flags, data, len, is_query);
+	ParseMessage(hdr.type, hdr.flags, data, len, is_query);
 	}
 
-int NetbiosSSN_Interpreter::ParseMessageUDP(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseMessageUDP(const u_char* data, int len,
+						bool is_query)
 	{
 
 	NetbiosDGM_RawMsgHdr hdr(data, len);
@@ -172,19 +175,19 @@ int NetbiosSSN_Interpreter::ParseMessageUDP(const u_char* data, int len,
 		len = hdr.length;
 		}
 
-	return ParseMessage(hdr.type, hdr.flags, data, len, is_query);
+	ParseMessage(hdr.type, hdr.flags, data, len, is_query);
 	}
 
 
-int NetbiosSSN_Interpreter::ParseSessionMsg(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseSessionMsg(const u_char* data, int len,
+						bool is_query)
 	{
 	if ( len < 4 || strncmp((const char*) data, "\xffSMB", 4) )
 		{
 		// This should be an event, too.
 		analyzer->Weird("netbios_raw_session_msg");
 		Event(netbios_session_raw_message, data, len, is_query);
-		return 0;
+		return;
 		}
 
 	//if ( smb_session )
@@ -197,14 +200,13 @@ int NetbiosSSN_Interpreter::ParseSessionMsg(const u_char* data, int len,
 		analyzer->Weird("no_smb_session_using_parsesambamsg");
 		data += 4;
 		len -= 4;
-		return ParseSambaMsg(data, len, is_query);
+		ParseSambaMsg(data, len, is_query);
 		}
 	}
 
-int NetbiosSSN_Interpreter::ParseSambaMsg(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseSambaMsg(const u_char* data, int len,
+						bool is_query)
 	{
-	return 0;
 	}
 
 int NetbiosSSN_Interpreter::ConvertName(const u_char* name, int name_len,
@@ -246,8 +248,8 @@ int NetbiosSSN_Interpreter::ConvertName(const u_char* name, int name_len,
 	return 1;
 	}
 
-int NetbiosSSN_Interpreter::ParseSessionReq(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseSessionReq(const u_char* data, int len,
+						bool is_query)
 	{
 	if ( ! is_query )
 		analyzer->Weird("netbios_server_session_request");
@@ -259,23 +261,19 @@ int NetbiosSSN_Interpreter::ParseSessionReq(const u_char* data, int len,
 		Event(netbios_session_request, xname, xlen);
 
 	delete [] xname;
-
-	return 0;
 	}
 
-int NetbiosSSN_Interpreter::ParseSessionPosResp(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseSessionPosResp(const u_char* data, int len,
+						bool is_query)
 	{
 	if ( is_query )
 		analyzer->Weird("netbios_client_session_reply");
 
 	Event(netbios_session_accepted, data, len);
-
-	return 0;
 	}
 
-int NetbiosSSN_Interpreter::ParseSessionNegResp(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseSessionNegResp(const u_char* data, int len,
+						bool is_query)
 	{
 	if ( is_query )
 		analyzer->Weird("netbios_client_session_reply");
@@ -299,27 +297,21 @@ int NetbiosSSN_Interpreter::ParseSessionNegResp(const u_char* data, int len,
 		printf("Unspecified error 0x%X\n",ecode);
 		break;
 #endif
-
-	return 0;
 	}
 
-int NetbiosSSN_Interpreter::ParseRetArgResp(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseRetArgResp(const u_char* data, int len,
+						bool is_query)
 	{
 	if ( is_query )
 		analyzer->Weird("netbios_client_session_reply");
 
 	Event(netbios_session_ret_arg_resp, data, len);
-
-	return 0;
 	}
 
-int NetbiosSSN_Interpreter::ParseKeepAlive(const u_char* data, int len,
-						int is_query)
+void NetbiosSSN_Interpreter::ParseKeepAlive(const u_char* data, int len,
+						bool is_query)
 	{
 	Event(netbios_session_keepalive, data, len);
-
-	return 0;
 	}
 
 void NetbiosSSN_Interpreter::Event(EventHandlerPtr event, const u_char* data,
@@ -332,12 +324,12 @@ void NetbiosSSN_Interpreter::Event(EventHandlerPtr event, const u_char* data,
 		analyzer->EnqueueConnEvent(event,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
 			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
-			make_intrusive<StringVal>(new BroString(data, len, 0))
+			make_intrusive<StringVal>(new BroString(data, len, false))
 		);
 	else
 		analyzer->EnqueueConnEvent(event,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			make_intrusive<StringVal>(new BroString(data, len, 0))
+			make_intrusive<StringVal>(new BroString(data, len, false))
 		);
 	}
 
@@ -448,7 +440,7 @@ void Contents_NetbiosSSN::DeliverStream(int len, const u_char* data, bool orig)
 		// Haven't filled up the message buffer yet, no more to do.
 		return;
 
-	(void) interp->ParseMessage(type, flags, msg_buf, msg_size, IsOrig());
+	interp->ParseMessage(type, flags, msg_buf, msg_size, IsOrig());
 	buf_n = 0;
 
 	state = NETBIOS_SSN_TYPE;
@@ -476,7 +468,7 @@ NetbiosSSN_Analyzer::NetbiosSSN_Analyzer(Connection* conn)
 	else
 		{
 		ADD_ANALYZER_TIMER(&NetbiosSSN_Analyzer::ExpireTimer,
-				network_time + netbios_ssn_session_timeout, 1,
+				network_time + netbios_ssn_session_timeout, true,
 				TIMER_NB_EXPIRE);
 		}
 	}
@@ -506,7 +498,7 @@ void NetbiosSSN_Analyzer::EndpointEOF(bool orig)
 	}
 
 void NetbiosSSN_Analyzer::ConnectionClosed(tcp::TCP_Endpoint* endpoint,
-				tcp::TCP_Endpoint* peer, int gen_event)
+				tcp::TCP_Endpoint* peer, bool gen_event)
 	{
 	tcp::TCP_ApplicationAnalyzer::ConnectionClosed(endpoint, peer, gen_event);
 
@@ -521,9 +513,9 @@ void NetbiosSSN_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 	tcp::TCP_ApplicationAnalyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
 
 	if ( orig )
-		interp->ParseMessageUDP(data, len, 1);
+		interp->ParseMessageUDP(data, len, true);
 	else
-		interp->ParseMessageUDP(data, len, 0);
+		interp->ParseMessageUDP(data, len, false);
 	}
 
 void NetbiosSSN_Analyzer::ExpireTimer(double t)
@@ -541,5 +533,5 @@ void NetbiosSSN_Analyzer::ExpireTimer(double t)
 	else
 		ADD_ANALYZER_TIMER(&NetbiosSSN_Analyzer::ExpireTimer,
 				t + netbios_ssn_session_timeout,
-				1, TIMER_NB_EXPIRE);
+				true, TIMER_NB_EXPIRE);
 	}

--- a/src/analyzer/protocol/netbios/NetbiosSSN.h
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.h
@@ -65,28 +65,28 @@ class NetbiosSSN_Interpreter {
 public:
 	explicit NetbiosSSN_Interpreter(Analyzer* analyzer);
 
-	int ParseMessage(unsigned int type, unsigned int flags,
-			const u_char* data, int len, int is_query);
+	void ParseMessage(unsigned int type, unsigned int flags,
+			const u_char* data, int len, bool is_query);
 
 	// Version used when data points to type/flags/length.
-	int ParseMessageTCP(const u_char* data, int len, int is_query);
-	int ParseMessageUDP(const u_char* data, int len, int is_query);
+	void ParseMessageTCP(const u_char* data, int len, bool is_query);
+	void ParseMessageUDP(const u_char* data, int len, bool is_query);
 
 	void Timeout()	{ }
 
 protected:
-	int ParseSessionMsg(const u_char* data, int len, int is_query);
-	int ParseSessionReq(const u_char* data, int len, int is_query);
-	int ParseSessionPosResp(const u_char* data, int len, int is_query);
-	int ParseSessionNegResp(const u_char* data, int len, int is_query);
-	int ParseRetArgResp(const u_char* data, int len, int is_query);
-	int ParseKeepAlive(const u_char* data, int len, int is_query);
+	void ParseSessionMsg(const u_char* data, int len, bool is_query);
+	void ParseSessionReq(const u_char* data, int len, bool is_query);
+	void ParseSessionPosResp(const u_char* data, int len, bool is_query);
+	void ParseSessionNegResp(const u_char* data, int len, bool is_query);
+	void ParseRetArgResp(const u_char* data, int len, bool is_query);
+	void ParseKeepAlive(const u_char* data, int len, bool is_query);
 
 	// Datagram parsing
-	int ParseBroadcast(const u_char* data, int len, int is_query);
-	int ParseDatagram(const u_char* data, int len, int is_query);
+	void ParseBroadcast(const u_char* data, int len, bool is_query);
+	void ParseDatagram(const u_char* data, int len, bool is_query);
 
-	int ParseSambaMsg(const u_char* data, int len, int is_query);
+	void ParseSambaMsg(const u_char* data, int len, bool is_query);
 
 	void Event(EventHandlerPtr event, const u_char* data, int len,
 			int is_orig = -1);
@@ -152,7 +152,7 @@ public:
 
 protected:
 	void ConnectionClosed(tcp::TCP_Endpoint* endpoint,
-					tcp::TCP_Endpoint* peer, int gen_event) override;
+					tcp::TCP_Endpoint* peer, bool gen_event) override;
 	void EndpointEOF(bool is_orig) override;
 
 	void ExpireTimer(double t);

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -78,7 +78,7 @@ void POP3_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	if ( (TCP() && TCP()->IsPartial()) )
 		return;
 
-	BroString terminated_string(data, len, 1);
+	BroString terminated_string(data, len, true);
 
 	if ( orig )
 		ProcessRequest(len, (char*) terminated_string.Bytes());
@@ -860,7 +860,7 @@ void POP3_Analyzer::EndData()
 
 void POP3_Analyzer::ProcessData(int length, const char* line)
 	{
-	mail->Deliver(length, line, 1);
+	mail->Deliver(length, line, true);
 	}
 
 int POP3_Analyzer::ParseCmd(string cmd)

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -15,7 +15,7 @@
 
 using namespace analyzer::rpc;
 
-int MOUNT_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
+bool MOUNT_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 	{
 	if ( c->Program() != 100005 )
 		Weird("bad_RPC_program", fmt("%d", c->Program()));
@@ -54,7 +54,7 @@ int MOUNT_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 
 		// Return 1 so that replies to unprocessed calls will still
 		// be processed, and the return status extracted.
-		return 1;
+		return true;
 	}
 
 	if ( ! buf )
@@ -66,15 +66,15 @@ int MOUNT_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 		// Unref() the call arguments, and we are fine.
 		Unref(callarg);
 		callarg = 0;
-		return 0;
+		return false;
 		}
 
 	c->AddVal(callarg); // It's save to AddVal(0).
 
-	return 1;
+	return true;
 	}
 
-int MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
+bool MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 			       const u_char*& buf, int& n, double start_time,
 			       double last_time, int reply_len)
 	{
@@ -143,7 +143,7 @@ int MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status
 			event = mount_proc_not_implemented;
 			}
 		else
-			return 0;
+			return false;
 	}
 
 	if ( rpc_success && ! buf )
@@ -152,7 +152,7 @@ int MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status
 		// also comments in RPC_BuildCall.
 		Unref(reply);
 		reply = 0;
-		return 0;
+		return false;
 		}
 
 	// Note: if reply == 0, it won't be added to the val_list for the
@@ -178,11 +178,11 @@ int MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status
 		}
 	else
 		Unref(reply);
-	return 1;
+	return true;
 	}
 
 zeek::Args MOUNT_Interp::event_common_vl(RPC_CallInfo *c,
-		      BifEnum::rpc_status rpc_status,
+				      BifEnum::rpc_status rpc_status,
 				      BifEnum::MOUNT3::status_t mount_status,
 				      double rep_start_time,
 				      double rep_last_time, int reply_len, int extra_elements)
@@ -232,7 +232,7 @@ StringVal* MOUNT_Interp::mount3_fh(const u_char*& buf, int& n)
 	if ( ! fh )
 		return 0;
 
-	return new StringVal(new BroString(fh, fh_n, 0));
+	return new StringVal(new BroString(fh, fh_n, false));
 	}
 
 StringVal* MOUNT_Interp::mount3_filename(const u_char*& buf, int& n)
@@ -243,7 +243,7 @@ StringVal* MOUNT_Interp::mount3_filename(const u_char*& buf, int& n)
 	if ( ! name )
 		return 0;
 
-	return new StringVal(new BroString(name, name_len, 0));
+	return new StringVal(new BroString(name, name_len, false));
 	}
 
 RecordVal* MOUNT_Interp::mount3_dirmntargs(const u_char*& buf, int& n)

--- a/src/analyzer/protocol/rpc/MOUNT.h
+++ b/src/analyzer/protocol/rpc/MOUNT.h
@@ -11,8 +11,8 @@ public:
 	explicit MOUNT_Interp(analyzer::Analyzer* arg_analyzer) : RPC_Interpreter(arg_analyzer) { }
 
 protected:
-	int RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n) override;
-	int RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
+	bool RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n) override;
+	bool RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 				const u_char*& buf, int& n, double start_time,
 				double last_time, int reply_len) override;
 

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -15,7 +15,7 @@
 
 using namespace analyzer::rpc;
 
-int NFS_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
+bool NFS_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 	{
 	if ( c->Program() != 100003 )
 		Weird("bad_RPC_program", fmt("%d", c->Program()));
@@ -108,7 +108,7 @@ int NFS_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 
 		// Return 1 so that replies to unprocessed calls will still
 		// be processed, and the return status extracted.
-		return 1;
+		return true;
 	}
 
 	if ( ! buf )
@@ -120,15 +120,15 @@ int NFS_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 		// Unref() the call arguments, and we are fine.
 		Unref(callarg);
 		callarg = 0;
-		return 0;
+		return false;
 		}
 
 	c->AddVal(callarg); // It's save to AddVal(0).
 
-	return 1;
+	return true;
 	}
 
-int NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
+bool NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 			       const u_char*& buf, int& n, double start_time,
 			       double last_time, int reply_len)
 	{
@@ -255,7 +255,7 @@ int NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 			event = nfs_proc_not_implemented;
 			}
 		else
-			return 0;
+			return false;
 	}
 
 	if ( rpc_success && ! buf )
@@ -264,7 +264,7 @@ int NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 		// also comments in RPC_BuildCall.
 		Unref(reply);
 		reply = 0;
-		return 0;
+		return false;
 		}
 
 	// Note: if reply == 0, it won't be added to the val_list for the
@@ -291,7 +291,7 @@ int NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 	else
 		Unref(reply);
 
-	return 1;
+	return true;
 	}
 
 StringVal* NFS_Interp::nfs3_file_data(const u_char*& buf, int& n, uint64_t offset, int size)
@@ -313,7 +313,7 @@ StringVal* NFS_Interp::nfs3_file_data(const u_char*& buf, int& n, uint64_t offse
 	data_n = min(data_n, int(BifConst::NFS3::return_data_max));
 
 	if ( data && data_n > 0 )
-		return new StringVal(new BroString(data, data_n, 0));
+		return new StringVal(new BroString(data, data_n, false));
 
 	return 0;
 	}
@@ -360,7 +360,7 @@ StringVal* NFS_Interp::nfs3_fh(const u_char*& buf, int& n)
 	if ( ! fh )
 		return 0;
 
-	return new StringVal(new BroString(fh, fh_n, 0));
+	return new StringVal(new BroString(fh, fh_n, false));
 	}
 
 
@@ -466,7 +466,7 @@ StringVal *NFS_Interp::nfs3_filename(const u_char*& buf, int& n)
 	if ( ! name )
 		return 0;
 
-	return new StringVal(new BroString(name, name_len, 0));
+	return new StringVal(new BroString(name, name_len, false));
 	}
 
 RecordVal *NFS_Interp::nfs3_diropargs(const u_char*& buf, int& n)

--- a/src/analyzer/protocol/rpc/NFS.h
+++ b/src/analyzer/protocol/rpc/NFS.h
@@ -12,8 +12,8 @@ public:
 	explicit NFS_Interp(analyzer::Analyzer* arg_analyzer) : RPC_Interpreter(arg_analyzer) { }
 
 protected:
-	int RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n) override;
-	int RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
+	bool RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n) override;
+	bool RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 				const u_char*& buf, int& n, double start_time,
 				double last_time, int reply_len) override;
 
@@ -89,4 +89,4 @@ public:
 };
 
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/rpc/Portmap.h
+++ b/src/analyzer/protocol/rpc/Portmap.h
@@ -11,8 +11,8 @@ public:
 	explicit PortmapperInterp(analyzer::Analyzer* arg_analyzer) : RPC_Interpreter(arg_analyzer) { }
 
 protected:
-	int RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n) override;
-	int RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status success,
+	bool RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n) override;
+	bool RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status success,
 			   const u_char*& buf, int& n, double start_time,
 			   double last_time, int reply_len) override;
 	uint32_t CheckPort(uint32_t port);
@@ -34,4 +34,4 @@ public:
 		{ return new Portmapper_Analyzer(conn); }
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/rpc/RPC.h
+++ b/src/analyzer/protocol/rpc/RPC.h
@@ -56,7 +56,7 @@ public:
 	Val* RequestVal() const		{ return v; }
 	Val* TakeRequestVal()		{ Val* rv = v; v = 0; return rv; }
 
-	int CompareRexmit(const u_char* buf, int n) const;
+	bool CompareRexmit(const u_char* buf, int n) const;
 
 	uint32_t Program() const		{ return prog; }
 	uint32_t Version() const		{ return vers; }
@@ -106,13 +106,13 @@ public:
 	// Delivers the given RPC.  Returns true if "len" bytes were
 	// enough, false otherwise.  "is_orig" is true if the data is
 	// from the originator of the connection.
-	int DeliverRPC(const u_char* data, int len, int caplen, int is_orig, double start_time, double last_time);
+	int DeliverRPC(const u_char* data, int len, int caplen, bool is_orig, double start_time, double last_time);
 
 	void Timeout();
 
 protected:
-	virtual int RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n) = 0;
-	virtual int RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status success,
+	virtual bool RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n) = 0;
+	virtual bool RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status success,
 				   const u_char*& buf, int& n, double start_time, double last_time,
 				   int reply_len) = 0;
 
@@ -250,4 +250,4 @@ protected:
 	Contents_RPC* resp_rpc;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/smb/smb1-com-locking-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-locking-andx.pac
@@ -50,7 +50,7 @@ type SMB1_locking_andx_request(header: SMB_Header, offset: uint16) = record {
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command          : SMB_andx_command(header, 1, offset+offsetof(andx_command), andx.command);
+	andx_command          : SMB_andx_command(header, true, offset+offsetof(andx_command), andx.command);
 } &let {
 	proc : bool = $context.connection.proc_smb1_locking_andx_request(header, this);
 };

--- a/src/analyzer/protocol/smb/smb1-com-logoff-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-logoff-andx.pac
@@ -17,7 +17,7 @@ type SMB1_logoff_andx(header: SMB_Header, offset: uint16, is_orig: bool) = recor
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command : SMB_andx_command(header, 1, offset+offsetof(andx_command), andx.command);
+	andx_command : SMB_andx_command(header, true, offset+offsetof(andx_command), andx.command);
 } &let {
 	proc : bool = $context.connection.proc_smb1_logoff_andx(header, this);
 };

--- a/src/analyzer/protocol/smb/smb1-com-nt-create-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-nt-create-andx.pac
@@ -70,7 +70,7 @@ type SMB1_nt_create_andx_request(header: SMB_Header, offset: uint16) = record {
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command        : SMB_andx_command(header, 1, offset+offsetof(andx_command), andx.command);
+	andx_command        : SMB_andx_command(header, true, offset+offsetof(andx_command), andx.command);
 } &let {
 	proc : bool = $context.connection.proc_smb1_nt_create_andx_request(header, this);
 };
@@ -96,7 +96,7 @@ type SMB1_nt_create_andx_response(header: SMB_Header, offset: uint16) = record {
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command       : SMB_andx_command(header, 0, offset+offsetof(andx_command), andx.command);
+	andx_command       : SMB_andx_command(header, false, offset+offsetof(andx_command), andx.command);
 } &let {
 	proc : bool = $context.connection.proc_smb1_nt_create_andx_response(header, this);
 };

--- a/src/analyzer/protocol/smb/smb1-com-read-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-read-andx.pac
@@ -64,7 +64,7 @@ type SMB1_read_andx_request(header: SMB_Header, offset: uint16) = record {
 
 	extra_byte_parameters : bytestring &transient &length=((andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters))));
 
-	andx_command   : SMB_andx_command(header, 1, offset+offsetof(andx_command), andx.command);
+	andx_command   : SMB_andx_command(header, true, offset+offsetof(andx_command), andx.command);
 } &let {
   offset_high_64 : uint64 = offset_high;
 	offset_high : uint32 = (word_count == 0x0C && offset_high_tmp != 0xffffffff) ? offset_high_tmp : 0;
@@ -91,7 +91,7 @@ type SMB1_read_andx_response(header: SMB_Header, offset: uint16) = record {
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command      : SMB_andx_command(header, 0, offset+offsetof(andx_command), andx.command);
+	andx_command      : SMB_andx_command(header, false, offset+offsetof(andx_command), andx.command);
 } &let {
 	pipe_proc   : bool   = $context.connection.forward_dce_rpc(data, 0, false) &if(header.is_pipe);
 

--- a/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
@@ -157,7 +157,7 @@ type SMB1_session_setup_andx_request_lanman(header: SMB_Header, offset: uint16) 
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command     : SMB_andx_command(header, 1, offset+offsetof(andx_command), andx.command);
+	andx_command     : SMB_andx_command(header, true, offset+offsetof(andx_command), andx.command);
 };
 
 type SMB1_session_setup_andx_response_lanman(header: SMB_Header, offset: uint16) = record {
@@ -171,7 +171,7 @@ type SMB1_session_setup_andx_response_lanman(header: SMB_Header, offset: uint16)
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command   : SMB_andx_command(header, 0, offset+offsetof(andx_command), andx.command);
+	andx_command   : SMB_andx_command(header, false, offset+offsetof(andx_command), andx.command);
 } &let {
 	is_guest: bool = ( action & 0x1 ) > 0;
 };
@@ -208,7 +208,7 @@ type SMB1_session_setup_andx_request_ntlm_nonextended_security(header: SMB_Heade
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command                 : SMB_andx_command(header, 1, offset+offsetof(andx_command), andx.command);
+	andx_command                 : SMB_andx_command(header, true, offset+offsetof(andx_command), andx.command);
 };
 
 type SMB1_session_setup_andx_request_ntlm_extended_security(header: SMB_Header, offset: uint16) = record {
@@ -228,7 +228,7 @@ type SMB1_session_setup_andx_request_ntlm_extended_security(header: SMB_Header, 
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command         : SMB_andx_command(header, 1, offset+offsetof(andx_command), andx.command);
+	andx_command         : SMB_andx_command(header, true, offset+offsetof(andx_command), andx.command);
 } &let {
 	pipe_proc : bool = $context.connection.forward_gssapi(security_blob, true);
 };
@@ -245,9 +245,8 @@ type SMB1_session_setup_andx_response_ntlm(header: SMB_Header, offset: uint16) =
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command         : SMB_andx_command(header, 0, offset+offsetof(andx_command), andx.command);
+	andx_command         : SMB_andx_command(header, false, offset+offsetof(andx_command), andx.command);
 } &let {
 	is_guest    : bool = ( action & 0x1 ) > 0;
 	gssapi_proc : bool = $context.connection.forward_gssapi(security_blob, false);
 };
-

--- a/src/analyzer/protocol/smb/smb1-com-tree-connect-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-tree-connect-andx.pac
@@ -41,11 +41,11 @@ type SMB1_tree_connect_andx_request(header: SMB_Header, offset: uint16) = record
 	byte_count      : uint16;
 	password        : uint8[password_length];
 	path            : SMB_string(header.unicode, offsetof(path));
-	service         : SMB_string(0, offsetof(service));
+	service         : SMB_string(false, offsetof(service));
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command    : SMB_andx_command(header, 1, offset+offsetof(andx_command), andx.command);
+	andx_command    : SMB_andx_command(header, true, offset+offsetof(andx_command), andx.command);
 } &let {
 	proc : bool = $context.connection.proc_smb1_tree_connect_andx_request(header, this);
 };
@@ -57,13 +57,12 @@ type SMB1_tree_connect_andx_response(header: SMB_Header, offset: uint16) = recor
 	pad                : padding[word_count<3 ? 0 : (word_count-3)*2];
 
 	byte_count         : uint16;
-	service            : SMB_string(0, offsetof(service));
+	service            : SMB_string(false, offsetof(service));
 	native_file_system : SMB_string(header.unicode, offsetof(native_file_system))[byte_count > sizeof(service) ? 1 : 0];
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command       : SMB_andx_command(header, 0, offset+offsetof(andx_command), andx.command);
+	andx_command       : SMB_andx_command(header, false, offset+offsetof(andx_command), andx.command);
 } &let {
 	proc : bool = $context.connection.proc_smb1_tree_connect_andx_response(header, this);
 };
-

--- a/src/analyzer/protocol/smb/smb1-com-write-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-write-andx.pac
@@ -56,7 +56,7 @@ type SMB1_write_andx_request(header: SMB_Header, offset: uint16) = record {
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command    : SMB_andx_command(header, 1, offset+offsetof(andx_command), andx.command);
+	andx_command    : SMB_andx_command(header, true, offset+offsetof(andx_command), andx.command);
 } &let {
 	pipe_proc   : bool   = $context.connection.forward_dce_rpc(data, 0, true) &if(header.is_pipe);
 
@@ -78,7 +78,7 @@ type SMB1_write_andx_response(header: SMB_Header, offset: uint16) = record {
 
 	extra_byte_parameters : bytestring &transient &length=(andx.offset == 0 || andx.offset >= (offset+offsetof(extra_byte_parameters))+2) ? 0 : (andx.offset-(offset+offsetof(extra_byte_parameters)));
 
-	andx_command    : SMB_andx_command(header, 0, offset+offsetof(andx_command), andx.command);
+	andx_command    : SMB_andx_command(header, false, offset+offsetof(andx_command), andx.command);
 } &let {
 	written_bytes : uint32 = (written_high * 0x10000) + written_low;
 	proc          : bool   = $context.connection.proc_smb1_write_andx_response(header, this);

--- a/src/analyzer/protocol/smtp/SMTP.h
+++ b/src/analyzer/protocol/smtp/SMTP.h
@@ -43,7 +43,7 @@ public:
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
-	void ConnectionFinished(int half_finished) override;
+	void ConnectionFinished(bool half_finished) override;
 	void Undelivered(uint64_t seq, int len, bool orig) override;
 
 	void SkipData()	{ skip_data = 1; }	// skip delivery of data lines
@@ -56,12 +56,12 @@ public:
 protected:
 
 	void ProcessLine(int length, const char* line, bool orig);
-	void NewCmd(const int cmd_code);
-	void NewReply(const int reply_code, bool orig);
+	void NewCmd(int cmd_code);
+	void NewReply(int reply_code, bool orig);
 	void ProcessExtension(int ext_len, const char* ext);
 	void ProcessData(int length, const char* line);
 
-	void UpdateState(const int cmd_code, const int reply_code, bool orig);
+	void UpdateState(int cmd_code, int reply_code, bool orig);
 
 	void BeginData(bool orig);
 	void EndData();
@@ -70,21 +70,21 @@ protected:
 
 	void RequestEvent(int cmd_len, const char* cmd,
 				int arg_len, const char* arg);
-	void Unexpected(const int is_orig, const char* msg,
+	void Unexpected(bool is_sender, const char* msg,
 				int detail_len, const char* detail);
-	void UnexpectedCommand(const int cmd_code, const int reply_code);
-	void UnexpectedReply(const int cmd_code, const int reply_code);
+	void UnexpectedCommand(int cmd_code, int reply_code);
+	void UnexpectedReply(int cmd_code, int reply_code);
 	void StartTLS();
 
 	bool orig_is_sender;
-	int expect_sender, expect_recver;
+	bool expect_sender, expect_recver;
+	bool pipelining;			// whether pipelining is supported
 	int state;
 	int last_replied_cmd;
 	int first_cmd;			// first un-replied SMTP cmd, or -1
 	int pending_reply;		// code assoc. w/ multi-line reply, or 0
-	int pipelining;			// whether pipelining is supported
 	list<int> pending_cmd_q;	// to support pipelining
-	int skip_data;			// whether to skip message body
+	bool skip_data;			// whether to skip message body
 	BroString* line_after_gap;	// last line before the first reply
 					// after a gap
 
@@ -95,4 +95,4 @@ private:
 	tcp::ContentLine_Analyzer* cl_resp;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/ssl/ssl-analyzer.pac
+++ b/src/analyzer/protocol/ssl/ssl-analyzer.pac
@@ -44,7 +44,7 @@ refine typeattr V2ClientHello += &let {
 refine typeattr V2ServerHello += &let {
 	check_v2 : bool = $context.connection.proc_check_v2_server_hello_version(server_version);
 
-	proc : bool = $context.connection.proc_server_hello(server_version, 1,
+	proc : bool = $context.connection.proc_server_hello(server_version, true,
 				conn_id_data, 0, 0, ciphers, 0) &requires(check_v2) &if(check_v2 == true);
 
 	cert : bool = $context.connection.proc_v2_certificate(rec.is_orig, cert_data)

--- a/src/analyzer/protocol/ssl/tls-handshake-analyzer.pac
+++ b/src/analyzer/protocol/ssl/tls-handshake-analyzer.pac
@@ -527,13 +527,13 @@ refine typeattr ClientHello += &let {
 
 refine typeattr ServerHello += &let {
 	proc : bool = $context.connection.proc_server_hello(server_version,
-			0, random_bytes, session_id, cipher_suite, 0,
+			false, random_bytes, session_id, cipher_suite, 0,
 			compression_method);
 };
 
 refine typeattr ServerHello13 += &let {
 	proc : bool = $context.connection.proc_server_hello(server_version,
-			0, random, 0, cipher_suite, 0,
+			false, random, 0, cipher_suite, 0,
 			0);
 };
 

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -60,7 +60,7 @@ void SteppingStoneEndpoint::Done()
 	Event(stp_remove_endp, stp_id);
 	}
 
-int SteppingStoneEndpoint::DataSent(double t, uint64_t seq, int len, int caplen,
+bool SteppingStoneEndpoint::DataSent(double t, uint64_t seq, int len, int caplen,
 		const u_char* data, const IP_Hdr* /* ip */,
 		const struct tcphdr* tp)
 	{
@@ -68,7 +68,7 @@ int SteppingStoneEndpoint::DataSent(double t, uint64_t seq, int len, int caplen,
 		len = caplen;
 
 	if ( len <= 0 )
-		return 0;
+		return false;
 
 	double tmin = t - stp_delta;
 
@@ -91,14 +91,14 @@ int SteppingStoneEndpoint::DataSent(double t, uint64_t seq, int len, int caplen,
 
 	if ( top_seq <= ack || top_seq <= stp_max_top_seq )
 		// There is no new data in this packet
-		return 0;
+		return false;
 
 	stp_max_top_seq = top_seq;
 
 	if ( stp_last_time && t <= stp_last_time + stp_idle_min )
 		{
 		stp_last_time = t;
-		return 1;
+		return true;
 		}
 
 	// Either just starts, or resumes from an idle period.
@@ -126,7 +126,7 @@ int SteppingStoneEndpoint::DataSent(double t, uint64_t seq, int len, int caplen,
 	stp_manager->OrderedEndpoints().push_back(this);
 	Ref(this);
 
-	return 1;
+	return true;
 	}
 
 void SteppingStoneEndpoint::Event(EventHandlerPtr f, int id1, int id2)
@@ -141,7 +141,7 @@ void SteppingStoneEndpoint::Event(EventHandlerPtr f, int id1, int id2)
 		endp->TCP()->EnqueueConnEvent(f, IntrusivePtr{AdoptRef{}, val_mgr->GetInt(id1)});
 	}
 
-void SteppingStoneEndpoint::CreateEndpEvent(int is_orig)
+void SteppingStoneEndpoint::CreateEndpEvent(bool is_orig)
 	{
 	if ( ! stp_create_endp )
 		return;

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.h
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.h
@@ -18,12 +18,12 @@ public:
 	~SteppingStoneEndpoint() override;
 	void Done();
 
-	int DataSent(double t, uint64_t seq, int len, int caplen, const u_char* data,
+	bool DataSent(double t, uint64_t seq, int len, int caplen, const u_char* data,
 		     const IP_Hdr* ip, const struct tcphdr* tp);
 
 protected:
 	void Event(EventHandlerPtr f, int id1, int id2 = -1);
-	void CreateEndpEvent(int is_orig);
+	void CreateEndpEvent(bool is_orig);
 
 	tcp::TCP_Endpoint* endp;
 	uint64_t stp_max_top_seq;
@@ -69,7 +69,6 @@ protected:
 // Manages ids for the possible stepping stone connections.
 class SteppingStoneManager {
 public:
-	SteppingStoneManager()		{ endp_cnt = 0; }
 
 	PQueue<SteppingStoneEndpoint>& OrderedEndpoints()
 		{ return ordered_endps; }
@@ -79,7 +78,7 @@ public:
 
 protected:
 	PQueue<SteppingStoneEndpoint> ordered_endps;
-	int endp_cnt;
+	int endp_cnt = 0;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/syslog/Syslog.cc
+++ b/src/analyzer/protocol/syslog/Syslog.cc
@@ -12,7 +12,7 @@ Syslog_Analyzer::Syslog_Analyzer(Connection* conn)
 	interp = new binpac::Syslog::Syslog_Conn(this);
 	did_session_done = 0;
 	//ADD_ANALYZER_TIMER(&Syslog_Analyzer::ExpireTimer,
-	//		network_time + Syslog_session_timeout, 1, TIMER_Syslog_EXPIRE);
+	//		network_time + Syslog_session_timeout, true, TIMER_Syslog_EXPIRE);
 	}
 
 Syslog_Analyzer::~Syslog_Analyzer()
@@ -46,7 +46,7 @@ void Syslog_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint
 //		}
 //	else
 //		ADD_ANALYZER_TIMER(&Syslog_Analyzer::ExpireTimer,
-//				t + Syslog_session_timeout, 1, TIMER_Syslog_EXPIRE);
+//				t + Syslog_session_timeout, true, TIMER_Syslog_EXPIRE);
 //	}
 
 //Syslog_tcp::TCP_Analyzer::Syslog_tcp::TCP_Analyzer(Connection* conn)

--- a/src/analyzer/protocol/tcp/ContentLine.cc
+++ b/src/analyzer/protocol/tcp/ContentLine.cc
@@ -312,7 +312,7 @@ void ContentLine_Analyzer::CheckNUL()
 			{
 			if ( ! suppress_weirds && Conn()->FlagEvent(NUL_IN_LINE) )
 				Conn()->Weird("NUL_in_line");
-			flag_NULs = 0;
+			flag_NULs = false;
 			}
 		}
 	}

--- a/src/analyzer/protocol/tcp/TCP.h
+++ b/src/analyzer/protocol/tcp/TCP.h
@@ -12,7 +12,7 @@
 // - TCP_Analyzer is the analyzer for the TCP protocol itself.
 // - TCP_ApplicationAnalyzer is an abstract base class for analyzers for a
 //   protocol running on top of TCP.
-// 
+//
 namespace analyzer { namespace pia { class PIA_TCP; } };
 
 namespace analyzer { namespace tcp {
@@ -37,10 +37,10 @@ public:
 	bool RemoveChildAnalyzer(ID id) override;
 
 	// True if the connection has closed in some sense, false otherwise.
-	int IsClosed() const	{ return orig->did_close || resp->did_close; }
-	int BothClosed() const	{ return orig->did_close && resp->did_close; }
+	bool IsClosed() const	{ return orig->did_close || resp->did_close; }
+	bool BothClosed() const	{ return orig->did_close && resp->did_close; }
 
-	int IsPartial() const	{ return is_partial; }
+	bool IsPartial() const	{ return is_partial; }
 
 	bool HadGap(bool orig) const;
 
@@ -58,7 +58,7 @@ public:
 	// which we have seen a FIN) - for it, data is pending unless
 	// everything's been delivered up to the FIN.  For its peer,
 	// the test is whether it has any outstanding, un-acked data.
-	int DataPending(TCP_Endpoint* closing_endp);
+	bool DataPending(TCP_Endpoint* closing_endp);
 
 	void SetContentsFile(unsigned int direction, BroFile* f) override;
 	BroFile* GetContentsFile(unsigned int direction) const override;
@@ -107,39 +107,39 @@ protected:
 	void UpdateStateMachine(double t,
 			TCP_Endpoint* endpoint, TCP_Endpoint* peer,
 			uint32_t base_seq, uint32_t ack_seq,
-			int len, int32_t delta_last, int is_orig, TCP_Flags flags,
-			int& do_close, int& gen_event);
+			int len, int32_t delta_last, bool is_orig, TCP_Flags flags,
+			bool& do_close, bool& gen_event);
 
 	void UpdateInactiveState(double t,
 				TCP_Endpoint* endpoint, TCP_Endpoint* peer,
 				uint32_t base_seq, uint32_t ack_seq,
-				int len, int is_orig, TCP_Flags flags,
-				int& do_close, int& gen_event);
+				int len, bool is_orig, TCP_Flags flags,
+				bool& do_close, bool& gen_event);
 
 	void UpdateSYN_SentState(TCP_Endpoint* endpoint, TCP_Endpoint* peer,
-				 int len, int is_orig, TCP_Flags flags,
-				 int& do_close, int& gen_event);
+				 int len, bool is_orig, TCP_Flags flags,
+				 bool& do_close, bool& gen_event);
 
 	void UpdateEstablishedState(TCP_Endpoint* endpoint, TCP_Endpoint* peer,
-				    TCP_Flags flags, int& do_close, int& gen_event);
+				    TCP_Flags flags, bool& do_close, bool& gen_event);
 
 	void UpdateClosedState(double t, TCP_Endpoint* endpoint,
 				int32_t delta_last, TCP_Flags flags,
-				int& do_close);
+				bool& do_close);
 
 	void UpdateResetState(int len, TCP_Flags flags);
 
 	void GeneratePacketEvent(uint64_t rel_seq, uint64_t rel_ack,
 				 const u_char* data, int len, int caplen,
-				 int is_orig, TCP_Flags flags);
+				 bool is_orig, TCP_Flags flags);
 
-	int DeliverData(double t, const u_char* data, int len, int caplen,
+	bool DeliverData(double t, const u_char* data, int len, int caplen,
 			const IP_Hdr* ip, const struct tcphdr* tp,
 			TCP_Endpoint* endpoint, uint64_t rel_data_seq,
-			int is_orig, TCP_Flags flags);
+			bool is_orig, TCP_Flags flags);
 
-	void CheckRecording(int need_contents, TCP_Flags flags);
-	void CheckPIA_FirstPacket(int is_orig, const IP_Hdr* ip);
+	void CheckRecording(bool need_contents, TCP_Flags flags);
+	void CheckPIA_FirstPacket(bool is_orig, const IP_Hdr* ip);
 
 	friend class ConnectionTimer;
 	void AttemptTimer(double t);
@@ -151,8 +151,8 @@ protected:
 
 	void EndpointEOF(TCP_Reassembler* endp);
 	void ConnectionClosed(TCP_Endpoint* endpoint,
-					TCP_Endpoint* peer, int gen_event);
-	void ConnectionFinished(int half_finished);
+					TCP_Endpoint* peer, bool gen_event);
+	void ConnectionFinished(bool half_finished);
 	void ConnectionReset();
 	void PacketWithRST();
 
@@ -220,8 +220,8 @@ public:
 	// is now fully closed, a connection_finished event will be
 	// generated; otherwise not.
 	virtual void ConnectionClosed(analyzer::tcp::TCP_Endpoint* endpoint,
-				      analyzer::tcp::TCP_Endpoint* peer, int gen_event);
-	virtual void ConnectionFinished(int half_finished);
+				      analyzer::tcp::TCP_Endpoint* peer, bool gen_event);
+	virtual void ConnectionFinished(bool half_finished);
 	virtual void ConnectionReset();
 
 	// Called whenever a RST packet is seen - sometimes the invocation
@@ -255,8 +255,8 @@ public:
 	// These are passed on from TCP_Analyzer.
 	virtual void EndpointEOF(bool is_orig)	{ }
 	virtual void ConnectionClosed(TCP_Endpoint* endpoint,
-					TCP_Endpoint* peer, int gen_event) 	{ }
-	virtual void ConnectionFinished(int half_finished)	{ }
+					TCP_Endpoint* peer, bool gen_event) 	{ }
+	virtual void ConnectionFinished(bool half_finished)	{ }
 	virtual void ConnectionReset()	{ }
 	virtual void PacketWithRST()	{ }
 };
@@ -266,7 +266,7 @@ class TCPStats_Endpoint {
 public:
 	explicit TCPStats_Endpoint(TCP_Endpoint* endp);
 
-	int DataSent(double t, uint64_t seq, int len, int caplen, const u_char* data,
+	bool DataSent(double t, uint64_t seq, int len, int caplen, const u_char* data,
 			const IP_Hdr* ip, const struct tcphdr* tp);
 
 	RecordVal* BuildStats();
@@ -303,4 +303,4 @@ protected:
 	TCPStats_Endpoint* resp_stats;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.cc
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.cc
@@ -14,7 +14,7 @@
 
 using namespace analyzer::tcp;
 
-TCP_Endpoint::TCP_Endpoint(TCP_Analyzer* arg_analyzer, int arg_is_orig)
+TCP_Endpoint::TCP_Endpoint(TCP_Analyzer* arg_analyzer, bool arg_is_orig)
 	{
 	contents_processor = 0;
 	prev_state = state = TCP_ENDPOINT_INACTIVE;
@@ -28,7 +28,7 @@ TCP_Endpoint::TCP_Endpoint(TCP_Analyzer* arg_analyzer, int arg_is_orig)
 	contents_start_seq = 0;
 	FIN_seq = 0;
 	SYN_cnt = FIN_cnt = RST_cnt = 0;
-	did_close = 0;
+	did_close = false;
 	contents_file = 0;
 	tcp_analyzer = arg_analyzer;
 	is_orig = arg_is_orig;
@@ -75,7 +75,7 @@ void TCP_Endpoint::SetPeer(TCP_Endpoint* p)
 		sessions->tcp_stats.StateEntered(state, peer->state);
 	}
 
-int TCP_Endpoint::HadGap() const
+bool TCP_Endpoint::HadGap() const
 	{
 	return contents_processor && contents_processor->HadGap();
 	}
@@ -90,20 +90,20 @@ void TCP_Endpoint::AddReassembler(TCP_Reassembler* arg_contents_processor)
 		contents_processor->SetContentsFile(contents_file);
 	}
 
-int TCP_Endpoint::DataPending() const
+bool TCP_Endpoint::DataPending() const
 	{
 	if ( contents_processor )
 		return contents_processor->DataPending();
 	else
-		return 0;
+		return false;
 	}
 
-int TCP_Endpoint::HasUndeliveredData() const
+bool TCP_Endpoint::HasUndeliveredData() const
 	{
 	if ( contents_processor )
 		return contents_processor->HasUndeliveredData();
 	else
-		return 0;
+		return false;
 	}
 
 void TCP_Endpoint::CheckEOF()
@@ -121,7 +121,7 @@ void TCP_Endpoint::SizeBufferedData(uint64_t& waiting_on_hole,
 		waiting_on_hole = waiting_on_ack = 0;
 	}
 
-int TCP_Endpoint::ValidChecksum(const struct tcphdr* tp, int len) const
+bool TCP_Endpoint::ValidChecksum(const struct tcphdr* tp, int len) const
 	{
 	uint32_t sum = checksum_base;
 	int tcp_len = tp->th_off * 4 + len;
@@ -199,11 +199,11 @@ uint64_t TCP_Endpoint::Size() const
 	return size;
 	}
 
-int TCP_Endpoint::DataSent(double t, uint64_t seq, int len, int caplen,
+bool TCP_Endpoint::DataSent(double t, uint64_t seq, int len, int caplen,
 				const u_char* data,
 				const IP_Hdr* ip, const struct tcphdr* tp)
 	{
-	int status = 0;
+	bool status = false;
 
 	if ( contents_processor )
 		{
@@ -267,7 +267,7 @@ void TCP_Endpoint::SetContentsFile(BroFile* f)
 		contents_processor->SetContentsFile(contents_file);
 	}
 
-int TCP_Endpoint::CheckHistory(uint32_t mask, char code)
+bool TCP_Endpoint::CheckHistory(uint32_t mask, char code)
 	{
 	if ( ! IsOrig() )
 		{

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.h
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.h
@@ -27,7 +27,7 @@ typedef enum {
 // One endpoint of a TCP connection.
 class TCP_Endpoint {
 public:
-	TCP_Endpoint(TCP_Analyzer* analyzer, int is_orig);
+	TCP_Endpoint(TCP_Analyzer* analyzer, bool is_orig);
 	~TCP_Endpoint();
 
 	void Done();
@@ -39,7 +39,7 @@ public:
 	EndpointState State() const 	{ return state; }
 	void SetState(EndpointState new_state);
 	uint64_t Size() const;
-	int IsActive() const
+	bool IsActive() const
 		{ return state != TCP_ENDPOINT_INACTIVE && ! did_close; }
 
 	double StartTime() const	{ return start_time; }
@@ -132,7 +132,7 @@ public:
 	// True if none of this endpoint's data has been acknowledged.
 	// We allow for possibly one octet being ack'd in the case of
 	// an initial SYN exchange.
-	int NoDataAcked() const
+	bool NoDataAcked() const
 		{
 		uint64_t ack = ToFullSeqSpace(ack_seq, ack_wraps);
 		uint64_t start = static_cast<uint64_t>(StartSeqI64());
@@ -141,17 +141,17 @@ public:
 
 	Connection* Conn() const;
 
-	int HasContents() const		{ return contents_processor != 0; }
-	int HadGap() const;
+	bool HasContents() const		{ return contents_processor != 0; }
+	bool HadGap() const;
 
-	inline int IsOrig() const		{ return is_orig; }
+	inline bool IsOrig() const		{ return is_orig; }
 
-	int HasDoneSomething() const	{ return last_time != 0.0; }
+	bool HasDoneSomething() const	{ return last_time != 0.0; }
 
 	void AddReassembler(TCP_Reassembler* contents_processor);
 
-	int DataPending() const;
-	int HasUndeliveredData() const;
+	bool DataPending() const;
+	bool HasUndeliveredData() const;
 	void CheckEOF();
 
 	// Returns the volume of data buffered in the reassembler.
@@ -166,7 +166,7 @@ public:
 	// WARNING: this is an O(n) operation and potentially very slow.
 	void SizeBufferedData(uint64_t& waiting_on_hole, uint64_t& waiting_on_ack);
 
-	int ValidChecksum(const struct tcphdr* tp, int len) const;
+	bool ValidChecksum(const struct tcphdr* tp, int len) const;
 
 	// Called to inform endpoint that it has generated a checksum error.
 	void ChecksumError();
@@ -182,7 +182,7 @@ public:
 
 	// Returns true if the data was used (and hence should be recorded
 	// in the save file), false otherwise.
-	int DataSent(double t, uint64_t seq, int len, int caplen, const u_char* data,
+	bool DataSent(double t, uint64_t seq, int len, int caplen, const u_char* data,
 			const IP_Hdr* ip, const struct tcphdr* tp);
 
 	void AckReceived(uint64_t seq);
@@ -203,7 +203,7 @@ public:
 #define HIST_CORRUPT_PKT 0x80
 #define HIST_RXMIT 0x100
 #define HIST_WIN0 0x200
-	int CheckHistory(uint32_t mask, char code);
+	bool CheckHistory(uint32_t mask, char code);
 	void AddHistory(char code);
 
 	//### combine into a set of flags:
@@ -224,8 +224,8 @@ public:
 	uint64_t contents_start_seq;	// relative seq # where contents file starts
 	uint64_t FIN_seq;		// relative seq # to start_seq
 	int SYN_cnt, FIN_cnt, RST_cnt;
-	int did_close;		// whether we've reported it closing
-	int is_orig;
+	bool did_close;		// whether we've reported it closing
+	bool is_orig;
 
 	// Relative sequence numbers associated with last control packets.
 	// Used to determine whether ones seen again are interesting,
@@ -253,4 +253,4 @@ protected:
 #define ENDIAN_BIG 2
 #define ENDIAN_CONFUSED 3
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -453,8 +453,8 @@ void TCP_Reassembler::Overlap(const u_char* b1, const u_char* b2, uint64_t n)
 	     // we've ever seen for the connection.
 	     (n > 1 || endp->peer->HasDoneSomething()) )
 		{
-		BroString* b1_s = new BroString((const u_char*) b1, n, 0);
-		BroString* b2_s = new BroString((const u_char*) b2, n, 0);
+		BroString* b1_s = new BroString((const u_char*) b1, n, false);
+		BroString* b2_s = new BroString((const u_char*) b2, n, false);
 
 		tcp_analyzer->EnqueueConnEvent(rexmit_inconsistency,
 			IntrusivePtr{AdoptRef{}, tcp_analyzer->BuildConnVal()},
@@ -473,7 +473,7 @@ void TCP_Reassembler::Deliver(uint64_t seq, int len, const u_char* data)
 		dst_analyzer->ForwardStream(len, data, IsOrig());
 	}
 
-int TCP_Reassembler::DataSent(double t, uint64_t seq, int len,
+bool TCP_Reassembler::DataSent(double t, uint64_t seq, int len,
 				const u_char* data, TCP_Flags arg_flags, bool replaying)
 	{
 	uint64_t ack = endp->ToRelativeSeqSpace(endp->AckSeq(), endp->AckWraps());
@@ -486,13 +486,13 @@ int TCP_Reassembler::DataSent(double t, uint64_t seq, int len,
 		}
 
 	if ( skip_deliveries )
-		return 0;
+		return false;
 
 	if ( seq < ack && ! replaying )
 		{
 		if ( upper_seq <= ack )
 			// We've already delivered this and it's been acked.
-			return 0;
+			return false;
 
 		// We've seen an ack for part of this packet, but not the
 		// whole thing.  This can happen when, for example, a previous
@@ -525,7 +525,7 @@ int TCP_Reassembler::DataSent(double t, uint64_t seq, int len,
 		skip_deliveries = true;
 		}
 
-	return 1;
+	return true;
 	}
 
 
@@ -647,19 +647,19 @@ void TCP_Reassembler::SkipToSeq(uint64_t seq)
 		}
 	}
 
-int TCP_Reassembler::DataPending() const
+bool TCP_Reassembler::DataPending() const
 	{
 	// If we are skipping deliveries, the reassembler will not get called
 	// in DataSent(), and DataSeq() will not be updated.
 	if ( skip_deliveries )
-		return 0;
+		return false;
 
 	uint64_t delivered_seq = Endpoint()->StartSeqI64() + DataSeq();
 	uint64_t last_seq = TCP_Endpoint::ToFullSeqSpace(Endpoint()->LastSeq(),
 	                                               Endpoint()->SeqWraps());
 
 	if ( last_seq < delivered_seq )
-		return 0;
+		return false;
 
 	// Q. Can we say that?
 	// ASSERT(delivered_seq <= last_seq);
@@ -676,12 +676,12 @@ int TCP_Reassembler::DataPending() const
 	// sequence space), or right at it (because a RST does not).
 	if ( delivered_seq != last_seq - 1 &&
 	     delivered_seq != last_seq )
-		return 1;
+		return true;
 
 	// If we've sent RST, then we can't send ACKs any more.
 	if ( Endpoint()->state != TCP_ENDPOINT_RESET &&
 	     Endpoint()->peer->HasUndeliveredData() )
-		return 1;
+		return true;
 
-	return 0;
+	return false;
 	}

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.h
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.h
@@ -60,7 +60,7 @@ public:
 	// Can be used to skip HTTP data for performance considerations.
 	void SkipToSeq(uint64_t seq);
 
-	int DataSent(double t, uint64_t seq, int len, const u_char* data,
+	bool DataSent(double t, uint64_t seq, int len, const u_char* data,
 		     analyzer::tcp::TCP_Flags flags, bool replaying=true);
 	void AckReceived(uint64_t seq);
 
@@ -69,9 +69,9 @@ public:
 	// when so.
 	void CheckEOF();
 
-	int HasUndeliveredData() const	{ return HasBlocks(); }
-	int HadGap() const	{ return had_gap; }
-	int DataPending() const;
+	bool HasUndeliveredData() const	{ return HasBlocks(); }
+	bool HadGap() const	{ return had_gap; }
+	bool DataPending() const;
 	uint64_t DataSeq() const		{ return LastReassemSeq(); }
 
 	void DeliverBlock(uint64_t seq, int len, const u_char* data);
@@ -80,7 +80,7 @@ public:
 	TCP_Endpoint* Endpoint()		{ return endp; }
 	const TCP_Endpoint* Endpoint() const	{ return endp; }
 
-	int IsOrig() const	{ return endp->IsOrig(); }
+	bool IsOrig() const	{ return endp->IsOrig(); }
 
 	bool IsSkippedContents(uint64_t seq, int length) const
 		{ return seq + length <= seq_to_skip; }

--- a/src/analyzer/protocol/teredo/Teredo.cc
+++ b/src/analyzer/protocol/teredo/Teredo.cc
@@ -119,9 +119,9 @@ RecordVal* TeredoEncapsulation::BuildVal(const IP_Hdr* inner) const
 		uint64_t nonce = ntohll(*((uint64_t*)(auth + 4 + id_len + au_len)));
 		uint8_t conf = *((uint8_t*)(auth + 4 + id_len + au_len + 8));
 		teredo_auth->Assign(0, make_intrusive<StringVal>(
-		    new BroString(auth + 4, id_len, 1)));
+		    new BroString(auth + 4, id_len, true)));
 		teredo_auth->Assign(1, make_intrusive<StringVal>(
-		    new BroString(auth + 4 + id_len, au_len, 1)));
+		    new BroString(auth + 4 + id_len, au_len, true)));
 		teredo_auth->Assign(2, val_mgr->GetCount(nonce));
 		teredo_auth->Assign(3, val_mgr->GetCount(conf));
 		teredo_hdr->Assign(0, teredo_auth);

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -207,14 +207,14 @@ void UDP_Analyzer::UpdateConnVal(RecordVal *conn_val)
 	RecordVal *orig_endp = conn_val->Lookup("orig")->AsRecordVal();
 	RecordVal *resp_endp = conn_val->Lookup("resp")->AsRecordVal();
 
-	UpdateEndpointVal(orig_endp, 1);
-	UpdateEndpointVal(resp_endp, 0);
+	UpdateEndpointVal(orig_endp, true);
+	UpdateEndpointVal(resp_endp, false);
 
 	// Call children's UpdateConnVal
 	Analyzer::UpdateConnVal(conn_val);
 	}
 
-void UDP_Analyzer::UpdateEndpointVal(RecordVal* endp, int is_orig)
+void UDP_Analyzer::UpdateEndpointVal(RecordVal* endp, bool is_orig)
 	{
 	bro_int_t size = is_orig ? request_len : reply_len;
 	if ( size < 0 )
@@ -232,7 +232,7 @@ void UDP_Analyzer::UpdateEndpointVal(RecordVal* endp, int is_orig)
 
 bool UDP_Analyzer::IsReuse(double /* t */, const u_char* /* pkt */)
 	{
-	return 0;
+	return false;
 	}
 
 unsigned int UDP_Analyzer::MemoryAllocation() const

--- a/src/analyzer/protocol/udp/UDP.h
+++ b/src/analyzer/protocol/udp/UDP.h
@@ -39,7 +39,7 @@ protected:
 	bro_int_t request_len, reply_len;
 
 private:
-	void UpdateEndpointVal(RecordVal* endp, int is_orig);
+	void UpdateEndpointVal(RecordVal* endp, bool is_orig);
 
 #define HIST_ORIG_DATA_PKT 0x1
 #define HIST_RESP_DATA_PKT 0x2
@@ -51,4 +51,4 @@ private:
 	uint32_t rep_chk_cnt, rep_chk_thresh;
 };
 
-} } // namespace analyzer::* 
+} } // namespace analyzer::*

--- a/src/file_analysis/AnalyzerSet.cc
+++ b/src/file_analysis/AnalyzerSet.cc
@@ -166,7 +166,7 @@ HashKey* AnalyzerSet::GetKey(const file_analysis::Tag& t, RecordVal* args) const
 	ListVal* lv = new ListVal(TYPE_ANY);
 	lv->Append(t.AsEnumVal()->Ref());
 	lv->Append(args->Ref());
-	HashKey* key = analyzer_hash->ComputeHash(lv, 1);
+	HashKey* key = analyzer_hash->ComputeHash(lv, true);
 	Unref(lv);
 	if ( ! key )
 		reporter->InternalError("AnalyzerArgs type mismatch");

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -301,7 +301,7 @@ bool File::SetMime(const string& mime_type)
 
 	auto meta = make_intrusive<RecordVal>(fa_metadata_type);
 	meta->Assign(meta_mime_type_idx, make_intrusive<StringVal>(mime_type));
-	meta->Assign(meta_inferred_idx, val_mgr->GetBool(0));
+	meta->Assign(meta_inferred_idx, val_mgr->GetFalse());
 
 	FileEvent(file_sniff, {IntrusivePtr{NewRef{}, val}, std::move(meta)});
 	return true;
@@ -352,7 +352,7 @@ bool File::BufferBOF(const u_char* data, uint64_t len)
 
 	uint64_t desired_size = LookupFieldDefaultCount(bof_buffer_size_idx);
 
-	bof_buffer.chunks.push_back(new BroString(data, len, 0));
+	bof_buffer.chunks.push_back(new BroString(data, len, false));
 	bof_buffer.size += len;
 
 	if ( bof_buffer.size < desired_size )

--- a/src/file_analysis/FileTimer.cc
+++ b/src/file_analysis/FileTimer.cc
@@ -13,7 +13,7 @@ FileTimer::FileTimer(double t, const string& id, double interval)
 	        interval, file_id.c_str());
 	}
 
-void FileTimer::Dispatch(double t, int is_expire)
+void FileTimer::Dispatch(double t, bool is_expire)
 	{
 	File* file = file_mgr->LookupFile(file_id);
 

--- a/src/file_analysis/FileTimer.h
+++ b/src/file_analysis/FileTimer.h
@@ -30,7 +30,7 @@ public:
 	 * @param t current unix time
 	 * @param is_expire true if all pending timers are being expired.
 	 */
-	void Dispatch(double t, int is_expire) override;
+	void Dispatch(double t, bool is_expire) override;
 
 private:
 	string file_id;

--- a/src/file_analysis/analyzer/data_event/DataEvent.cc
+++ b/src/file_analysis/analyzer/data_event/DataEvent.cc
@@ -44,7 +44,7 @@ bool DataEvent::DeliverChunk(const u_char* data, uint64_t len, uint64_t offset)
 
 	mgr.Enqueue(chunk_event,
 		IntrusivePtr{NewRef{}, GetFile()->GetVal()},
-		make_intrusive<StringVal>(new BroString(data, len, 0)),
+		make_intrusive<StringVal>(new BroString(data, len, false)),
 		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(offset)}
 	);
 
@@ -57,7 +57,7 @@ bool DataEvent::DeliverStream(const u_char* data, uint64_t len)
 
 	mgr.Enqueue(stream_event,
 		IntrusivePtr{NewRef{}, GetFile()->GetVal()},
-		make_intrusive<StringVal>(new BroString(data, len, 0))
+		make_intrusive<StringVal>(new BroString(data, len, false))
 	);
 
 	return true;

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -290,7 +290,7 @@ void file_analysis::X509::ParseBasicConstraints(X509_EXTENSION* ex)
 		if ( x509_ext_basic_constraints )
 			{
 			auto pBasicConstraint = make_intrusive<RecordVal>(BifType::Record::X509::BasicConstraints);
-			pBasicConstraint->Assign(0, val_mgr->GetBool(constr->ca ? 1 : 0));
+			pBasicConstraint->Assign(0, val_mgr->GetBool(constr->ca));
 
 			if ( constr->pathlen )
 				pBasicConstraint->Assign(1, val_mgr->GetCount((int32_t) ASN1_INTEGER_get(constr->pathlen)));
@@ -344,7 +344,7 @@ void file_analysis::X509::ParseSAN(X509_EXTENSION* ext)
 	VectorVal* uris = 0;
 	VectorVal* ips = 0;
 
-	unsigned int otherfields = 0;
+	bool otherfields = false;
 
 	for ( int i = 0; i < sk_GENERAL_NAME_num(altname); i++ )
 		{
@@ -415,7 +415,7 @@ void file_analysis::X509::ParseSAN(X509_EXTENSION* ext)
 			{
 			// reporter->Error("Subject alternative name contained unsupported fields. fuid %s", GetFile()->GetID().c_str());
 			// This happens quite often - just mark it
-			otherfields = 1;
+			otherfields = true;
 			continue;
 			}
 		}

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -623,7 +623,7 @@ function sct_verify%(cert: opaque of x509, logid: string, log_key: string, signa
 	if ( precert && issuer_key_hash->Len() != 32)
 		{
 		reporter->Error("Invalid issuer_key_hash length");
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 		}
 
 	std::string data;
@@ -647,7 +647,7 @@ function sct_verify%(cert: opaque of x509, logid: string, log_key: string, signa
 		if ( pos < 0 )
 			{
 			reporter->Error("NID_ct_precert_scts not found");
-			return val_mgr->GetBool(0);
+			return val_mgr->GetFalse();
 			}
 #else
 		int num_ext = X509_get_ext_count(x);
@@ -751,7 +751,7 @@ sct_verify_err:
 		EVP_PKEY_free(key);
 
 	reporter->Error("%s", errstr.c_str());
-	return val_mgr->GetBool(0);
+	return val_mgr->GetFalse();
 	%}
 
 

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -224,9 +224,9 @@ ReaderBackend* Manager::CreateBackend(ReaderFrontend* frontend, EnumVal* tag)
 bool Manager::CreateStream(Stream* info, RecordVal* description)
 	{
 	RecordType* rtype = description->Type()->AsRecordType();
-	if ( ! ( same_type(rtype, BifType::Record::Input::TableDescription, 0)
-		|| same_type(rtype, BifType::Record::Input::EventDescription, 0)
-		|| same_type(rtype, BifType::Record::Input::AnalysisDescription, 0) ) )
+	if ( ! ( same_type(rtype, BifType::Record::Input::TableDescription, false)
+		|| same_type(rtype, BifType::Record::Input::EventDescription, false)
+		|| same_type(rtype, BifType::Record::Input::AnalysisDescription, false) ) )
 		{
 		reporter->Error("Stream description argument not of right type for new input stream");
 		return false;
@@ -311,7 +311,7 @@ bool Manager::CreateStream(Stream* info, RecordVal* description)
 bool Manager::CreateEventStream(RecordVal* fval)
 	{
 	RecordType* rtype = fval->Type()->AsRecordType();
-	if ( ! same_type(rtype, BifType::Record::Input::EventDescription, 0) )
+	if ( ! same_type(rtype, BifType::Record::Input::EventDescription, false) )
 		{
 		reporter->Error("EventDescription argument not of right type");
 		return false;
@@ -344,13 +344,13 @@ bool Manager::CreateEventStream(RecordVal* fval)
 		return false;
 		}
 
-	if ( ! same_type((*args)[1], BifType::Enum::Input::Event, 0) )
+	if ( ! same_type((*args)[1], BifType::Enum::Input::Event, false) )
 		{
 		reporter->Error("Input stream %s: Event's second attribute must be of type Input::Event", stream_name.c_str());
 		return false;
 		}
 
-	if ( ! same_type((*args)[0], BifType::Record::Input::EventDescription, 0) )
+	if ( ! same_type((*args)[0], BifType::Record::Input::EventDescription, false) )
 		{
 		reporter->Error("Input stream %s: Event's first attribute must be of type Input::EventDescription", stream_name.c_str());
 		return false;
@@ -464,7 +464,7 @@ bool Manager::CreateEventStream(RecordVal* fval)
 bool Manager::CreateTableStream(RecordVal* fval)
 	{
 	RecordType* rtype = fval->Type()->AsRecordType();
-	if ( ! same_type(rtype, BifType::Record::Input::TableDescription, 0) )
+	if ( ! same_type(rtype, BifType::Record::Input::TableDescription, false) )
 		{
 		reporter->Error("TableDescription argument not of right type");
 		return false;
@@ -571,13 +571,13 @@ bool Manager::CreateTableStream(RecordVal* fval)
 			return false;
 			}
 
-		if ( ! same_type((*args)[0], BifType::Record::Input::TableDescription, 0) )
+		if ( ! same_type((*args)[0], BifType::Record::Input::TableDescription, false) )
 			{
 			reporter->Error("Input stream %s: Table event's first attribute must be of type Input::TableDescription", stream_name.c_str());
 			return false;
 			}
 
-		if ( ! same_type((*args)[1], BifType::Enum::Input::Event, 0) )
+		if ( ! same_type((*args)[1], BifType::Enum::Input::Event, false) )
 			{
 			reporter->Error("Input stream %s: Table event's second attribute must be of type Input::Event", stream_name.c_str());
 			return false;
@@ -718,13 +718,13 @@ bool Manager::CheckErrorEventTypes(const std::string& stream_name, const Func* e
 		return false;
 		}
 
-	if ( table && ! same_type((*args)[0], BifType::Record::Input::TableDescription, 0) )
+	if ( table && ! same_type((*args)[0], BifType::Record::Input::TableDescription, false) )
 		{
 		reporter->Error("Input stream %s: Error event's first attribute must be of type Input::TableDescription", stream_name.c_str());
 		return false;
 		}
 
-	if ( ! table && ! same_type((*args)[0], BifType::Record::Input::EventDescription, 0) )
+	if ( ! table && ! same_type((*args)[0], BifType::Record::Input::EventDescription, false) )
 		{
 		reporter->Error("Input stream %s: Error event's first attribute must be of type Input::EventDescription", stream_name.c_str());
 		return false;
@@ -736,7 +736,7 @@ bool Manager::CheckErrorEventTypes(const std::string& stream_name, const Func* e
 		return false;
 		}
 
-	if ( ! same_type((*args)[2], BifType::Enum::Reporter::Level, 0) )
+	if ( ! same_type((*args)[2], BifType::Enum::Reporter::Level, false) )
 		{
 		reporter->Error("Input stream %s: Error event's third attribute must be of type Reporter::Level", stream_name.c_str());
 		return false;
@@ -749,7 +749,7 @@ bool Manager::CreateAnalysisStream(RecordVal* fval)
 	{
 	RecordType* rtype = fval->Type()->AsRecordType();
 
-	if ( ! same_type(rtype, BifType::Record::Input::AnalysisDescription, 0) )
+	if ( ! same_type(rtype, BifType::Record::Input::AnalysisDescription, false) )
 		{
 		reporter->Error("AnalysisDescription argument not of right type");
 		return false;
@@ -1536,7 +1536,7 @@ int Manager::PutTable(Stream* i, const Value* const *vals)
 	assert(i->stream_type == TABLE_STREAM);
 	TableStream* stream = (TableStream*) i;
 
-	bool convert_error = 0;
+	bool convert_error = false;
 
 	Val* idxval = ValueToIndexVal(i, stream->num_idx_fields, stream->itype, vals, convert_error);
 	Val* valval;
@@ -2276,7 +2276,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, BroType* request_typ
 
 	case TYPE_STRING:
 		{
-		BroString *s = new BroString((const u_char*)val->val.string_val.data, val->val.string_val.length, 1);
+		BroString *s = new BroString((const u_char*)val->val.string_val.data, val->val.string_val.length, true);
 		return new StringVal(s);
 		}
 
@@ -2424,7 +2424,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, bool& have_error) co
 
 	case TYPE_STRING:
 		{
-		BroString *s = new BroString((const u_char*)val->val.string_val.data, val->val.string_val.length, 1);
+		BroString *s = new BroString((const u_char*)val->val.string_val.data, val->val.string_val.length, true);
 		return new StringVal(s);
 		}
 

--- a/src/iosource/Packet.cc
+++ b/src/iosource/Packet.cc
@@ -19,7 +19,7 @@ extern "C" {
 }
 
 void Packet::Init(int arg_link_type, pkt_timeval *arg_ts, uint32_t arg_caplen,
-		  uint32_t arg_len, const u_char *arg_data, int arg_copy,
+		  uint32_t arg_len, const u_char *arg_data, bool arg_copy,
 		  std::string arg_tag)
 	{
 	if ( data && copy )
@@ -595,7 +595,7 @@ RecordVal* Packet::BuildPktHdrVal() const
 	RecordVal* pkt_hdr = new RecordVal(raw_pkt_hdr_type);
 	RecordVal* l2_hdr = new RecordVal(l2_hdr_type);
 
-	int is_ethernet = (link_type == DLT_EN10MB) ? 1 : 0;
+	bool is_ethernet = link_type == DLT_EN10MB;
 
 	int l3 = BifEnum::L3_UNKNOWN;
 

--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -57,7 +57,7 @@ public:
 	 * differentiating the input streams.
 	 */
 	Packet(int link_type, pkt_timeval *ts, uint32_t caplen,
-	       uint32_t len, const u_char *data, int copy = false,
+	       uint32_t len, const u_char *data, bool copy = false,
 	       std::string tag = std::string(""))
 	           : data(0), l2_src(0), l2_dst(0)
 	       {
@@ -105,7 +105,7 @@ public:
 	 * differentiating the input streams.
 	 */
 	void Init(int link_type, pkt_timeval *ts, uint32_t caplen,
-		uint32_t len, const u_char *data, int copy = false,
+		uint32_t len, const u_char *data, bool copy = false,
 		std::string tag = std::string(""));
 
 	/**

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -230,7 +230,7 @@ bool Manager::CreateStream(EnumVal* id, RecordVal* sval)
 	{
 	RecordType* rtype = sval->Type()->AsRecordType();
 
-	if ( ! same_type(rtype, BifType::Record::Log::Stream, 0) )
+	if ( ! same_type(rtype, BifType::Record::Log::Stream, false) )
 		{
 		reporter->Error("sval argument not of right type");
 		return false;
@@ -288,7 +288,7 @@ bool Manager::CreateStream(EnumVal* id, RecordVal* sval)
 		if ( ! same_type((*args)[0], columns) )
 			{
 			reporter->Error("stream event's argument type does not match column record type");
-			return val_mgr->GetBool(0);
+			return val_mgr->GetFalse();
 			}
 		}
 
@@ -533,7 +533,7 @@ bool Manager::AddFilter(EnumVal* id, RecordVal* fval)
 	{
 	RecordType* rtype = fval->Type()->AsRecordType();
 
-	if ( ! same_type(rtype, BifType::Record::Log::Filter, 0) )
+	if ( ! same_type(rtype, BifType::Record::Log::Filter, false) )
 		{
 		reporter->Error("filter argument not of right type");
 		return false;
@@ -1401,7 +1401,7 @@ public:
 
 	~RotationTimer();
 
-	void Dispatch(double t, int is_expire);
+	void Dispatch(double t, bool is_expire) override;
 
 protected:
 	Manager::WriterInfo* winfo;
@@ -1414,7 +1414,7 @@ RotationTimer::~RotationTimer()
 		winfo->rotation_timer = 0;
 	}
 
-void RotationTimer::Dispatch(double t, int is_expire)
+void RotationTimer::Dispatch(double t, bool is_expire)
 	{
 	winfo->rotation_timer = 0;
 

--- a/src/probabilistic/Topk.cc
+++ b/src/probabilistic/Topk.cc
@@ -34,7 +34,7 @@ void TopkVal::Typify(BroType* t)
 
 HashKey* TopkVal::GetHash(Val* v) const
 	{
-	HashKey* key = hash->ComputeHash(v, 1);
+	HashKey* key = hash->ComputeHash(v, true);
 	assert(key);
 	return key;
 	}

--- a/src/probabilistic/cardinality-counter.bif
+++ b/src/probabilistic/cardinality-counter.bif
@@ -45,17 +45,17 @@ function hll_cardinality_add%(handle: opaque of cardinality, elem: any%): bool
 	if ( ! cv->Type() && ! cv->Typify(elem->Type()) )
 		{
 		reporter->Error("failed to set HLL type");
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 		}
 
 	else if ( ! same_type(cv->Type(), elem->Type()) )
 		{
 		reporter->Error("incompatible HLL data type");
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 		}
 
 	cv->Add(elem);
-	return val_mgr->GetBool(1);
+	return val_mgr->GetTrue();
 	%}
 
 ## Merges a HLL cardinality counter into another.
@@ -82,7 +82,7 @@ function hll_cardinality_merge_into%(handle1: opaque of cardinality, handle2: op
 	     ! same_type(v1->Type(), v2->Type()) )
 		{
 		reporter->Error("incompatible HLL types");
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 		}
 
 	CardinalityCounter* h1 = v1->Get();
@@ -92,10 +92,10 @@ function hll_cardinality_merge_into%(handle1: opaque of cardinality, handle2: op
 	if ( ! res )
 		{
 		reporter->Error("Cardinality counters with different parameters cannot be merged");
-		return val_mgr->GetBool(0);
+		return val_mgr->GetFalse();
 		}
 
-	return val_mgr->GetBool(1);
+	return val_mgr->GetTrue();
 	%}
 
 ## Estimate the current cardinality of an HLL cardinality counter.

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -145,7 +145,7 @@ ParentProcessCheckTimer::ParentProcessCheckTimer(double t, double arg_interval)
 	{
 	}
 
-void ParentProcessCheckTimer::Dispatch(double t, int is_expire)
+void ParentProcessCheckTimer::Dispatch(double t, bool is_expire)
 	{
 	// Note: only simple + portable way of detecting loss of parent
 	// process seems to be polling for change in PPID.  There's platform

--- a/src/supervisor/Supervisor.h
+++ b/src/supervisor/Supervisor.h
@@ -406,7 +406,7 @@ public:
 
 protected:
 
-	void Dispatch(double t, int is_expire) override;
+	void Dispatch(double t, bool is_expire) override;
 
 	double interval;
 };

--- a/src/threading/Manager.cc
+++ b/src/threading/Manager.cc
@@ -8,7 +8,7 @@
 
 using namespace threading;
 
-void HeartbeatTimer::Dispatch(double t, int is_expire)
+void HeartbeatTimer::Dispatch(double t, bool is_expire)
 	{
 	if ( is_expire )
 		return;

--- a/src/threading/Manager.h
+++ b/src/threading/Manager.h
@@ -14,7 +14,7 @@ public:
 	HeartbeatTimer(double t) : Timer(t, TIMER_THREAD_HEARTBEAT) {}
 	virtual ~HeartbeatTimer() {}
 
-	void Dispatch(double t, int is_expire);
+	void Dispatch(double t, bool is_expire) override;
 
 protected:
 

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -144,7 +144,7 @@ static void do_fmt(const char*& fmt, Val* v, ODesc* d)
 		time_t time = time_t(v->InternalDouble());
 		struct tm t;
 
-		int is_time_fmt = *fmt == 'T';
+		bool is_time_fmt = *fmt == 'T';
 
 		if ( ! localtime_r(&time, &t) )
 			s.AddSP("<problem getting time>");

--- a/src/zeekygen/ScriptInfo.cc
+++ b/src/zeekygen/ScriptInfo.cc
@@ -83,7 +83,7 @@ static string make_summary(const string& heading, char underline, char border,
 		{
 		ID* id = (*it)->GetID();
 		ODesc d;
-		d.SetQuotes(1);
+		d.SetQuotes(true);
 		id->DescribeReSTShort(&d);
 		add_summary_rows(d, summary_comment((*it)->GetComments()), &table);
 		}
@@ -106,7 +106,7 @@ static string make_redef_summary(const string& heading, char underline,
 		{
 		ID* id = (*it)->GetID();
 		ODesc d;
-		d.SetQuotes(1);
+		d.SetQuotes(true);
 		id->DescribeReSTShort(&d);
 
 		typedef list<IdentifierInfo::Redefinition> redef_list;
@@ -389,5 +389,3 @@ time_t ScriptInfo::DoGetModificationTime() const
 
 	return most_recent;
 	}
-
-


### PR DESCRIPTION
This PR makes the massive switch from using `int` types for boolean values to using `bool` types for most of them. This has bugged me for a while and I thought I'd finally take care of it.

There's a few other things in here:
- Some of the `Dispatch` methods for timers where not marked as `override`. These have been fixed.
- The logic in `Event::Describe` changed a little bit, but the old logic didn't make a lot of sense to begin with.
- `NVT_Analyzer`'s constructor changes from calling the default initializer on basic types to using in-class intiialization.
- I left the bit-set-being-used-as-booleans in `Conn` alone, since we already know changing that causes performance issues from a previous PR.
- Removed the `virtual` keyword from `NCP_Session::Deliver`, since that class is never inherited from anywhere.
- Removed unnecessary `const` from a number of method arguments in `SMTP_Analyzer`

I tried to make as few changes to virtual methods that may be overridden so as to minimize API breakage. I admittedly didn't go through all of the call sites for the methods I changed so I'm sure I missed places that could be converted as well, but this is the large majority of it.