### PR TITLE
Add missing override specifiers

### DIFF
--- a/src/Var.cc
+++ b/src/Var.cc
@@ -421,8 +421,8 @@ public:
 	OuterIDBindingFinder(Scope* s)
 		: scope(s) { }
 
-	virtual TraversalCode PreExpr(const Expr*);
-	virtual TraversalCode PostExpr(const Expr*);
+	TraversalCode PreExpr(const Expr*) override;
+	TraversalCode PostExpr(const Expr*) override;
 
 	Scope* scope;
 	vector<const NameExpr*> outer_id_references;

--- a/src/analyzer/protocol/arp/Plugin.cc
+++ b/src/analyzer/protocol/arp/Plugin.cc
@@ -8,7 +8,7 @@ namespace Zeek_ARP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		plugin::Configuration config;
 		config.name = "Zeek::ARP";

--- a/src/analyzer/protocol/ayiya/Plugin.cc
+++ b/src/analyzer/protocol/ayiya/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_AYIYA {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("AYIYA", ::analyzer::ayiya::AYIYA_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/bittorrent/Plugin.cc
+++ b/src/analyzer/protocol/bittorrent/Plugin.cc
@@ -10,7 +10,7 @@ namespace Zeek_BitTorrent {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("BitTorrent", ::analyzer::bittorrent::BitTorrent_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("BitTorrentTracker", ::analyzer::bittorrent::BitTorrentTracker_Analyzer::Instantiate));

--- a/src/analyzer/protocol/conn-size/Plugin.cc
+++ b/src/analyzer/protocol/conn-size/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_ConnSize {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("ConnSize", ::analyzer::conn_size::ConnSize_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/dce-rpc/Plugin.cc
+++ b/src/analyzer/protocol/dce-rpc/Plugin.cc
@@ -10,7 +10,7 @@ namespace Zeek_DCE_RPC {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("DCE_RPC", ::analyzer::dce_rpc::DCE_RPC_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/dhcp/Plugin.cc
+++ b/src/analyzer/protocol/dhcp/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_DHCP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("DHCP", ::analyzer::dhcp::DHCP_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/dnp3/Plugin.cc
+++ b/src/analyzer/protocol/dnp3/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_DNP3 {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("DNP3_TCP", ::analyzer::dnp3::DNP3_TCP_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("DNP3_UDP", ::analyzer::dnp3::DNP3_UDP_Analyzer::Instantiate));

--- a/src/analyzer/protocol/dns/Plugin.cc
+++ b/src/analyzer/protocol/dns/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_DNS {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("DNS", ::analyzer::dns::DNS_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("Contents_DNS", 0));

--- a/src/analyzer/protocol/file/Plugin.cc
+++ b/src/analyzer/protocol/file/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_File {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("FTP_Data", ::analyzer::file::FTP_Data::Instantiate));
 		AddComponent(new ::analyzer::Component("IRC_Data", ::analyzer::file::IRC_Data::Instantiate));

--- a/src/analyzer/protocol/finger/Plugin.cc
+++ b/src/analyzer/protocol/finger/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_Finger {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("Finger", ::analyzer::finger::Finger_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/ftp/Plugin.cc
+++ b/src/analyzer/protocol/ftp/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_FTP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("FTP", ::analyzer::ftp::FTP_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("FTP_ADAT", 0));

--- a/src/analyzer/protocol/gnutella/Plugin.cc
+++ b/src/analyzer/protocol/gnutella/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_Gnutella {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("Gnutella", ::analyzer::gnutella::Gnutella_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/gssapi/Plugin.cc
+++ b/src/analyzer/protocol/gssapi/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_GSSAPI {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("GSSAPI", ::analyzer::gssapi::GSSAPI_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/gtpv1/Plugin.cc
+++ b/src/analyzer/protocol/gtpv1/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_GTPv1 {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("GTPv1", ::analyzer::gtpv1::GTPv1_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -176,7 +176,7 @@ void HTTP_Entity::Deliver(int len, const char* data, int trailing_CRLF)
 class HTTP_Entity::UncompressedOutput : public analyzer::OutputHandler {
 public:
 	UncompressedOutput(HTTP_Entity* e)	{ entity = e; }
-	virtual void DeliverStream(int len, const u_char* data, bool orig)
+	void DeliverStream(int len, const u_char* data, bool orig) override
 		{
 		entity->DeliverBodyClear(len, (char*) data, false);
 		}

--- a/src/analyzer/protocol/http/Plugin.cc
+++ b/src/analyzer/protocol/http/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_HTTP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("HTTP", ::analyzer::http::HTTP_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/icmp/Plugin.cc
+++ b/src/analyzer/protocol/icmp/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_ICMP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("ICMP", ::analyzer::icmp::ICMP_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/ident/Plugin.cc
+++ b/src/analyzer/protocol/ident/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_Ident {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("Ident", ::analyzer::ident::Ident_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/imap/Plugin.cc
+++ b/src/analyzer/protocol/imap/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_IMAP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("IMAP", ::analyzer::imap::IMAP_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/irc/Plugin.cc
+++ b/src/analyzer/protocol/irc/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_IRC {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("IRC", ::analyzer::irc::IRC_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/krb/Plugin.cc
+++ b/src/analyzer/protocol/krb/Plugin.cc
@@ -9,7 +9,7 @@ namespace plugin {
 	namespace Zeek_KRB {
 		class Plugin : public plugin::Plugin {
 		public:
-			plugin::Configuration Configure()
+			plugin::Configuration Configure() override
 				{
 				AddComponent(new ::analyzer::Component("KRB", ::analyzer::krb::KRB_Analyzer::Instantiate));
 				AddComponent(new ::analyzer::Component("KRB_TCP", ::analyzer::krb_tcp::KRB_Analyzer::Instantiate));

--- a/src/analyzer/protocol/login/Plugin.cc
+++ b/src/analyzer/protocol/login/Plugin.cc
@@ -12,7 +12,7 @@ namespace Zeek_Login {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("Telnet", ::analyzer::login::Telnet_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("Rsh", ::analyzer::login::Rsh_Analyzer::Instantiate));

--- a/src/analyzer/protocol/mime/Plugin.cc
+++ b/src/analyzer/protocol/mime/Plugin.cc
@@ -8,7 +8,7 @@ namespace Zeek_MIME {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		plugin::Configuration config;
 		config.name = "Zeek::MIME";

--- a/src/analyzer/protocol/modbus/Plugin.cc
+++ b/src/analyzer/protocol/modbus/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_Modbus {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("MODBUS", ::analyzer::modbus::ModbusTCP_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/mqtt/Plugin.cc
+++ b/src/analyzer/protocol/mqtt/Plugin.cc
@@ -4,16 +4,16 @@
 #include "plugin/Plugin.h"
 #include "analyzer/Component.h"
 
-namespace plugin { 
+namespace plugin {
 namespace Zeek_MQTT {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("MQTT",
 		             ::analyzer::MQTT::MQTT_Analyzer::InstantiateAnalyzer));
-		
+
 		plugin::Configuration config;
 		config.name = "Zeek::MQTT";
 		config.description = "Message Queuing Telemetry Transport v3.1.1 Protocol analyzer";

--- a/src/analyzer/protocol/mysql/Plugin.cc
+++ b/src/analyzer/protocol/mysql/Plugin.cc
@@ -8,7 +8,7 @@ namespace plugin {
 	namespace Zeek_MySQL {
 		class Plugin : public plugin::Plugin {
 		public:
-			plugin::Configuration Configure()
+			plugin::Configuration Configure() override
 				{
 				AddComponent(new ::analyzer::Component("MySQL", ::analyzer::MySQL::MySQL_Analyzer::Instantiate));
 				plugin::Configuration config;

--- a/src/analyzer/protocol/ncp/Plugin.cc
+++ b/src/analyzer/protocol/ncp/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_NCP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("NCP", ::analyzer::ncp::NCP_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("Contents_NCP", 0));

--- a/src/analyzer/protocol/netbios/Plugin.cc
+++ b/src/analyzer/protocol/netbios/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_NetBIOS {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("NetbiosSSN", ::analyzer::netbios_ssn::NetbiosSSN_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("Contents_NetbiosSSN", 0));

--- a/src/analyzer/protocol/ntlm/Plugin.cc
+++ b/src/analyzer/protocol/ntlm/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_NTLM {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("NTLM", ::analyzer::ntlm::NTLM_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/ntp/Plugin.cc
+++ b/src/analyzer/protocol/ntp/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_NTP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("NTP", ::analyzer::NTP::NTP_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/pia/Plugin.cc
+++ b/src/analyzer/protocol/pia/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_PIA {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("PIA_TCP", ::analyzer::pia::PIA_TCP::Instantiate));
 		AddComponent(new ::analyzer::Component("PIA_UDP", ::analyzer::pia::PIA_UDP::Instantiate));

--- a/src/analyzer/protocol/pop3/Plugin.cc
+++ b/src/analyzer/protocol/pop3/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_POP3 {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("POP3", ::analyzer::pop3::POP3_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/radius/Plugin.cc
+++ b/src/analyzer/protocol/radius/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_RADIUS {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("RADIUS", ::analyzer::RADIUS::RADIUS_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/rdp/Plugin.cc
+++ b/src/analyzer/protocol/rdp/Plugin.cc
@@ -7,7 +7,7 @@ namespace Zeek_RDP {
 
 class Plugin : public plugin::Plugin {
 public:
-        plugin::Configuration Configure()
+        plugin::Configuration Configure() override
                 {
                 AddComponent(new ::analyzer::Component("RDP", ::analyzer::rdp::RDP_Analyzer::InstantiateAnalyzer));
 

--- a/src/analyzer/protocol/rfb/Plugin.cc
+++ b/src/analyzer/protocol/rfb/Plugin.cc
@@ -7,7 +7,7 @@ namespace Zeek_RFB {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("RFB",
 		             ::analyzer::rfb::RFB_Analyzer::InstantiateAnalyzer));

--- a/src/analyzer/protocol/rpc/Plugin.cc
+++ b/src/analyzer/protocol/rpc/Plugin.cc
@@ -12,7 +12,7 @@ namespace Zeek_RPC {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("NFS", ::analyzer::rpc::NFS_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("MOUNT", ::analyzer::rpc::MOUNT_Analyzer::Instantiate));

--- a/src/analyzer/protocol/sip/Plugin.cc
+++ b/src/analyzer/protocol/sip/Plugin.cc
@@ -10,7 +10,7 @@ namespace Zeek_SIP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("SIP", ::analyzer::SIP::SIP_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/smb/Plugin.cc
+++ b/src/analyzer/protocol/smb/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_SMB {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("SMB", ::analyzer::smb::SMB_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("Contents_SMB", 0));

--- a/src/analyzer/protocol/smtp/Plugin.cc
+++ b/src/analyzer/protocol/smtp/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_SMTP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("SMTP", ::analyzer::smtp::SMTP_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/snmp/Plugin.cc
+++ b/src/analyzer/protocol/snmp/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_SNMP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("SNMP", ::analyzer::snmp::SNMP_Analyzer::InstantiateAnalyzer));
 

--- a/src/analyzer/protocol/socks/Plugin.cc
+++ b/src/analyzer/protocol/socks/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_SOCKS {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("SOCKS", ::analyzer::socks::SOCKS_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/ssh/Plugin.cc
+++ b/src/analyzer/protocol/ssh/Plugin.cc
@@ -9,7 +9,7 @@ namespace plugin {
 
 		class Plugin : public plugin::Plugin {
 		public:
-			plugin::Configuration Configure()
+			plugin::Configuration Configure() override
 				{
 				AddComponent(new ::analyzer::Component("SSH", ::analyzer::SSH::SSH_Analyzer::Instantiate));
 
@@ -22,4 +22,3 @@ namespace plugin {
 
 		}
 	}
-

--- a/src/analyzer/protocol/ssl/Plugin.cc
+++ b/src/analyzer/protocol/ssl/Plugin.cc
@@ -10,7 +10,7 @@ namespace Zeek_SSL {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("SSL", ::analyzer::ssl::SSL_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("DTLS", ::analyzer::dtls::DTLS_Analyzer::Instantiate));
@@ -24,4 +24,3 @@ public:
 
 }
 }
-

--- a/src/analyzer/protocol/stepping-stone/Plugin.cc
+++ b/src/analyzer/protocol/stepping-stone/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_SteppingStone {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("SteppingStone", ::analyzer::stepping_stone::SteppingStone_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/syslog/Plugin.cc
+++ b/src/analyzer/protocol/syslog/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_Syslog {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("Syslog", ::analyzer::syslog::Syslog_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/tcp/Plugin.cc
+++ b/src/analyzer/protocol/tcp/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_TCP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("TCP", ::analyzer::tcp::TCP_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("TCPStats", ::analyzer::tcp::TCPStats_Analyzer::Instantiate));

--- a/src/analyzer/protocol/teredo/Plugin.cc
+++ b/src/analyzer/protocol/teredo/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_Teredo {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("Teredo", ::analyzer::teredo::Teredo_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/udp/Plugin.cc
+++ b/src/analyzer/protocol/udp/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_UDP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("UDP", ::analyzer::udp::UDP_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/vxlan/Plugin.cc
+++ b/src/analyzer/protocol/vxlan/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_VXLAN {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("VXLAN", ::analyzer::vxlan::VXLAN_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/xmpp/Plugin.cc
+++ b/src/analyzer/protocol/xmpp/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_XMPP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("XMPP", ::analyzer::xmpp::XMPP_Analyzer::Instantiate));
 

--- a/src/analyzer/protocol/zip/Plugin.cc
+++ b/src/analyzer/protocol/zip/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_ZIP {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("ZIP", 0));
 

--- a/src/file_analysis/analyzer/data_event/Plugin.cc
+++ b/src/file_analysis/analyzer/data_event/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_FileDataEvent {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::file_analysis::Component("DATA_EVENT", ::file_analysis::DataEvent::Instantiate));
 

--- a/src/file_analysis/analyzer/entropy/Plugin.cc
+++ b/src/file_analysis/analyzer/entropy/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_FileEntropy {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::file_analysis::Component("ENTROPY", ::file_analysis::Entropy::Instantiate));
 

--- a/src/file_analysis/analyzer/extract/Plugin.cc
+++ b/src/file_analysis/analyzer/extract/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_FileExtract {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::file_analysis::Component("EXTRACT", ::file_analysis::Extract::Instantiate));
 

--- a/src/file_analysis/analyzer/hash/Plugin.cc
+++ b/src/file_analysis/analyzer/hash/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_FileHash {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::file_analysis::Component("MD5", ::file_analysis::MD5::Instantiate));
 		AddComponent(new ::file_analysis::Component("SHA1", ::file_analysis::SHA1::Instantiate));

--- a/src/file_analysis/analyzer/pe/Plugin.cc
+++ b/src/file_analysis/analyzer/pe/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_PE {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::file_analysis::Component("PE", ::file_analysis::PE::Instantiate));
 

--- a/src/file_analysis/analyzer/unified2/Plugin.cc
+++ b/src/file_analysis/analyzer/unified2/Plugin.cc
@@ -11,7 +11,7 @@ namespace Zeek_Unified2 {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::file_analysis::Component("UNIFIED2", ::file_analysis::Unified2::Instantiate));
 

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -113,7 +113,7 @@ public:
 	EventHandlerPtr event;
 
 	TableStream();
-	~TableStream();
+	~TableStream() override;
 };
 
 class Manager::EventStream: public Manager::Stream {
@@ -125,7 +125,7 @@ public:
 
 	bool want_record;
 	EventStream();
-	~EventStream();
+	~EventStream() override;
 };
 
 class Manager::AnalysisStream: public Manager::Stream {
@@ -133,7 +133,7 @@ public:
 	string file_id;
 
 	AnalysisStream();
-	~AnalysisStream();
+	~AnalysisStream() override;
 };
 
 Manager::TableStream::TableStream()

--- a/src/input/ReaderBackend.cc
+++ b/src/input/ReaderBackend.cc
@@ -15,7 +15,7 @@ public:
 		: threading::OutputMessage<ReaderFrontend>("Put", reader),
 		val(val) {}
 
-	virtual bool Process()
+	bool Process() override
 		{
 		input_mgr->Put(Object(), val);
 		return true;
@@ -31,7 +31,7 @@ public:
 		: threading::OutputMessage<ReaderFrontend>("Delete", reader),
 		val(val) {}
 
-	virtual bool Process()
+	bool Process() override
 		{
 		return input_mgr->Delete(Object(), val);
 		}
@@ -45,7 +45,7 @@ public:
 	ClearMessage(ReaderFrontend* reader)
 		: threading::OutputMessage<ReaderFrontend>("Clear", reader) {}
 
-	virtual bool Process()
+	bool Process() override
 		{
 		input_mgr->Clear(Object());
 		return true;
@@ -60,9 +60,9 @@ public:
 		: threading::OutputMessage<ReaderFrontend>("SendEvent", reader),
 		name(copy_string(name)), num_vals(num_vals), val(val) {}
 
-	virtual ~SendEventMessage()	{ delete [] name; }
+	~SendEventMessage() override	{ delete [] name; }
 
-	virtual bool Process()
+	bool Process() override
 		{
 		bool success = input_mgr->SendEvent(Object(), name, num_vals, val);
 
@@ -89,9 +89,9 @@ public:
 		: threading::OutputMessage<ReaderFrontend>("ReaderErrorMessage", reader)
 		{ type = arg_type; msg = copy_string(arg_msg); }
 
-	virtual ~ReaderErrorMessage() 	 { delete [] msg; }
+	~ReaderErrorMessage() override 	 { delete [] msg; }
 
-	virtual bool Process();
+	bool Process() override;
 
 private:
 	const char* msg;
@@ -104,7 +104,7 @@ public:
 		: threading::OutputMessage<ReaderFrontend>("SendEntry", reader),
 		val(val) { }
 
-	virtual bool Process()
+	bool Process() override
 		{
 		input_mgr->SendEntry(Object(), val);
 		return true;
@@ -119,7 +119,7 @@ public:
 	EndCurrentSendMessage(ReaderFrontend* reader)
 		: threading::OutputMessage<ReaderFrontend>("EndCurrentSend", reader) {}
 
-	virtual bool Process()
+	bool Process() override
 		{
 		input_mgr->EndCurrentSend(Object());
 		return true;
@@ -133,7 +133,7 @@ public:
 	EndOfDataMessage(ReaderFrontend* reader)
 		: threading::OutputMessage<ReaderFrontend>("EndOfData", reader) {}
 
-	virtual bool Process()
+	bool Process() override
 		{
 		input_mgr->SendEndOfData(Object());
 		return true;
@@ -147,7 +147,7 @@ public:
 	ReaderClosedMessage(ReaderFrontend* reader)
 		: threading::OutputMessage<ReaderFrontend>("ReaderClosed", reader) {}
 
-	virtual bool Process()
+	bool Process() override
 		{
 		Object()->SetDisable();
 		return input_mgr->RemoveStreamContinuation(Object());
@@ -159,10 +159,10 @@ private:
 class DisableMessage : public threading::OutputMessage<ReaderFrontend>
 {
 public:
-        DisableMessage(ReaderFrontend* writer)
+	DisableMessage(ReaderFrontend* writer)
 		: threading::OutputMessage<ReaderFrontend>("Disable", writer)	{}
 
-	virtual bool Process()
+	bool Process() override
 		{
 		Object()->SetDisable();
 		// And - because we do not need disabled objects any more -

--- a/src/input/ReaderBackend.cc
+++ b/src/input/ReaderBackend.cc
@@ -9,7 +9,7 @@ using threading::Field;
 
 namespace input {
 
-class PutMessage : public threading::OutputMessage<ReaderFrontend> {
+class PutMessage final : public threading::OutputMessage<ReaderFrontend> {
 public:
 	PutMessage(ReaderFrontend* reader, Value* *val)
 		: threading::OutputMessage<ReaderFrontend>("Put", reader),
@@ -25,7 +25,7 @@ private:
 	Value* *val;
 };
 
-class DeleteMessage : public threading::OutputMessage<ReaderFrontend> {
+class DeleteMessage final : public threading::OutputMessage<ReaderFrontend> {
 public:
 	DeleteMessage(ReaderFrontend* reader, Value* *val)
 		: threading::OutputMessage<ReaderFrontend>("Delete", reader),
@@ -40,7 +40,7 @@ private:
 	Value* *val;
 };
 
-class ClearMessage : public threading::OutputMessage<ReaderFrontend> {
+class ClearMessage final : public threading::OutputMessage<ReaderFrontend> {
 public:
 	ClearMessage(ReaderFrontend* reader)
 		: threading::OutputMessage<ReaderFrontend>("Clear", reader) {}
@@ -54,7 +54,7 @@ public:
 private:
 };
 
-class SendEventMessage : public threading::OutputMessage<ReaderFrontend> {
+class SendEventMessage final : public threading::OutputMessage<ReaderFrontend> {
 public:
 	SendEventMessage(ReaderFrontend* reader, const char* name, const int num_vals, Value* *val)
 		: threading::OutputMessage<ReaderFrontend>("SendEvent", reader),
@@ -78,7 +78,7 @@ private:
 	Value* *val;
 };
 
-class ReaderErrorMessage : public threading::OutputMessage<ReaderFrontend>
+class ReaderErrorMessage final : public threading::OutputMessage<ReaderFrontend>
 {
 public:
 	enum Type {
@@ -98,7 +98,7 @@ private:
 	Type type;
 };
 
-class SendEntryMessage : public threading::OutputMessage<ReaderFrontend> {
+class SendEntryMessage final : public threading::OutputMessage<ReaderFrontend> {
 public:
 	SendEntryMessage(ReaderFrontend* reader, Value* *val)
 		: threading::OutputMessage<ReaderFrontend>("SendEntry", reader),
@@ -114,7 +114,7 @@ private:
 	Value* *val;
 };
 
-class EndCurrentSendMessage : public threading::OutputMessage<ReaderFrontend> {
+class EndCurrentSendMessage final : public threading::OutputMessage<ReaderFrontend> {
 public:
 	EndCurrentSendMessage(ReaderFrontend* reader)
 		: threading::OutputMessage<ReaderFrontend>("EndCurrentSend", reader) {}
@@ -128,7 +128,7 @@ public:
 private:
 };
 
-class EndOfDataMessage : public threading::OutputMessage<ReaderFrontend> {
+class EndOfDataMessage final : public threading::OutputMessage<ReaderFrontend> {
 public:
 	EndOfDataMessage(ReaderFrontend* reader)
 		: threading::OutputMessage<ReaderFrontend>("EndOfData", reader) {}
@@ -142,7 +142,7 @@ public:
 private:
 };
 
-class ReaderClosedMessage : public threading::OutputMessage<ReaderFrontend> {
+class ReaderClosedMessage final : public threading::OutputMessage<ReaderFrontend> {
 public:
 	ReaderClosedMessage(ReaderFrontend* reader)
 		: threading::OutputMessage<ReaderFrontend>("ReaderClosed", reader) {}
@@ -156,7 +156,7 @@ public:
 private:
 };
 
-class DisableMessage : public threading::OutputMessage<ReaderFrontend>
+class DisableMessage final : public threading::OutputMessage<ReaderFrontend>
 {
 public:
 	DisableMessage(ReaderFrontend* writer)

--- a/src/input/ReaderFrontend.cc
+++ b/src/input/ReaderFrontend.cc
@@ -14,7 +14,7 @@ public:
 		: threading::InputMessage<ReaderBackend>("Init", backend),
 		num_fields(num_fields), fields(fields) { }
 
-	virtual bool Process()
+	bool Process() override
 		{
 		return Object()->Init(num_fields, fields);
 		}
@@ -31,7 +31,7 @@ public:
 		: threading::InputMessage<ReaderBackend>("Update", backend)
 		 { }
 
-	virtual bool Process() { return Object()->Update(); }
+	bool Process() override { return Object()->Update(); }
 };
 
 ReaderFrontend::ReaderFrontend(const ReaderBackend::ReaderInfo& arg_info, EnumVal* type)
@@ -98,4 +98,3 @@ const char* ReaderFrontend::Name() const
 	}
 
 }
-

--- a/src/input/ReaderFrontend.cc
+++ b/src/input/ReaderFrontend.cc
@@ -6,7 +6,7 @@
 
 namespace input {
 
-class InitMessage : public threading::InputMessage<ReaderBackend>
+class InitMessage final : public threading::InputMessage<ReaderBackend>
 {
 public:
 	InitMessage(ReaderBackend* backend,
@@ -24,7 +24,7 @@ private:
 	const threading::Field* const* fields;
 };
 
-class UpdateMessage : public threading::InputMessage<ReaderBackend>
+class UpdateMessage final : public threading::InputMessage<ReaderBackend>
 {
 public:
 	UpdateMessage(ReaderBackend* backend)

--- a/src/input/readers/ascii/Plugin.cc
+++ b/src/input/readers/ascii/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_AsciiReader {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::input::Component("Ascii", ::input::reader::Ascii::Instantiate));
 

--- a/src/input/readers/benchmark/Plugin.cc
+++ b/src/input/readers/benchmark/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_BenchmarkReader {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::input::Component("Benchmark", ::input::reader::Benchmark::Instantiate));
 

--- a/src/input/readers/binary/Plugin.cc
+++ b/src/input/readers/binary/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_BinaryReader {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::input::Component("Binary", ::input::reader::Binary::Instantiate));
 

--- a/src/input/readers/config/Plugin.cc
+++ b/src/input/readers/config/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_ConfigReader {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::input::Component("Config", ::input::reader::Config::Instantiate));
 

--- a/src/input/readers/raw/Plugin.cc
+++ b/src/input/readers/raw/Plugin.cc
@@ -32,4 +32,3 @@ std::unique_lock<std::mutex> Plugin::ForkMutex()
 	{
 	return std::unique_lock<std::mutex>(fork_mutex, std::defer_lock);
 	}
-

--- a/src/input/readers/sqlite/Plugin.cc
+++ b/src/input/readers/sqlite/Plugin.cc
@@ -9,7 +9,7 @@ namespace Zeek_SQLiteReader {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::input::Component("SQLite", ::input::reader::SQLite::Instantiate));
 

--- a/src/iosource/pcap/Plugin.cc
+++ b/src/iosource/pcap/Plugin.cc
@@ -10,7 +10,7 @@ namespace Zeek_Pcap {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::iosource::PktSrcComponent("PcapReader", "pcap", ::iosource::PktSrcComponent::BOTH, ::iosource::pcap::PcapSource::Instantiate));
 		AddComponent(new ::iosource::PktDumperComponent("PcapWriter", "pcap", ::iosource::pcap::PcapDumper::Instantiate));
@@ -24,4 +24,3 @@ public:
 
 }
 }
-

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -1399,9 +1399,9 @@ public:
 			rotate = arg_rotate;
 			}
 
-	~RotationTimer();
+	~RotationTimer() override;
 
-	void Dispatch(double t, int is_expire);
+	void Dispatch(double t, int is_expire) override;
 
 protected:
 	Manager::WriterInfo* winfo;

--- a/src/logging/WriterBackend.cc
+++ b/src/logging/WriterBackend.cc
@@ -25,13 +25,13 @@ public:
 		new_name(copy_string(new_name)), old_name(copy_string(old_name)), open(open),
 		close(close), success(success), terminating(terminating)	{ }
 
-	virtual ~RotationFinishedMessage()
+	~RotationFinishedMessage() override
 		{
 		delete [] new_name;
 		delete [] old_name;
 		}
 
-	virtual bool Process()
+	bool Process() override
 		{
 		return log_mgr->FinishedRotation(Object(), new_name, old_name, open, close, success, terminating);
 		}
@@ -48,19 +48,19 @@ private:
 class FlushWriteBufferMessage : public threading::OutputMessage<WriterFrontend>
 {
 public:
-        FlushWriteBufferMessage(WriterFrontend* writer)
+	FlushWriteBufferMessage(WriterFrontend* writer)
 		: threading::OutputMessage<WriterFrontend>("FlushWriteBuffer", writer)	{}
 
-	virtual bool Process()	{ Object()->FlushWriteBuffer(); return true; }
+	bool Process() override	{ Object()->FlushWriteBuffer(); return true; }
 };
 
 class DisableMessage : public threading::OutputMessage<WriterFrontend>
 {
 public:
-        DisableMessage(WriterFrontend* writer)
+	DisableMessage(WriterFrontend* writer)
 		: threading::OutputMessage<WriterFrontend>("Disable", writer)	{}
 
-	virtual bool Process()	{ Object()->SetDisable(); return true; }
+	bool Process() override	{ Object()->SetDisable(); return true; }
 };
 
 }

--- a/src/logging/WriterBackend.cc
+++ b/src/logging/WriterBackend.cc
@@ -16,7 +16,7 @@ using threading::Field;
 
 namespace logging  {
 
-class RotationFinishedMessage : public threading::OutputMessage<WriterFrontend>
+class RotationFinishedMessage final : public threading::OutputMessage<WriterFrontend>
 {
 public:
 	RotationFinishedMessage(WriterFrontend* writer, const char* new_name, const char* old_name,
@@ -45,7 +45,7 @@ private:
         bool terminating;
 };
 
-class FlushWriteBufferMessage : public threading::OutputMessage<WriterFrontend>
+class FlushWriteBufferMessage final : public threading::OutputMessage<WriterFrontend>
 {
 public:
 	FlushWriteBufferMessage(WriterFrontend* writer)
@@ -54,7 +54,7 @@ public:
 	bool Process() override	{ Object()->FlushWriteBuffer(); return true; }
 };
 
-class DisableMessage : public threading::OutputMessage<WriterFrontend>
+class DisableMessage final : public threading::OutputMessage<WriterFrontend>
 {
 public:
 	DisableMessage(WriterFrontend* writer)

--- a/src/logging/WriterFrontend.cc
+++ b/src/logging/WriterFrontend.cc
@@ -23,7 +23,7 @@ public:
 			{}
 
 
-	virtual bool Process() { return Object()->Init(num_fields, fields); }
+	bool Process() override { return Object()->Init(num_fields, fields); }
 
 private:
 	const int num_fields;
@@ -42,7 +42,7 @@ public:
 
 	virtual ~RotateMessage()	{ delete [] rotated_path; }
 
-	virtual bool Process() { return Object()->Rotate(rotated_path, open, close, terminating); }
+	bool Process() override { return Object()->Rotate(rotated_path, open, close, terminating); }
 
 private:
 	WriterFrontend* frontend;
@@ -59,7 +59,7 @@ public:
 		: threading::InputMessage<WriterBackend>("Write", backend),
 		num_fields(num_fields), num_writes(num_writes), vals(vals)	{}
 
-	virtual bool Process() { return Object()->Write(num_fields, num_writes, vals); }
+	bool Process() override { return Object()->Write(num_fields, num_writes, vals); }
 
 private:
 	int num_fields;
@@ -74,7 +74,7 @@ public:
 		: threading::InputMessage<WriterBackend>("SetBuf", backend),
 		enabled(enabled) { }
 
-	virtual bool Process() { return Object()->SetBuf(enabled); }
+	bool Process() override { return Object()->SetBuf(enabled); }
 
 private:
 	const bool enabled;
@@ -87,7 +87,7 @@ public:
 		: threading::InputMessage<WriterBackend>("Flush", backend),
 		network_time(network_time) {}
 
-	virtual bool Process() { return Object()->Flush(network_time); }
+	bool Process() override { return Object()->Flush(network_time); }
 private:
 	double network_time;
 };

--- a/src/logging/WriterFrontend.cc
+++ b/src/logging/WriterFrontend.cc
@@ -14,7 +14,7 @@ namespace logging  {
 
 // Messages sent from frontend to backend (i.e., "InputMessages").
 
-class InitMessage : public threading::InputMessage<WriterBackend>
+class InitMessage final : public threading::InputMessage<WriterBackend>
 {
 public:
 	InitMessage(WriterBackend* backend, const int num_fields, const Field* const* fields)
@@ -30,7 +30,7 @@ private:
 	const Field * const* fields;
 };
 
-class RotateMessage : public threading::InputMessage<WriterBackend>
+class RotateMessage final : public threading::InputMessage<WriterBackend>
 {
 public:
 	RotateMessage(WriterBackend* backend, WriterFrontend* frontend, const char* rotated_path, const double open,
@@ -52,7 +52,7 @@ private:
 	const bool terminating;
 };
 
-class WriteMessage : public threading::InputMessage<WriterBackend>
+class WriteMessage final : public threading::InputMessage<WriterBackend>
 {
 public:
 	WriteMessage(WriterBackend* backend, int num_fields, int num_writes, Value*** vals)
@@ -67,7 +67,7 @@ private:
 	Value ***vals;
 };
 
-class SetBufMessage : public threading::InputMessage<WriterBackend>
+class SetBufMessage final : public threading::InputMessage<WriterBackend>
 {
 public:
 	SetBufMessage(WriterBackend* backend, const bool enabled)
@@ -80,7 +80,7 @@ private:
 	const bool enabled;
 };
 
-class FlushMessage : public threading::InputMessage<WriterBackend>
+class FlushMessage final : public threading::InputMessage<WriterBackend>
 {
 public:
 	FlushMessage(WriterBackend* backend, double network_time)

--- a/src/logging/writers/ascii/Plugin.cc
+++ b/src/logging/writers/ascii/Plugin.cc
@@ -10,7 +10,7 @@ namespace Zeek_AsciiWriter {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::logging::Component("Ascii", ::logging::writer::Ascii::Instantiate));
 

--- a/src/logging/writers/none/Plugin.cc
+++ b/src/logging/writers/none/Plugin.cc
@@ -10,7 +10,7 @@ namespace Zeek_NoneWriter {
 
 class Plugin : public plugin::Plugin {
 public:
-	plugin::Configuration Configure()
+	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::logging::Component("None", ::logging::writer::None::Instantiate));
 

--- a/src/threading/MsgThread.cc
+++ b/src/threading/MsgThread.cc
@@ -21,7 +21,7 @@ public:
 	FinishMessage(MsgThread* thread, double network_time) : InputMessage<MsgThread>("Finish", thread),
 		network_time(network_time) { }
 
-	virtual bool Process()	{
+	bool Process() override	{
 		if ( Object()->child_finished )
 			return true;
 		bool result = Object()->OnFinish(network_time);
@@ -41,7 +41,7 @@ public:
 		: OutputMessage<MsgThread>("FinishedMessage", thread)
 		{ }
 
-	virtual bool Process() {
+	bool Process() override {
 		Object()->main_finished = true;
 		return true;
 	}
@@ -55,7 +55,7 @@ public:
 		: InputMessage<MsgThread>("Heartbeat", thread)
 		{ network_time = arg_network_time; current_time = arg_current_time; }
 
-	virtual bool Process()	{
+	bool Process() override	{
 		return Object()->OnHeartbeat(network_time, current_time);
 	}
 
@@ -77,9 +77,9 @@ public:
 		: OutputMessage<MsgThread>("ReporterMessage", thread)
 		{ type = arg_type; msg = copy_string(arg_msg); }
 
-	~ReporterMessage() 	 { delete [] msg; }
+	~ReporterMessage() override 	 { delete [] msg; }
 
-	virtual bool Process();
+	bool Process() override;
 
 private:
 	const char* msg;
@@ -93,7 +93,7 @@ public:
 	KillMeMessage(MsgThread* thread)
 		: OutputMessage<MsgThread>("ReporterMessage", thread) 	{}
 
-	virtual bool Process()
+	bool Process() override
 		{
 		Object()->SignalStop();
 		Object()->WaitForStop();
@@ -111,9 +111,9 @@ public:
 		: OutputMessage<MsgThread>("DebugMessage", thread)
 		{ stream = arg_stream; msg = copy_string(arg_msg); }
 
-	virtual ~DebugMessage()	{ delete [] msg; }
+	~DebugMessage() override	{ delete [] msg; }
 
-	virtual bool Process()
+	bool Process() override
 		{
 		debug_logger.Log(stream, "%s: %s", Object()->Name(), msg);
 		return true;

--- a/src/threading/MsgThread.cc
+++ b/src/threading/MsgThread.cc
@@ -15,7 +15,7 @@ namespace threading  {
 ////// Messages.
 
 // Signals child thread to shutdown operation.
-class FinishMessage : public InputMessage<MsgThread>
+class FinishMessage final : public InputMessage<MsgThread>
 {
 public:
 	FinishMessage(MsgThread* thread, double network_time) : InputMessage<MsgThread>("Finish", thread),
@@ -34,7 +34,7 @@ private:
 };
 
 // Signals main thread that operations shut down.
-class FinishedMessage : public OutputMessage<MsgThread>
+class FinishedMessage final : public OutputMessage<MsgThread>
 {
 public:
 	FinishedMessage(MsgThread* thread)
@@ -48,7 +48,7 @@ public:
 };
 
 /// Sends a heartbeat to the child thread.
-class HeartbeatMessage : public InputMessage<MsgThread>
+class HeartbeatMessage final : public InputMessage<MsgThread>
 {
 public:
 	HeartbeatMessage(MsgThread* thread, double arg_network_time, double arg_current_time)
@@ -65,7 +65,7 @@ private:
 };
 
 // A message from the child to be passed on to the Reporter.
-class ReporterMessage : public OutputMessage<MsgThread>
+class ReporterMessage final : public OutputMessage<MsgThread>
 {
 public:
 	enum Type {
@@ -87,7 +87,7 @@ private:
 };
 
 // A message from the the child to the main process, requesting suicide.
-class KillMeMessage : public OutputMessage<MsgThread>
+class KillMeMessage final : public OutputMessage<MsgThread>
 {
 public:
 	KillMeMessage(MsgThread* thread)
@@ -104,7 +104,7 @@ public:
 
 #ifdef DEBUG
 // A debug message from the child to be passed on to the DebugLogger.
-class DebugMessage : public OutputMessage<MsgThread>
+class DebugMessage final : public OutputMessage<MsgThread>
 {
 public:
 	DebugMessage(DebugStream arg_stream, MsgThread* thread, const char* arg_msg)


### PR DESCRIPTION
I'm tempted to mark all of the plugins as `final` as well since none of them should ever be inherited from, but I doubt it'll make any sort of performance difference. The ones I added to the message types don't either but I had already done them.