### PR TITLE
Fix connection duration thresholding

### DIFF
--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -90,7 +90,7 @@ void ConnSize_Analyzer::CheckThresholds(bool is_orig)
 
 	if ( duration_thresh != 0 )
 		{
-		if ( duration_thresh > ( network_time - start_time ) && conn_duration_threshold_crossed )
+		if ( ( network_time - start_time ) > duration_thresh && conn_duration_threshold_crossed )
 			{
 			EnqueueConnEvent(conn_duration_threshold_crossed,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},

--- a/testing/btest/Baseline/core.conn-size-threshold/.stdout
+++ b/testing/btest/Baseline/core.conn-size-threshold/.stdout
@@ -8,8 +8,8 @@ Threshold set for [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, r
 2000
 63
 50
-0.0
-triggered duration, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 0.1, T
+0.1, 0.053051
+triggered duration, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 0.1, F, 0.10508
 triggered bytes, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 2000, F
 triggered bytes, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 3000, T
 triggered packets, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 50, F
@@ -23,6 +23,7 @@ Threshold set for [orig_h=192.168.1.77, orig_p=57655/tcp, resp_h=209.197.168.151
 2000
 63
 50
-0.1
+0.0, 0.176573
+triggered duration, [orig_h=192.168.1.77, orig_p=57655/tcp, resp_h=209.197.168.151, resp_p=1024/tcp], 0.1, T, 0.176573
 triggered bytes, [orig_h=192.168.1.77, orig_p=57655/tcp, resp_h=209.197.168.151, resp_p=1024/tcp], 2000, F
 triggered packets, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 63, T

--- a/testing/btest/Baseline/scripts.base.protocols.conn.threshold/.stdout
+++ b/testing/btest/Baseline/scripts.base.protocols.conn.threshold/.stdout
@@ -1,12 +1,12 @@
 Threshold set for [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp]
 triggered bytes, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 1, T
-triggered duration, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 0.2, T
+triggered duration, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 0.2, F
 triggered bytes, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 2000, F
 triggered bytes, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 2500, T
 triggered bytes, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 2700, T
 triggered packets, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 50, F
 Threshold set for [orig_h=192.168.1.77, orig_p=57655/tcp, resp_h=209.197.168.151, resp_p=1024/tcp]
 triggered bytes, [orig_h=192.168.1.77, orig_p=57655/tcp, resp_h=209.197.168.151, resp_p=1024/tcp], 1, T
-triggered duration, [orig_h=192.168.1.77, orig_p=57655/tcp, resp_h=209.197.168.151, resp_p=1024/tcp], 0.2, T
+triggered duration, [orig_h=192.168.1.77, orig_p=57655/tcp, resp_h=209.197.168.151, resp_p=1024/tcp], 0.2, F
 triggered bytes, [orig_h=192.168.1.77, orig_p=57655/tcp, resp_h=209.197.168.151, resp_p=1024/tcp], 2000, F
 triggered packets, [orig_h=192.168.1.77, orig_p=57640/tcp, resp_h=66.198.80.67, resp_p=6667/tcp], 52, F

--- a/testing/btest/core/conn-size-threshold.zeek
+++ b/testing/btest/core/conn-size-threshold.zeek
@@ -23,7 +23,7 @@ event connection_established(c: connection)
 	print get_current_conn_bytes_threshold(c$id, F);
 	print get_current_conn_packets_threshold(c$id, T);
 	print get_current_conn_packets_threshold(c$id, F);
-	print get_current_conn_duration_threshold(c$id);
+	print get_current_conn_duration_threshold(c$id), c$duration;
 	}
 
 event conn_bytes_threshold_crossed(c: connection, threshold: count, is_orig: bool)
@@ -38,5 +38,5 @@ event conn_packets_threshold_crossed(c: connection, threshold: count, is_orig: b
 
 event conn_duration_threshold_crossed(c: connection, threshold: interval, is_orig: bool)
 	{
-	print "triggered duration", c$id, threshold, is_orig;
+	print "triggered duration", c$id, threshold, is_orig, c$duration;
 	}


### PR DESCRIPTION
Connection durations were being compared "less than" instead of "greater
than" the desired duration threshold as provided to
set_current_conn_bytes_threshold() or
ConnThreshold::set_duration_threshold()