### PR TITLE
Fantastic nullptrs and where to find them

### DIFF
--- a/src/Anon.cc
+++ b/src/Anon.cc
@@ -12,7 +12,7 @@
 #include "Reporter.h"
 
 
-AnonymizeIPAddr* ip_anonymizer[NUM_ADDR_ANONYMIZATION_METHODS] = {0};
+AnonymizeIPAddr* ip_anonymizer[NUM_ADDR_ANONYMIZATION_METHODS] = {nullptr};
 
 static uint32_t rand32()
 	{
@@ -148,7 +148,7 @@ AnonymizeIPAddr_A50::~AnonymizeIPAddr_A50()
 
 void AnonymizeIPAddr_A50::init()
 	{
-	root = next_free_node = 0;
+	root = next_free_node = nullptr;
 
 	// Prepare special nodes for 0.0.0.0 and 255.255.255.255.
 	memset(&special_nodes[0], 0, sizeof(special_nodes));
@@ -222,7 +222,7 @@ AnonymizeIPAddr_A50::Node* AnonymizeIPAddr_A50::new_node_block()
 	for ( int i = 1; i < block_size - 1; ++i )
 		block[i].child[0] = &block[i+1];
 
-	block[block_size - 1].child[0] = 0;
+	block[block_size - 1].child[0] = nullptr;
 	next_free_node = &block[1];
 
 	return &block[0];
@@ -276,12 +276,12 @@ AnonymizeIPAddr_A50::Node* AnonymizeIPAddr_A50::make_peer(ipaddr32_t a, Node* n)
 	Node* down[2];
 
 	if ( ! (down[0] = new_node()) )
-		return 0;
+		return nullptr;
 
 	if ( ! (down[1] = new_node()) )
 		{
 		free_node(down[0]);
-		return 0;
+		return nullptr;
 		}
 
 	// swivel is first bit 'a' and 'old->input' differ.
@@ -292,7 +292,7 @@ AnonymizeIPAddr_A50::Node* AnonymizeIPAddr_A50::make_peer(ipaddr32_t a, Node* n)
 
 	down[bitvalue]->input = a;
 	down[bitvalue]->output = make_output(n->output, swivel);
-	down[bitvalue]->child[0] = down[bitvalue]->child[1] = 0;
+	down[bitvalue]->child[0] = down[bitvalue]->child[1] = nullptr;
 
 	*down[1 - bitvalue] = *n;	// copy orig node down one level
 
@@ -316,7 +316,7 @@ AnonymizeIPAddr_A50::Node* AnonymizeIPAddr_A50::find_node(ipaddr32_t a)
 		root = new_node();
 		root->input = a;
 		root->output = rand32();
-		root->child[0] = root->child[1] = 0;
+		root->child[0] = root->child[1] = nullptr;
 
 		return root;
 		}
@@ -351,12 +351,12 @@ AnonymizeIPAddr_A50::Node* AnonymizeIPAddr_A50::find_node(ipaddr32_t a)
 		}
 
 	reporter->InternalError("out of memory!");
-	return 0;
+	return nullptr;
 	}
 
 void init_ip_addr_anonymizers()
 	{
-	ip_anonymizer[KEEP_ORIG_ADDR] = 0;
+	ip_anonymizer[KEEP_ORIG_ADDR] = nullptr;
 	ip_anonymizer[SEQUENTIALLY_NUMBERED] = new AnonymizeIPAddr_Seq();
 	ip_anonymizer[RANDOM_MD5] = new AnonymizeIPAddr_RandomMD5();
 	ip_anonymizer[PREFIX_PRESERVING_A50] = new AnonymizeIPAddr_A50();
@@ -365,7 +365,7 @@ void init_ip_addr_anonymizers()
 
 ipaddr32_t anonymize_ip(ipaddr32_t ip, enum ip_addr_anonymization_class_t cl)
 	{
-	TableVal* preserve_addr = 0;
+	TableVal* preserve_addr = nullptr;
 	AddrVal addr(ip);
 
 	int method = -1;

--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -197,7 +197,7 @@ void Attributes::AddAttrs(Attributes* a)
 Attr* Attributes::FindAttr(attr_tag t) const
 	{
 	if ( ! attrs )
-		return 0;
+		return nullptr;
 
 	for ( const auto& a : *attrs )
 		{
@@ -205,7 +205,7 @@ Attr* Attributes::FindAttr(attr_tag t) const
 			return a;
 		}
 
-	return 0;
+	return nullptr;
 	}
 
 void Attributes::RemoveAttr(attr_tag t)

--- a/src/Base64.cc
+++ b/src/Base64.cc
@@ -55,7 +55,7 @@ int* Base64Converter::InitBase64Table(const string& alphabet)
 	if ( alphabet == default_alphabet && default_table_initialized )
 		return default_base64_table;
 
-	int* base64_table = 0;
+	int* base64_table = nullptr;
 
 	if ( alphabet == default_alphabet )
 		{
@@ -98,7 +98,7 @@ Base64Converter::Base64Converter(Connection* arg_conn, const string& arg_alphabe
 		alphabet = default_alphabet;
 		}
 
-	base64_table = 0;
+	base64_table = nullptr;
 	base64_group_next = 0;
 	base64_padding = base64_after_padding = 0;
 	errored = 0;
@@ -234,7 +234,7 @@ BroString* decode_base64(const BroString* s, const BroString* a, Connection* con
 		{
 		reporter->Error("base64 decoding alphabet is not 64 characters: %s",
 		                a->CheckString());
-		return 0;
+		return nullptr;
 		}
 
 	int buf_len = int((s->Len() + 3) / 4) * 3 + 1;
@@ -259,7 +259,7 @@ BroString* decode_base64(const BroString* s, const BroString* a, Connection* con
 
 err:
 	delete [] rbuf;
-	return 0;
+	return nullptr;
 	}
 
 BroString* encode_base64(const BroString* s, const BroString* a, Connection* conn)
@@ -268,10 +268,10 @@ BroString* encode_base64(const BroString* s, const BroString* a, Connection* con
 		{
 		reporter->Error("base64 alphabet is not 64 characters: %s",
 		                a->CheckString());
-		return 0;
+		return nullptr;
 		}
 
-	char* outbuf = 0;
+	char* outbuf = nullptr;
 	int outlen = 0;
 	Base64Converter enc(conn, a ? a->CheckString() : "");
 	enc.Encode(s->Len(), (const unsigned char*) s->Bytes(), &outlen, &outbuf);

--- a/src/Base64.h
+++ b/src/Base64.h
@@ -59,5 +59,5 @@ protected:
 
 };
 
-BroString* decode_base64(const BroString* s, const BroString* a = 0, Connection* conn = 0);
-BroString* encode_base64(const BroString* s, const BroString* a = 0, Connection* conn = 0);
+BroString* decode_base64(const BroString* s, const BroString* a = nullptr, Connection* conn = nullptr);
+BroString* encode_base64(const BroString* s, const BroString* a = nullptr, Connection* conn = nullptr);

--- a/src/BroString.cc
+++ b/src/BroString.cc
@@ -284,7 +284,7 @@ BroString* BroString::GetSubstring(int start, int len) const
 	{
 	// This code used to live in zeek.bif's sub_bytes() routine.
 	if ( start < 0 || start > n )
-		return 0;
+		return nullptr;
 
 	if ( len < 0 || len > n - start )
 		len = n - start;
@@ -302,7 +302,7 @@ BroString::Vec* BroString::Split(const BroString::IdxVec& indices) const
 	unsigned int i;
 
 	if ( indices.empty() )
-		return 0;
+		return nullptr;
 
 	// Copy input, ensuring space for "0":
 	IdxVec idx(1 + indices.size());
@@ -343,7 +343,7 @@ VectorVal* BroString:: VecToPolicy(Vec* vec)
 	VectorVal* result =
 		new VectorVal(internal_type("string_vec")->AsVectorType());
 	if ( ! result )
-		return 0;
+		return nullptr;
 
 	for ( unsigned int i = 0; i < vec->size(); ++i )
 		{

--- a/src/BroString.h
+++ b/src/BroString.h
@@ -94,7 +94,7 @@ public:
 	//
 	// Note that you need to delete[] the resulting string.
 	//
-	char* Render(int format = EXPANDED_STRING, int* len = 0) const;
+	char* Render(int format = EXPANDED_STRING, int* len = nullptr) const;
 
 	// Similar to the above, but useful for output streams.
 	// Also more useful for debugging purposes since no deallocation

--- a/src/Brofiler.cc
+++ b/src/Brofiler.cc
@@ -76,7 +76,7 @@ bool Brofiler::ReadStats()
 
 		pair<string, string> location_desc(std::move(location), std::move(desc));
 		uint64_t count;
-		atoi_n(cnt.size(), cnt.c_str(), 0, 10, count);
+		atoi_n(cnt.size(), cnt.c_str(), nullptr, 10, count);
 		usage_map.emplace(std::move(location_desc), count);
 		}
 

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -120,7 +120,7 @@ Connection::Connection(NetSessions* s, const ConnIDKey& k, double t, const ConnI
 	if ( arg_encap )
 		encapsulation = new EncapsulationStack(*arg_encap);
 	else
-		encapsulation = 0;
+		encapsulation = nullptr;
 	}
 
 Connection::~Connection()
@@ -132,7 +132,7 @@ Connection::~Connection()
 
 	if ( conn_val )
 		{
-		conn_val->SetOrigin(0);
+		conn_val->SetOrigin(nullptr);
 		Unref(conn_val);
 		}
 
@@ -148,7 +148,7 @@ void Connection::CheckEncapsulation(const EncapsulationStack* arg_encap)
 		{
 		if ( *encapsulation != *arg_encap )
 			{
-			Event(tunnel_changed, 0, arg_encap->GetVectorVal());
+			Event(tunnel_changed, nullptr, arg_encap->GetVectorVal());
 			delete encapsulation;
 			encapsulation = new EncapsulationStack(*arg_encap);
 			}
@@ -157,14 +157,14 @@ void Connection::CheckEncapsulation(const EncapsulationStack* arg_encap)
 	else if ( encapsulation )
 		{
 		EncapsulationStack empty;
-		Event(tunnel_changed, 0, empty.GetVectorVal());
+		Event(tunnel_changed, nullptr, empty.GetVectorVal());
 		delete encapsulation;
 		encapsulation = nullptr;
 		}
 
 	else if ( arg_encap )
 		{
-		Event(tunnel_changed, 0, arg_encap->GetVectorVal());
+		Event(tunnel_changed, nullptr, arg_encap->GetVectorVal());
 		encapsulation = new EncapsulationStack(*arg_encap);
 		}
 	}
@@ -269,7 +269,7 @@ void Connection::HistoryThresholdEvent(EventHandlerPtr e, bool is_orig,
 void Connection::DeleteTimer(double /* t */)
 	{
 	if ( is_active )
-		Event(connection_timeout, 0);
+		Event(connection_timeout, nullptr);
 
 	sessions->Remove(this);
 	}
@@ -282,7 +282,7 @@ void Connection::InactivityTimer(double t)
 		{
 		if ( last_time + inactivity_timeout <= t )
 			{
-			Event(connection_timeout, 0);
+			Event(connection_timeout, nullptr);
 			sessions->Remove(this);
 			++killed_by_inactivity;
 			}
@@ -402,12 +402,12 @@ RecordVal* Connection::BuildConnVal()
 
 analyzer::Analyzer* Connection::FindAnalyzer(analyzer::ID id)
 	{
-	return root_analyzer ? root_analyzer->FindChild(id) : 0;
+	return root_analyzer ? root_analyzer->FindChild(id) : nullptr;
 	}
 
 analyzer::Analyzer* Connection::FindAnalyzer(const analyzer::Tag& tag)
 	{
-	return root_analyzer ? root_analyzer->FindChild(tag) : 0;
+	return root_analyzer ? root_analyzer->FindChild(tag) : nullptr;
 	}
 
 analyzer::Analyzer* Connection::FindAnalyzer(const char* name)
@@ -696,7 +696,7 @@ void Connection::CheckFlowLabel(bool is_orig, uint32_t flow_label)
 		if ( connection_flow_label_changed &&
 		     (is_orig ? saw_first_orig_packet : saw_first_resp_packet) )
 			{
-			EnqueueEvent(connection_flow_label_changed, 0,
+			EnqueueEvent(connection_flow_label_changed, nullptr,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
 				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
 				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(my_flow_label)},

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -180,13 +180,13 @@ public:
 	// given that event's first argument will be it, and it's second will be
 	// the connection value.  If 'name' is null, then the event's first
 	// argument is the connection value.
-	void Event(EventHandlerPtr f, analyzer::Analyzer* analyzer, const char* name = 0);
+	void Event(EventHandlerPtr f, analyzer::Analyzer* analyzer, const char* name = nullptr);
 
 	// If a handler exists for 'f', an event will be generated.  In any case,
 	// 'v1' and 'v2' reference counts get decremented.  The event's first
 	// argument is the connection value, second argument is 'v1', and if 'v2'
 	// is given that will be it's third argument.
-	void Event(EventHandlerPtr f, analyzer::Analyzer* analyzer, Val* v1, Val* v2 = 0);
+	void Event(EventHandlerPtr f, analyzer::Analyzer* analyzer, Val* v1, Val* v2 = nullptr);
 
 	// If a handler exists for 'f', an event will be generated.  In any case,
 	// reference count for each element in the 'vl' list are decremented.  The

--- a/src/DFA.cc
+++ b/src/DFA.cc
@@ -17,7 +17,7 @@ DFA_State::DFA_State(int arg_state_num, const EquivClass* ec,
 	num_sym = ec->NumClasses();
 	nfa_states = arg_nfa_states;
 	accept = arg_accept;
-	mark = 0;
+	mark = nullptr;
 
 	SymPartition(ec);
 
@@ -96,7 +96,7 @@ DFA_State* DFA_State::ComputeXtion(int sym, DFA_Machine* machine)
 	else
 		{
 		delete ns;
-		next_d = 0;	// Jam
+		next_d = nullptr;	// Jam
 		}
 
 	AddXtion(equiv_sym, next_d);
@@ -182,7 +182,7 @@ void DFA_State::ClearMarks()
 	{
 	if ( mark )
 		{
-		SetMark(0);
+		SetMark(nullptr);
 
 		for ( int i = 0; i < num_sym; ++i )
 			{
@@ -395,7 +395,7 @@ DFA_Machine::DFA_Machine(NFA_Machine* n, EquivClass* arg_ec)
 		}
 	else
 		{
-		start_state = 0; // Jam
+		start_state = nullptr; // Jam
 		delete ns;
 		}
 	}
@@ -451,7 +451,7 @@ bool DFA_Machine::StateSetToDFA_State(NFA_state_list* state_set,
 	if ( accept->empty() )
 		{
 		delete accept;
-		accept = 0;
+		accept = nullptr;
 		}
 
 	DFA_State* ds = new DFA_State(state_count++, ec, state_set, accept);

--- a/src/DbgBreakpoint.cc
+++ b/src/DbgBreakpoint.cc
@@ -49,13 +49,13 @@ DbgBreakpoint::DbgBreakpoint()
 	enabled = temporary = false;
 	BPID = -1;
 
-	at_stmt = 0;
+	at_stmt = nullptr;
 	at_time = -1.0;
 
 	repeat_count = hit_count = 0;
 
 	description[0] = 0;
-	source_filename = 0;
+	source_filename = nullptr;
 	source_line = 0;
 	}
 

--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -55,7 +55,7 @@ DebuggerState::DebuggerState()
 	BreakFromSignal(false);
 
 	// ### Don't choose this arbitrary size! Extend Frame.
-	dbg_locals = new Frame(1024, /* func = */ 0, /* fn_args = */ 0);
+	dbg_locals = new Frame(1024, /* func = */ nullptr, /* fn_args = */ nullptr);
 	}
 
 DebuggerState::~DebuggerState()
@@ -107,7 +107,7 @@ FILE* TraceState::SetTraceFile(const char* filename)
 	else
 		{
 		fprintf(stderr, "Unable to open trace file %s\n", filename);
-		trace_file = 0;
+		trace_file = nullptr;
 		}
 
 	return oldfile;
@@ -137,7 +137,7 @@ int TraceState::LogTrace(const char* fmt, ...)
 
 	const Stmt* stmt;
 	Location loc;
-	loc.filename = 0;
+	loc.filename = nullptr;
 
 	if ( g_frame_stack.size() > 0 && g_frame_stack.back() )
 		{
@@ -178,7 +178,7 @@ void get_first_statement(Stmt* list, Stmt*& first, Location& loc)
 	{
 	if ( ! list )
 		{
-		first = 0;
+		first = nullptr;
 		return;
 		}
 
@@ -231,7 +231,7 @@ static void parse_function_name(vector<ParseLocationRec>& result,
 		return;
 		}
 
-	Stmt* body = 0;	// the particular body we care about; 0 = all
+	Stmt* body = nullptr;	// the particular body we care about; 0 = all
 
 	if ( bodies.size() == 1 )
 		body = bodies[0].stmts.get();
@@ -380,7 +380,7 @@ vector<ParseLocationRec> parse_location_string(const string& s)
 			return result;
 			}
 
-		StmtLocMapping* hit = 0;
+		StmtLocMapping* hit = nullptr;
 		for ( const auto entry : *(iter->second) )
 			{
 			plr.filename = entry->Loc().filename;
@@ -399,7 +399,7 @@ vector<ParseLocationRec> parse_location_string(const string& s)
 		if ( hit )
 			plr.stmt = hit->Statement();
 		else
-			plr.stmt = 0;
+			plr.stmt = nullptr;
 		}
 
 	return result;
@@ -730,7 +730,7 @@ static char* get_prompt(bool reset_counter = false)
 string get_context_description(const Stmt* stmt, const Frame* frame)
 	{
 	ODesc d;
-	const BroFunc* func = frame ? frame->GetFunction() : 0;
+	const BroFunc* func = frame ? frame->GetFunction() : nullptr;
 
 	if ( func )
 		func->DescribeDebug(&d, frame->GetFuncArgs());
@@ -758,7 +758,7 @@ string get_context_description(const Stmt* stmt, const Frame* frame)
 
 int dbg_handle_debug_input()
 	{
-	static char* input_line = 0;
+	static char* input_line = nullptr;
 	int status = 0;
 
 	if ( g_debugger_state.BreakFromSignal() )
@@ -820,7 +820,7 @@ int dbg_handle_debug_input()
 		if ( input_line )
 			{
 			free(input_line);	// this was malloc'ed
-			input_line = 0;
+			input_line = nullptr;
 			}
 		else
 			exit(0);
@@ -934,8 +934,8 @@ bool post_execute_stmt(Stmt* stmt, Frame* f, Val* result, stmt_flow_type* flow)
 
 // Evaluates the given expression in the context of the currently selected
 // frame.  Returns the resulting value, or nil if none (or there was an error).
-Expr* g_curr_debug_expr = 0;
-const char* g_curr_debug_error = 0;
+Expr* g_curr_debug_expr = nullptr;
+const char* g_curr_debug_error = nullptr;
 bool in_debug = false;
 
 // ### fix this hardwired access to external variables etc.
@@ -993,7 +993,7 @@ IntrusivePtr<Val> dbg_eval_expr(const char* expr)
 		if ( g_curr_debug_expr )
 			{
 			delete g_curr_debug_expr;
-			g_curr_debug_expr = 0;
+			g_curr_debug_expr = nullptr;
 			}
 		}
 	else
@@ -1003,9 +1003,9 @@ IntrusivePtr<Val> dbg_eval_expr(const char* expr)
 		pop_scope();
 
 	delete g_curr_debug_expr;
-	g_curr_debug_expr = 0;
+	g_curr_debug_expr = nullptr;
 	delete [] g_curr_debug_error;
-	g_curr_debug_error = 0;
+	g_curr_debug_error = nullptr;
 	in_debug = false;
 
 	return result;

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -149,7 +149,7 @@ bool post_execute_stmt(Stmt* stmt, Frame* f, Val* result, stmt_flow_type* flow);
 // Returns 1 if successful, 0 otherwise.
 // If cmdfile is non-nil, it contains the location of a file of commands
 // to be executed as debug commands.
-int dbg_init_debugger(const char* cmdfile = 0);
+int dbg_init_debugger(const char* cmdfile = nullptr);
 int dbg_shutdown_debugger();
 
 // Returns 1 if successful, 0 otherwise.

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -125,7 +125,7 @@ void choose_global_symbols_regex(const string& regex, vector<ID*>& choices,
 PQueue<DebugCmdInfo> g_DebugCmdInfos;
 
 DebugCmdInfo::DebugCmdInfo(const DebugCmdInfo& info)
-: cmd(info.cmd), helpstring(0)
+: cmd(info.cmd), helpstring(nullptr)
 	{
 	num_names = info.num_names;
 	names = info.names;
@@ -153,7 +153,7 @@ const DebugCmdInfo* get_debug_cmd_info(DebugCmd cmd)
 	if ( (int) cmd < g_DebugCmdInfos.length() )
 		return g_DebugCmdInfos[(int) cmd];
 	else
-		return 0;
+		return nullptr;
 	}
 
 int find_all_matching_cmds(const string& prefix, const char* array_of_matches[])
@@ -165,7 +165,7 @@ int find_all_matching_cmds(const string& prefix, const char* array_of_matches[])
 
 	for ( int i = 0; i < num_debug_cmds(); ++i )
 		{
-		array_of_matches[g_DebugCmdInfos[i]->Cmd()] = 0;
+		array_of_matches[g_DebugCmdInfos[i]->Cmd()] = nullptr;
 
 		for ( int j = 0; j < g_DebugCmdInfos[i]->NumNames(); ++j )
 			{
@@ -177,7 +177,7 @@ int find_all_matching_cmds(const string& prefix, const char* array_of_matches[])
 			if ( ! prefix.compare(curr_name) )
 				{
 				for ( int k = 0; k < num_debug_cmds(); ++k )
-					array_of_matches[k] = 0;
+					array_of_matches[k] = nullptr;
 
 				array_of_matches[g_DebugCmdInfos[i]->Cmd()] = curr_name;
 				return 1;
@@ -214,7 +214,7 @@ static int dbg_backtrace_internal(int start, int end)
 	for ( int i = start; i >= end; --i )
 		{
 		const Frame* f = g_frame_stack[i];
-		const Stmt* stmt = f ? f->GetNextStmt() : 0;
+		const Stmt* stmt = f ? f->GetNextStmt() : nullptr;
 
 		string context = get_context_description(stmt, f);
 		debug_msg("#%d  %s\n",

--- a/src/DebugCmds.h
+++ b/src/DebugCmds.h
@@ -18,7 +18,7 @@ public:
 			bool resume_execution, const char* const helpstring,
 			bool repeatable);
 
-	DebugCmdInfo() : helpstring(0) {}
+	DebugCmdInfo() : helpstring(nullptr) {}
 
 	int Cmd() const		{ return cmd; }
 	int NumNames() const	{ return num_names; }

--- a/src/DebugLogger.cc
+++ b/src/DebugLogger.cc
@@ -26,7 +26,7 @@ DebugLogger::Stream DebugLogger::streams[NUM_DBGS] = {
 DebugLogger::DebugLogger()
 	{
 	verbose = false;
-	file = 0;
+	file = nullptr;
 	}
 
 DebugLogger::~DebugLogger()

--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -21,7 +21,7 @@ ODesc::ODesc(desc_type t, BroFile* arg_f)
 	style = STANDARD_STYLE;
 	f = arg_f;
 
-	if ( f == 0 )
+	if ( f == nullptr )
 		{
 		size = DEFAULT_SIZE;
 		base = safe_malloc(size);
@@ -31,7 +31,7 @@ ODesc::ODesc(desc_type t, BroFile* arg_f)
 	else
 		{
 		offset = size = 0;
-		base = 0;
+		base = nullptr;
 		}
 
 	indent_level = 0;

--- a/src/Desc.h
+++ b/src/Desc.h
@@ -29,7 +29,7 @@ class BroType;
 
 class ODesc {
 public:
-	explicit ODesc(desc_type t=DESC_READABLE, BroFile* f=0);
+	explicit ODesc(desc_type t=DESC_READABLE, BroFile* f=nullptr);
 
 	~ODesc();
 
@@ -131,7 +131,7 @@ public:
 	byte_vec TakeBytes()
 		{
 		const void* t = base;
-		base = 0;
+		base = nullptr;
 		size = 0;
 
 		// Don't clear offset, as we want to still support

--- a/src/Dict.cc
+++ b/src/Dict.cc
@@ -81,7 +81,7 @@ TEST_CASE("dict operation")
 	dict.Remove(key2);
 	CHECK(dict.Length() == 0);
 	uint32_t* lookup2 = dict.Lookup(key2);
-	CHECK(lookup2 == (uint32_t*)0);
+	CHECK(lookup2 == (uint32_t*)nullptr);
 	delete key2;
 
 	CHECK(dict.MaxLength() == 1);
@@ -132,7 +132,7 @@ TEST_CASE("dict nthentry")
 
 	// NthEntry returns null for unordered dicts
 	uint32_t* lookup = unordered.NthEntry(0);
-	CHECK(lookup == (uint32_t*)0);
+	CHECK(lookup == (uint32_t*)nullptr);
 
 	// Ordered dicts are based on order of insertion, nothing about the
 	// data itself
@@ -256,7 +256,7 @@ void Dictionary::DeInit()
 void* Dictionary::Lookup(const void* key, int key_size, hash_t hash) const
 	{
 	if ( ! tbl && ! tbl2 )
-		return 0;
+		return nullptr;
 
 	hash_t h;
 	PList<DictEntry>* chain;
@@ -280,7 +280,7 @@ void* Dictionary::Lookup(const void* key, int key_size, hash_t hash) const
 			}
 		}
 
-	return 0;
+	return nullptr;
 	}
 
 void* Dictionary::Insert(void* key, int key_size, hash_t hash, void* val,
@@ -314,7 +314,7 @@ void* Dictionary::Remove(const void* key, int key_size, hash_t hash,
 				bool dont_delete)
 	{
 	if ( ! tbl && ! tbl2 )
-		return 0;
+		return nullptr;
 
 	hash_t h;
 	PList<DictEntry>* chain;
@@ -334,7 +334,7 @@ void* Dictionary::Remove(const void* key, int key_size, hash_t hash,
 		}
 
 	if ( ! chain )
-		return 0;
+		return nullptr;
 
 	for ( int i = 0; i < chain->length(); ++i )
 		{
@@ -346,7 +346,7 @@ void* Dictionary::Remove(const void* key, int key_size, hash_t hash,
 			void* entry_value = DoRemove(entry, h, chain, i);
 
 			if ( dont_delete )
-				entry->key = 0;
+				entry->key = nullptr;
 
 			delete entry;
 			--*num_entries_ptr;
@@ -354,7 +354,7 @@ void* Dictionary::Remove(const void* key, int key_size, hash_t hash,
 			}
 		}
 
-	return 0;
+	return nullptr;
 	}
 
 void* Dictionary::DoRemove(DictEntry* entry, hash_t h,
@@ -395,7 +395,7 @@ void* Dictionary::DoRemove(DictEntry* entry, hash_t h,
 void* Dictionary::NthEntry(int n, const void*& key, int& key_len) const
 	{
 	if ( ! order || n < 0 || n >= Length() )
-		return 0;
+		return nullptr;
 
 	DictEntry* entry = (*order)[n];
 	key = entry->key;
@@ -419,8 +419,8 @@ void* Dictionary::NextEntry(HashKey*& h, IterCookie*& cookie, int return_hash) c
 		{
 		const_cast<PList<IterCookie>*>(&cookies)->remove(cookie);
 		delete cookie;
-		cookie = 0;
-		return 0;
+		cookie = nullptr;
+		return nullptr;
 		}
 
 	// If there are any inserted entries, return them first.
@@ -486,8 +486,8 @@ void* Dictionary::NextEntry(HashKey*& h, IterCookie*& cookie, int return_hash) c
 		// a better way?
 		const_cast<PList<IterCookie>*>(&cookies)->remove(cookie);
 		delete cookie;
-		cookie = 0;
-		return 0;
+		cookie = nullptr;
+		return nullptr;
 		}
 
 	entry = (*ttbl[b])[0];
@@ -604,7 +604,7 @@ void* Dictionary::Insert(DictEntry* new_entry, bool copy_key)
 			c->inserted.push_back(new_entry);
 		}
 
-	return 0;
+	return nullptr;
 	}
 
 int Dictionary::NextPrime(int n) const
@@ -665,7 +665,7 @@ void Dictionary::MoveChains()
 		if ( ! chain )
 			continue;
 
-		tbl[tbl_next_ind - 1] = 0;
+		tbl[tbl_next_ind - 1] = nullptr;
 
 		for ( int j = 0; j < chain->length(); ++j )
 			{

--- a/src/Dict.h
+++ b/src/Dict.h
@@ -70,7 +70,7 @@ public:
 		}
 
 	// True if the dictionary is ordered, false otherwise.
-	bool IsOrdered() const		{ return order != 0; }
+	bool IsOrdered() const		{ return order != nullptr; }
 
 	// If the dictionary is ordered then returns the n'th entry's value;
 	// the second method also returns the key.  The first entry inserted

--- a/src/EquivClass.cc
+++ b/src/EquivClass.cc
@@ -12,7 +12,7 @@ EquivClass::EquivClass(int arg_size)
 	bck = new int[size];
 	equiv_class = new int[size];
 	rep = new int[size];
-	ccl_flags = 0;
+	ccl_flags = nullptr;
 	num_ecs = 0;
 
 	ec_nil = no_class = no_rep = size + 1;

--- a/src/Event.cc
+++ b/src/Event.cc
@@ -74,10 +74,10 @@ void Event::Dispatch(bool no_remote)
 
 EventMgr::EventMgr()
 	{
-	head = tail = 0;
+	head = tail = nullptr;
 	current_src = SOURCE_LOCAL;
 	current_aid = 0;
-	src_val = 0;
+	src_val = nullptr;
 	draining = false;
 	}
 
@@ -176,8 +176,8 @@ void EventMgr::Drain()
 	for ( int round = 0; head && round < 2; round++ )
 		{
 		Event* current = head;
-		head = 0;
-		tail = 0;
+		head = nullptr;
+		tail = nullptr;
 
 		while ( current )
 			{

--- a/src/Event.h
+++ b/src/Event.h
@@ -64,7 +64,7 @@ public:
 	[[deprecated("Remove in v4.1.  Use Enqueue() instead.")]]
 	void QueueEventFast(const EventHandlerPtr &h, val_list vl,
 			SourceID src = SOURCE_LOCAL, analyzer::ID aid = 0,
-			TimerMgr* mgr = 0, BroObj* obj = 0);
+			TimerMgr* mgr = nullptr, BroObj* obj = nullptr);
 
 	// Queues an event if there's an event handler (or remote consumer).  This
 	// function always takes ownership of decrementing the reference count of
@@ -75,7 +75,7 @@ public:
 	[[deprecated("Remove in v4.1.  Use Enqueue() instead.")]]
 	void QueueEvent(const EventHandlerPtr &h, val_list vl,
 			SourceID src = SOURCE_LOCAL, analyzer::ID aid = 0,
-			TimerMgr* mgr = 0, BroObj* obj = 0);
+			TimerMgr* mgr = nullptr, BroObj* obj = nullptr);
 
 	// Same as QueueEvent, except taking the event's argument list via a
 	// pointer instead of by value.  This function takes ownership of the
@@ -84,7 +84,7 @@ public:
 	[[deprecated("Remove in v4.1.  Use Enqueue() instead.")]]
 	void QueueEvent(const EventHandlerPtr &h, val_list* vl,
 			SourceID src = SOURCE_LOCAL, analyzer::ID aid = 0,
-			TimerMgr* mgr = 0, BroObj* obj = 0);
+			TimerMgr* mgr = nullptr, BroObj* obj = nullptr);
 
 	/**
 	 * Adds an event to the queue.  If no handler is found for the event
@@ -117,7 +117,7 @@ public:
 	void Drain();
 	bool IsDraining() const	{ return draining; }
 
-	bool HasEvents() const	{ return head != 0; }
+	bool HasEvents() const	{ return head != nullptr; }
 
 	// Returns the source ID of last raised event.
 	SourceID CurrentSource() const	{ return current_src; }

--- a/src/EventHandler.cc
+++ b/src/EventHandler.cc
@@ -13,8 +13,8 @@ EventHandler::EventHandler(const char* arg_name)
 	{
 	name = copy_string(arg_name);
 	used = false;
-	local = 0;
-	type = 0;
+	local = nullptr;
+	type = nullptr;
 	error_handler = false;
 	enabled = true;
 	generate_always = false;
@@ -42,10 +42,10 @@ FuncType* EventHandler::FType(bool check_export)
 	                    check_export);
 
 	if ( ! id )
-		return 0;
+		return nullptr;
 
 	if ( id->Type()->Tag() != TYPE_FUNC )
-		return 0;
+		return nullptr;
 
 	type = id->Type()->AsFuncType();
 	return type;

--- a/src/EventHandler.h
+++ b/src/EventHandler.h
@@ -69,7 +69,7 @@ private:
 // Encapsulates a ptr to an event handler to overload the boolean operator.
 class EventHandlerPtr {
 public:
-	EventHandlerPtr(EventHandler* p = 0)		{ handler = p; }
+	EventHandlerPtr(EventHandler* p = nullptr)		{ handler = p; }
 	EventHandlerPtr(const EventHandlerPtr& h)	{ handler = h.handler; }
 
 	const EventHandlerPtr& operator=(EventHandler* p)

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -54,7 +54,7 @@ const char* expr_name(BroExprTag t)
 	return expr_names[int(t)];
 	}
 
-Expr::Expr(BroExprTag arg_tag) : tag(arg_tag), type(0), paren(false)
+Expr::Expr(BroExprTag arg_tag) : tag(arg_tag), type(nullptr), paren(false)
 	{
 	SetLocationInfo(&start_location, &end_location);
 	}
@@ -1623,7 +1623,7 @@ IntrusivePtr<Val> BoolExpr::Eval(Frame* f) const
 			result->Assign(i, val_mgr->GetBool(local_result));
 			}
 		else
-			result->Assign(i, 0);
+			result->Assign(i, nullptr);
 		}
 
 	return result;
@@ -1952,7 +1952,7 @@ IntrusivePtr<Val> CondExpr::Eval(Frame* f) const
 			result->Assign(i, v ? v->Ref() : nullptr);
 			}
 		else
-			result->Assign(i, 0);
+			result->Assign(i, nullptr);
 		}
 
 	return result;
@@ -2019,7 +2019,7 @@ AssignExpr::AssignExpr(IntrusivePtr<Expr> arg_op1, IntrusivePtr<Expr> arg_op2,
 	             std::move(arg_op1) : arg_op1->MakeLvalue(),
 	             std::move(arg_op2))
 	{
-	val = 0;
+	val = nullptr;
 	is_init = arg_is_init;
 
 	if ( IsError() )
@@ -2079,7 +2079,7 @@ bool AssignExpr::TypeCheck(attr_list* attrs)
 
 	if ( bt1 == TYPE_TABLE && op2->Tag() == EXPR_LIST )
 		{
-		attr_list* attr_copy = 0;
+		attr_list* attr_copy = nullptr;
 
 		if ( attrs )
 			{
@@ -2178,7 +2178,7 @@ bool AssignExpr::TypeCheck(attr_list* attrs)
 					return false;
 					}
 
-				attr_list* attr_copy = 0;
+				attr_list* attr_copy = nullptr;
 
 				if ( sce->Attrs() )
 					{
@@ -2293,7 +2293,7 @@ void AssignExpr::EvalIntoAggregate(const BroType* t, Val* aggr, Frame* f) const
 	if ( IsError() )
 		return;
 
-	TypeDecl td(0, 0);
+	TypeDecl td(nullptr, nullptr);
 
 	if ( IsRecordElement(&td) )
 		{
@@ -2348,7 +2348,7 @@ IntrusivePtr<Val> AssignExpr::InitVal(const BroType* t, IntrusivePtr<Val> aggr) 
 	if ( IsError() )
 		return nullptr;
 
-	TypeDecl td(0, 0);
+	TypeDecl td(nullptr, nullptr);
 
 	if ( IsRecordElement(&td) )
 		{
@@ -2690,7 +2690,7 @@ IntrusivePtr<Val> IndexExpr::Fold(Val* v1, Val* v2) const
 		const ListVal* lv = v2->AsListVal();
 		const BroString* s = v1->AsString();
 		int len = s->Len();
-		BroString* substring = 0;
+		BroString* substring = nullptr;
 
 		if ( lv->Length() == 1 )
 			{
@@ -2709,7 +2709,7 @@ IntrusivePtr<Val> IndexExpr::Fold(Val* v1, Val* v2) const
 			bro_int_t substring_len = last - first;
 
 			if ( substring_len < 0 )
-				substring = 0;
+				substring = nullptr;
 			else
 				substring = s->GetSubstring(first, substring_len);
 			}
@@ -2851,7 +2851,7 @@ TraversalCode IndexExpr::Traverse(TraversalCallback* cb) const
 
 FieldExpr::FieldExpr(IntrusivePtr<Expr> arg_op, const char* arg_field_name)
 	: UnaryExpr(EXPR_FIELD, std::move(arg_op)),
-	  field_name(copy_string(arg_field_name)), td(0), field(0)
+	  field_name(copy_string(arg_field_name)), td(nullptr), field(0)
 	{
 	if ( IsError() )
 		return;
@@ -2905,7 +2905,7 @@ void FieldExpr::Assign(Frame* f, IntrusivePtr<Val> v)
 
 void FieldExpr::Delete(Frame* f)
 	{
-	Assign(f, 0);
+	Assign(f, nullptr);
 	}
 
 IntrusivePtr<Val> FieldExpr::Fold(Val* v) const
@@ -2914,7 +2914,7 @@ IntrusivePtr<Val> FieldExpr::Fold(Val* v) const
 		return {NewRef{}, result};
 
 	// Check for &default.
-	const Attr* def_attr = td ? td->FindAttr(ATTR_DEFAULT) : 0;
+	const Attr* def_attr = td ? td->FindAttr(ATTR_DEFAULT) : nullptr;
 
 	if ( def_attr )
 		return def_attr->AttrExpr()->Eval(nullptr);
@@ -3101,7 +3101,7 @@ TableConstructorExpr::TableConstructorExpr(IntrusivePtr<ListExpr> constructor_li
 			}
 		}
 
-	attrs = arg_attrs ? new Attributes(arg_attrs, type, false, false) : 0;
+	attrs = arg_attrs ? new Attributes(arg_attrs, type, false, false) : nullptr;
 
 	type_list* indices = type->AsTableType()->Indices()->Types();
 	const expr_list& cle = op->AsListExpr()->Exprs();
@@ -3173,7 +3173,7 @@ IntrusivePtr<Val> TableConstructorExpr::InitVal(const BroType* t, IntrusivePtr<V
 	const expr_list& exprs = op->AsListExpr()->Exprs();
 
 	for ( const auto& expr : exprs )
-		expr->EvalIntoAggregate(t, tval.get(), 0);
+		expr->EvalIntoAggregate(t, tval.get(), nullptr);
 
 	return tval;
 	}
@@ -3219,7 +3219,7 @@ SetConstructorExpr::SetConstructorExpr(IntrusivePtr<ListExpr> constructor_list,
 	else if ( type->Tag() != TYPE_TABLE || ! type->AsTableType()->IsSet() )
 		SetError("values in set(...) constructor do not specify a set");
 
-	attrs = arg_attrs ? new Attributes(arg_attrs, type, false, false) : 0;
+	attrs = arg_attrs ? new Attributes(arg_attrs, type, false, false) : nullptr;
 
 	type_list* indices = type->AsTableType()->Indices()->Types();
 	expr_list& cle = op->AsListExpr()->Exprs();
@@ -3265,7 +3265,7 @@ IntrusivePtr<Val> SetConstructorExpr::Eval(Frame* f) const
 	for ( const auto& expr : exprs )
 		{
 		auto element = expr->Eval(f);
-		aggr->Assign(element.get(), 0);
+		aggr->Assign(element.get(), nullptr);
 		}
 
 	return aggr;
@@ -3287,7 +3287,7 @@ IntrusivePtr<Val> SetConstructorExpr::InitVal(const BroType* t, IntrusivePtr<Val
 		{
 		auto element = check_and_promote(e->Eval(nullptr), index_type, true);
 
-		if ( ! element || ! tval->Assign(element.get(), 0) )
+		if ( ! element || ! tval->Assign(element.get(), nullptr) )
 			{
 			Error(fmt("initialization type mismatch in set"), e);
 			return nullptr;
@@ -3521,7 +3521,7 @@ IntrusivePtr<Val> ArithCoerceExpr::Fold(Val* v) const
 		if ( Val* elt = vv->Lookup(i) )
 			result->Assign(i, FoldSingleVal(elt, t));
 		else
-			result->Assign(i, 0);
+			result->Assign(i, nullptr);
 		}
 
 	return result;
@@ -4191,7 +4191,7 @@ IntrusivePtr<Val> CallExpr::Eval(Frame* f) const
 	if ( func_val && v )
 		{
 		const ::Func* funcv = func_val->AsFunc();
-		const CallExpr* current_call = f ? f->GetCall() : 0;
+		const CallExpr* current_call = f ? f->GetCall() : nullptr;
 
 		if ( f )
 			f->SetCall(this);
@@ -4491,12 +4491,12 @@ IntrusivePtr<BroType> ListExpr::InitType() const
 		return nullptr;
 		}
 
-	if ( exprs[0]->IsRecordElement(0) )
+	if ( exprs[0]->IsRecordElement(nullptr) )
 		{
 		type_decl_list* types = new type_decl_list(exprs.length());
 		for ( const auto& expr : exprs )
 			{
-			TypeDecl* td = new TypeDecl(0, 0);
+			TypeDecl* td = new TypeDecl(nullptr, nullptr);
 			if ( ! expr->IsRecordElement(td) )
 				{
 				expr->Error("record element expected");
@@ -5063,7 +5063,7 @@ bool check_and_promote_args(ListExpr* const args, RecordType* types)
 		for ( int i = ntypes - 1; i >= el.length(); --i )
 			{
 			TypeDecl* td = types->FieldDecl(i);
-			Attr* def_attr = td->attrs ? td->attrs->FindAttr(ATTR_DEFAULT) : 0;
+			Attr* def_attr = td->attrs ? td->attrs->FindAttr(ATTR_DEFAULT) : nullptr;
 
 			if ( ! def_attr )
 				{

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -523,7 +523,7 @@ public:
 	bool IsPure() const override;
 
 protected:
-	bool TypeCheck(attr_list* attrs = 0);
+	bool TypeCheck(attr_list* attrs = nullptr);
 	bool TypeCheckArithmetics(TypeTag bt1, TypeTag bt2);
 
 	bool is_init;

--- a/src/File.cc
+++ b/src/File.cc
@@ -56,9 +56,9 @@ BroFile::BroFile(FILE* arg_f)
 	{
 	Init();
 	f = arg_f;
-	name = access = 0;
+	name = access = nullptr;
 	t = base_type(TYPE_STRING);
-	is_open = (f != 0);
+	is_open = (f != nullptr);
 	}
 
 BroFile::BroFile(FILE* arg_f, const char* arg_name, const char* arg_access)
@@ -68,13 +68,13 @@ BroFile::BroFile(FILE* arg_f, const char* arg_name, const char* arg_access)
 	name = copy_string(arg_name);
 	access = copy_string(arg_access);
 	t = base_type(TYPE_STRING);
-	is_open = (f != 0);
+	is_open = (f != nullptr);
 	}
 
 BroFile::BroFile(const char* arg_name, const char* arg_access)
 	{
 	Init();
-	f = 0;
+	f = nullptr;
 	name = copy_string(arg_name);
 	access = copy_string(arg_access);
 	t = base_type(TYPE_STRING);
@@ -110,7 +110,7 @@ const char* BroFile::Name() const
 	if ( f == stderr )
 		return "/dev/stderr";
 
-	return 0;
+	return nullptr;
 	}
 
 bool BroFile::Open(FILE* file, const char* mode)
@@ -168,7 +168,7 @@ void BroFile::Init()
 	{
 	open_time = 0;
 	is_open = false;
-	attrs = 0;
+	attrs = nullptr;
 	buffered = true;
 	raw_output = false;
 
@@ -185,7 +185,7 @@ FILE* BroFile::File()
 FILE* BroFile::Seek(long new_position)
 	{
 	if ( ! File() )
-		return 0;
+		return nullptr;
 
 	if ( fseek(f, new_position, SEEK_SET) < 0 )
 		reporter->Error("seek failed");
@@ -271,11 +271,11 @@ void BroFile::SetAttrs(Attributes* arg_attrs)
 RecordVal* BroFile::Rotate()
 	{
 	if ( ! is_open )
-		return 0;
+		return nullptr;
 
 	// Do not rotate stdin/stdout/stderr.
 	if ( f == stdin || f == stdout || f == stderr )
-		return 0;
+		return nullptr;
 
 	RecordVal* info = new RecordVal(rotate_info);
 	FILE* newf = rotate_file(name, info);
@@ -283,7 +283,7 @@ RecordVal* BroFile::Rotate()
 	if ( ! newf )
 		{
 		Unref(info);
-		return 0;
+		return nullptr;
 		}
 
 	info->Assign(2, make_intrusive<Val>(open_time, TYPE_TIME));
@@ -291,7 +291,7 @@ RecordVal* BroFile::Rotate()
 	Unlink();
 
  	fclose(f);
-	f = 0;
+	f = nullptr;
 
 	Open(newf);
 	return info;

--- a/src/File.h
+++ b/src/File.h
@@ -80,7 +80,7 @@ protected:
 	 * If file is not given and mode is, the filename will be opened with that
 	 * access mode.
 	 */
-	bool Open(FILE* f = nullptr, const char* mode = 0);
+	bool Open(FILE* f = nullptr, const char* mode = nullptr);
 
 	void Unlink();
 

--- a/src/Frag.cc
+++ b/src/Frag.cc
@@ -49,7 +49,7 @@ FragReassembler::FragReassembler(NetSessions* arg_s,
 		memcpy(proto_hdr, ip->IP6_Hdr(), proto_hdr_len);
 		}
 
-	reassembled_pkt = 0;
+	reassembled_pkt = nullptr;
 	frag_size = 0;	// flag meaning "not known"
 	next_proto = ip->NextProto();
 
@@ -59,7 +59,7 @@ FragReassembler::FragReassembler(NetSessions* arg_s,
 		timer_mgr->Add(expire_timer);
 		}
 	else
-		expire_timer = 0;
+		expire_timer = nullptr;
 
 	AddFragment(t, ip, pkt);
 	}
@@ -285,7 +285,7 @@ void FragReassembler::BlockInserted(DataBlockMap::const_iterator /* it */)
 		}
 
 	delete reassembled_pkt;
-	reassembled_pkt = 0;
+	reassembled_pkt = nullptr;
 
 	unsigned int version = ((const struct ip*)pkt_start)->ip_v;
 
@@ -318,7 +318,7 @@ void FragReassembler::Expire(double t)
 	{
 	block_list.Clear();
 	expire_timer->ClearReassembler();
-	expire_timer = 0;	// timer manager will delete it
+	expire_timer = nullptr;	// timer manager will delete it
 
 	sessions->Remove(this);
 	}
@@ -329,6 +329,6 @@ void FragReassembler::DeleteTimer()
 		{
 		expire_timer->ClearReassembler();
 		timer_mgr->Cancel(expire_timer);
-		expire_timer = 0;	// timer manager will delete it
+		expire_timer = nullptr;	// timer manager will delete it
 		}
 	}

--- a/src/Frag.h
+++ b/src/Frag.h
@@ -32,7 +32,7 @@ public:
 
 	void Expire(double t);
 	void DeleteTimer();
-	void ClearTimer()	{ expire_timer = 0; }
+	void ClearTimer()	{ expire_timer = nullptr; }
 
 	const IP_Hdr* ReassembledPkt()	{ return reassembled_pkt; }
 	const FragReassemblerKey& Key() const	{ return key; }
@@ -63,7 +63,7 @@ public:
 	void Dispatch(double t, bool is_expire) override;
 
 	// Break the association between this timer and its creator.
-	void ClearReassembler()	{ f = 0; }
+	void ClearReassembler()	{ f = nullptr; }
 
 protected:
 	FragReassembler* f;

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -136,7 +136,7 @@ void Frame::Reset(int startIdx)
 	for ( int i = startIdx; i < size; ++i )
 		{
 		UnrefElement(i);
-		frame[i] = 0;
+		frame[i] = nullptr;
 		}
 	}
 
@@ -159,7 +159,7 @@ void Frame::Describe(ODesc* d) const
 
 		for ( int i = 0; i < size; ++i )
 			 {
-			 d->Add(frame[i] != 0);
+			 d->Add(frame[i] != nullptr);
 			 d->SP();
 			 }
 		}

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -217,7 +217,7 @@ public:
 	trigger::Trigger* GetTrigger() const		{ return trigger.get(); }
 
 	void SetCall(const CallExpr* arg_call)	{ call = arg_call; }
-	void ClearCall()			{ call = 0; }
+	void ClearCall()			{ call = nullptr; }
 	const CallExpr* GetCall() const		{ return call; }
 
 	void SetDelayed()	{ delayed = true; }

--- a/src/Func.h
+++ b/src/Func.h
@@ -97,7 +97,7 @@ public:
 
 	uint32_t GetUniqueFuncID() const { return unique_id; }
 	static Func* GetFuncPtrByID(uint32_t id)
-		{ return id >= unique_ids.size() ? 0 : unique_ids[id]; }
+		{ return id >= unique_ids.size() ? nullptr : unique_ids[id]; }
 
 protected:
 	Func();
@@ -205,7 +205,7 @@ public:
 	void Describe(ODesc* d) const override;
 
 protected:
-	BuiltinFunc()	{ func = 0; is_pure = 0; }
+	BuiltinFunc()	{ func = nullptr; is_pure = 0; }
 
 	built_in_func func;
 	bool is_pure;

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -25,7 +25,7 @@ ID::ID(const char* arg_name, IDScope arg_scope, bool arg_is_export)
 	scope = arg_scope;
 	is_export = arg_is_export;
 	is_option = false;
-	val = 0;
+	val = nullptr;
 	is_const = false;
 	is_enum_const = false;
 	is_type = false;
@@ -60,7 +60,7 @@ void ID::ClearVal()
 	if ( ! weak_ref )
 		Unref(val);
 
-	val = 0;
+	val = nullptr;
 	}
 
 void ID::SetVal(IntrusivePtr<Val> v, bool arg_weak_ref)
@@ -147,12 +147,12 @@ void ID::SetVal(IntrusivePtr<Expr> ev, init_class c)
 
 bool ID::IsRedefinable() const
 	{
-	return FindAttr(ATTR_REDEF) != 0;
+	return FindAttr(ATTR_REDEF) != nullptr;
 	}
 
 void ID::SetAttrs(IntrusivePtr<Attributes> a)
 	{
-	attrs = 0;
+	attrs = nullptr;
 	AddAttrs(std::move(a));
 	}
 
@@ -197,12 +197,12 @@ void ID::UpdateValAttrs()
 
 Attr* ID::FindAttr(attr_tag t) const
 	{
-	return attrs ? attrs->FindAttr(t) : 0;
+	return attrs ? attrs->FindAttr(t) : nullptr;
 	}
 
 bool ID::IsDeprecated() const
 	{
-	return FindAttr(ATTR_DEPRECATED) != 0;
+	return FindAttr(ATTR_DEPRECATED) != nullptr;
 	}
 
 void ID::MakeDeprecated(IntrusivePtr<Expr> deprecation)

--- a/src/ID.h
+++ b/src/ID.h
@@ -41,8 +41,8 @@ public:
 	const BroType* Type() const	{ return type.get(); }
 
 	void MakeType()			{ is_type = true; }
-	BroType* AsType()		{ return is_type ? Type() : 0; }
-	const BroType* AsType() const	{ return is_type ? Type() : 0; }
+	BroType* AsType()		{ return is_type ? Type() : nullptr; }
+	const BroType* AsType() const	{ return is_type ? Type() : nullptr; }
 
 	// If weak_ref is false, the Val is assumed to be already ref'ed
 	// and will be deref'ed when the ID is deleted.
@@ -57,7 +57,7 @@ public:
 	void SetVal(IntrusivePtr<Val> v, init_class c);
 	void SetVal(IntrusivePtr<Expr> ev, init_class c);
 
-	bool HasVal() const		{ return val != 0; }
+	bool HasVal() const		{ return val != nullptr; }
 	Val* ID_Val()			{ return val; }
 	const Val* ID_Val() const	{ return val; }
 	void ClearVal();
@@ -90,7 +90,7 @@ public:
 
 	std::string GetDeprecationWarning() const;
 
-	void Error(const char* msg, const BroObj* o2 = 0);
+	void Error(const char* msg, const BroObj* o2 = nullptr);
 
 	void Describe(ODesc* d) const override;
 	// Adds type and value to description.

--- a/src/IP.cc
+++ b/src/IP.cc
@@ -13,26 +13,26 @@
 #include "BroString.h"
 #include "Reporter.h"
 
-static RecordType* ip4_hdr_type = 0;
-static RecordType* ip6_hdr_type = 0;
-static RecordType* ip6_ext_hdr_type = 0;
-static RecordType* ip6_option_type = 0;
-static RecordType* ip6_hopopts_type = 0;
-static RecordType* ip6_dstopts_type = 0;
-static RecordType* ip6_routing_type = 0;
-static RecordType* ip6_fragment_type = 0;
-static RecordType* ip6_ah_type = 0;
-static RecordType* ip6_esp_type = 0;
-static RecordType* ip6_mob_type = 0;
-static RecordType* ip6_mob_msg_type = 0;
-static RecordType* ip6_mob_brr_type = 0;
-static RecordType* ip6_mob_hoti_type = 0;
-static RecordType* ip6_mob_coti_type = 0;
-static RecordType* ip6_mob_hot_type = 0;
-static RecordType* ip6_mob_cot_type = 0;
-static RecordType* ip6_mob_bu_type = 0;
-static RecordType* ip6_mob_back_type = 0;
-static RecordType* ip6_mob_be_type = 0;
+static RecordType* ip4_hdr_type = nullptr;
+static RecordType* ip6_hdr_type = nullptr;
+static RecordType* ip6_ext_hdr_type = nullptr;
+static RecordType* ip6_option_type = nullptr;
+static RecordType* ip6_hopopts_type = nullptr;
+static RecordType* ip6_dstopts_type = nullptr;
+static RecordType* ip6_routing_type = nullptr;
+static RecordType* ip6_fragment_type = nullptr;
+static RecordType* ip6_ah_type = nullptr;
+static RecordType* ip6_esp_type = nullptr;
+static RecordType* ip6_mob_type = nullptr;
+static RecordType* ip6_mob_msg_type = nullptr;
+static RecordType* ip6_mob_brr_type = nullptr;
+static RecordType* ip6_mob_hoti_type = nullptr;
+static RecordType* ip6_mob_coti_type = nullptr;
+static RecordType* ip6_mob_hot_type = nullptr;
+static RecordType* ip6_mob_cot_type = nullptr;
+static RecordType* ip6_mob_bu_type = nullptr;
+static RecordType* ip6_mob_back_type = nullptr;
+static RecordType* ip6_mob_be_type = nullptr;
 
 static inline RecordType* hdrType(RecordType*& type, const char* name)
 	{
@@ -79,7 +79,7 @@ static VectorVal* BuildOptionsVal(const u_char* data, int len)
 
 RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 	{
-	RecordVal* rv = 0;
+	RecordVal* rv = nullptr;
 
 	switch ( type ) {
 	case IPPROTO_IPV6:
@@ -330,7 +330,7 @@ IPAddr IP_Hdr::DstAddr() const
 
 RecordVal* IP_Hdr::BuildIPHdrVal() const
 	{
-	RecordVal* rval = 0;
+	RecordVal* rval = nullptr;
 
 	if ( ip4 )
 		{
@@ -354,7 +354,7 @@ RecordVal* IP_Hdr::BuildIPHdrVal() const
 
 RecordVal* IP_Hdr::BuildPktHdrVal() const
 	{
-	static RecordType* pkt_hdr_type = 0;
+	static RecordType* pkt_hdr_type = nullptr;
 
 	if ( ! pkt_hdr_type )
 		pkt_hdr_type = internal_type("pkt_hdr")->AsRecordType();
@@ -365,9 +365,9 @@ RecordVal* IP_Hdr::BuildPktHdrVal() const
 
 RecordVal* IP_Hdr::BuildPktHdrVal(RecordVal* pkt_hdr, int sindex) const
 	{
-	static RecordType* tcp_hdr_type = 0;
-	static RecordType* udp_hdr_type = 0;
-	static RecordType* icmp_hdr_type = 0;
+	static RecordType* tcp_hdr_type = nullptr;
+	static RecordType* udp_hdr_type = nullptr;
+	static RecordType* icmp_hdr_type = nullptr;
 
 	if ( ! tcp_hdr_type )
 		{

--- a/src/IP.h
+++ b/src/IP.h
@@ -136,7 +136,7 @@ public:
 	/**
 	 * Returns the script-layer record representation of the header.
 	 */
-	RecordVal* BuildRecordVal(VectorVal* chain = 0) const;
+	RecordVal* BuildRecordVal(VectorVal* chain = nullptr) const;
 
 protected:
 	uint8_t type;
@@ -184,7 +184,7 @@ public:
 	 */
 	const struct ip6_frag* GetFragHdr() const
 		{ return IsFragment() ?
-				(const struct ip6_frag*)chain[chain.size()-1]->Data(): 0; }
+				(const struct ip6_frag*)chain[chain.size()-1]->Data(): nullptr; }
 
 	/**
 	 * If the header chain is a fragment, returns the offset in number of bytes

--- a/src/NFA.cc
+++ b/src/NFA.cc
@@ -14,11 +14,11 @@ static int nfa_state_id = 0;
 NFA_State::NFA_State(int arg_sym, EquivClass* ec)
 	{
 	sym = arg_sym;
-	ccl = 0;
+	ccl = nullptr;
 	accept = NO_ACCEPT;
 	first_trans_is_back_ref = false;
-	mark = 0;
-	epsclosure = 0;
+	mark = nullptr;
+	epsclosure = nullptr;
 	id = ++nfa_state_id;
 
 	// Fix up equivalence classes based on this transition.  Note that any
@@ -39,9 +39,9 @@ NFA_State::NFA_State(CCL* arg_ccl)
 	ccl = arg_ccl;
 	accept = NO_ACCEPT;
 	first_trans_is_back_ref = false;
-	mark = 0;
+	mark = nullptr;
 	id = ++nfa_state_id;
-	epsclosure = 0;
+	epsclosure = nullptr;
 	}
 
 NFA_State::~NFA_State()
@@ -67,7 +67,7 @@ NFA_State* NFA_State::DeepCopy()
 		return mark;
 		}
 
-	NFA_State* copy = ccl ? new NFA_State(ccl) : new NFA_State(sym, 0);
+	NFA_State* copy = ccl ? new NFA_State(ccl) : new NFA_State(sym, nullptr);
 	SetMark(copy);
 
 	for ( int i = 0; i < xtions.length(); ++i )
@@ -80,7 +80,7 @@ void NFA_State::ClearMarks()
 	{
 	if ( mark )
 		{
-		SetMark(0);
+		SetMark(nullptr);
 		for ( int i = 0; i < xtions.length(); ++i )
 			xtions[i]->ClearMarks();
 		}
@@ -125,7 +125,7 @@ NFA_state_list* NFA_State::EpsilonClosure()
 
 	// Clear out markers.
 	for ( i = 0; i < states.length(); ++i )
-		states[i]->SetMark(0);
+		states[i]->SetMark(nullptr);
 
 	// Make it fit.
 	epsclosure->resize(0);
@@ -262,7 +262,7 @@ void NFA_Machine::MakePositiveClosure()
 
 void NFA_Machine::MakeRepl(int lower, int upper)
 	{
-	NFA_Machine* dup = 0;
+	NFA_Machine* dup = nullptr;
 	if ( upper > lower || upper == NO_UPPER_BOUND )
 		dup = DuplicateMachine();
 

--- a/src/NFA.h
+++ b/src/NFA.h
@@ -78,12 +78,12 @@ protected:
 
 class EpsilonState : public NFA_State {
 public:
-	EpsilonState()	: NFA_State(SYM_EPSILON, 0)	{ }
+	EpsilonState()	: NFA_State(SYM_EPSILON, nullptr)	{ }
 };
 
 class NFA_Machine : public BroObj {
 public:
-	explicit NFA_Machine(NFA_State* first, NFA_State* final = 0);
+	explicit NFA_Machine(NFA_State* first, NFA_State* final = nullptr);
 	~NFA_Machine() override;
 
 	NFA_State* FirstState() const	{ return first_state; }

--- a/src/Net.cc
+++ b/src/Net.cc
@@ -115,7 +115,7 @@ RETSIGTYPE watchdog(int /* signo */)
 					if ( ! pkt_dumper || pkt_dumper->IsError() )
 						{
 						reporter->Error("watchdog: can't open watchdog-pkt.pcap for writing");
-						pkt_dumper = 0;
+						pkt_dumper = nullptr;
 						}
 					}
 

--- a/src/Net.h
+++ b/src/Net.h
@@ -30,7 +30,7 @@ extern void net_delete();	// Reclaim all memory, etc.
 extern void net_update_time(double new_network_time);
 extern void net_packet_dispatch(double t, const Packet* pkt,
 			iosource::PktSrc* src_ps);
-extern void expire_timers(iosource::PktSrc* src_ps = 0);
+extern void expire_timers(iosource::PktSrc* src_ps = nullptr);
 extern void zeek_terminate_loop(const char* reason);
 
 // Functions to temporarily suspend processing of live input (network packets

--- a/src/Obj.cc
+++ b/src/Obj.cc
@@ -165,7 +165,7 @@ void BroObj::DoMsg(ODesc* d, const char s1[], const BroObj* obj2,
 	d->Add(s1);
 	PinPoint(d, obj2, pinpoint_only);
 
-	const Location* loc2 = 0;
+	const Location* loc2 = nullptr;
 	if ( obj2 && obj2->GetLocationInfo() != &no_location &&
 		 *obj2->GetLocationInfo() != *GetLocationInfo() )
 		loc2 = obj2->GetLocationInfo();

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -66,7 +66,7 @@ public:
 		// we check for whether start_location has a line number
 		// of 0, which should only happen if it's been assigned
 		// to no_location (or hasn't been initialized at all).
-		location = 0;
+		location = nullptr;
 		if ( start_location.first_line != 0 )
 			SetLocationInfo(&start_location, &end_location);
 		}
@@ -80,14 +80,14 @@ public:
 	// Report user warnings/errors.  If obj2 is given, then it's
 	// included in the message, though if pinpoint_only is non-zero,
 	// then obj2 is only used to pinpoint the location.
-	void Warn(const char* msg, const BroObj* obj2 = 0,
-			bool pinpoint_only = false, const Location* expr_location = 0) const;
-	void Error(const char* msg, const BroObj* obj2 = 0,
-			bool pinpoint_only = false, const Location* expr_location = 0) const;
+	void Warn(const char* msg, const BroObj* obj2 = nullptr,
+			bool pinpoint_only = false, const Location* expr_location = nullptr) const;
+	void Error(const char* msg, const BroObj* obj2 = nullptr,
+			bool pinpoint_only = false, const Location* expr_location = nullptr) const;
 
 	// Report internal errors.
-	void BadTag(const char* msg, const char* t1 = 0,
-			const char* t2 = 0) const;
+	void BadTag(const char* msg, const char* t1 = nullptr,
+			const char* t2 = nullptr) const;
 #define CHECK_TAG(t1, t2, text, tag_to_text_func) \
 	{ \
 	if ( t1 != t2 ) \
@@ -134,9 +134,9 @@ protected:
 private:
 	friend class SuppressErrors;
 
-	void DoMsg(ODesc* d, const char s1[], const BroObj* obj2 = 0,
-			bool pinpoint_only = false, const Location* expr_location = 0) const;
-	void PinPoint(ODesc* d, const BroObj* obj2 = 0,
+	void DoMsg(ODesc* d, const char s1[], const BroObj* obj2 = nullptr,
+			bool pinpoint_only = false, const Location* expr_location = nullptr) const;
+	void PinPoint(ODesc* d, const BroObj* obj2 = nullptr,
 			bool pinpoint_only = false) const;
 
 	friend inline void Ref(BroObj* o);

--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -699,24 +699,24 @@ bool EntropyVal::DoUnserialize(const broker::data& data)
 BloomFilterVal::BloomFilterVal()
 	: OpaqueVal(bloomfilter_type)
 	{
-	type = 0;
-	hash = 0;
-	bloom_filter = 0;
+	type = nullptr;
+	hash = nullptr;
+	bloom_filter = nullptr;
 	}
 
 BloomFilterVal::BloomFilterVal(OpaqueType* t)
 	: OpaqueVal(t)
 	{
-	type = 0;
-	hash = 0;
-	bloom_filter = 0;
+	type = nullptr;
+	hash = nullptr;
+	bloom_filter = nullptr;
 	}
 
 BloomFilterVal::BloomFilterVal(probabilistic::BloomFilter* bf)
 	: OpaqueVal(bloomfilter_type)
 	{
-	type = 0;
-	hash = 0;
+	type = nullptr;
+	hash = nullptr;
 	bloom_filter = bf;
 	}
 
@@ -790,13 +790,13 @@ IntrusivePtr<BloomFilterVal> BloomFilterVal::Merge(const BloomFilterVal* x,
 	     ! same_type(x->Type(), y->Type()) )
 		{
 		reporter->Error("cannot merge Bloom filters with different types");
-		return 0;
+		return nullptr;
 		}
 
 	if ( typeid(*x->bloom_filter) != typeid(*y->bloom_filter) )
 		{
 		reporter->Error("cannot merge different Bloom filter types");
-		return 0;
+		return nullptr;
 		}
 
 	probabilistic::BloomFilter* copy = x->bloom_filter->Clone();
@@ -805,7 +805,7 @@ IntrusivePtr<BloomFilterVal> BloomFilterVal::Merge(const BloomFilterVal* x,
 		{
 		delete copy;
 		reporter->Error("failed to merge Bloom filter");
-		return 0;
+		return nullptr;
 		}
 
 	auto merged = make_intrusive<BloomFilterVal>(copy);
@@ -813,7 +813,7 @@ IntrusivePtr<BloomFilterVal> BloomFilterVal::Merge(const BloomFilterVal* x,
 	if ( x->Type() && ! merged->Typify(x->Type()) )
 		{
 		reporter->Error("failed to set type on merged Bloom filter");
-		return 0;
+		return nullptr;
 		}
 
 	return merged;
@@ -876,17 +876,17 @@ bool BloomFilterVal::DoUnserialize(const broker::data& data)
 
 CardinalityVal::CardinalityVal() : OpaqueVal(cardinality_type)
 	{
-	c = 0;
-	type = 0;
-	hash = 0;
+	c = nullptr;
+	type = nullptr;
+	hash = nullptr;
 	}
 
 CardinalityVal::CardinalityVal(probabilistic::CardinalityCounter* arg_c)
 	: OpaqueVal(cardinality_type)
 	{
 	c = arg_c;
-	type = 0;
-	hash = 0;
+	type = nullptr;
+	hash = nullptr;
 	}
 
 CardinalityVal::~CardinalityVal()

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -186,49 +186,49 @@ zeek::Options zeek::parse_cmdline(int argc, char** argv)
 		}
 
 	constexpr struct option long_opts[] = {
-		{"parse-only",	no_argument,		0,	'a'},
-		{"bare-mode",	no_argument,		0,	'b'},
-		{"debug-script",	no_argument,		0,	'd'},
-		{"exec",		required_argument,	0,	'e'},
-		{"filter",		required_argument,	0,	'f'},
-		{"help",		no_argument,		0,	'h'},
-		{"iface",		required_argument,	0,	'i'},
-		{"zeekygen",		required_argument,		0,	'X'},
-		{"prefix",		required_argument,	0,	'p'},
-		{"readfile",		required_argument,	0,	'r'},
-		{"rulefile",		required_argument,	0,	's'},
-		{"tracefile",		required_argument,	0,	't'},
-		{"writefile",		required_argument,	0,	'w'},
-		{"version",		no_argument,		0,	'v'},
-		{"no-checksums",	no_argument,		0,	'C'},
-		{"force-dns",		no_argument,		0,	'F'},
-		{"load-seeds",		required_argument,	0,	'G'},
-		{"save-seeds",		required_argument,	0,	'H'},
-		{"print-plugins",	no_argument,		0,	'N'},
-		{"prime-dns",		no_argument,		0,	'P'},
-		{"time",		no_argument,		0,	'Q'},
-		{"debug-rules",		no_argument,		0,	'S'},
-		{"re-level",		required_argument,	0,	'T'},
-		{"watchdog",		no_argument,		0,	'W'},
-		{"print-id",		required_argument,	0,	'I'},
-		{"status-file",		required_argument,	0,	'U'},
+		{"parse-only",	no_argument,		nullptr,	'a'},
+		{"bare-mode",	no_argument,		nullptr,	'b'},
+		{"debug-script",	no_argument,		nullptr,	'd'},
+		{"exec",		required_argument,	nullptr,	'e'},
+		{"filter",		required_argument,	nullptr,	'f'},
+		{"help",		no_argument,		nullptr,	'h'},
+		{"iface",		required_argument,	nullptr,	'i'},
+		{"zeekygen",		required_argument,		nullptr,	'X'},
+		{"prefix",		required_argument,	nullptr,	'p'},
+		{"readfile",		required_argument,	nullptr,	'r'},
+		{"rulefile",		required_argument,	nullptr,	's'},
+		{"tracefile",		required_argument,	nullptr,	't'},
+		{"writefile",		required_argument,	nullptr,	'w'},
+		{"version",		no_argument,		nullptr,	'v'},
+		{"no-checksums",	no_argument,		nullptr,	'C'},
+		{"force-dns",		no_argument,		nullptr,	'F'},
+		{"load-seeds",		required_argument,	nullptr,	'G'},
+		{"save-seeds",		required_argument,	nullptr,	'H'},
+		{"print-plugins",	no_argument,		nullptr,	'N'},
+		{"prime-dns",		no_argument,		nullptr,	'P'},
+		{"time",		no_argument,		nullptr,	'Q'},
+		{"debug-rules",		no_argument,		nullptr,	'S'},
+		{"re-level",		required_argument,	nullptr,	'T'},
+		{"watchdog",		no_argument,		nullptr,	'W'},
+		{"print-id",		required_argument,	nullptr,	'I'},
+		{"status-file",		required_argument,	nullptr,	'U'},
 
 #ifdef	DEBUG
-		{"debug",		required_argument,	0,	'B'},
+		{"debug",		required_argument,	nullptr,	'B'},
 #endif
 #ifdef	USE_IDMEF
-		{"idmef-dtd",		required_argument,	0,	'n'},
+		{"idmef-dtd",		required_argument,	nullptr,	'n'},
 #endif
 #ifdef	USE_PERFTOOLS_DEBUG
-		{"mem-leaks",	no_argument,		0,	'm'},
-		{"mem-profile",	no_argument,		0,	'M'},
+		{"mem-leaks",	no_argument,		nullptr,	'm'},
+		{"mem-profile",	no_argument,		nullptr,	'M'},
 #endif
 
-		{"pseudo-realtime",	optional_argument, 0,	'E'},
-		{"jobs",	optional_argument, 0,	'j'},
-		{"test",		no_argument,		0,	'#'},
+		{"pseudo-realtime",	optional_argument, nullptr,	'E'},
+		{"jobs",	optional_argument, nullptr,	'j'},
+		{"test",		no_argument,		nullptr,	'#'},
 
-		{0,			0,			0,	0},
+		{nullptr,			0,			nullptr,	0},
 	};
 
 	char opts[256];

--- a/src/PolicyFile.cc
+++ b/src/PolicyFile.cc
@@ -18,8 +18,8 @@ using namespace std;
 #include "Reporter.h"
 
 struct PolicyFile {
-	PolicyFile ()	{ filedata = 0; lmtime = 0; }
-	~PolicyFile ()	{ delete [] filedata; filedata = 0; }
+	PolicyFile ()	{ filedata = nullptr; lmtime = 0; }
+	~PolicyFile ()	{ delete [] filedata; filedata = nullptr; }
 
 	time_t lmtime;
 	char* filedata;

--- a/src/PrefixTable.cc
+++ b/src/PrefixTable.cc
@@ -28,7 +28,7 @@ void* PrefixTable::Insert(const IPAddr& addr, int width, void* data)
 	if ( ! node )
 		{
 		reporter->InternalWarning("Cannot create node in patricia tree");
-		return 0;
+		return nullptr;
 		}
 
 	void* old = node->data;
@@ -59,7 +59,7 @@ void* PrefixTable::Insert(const Val* value, void* data)
 
 	default:
 		reporter->InternalWarning("Wrong index type for PrefixTable");
-		return 0;
+		return nullptr;
 	}
 	}
 
@@ -97,7 +97,7 @@ void* PrefixTable::Lookup(const IPAddr& addr, int width, bool exact) const
 	patricia_node_t** list = nullptr;
 
 	Deref_Prefix(prefix);
-	return node ? node->data : 0;
+	return node ? node->data : nullptr;
 	}
 
 void* PrefixTable::Lookup(const Val* value, bool exact) const
@@ -120,7 +120,7 @@ void* PrefixTable::Lookup(const Val* value, bool exact) const
 	default:
 		reporter->InternalWarning("Wrong index type %d for PrefixTable",
 		                          value->Type()->Tag());
-		return 0;
+		return nullptr;
 	}
 	}
 
@@ -131,7 +131,7 @@ void* PrefixTable::Remove(const IPAddr& addr, int width)
 	Deref_Prefix(prefix);
 
 	if ( ! node )
-		return 0;
+		return nullptr;
 
 	void* old = node->data;
 	patricia_remove(tree, node);
@@ -158,7 +158,7 @@ void* PrefixTable::Remove(const Val* value)
 
 	default:
 		reporter->InternalWarning("Wrong index type for PrefixTable");
-		return 0;
+		return nullptr;
 	}
 	}
 
@@ -167,7 +167,7 @@ PrefixTable::iterator PrefixTable::InitIterator()
 	iterator i;
 	i.Xsp = i.Xstack;
 	i.Xrn = tree->head;
-	i.Xnode = 0;
+	i.Xnode = nullptr;
 	return i;
 	}
 
@@ -177,7 +177,7 @@ void* PrefixTable::GetNext(iterator* i)
 		{
 		i->Xnode = i->Xrn;
 		if ( ! i->Xnode )
-			return 0;
+			return nullptr;
 
 		if ( i->Xrn->l )
 			{
@@ -194,7 +194,7 @@ void* PrefixTable::GetNext(iterator* i)
 			i->Xrn = *(--i->Xsp);
 
 		else
-			i->Xrn = (patricia_node_t*) 0;
+			i->Xrn = (patricia_node_t*) nullptr;
 
 		if ( i->Xnode->prefix )
 			return (void*) i->Xnode->data;

--- a/src/PrefixTable.h
+++ b/src/PrefixTable.h
@@ -30,10 +30,10 @@ public:
 	// Addr in network byte order. If data is zero, acts like a set.
 	// Returns ptr to old data if already existing.
 	// For existing items without data, returns non-nil if found.
-	void* Insert(const IPAddr& addr, int width, void* data = 0);
+	void* Insert(const IPAddr& addr, int width, void* data = nullptr);
 
 	// Value may be addr or subnet.
-	void* Insert(const Val* value, void* data = 0);
+	void* Insert(const Val* value, void* data = nullptr);
 
 	// Returns nil if not found, pointer to data otherwise.
 	// For items without data, returns non-nil if found.

--- a/src/PriorityQueue.h
+++ b/src/PriorityQueue.h
@@ -34,7 +34,7 @@ public:
 	PQ_Element* Top() const
 		{
 		if ( heap_size == 0 )
-			return 0;
+			return nullptr;
 
 		return heap[0];
 		}

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -12,10 +12,10 @@
 #include "Reporter.h"
 #include "BroString.h"
 
-CCL* curr_ccl = 0;
+CCL* curr_ccl = nullptr;
 
 Specific_RE_Matcher* rem;
-NFA_Machine* nfa = 0;
+NFA_Machine* nfa = nullptr;
 int case_insensitive = 0;
 
 extern int RE_parse(void);
@@ -27,10 +27,10 @@ Specific_RE_Matcher::Specific_RE_Matcher(match_type arg_mt, int arg_multiline)
 	{
 	mt = arg_mt;
 	multiline = arg_multiline;
-	any_ccl = 0;
-	pattern_text = 0;
-	dfa = 0;
-	ecs = 0;
+	any_ccl = nullptr;
+	pattern_text = nullptr;
+	dfa = nullptr;
+	ecs = nullptr;
 	accepted = new AcceptingSet();
 	}
 
@@ -131,7 +131,7 @@ bool Specific_RE_Matcher::Compile(bool lazy)
 		{
 		reporter->Error("error compiling pattern /%s/", pattern_text);
 		Unref(nfa);
-		nfa = 0;
+		nfa = nullptr;
 		return false;
 		}
 
@@ -141,7 +141,7 @@ bool Specific_RE_Matcher::Compile(bool lazy)
 	dfa = new DFA_Machine(nfa, EC());
 
 	Unref(nfa);
-	nfa = 0;
+	nfa = nullptr;
 
 	ecs = EC()->EquivClasses();
 
@@ -155,7 +155,7 @@ bool Specific_RE_Matcher::CompileSet(const string_list& set, const int_list& idx
 
 	rem = this;
 
-	NFA_Machine* set_nfa = 0;
+	NFA_Machine* set_nfa = nullptr;
 
 	loop_over_list(set, i)
 		{
@@ -172,7 +172,7 @@ bool Specific_RE_Matcher::CompileSet(const string_list& set, const int_list& idx
 			else
 				Unref(nfa);
 
-			nfa = 0;
+			nfa = nullptr;
 			return false;
 			}
 
@@ -257,7 +257,7 @@ bool Specific_RE_Matcher::MatchAll(const u_char* bv, int n)
 	if ( d )
 		d = d->Xtion(ecs[SYM_EOL], dfa);
 
-	return d && d->Accept() != 0;
+	return d && d->Accept() != nullptr;
 	}
 
 
@@ -354,7 +354,7 @@ bool RE_Match_State::Match(const u_char* bv, int n,
 
 		if ( ! next_state )
 			{
-			current_state = 0;
+			current_state = nullptr;
 			break;
 			}
 

--- a/src/RE.h
+++ b/src/RE.h
@@ -140,10 +140,10 @@ class RE_Match_State {
 public:
 	explicit RE_Match_State(Specific_RE_Matcher* matcher)
 		{
-		dfa = matcher->DFA() ? matcher->DFA() : 0;
+		dfa = matcher->DFA() ? matcher->DFA() : nullptr;
 		ecs = matcher->EC()->EquivClasses();
 		current_pos = -1;
-		current_state = 0;
+		current_state = nullptr;
 		}
 
 	const AcceptingMatchSet& AcceptedMatches() const
@@ -159,7 +159,7 @@ public:
 	void Clear()
 		{
 		current_pos = -1;
-		current_state = 0;
+		current_state = nullptr;
 		accepted_matches.clear();
 		}
 

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -30,7 +30,7 @@ int closelog();
 }
 #endif
 
-Reporter* reporter = 0;
+Reporter* reporter = nullptr;
 
 Reporter::Reporter()
 	{
@@ -88,8 +88,8 @@ void Reporter::Info(const char* fmt, ...)
 	{
 	va_list ap;
 	va_start(ap, fmt);
-	FILE* out = EmitToStderr(info_to_stderr) ? stderr : 0;
-	DoLog("", reporter_info, out, 0, 0, true, true, 0, fmt, ap);
+	FILE* out = EmitToStderr(info_to_stderr) ? stderr : nullptr;
+	DoLog("", reporter_info, out, nullptr, nullptr, true, true, nullptr, fmt, ap);
 	va_end(ap);
 	}
 
@@ -97,8 +97,8 @@ void Reporter::Warning(const char* fmt, ...)
 	{
 	va_list ap;
 	va_start(ap, fmt);
-	FILE* out = EmitToStderr(warnings_to_stderr) ? stderr : 0;
-	DoLog("warning", reporter_warning, out, 0, 0, true, true, 0, fmt, ap);
+	FILE* out = EmitToStderr(warnings_to_stderr) ? stderr : nullptr;
+	DoLog("warning", reporter_warning, out, nullptr, nullptr, true, true, nullptr, fmt, ap);
 	va_end(ap);
 	}
 
@@ -107,8 +107,8 @@ void Reporter::Error(const char* fmt, ...)
 	++errors;
 	va_list ap;
 	va_start(ap, fmt);
-	FILE* out = EmitToStderr(errors_to_stderr) ? stderr : 0;
-	DoLog("error", reporter_error, out, 0, 0, true, true, 0, fmt, ap);
+	FILE* out = EmitToStderr(errors_to_stderr) ? stderr : nullptr;
+	DoLog("error", reporter_error, out, nullptr, nullptr, true, true, nullptr, fmt, ap);
 	va_end(ap);
 	}
 
@@ -118,7 +118,7 @@ void Reporter::FatalError(const char* fmt, ...)
 	va_start(ap, fmt);
 
 	// Always log to stderr.
-	DoLog("fatal error", 0, stderr, 0, 0, true, false, 0, fmt, ap);
+	DoLog("fatal error", nullptr, stderr, nullptr, nullptr, true, false, nullptr, fmt, ap);
 
 	va_end(ap);
 
@@ -134,7 +134,7 @@ void Reporter::FatalErrorWithCore(const char* fmt, ...)
 	va_start(ap, fmt);
 
 	// Always log to stderr.
-	DoLog("fatal error", 0, stderr, 0, 0, true, false, 0, fmt, ap);
+	DoLog("fatal error", nullptr, stderr, nullptr, nullptr, true, false, nullptr, fmt, ap);
 
 	va_end(ap);
 
@@ -152,8 +152,8 @@ void Reporter::ExprRuntimeError(const Expr* expr, const char* fmt, ...)
 	PushLocation(expr->GetLocationInfo());
 	va_list ap;
 	va_start(ap, fmt);
-	FILE* out = EmitToStderr(errors_to_stderr) ? stderr : 0;
-	DoLog("expression error", reporter_error, out, 0, 0, true, true,
+	FILE* out = EmitToStderr(errors_to_stderr) ? stderr : nullptr;
+	DoLog("expression error", reporter_error, out, nullptr, nullptr, true, true,
 	      d.Description(), fmt, ap);
 	va_end(ap);
 	PopLocation();
@@ -166,8 +166,8 @@ void Reporter::RuntimeError(const Location* location, const char* fmt, ...)
 	PushLocation(location);
 	va_list ap;
 	va_start(ap, fmt);
-	FILE* out = EmitToStderr(errors_to_stderr) ? stderr : 0;
-	DoLog("runtime error", reporter_error, out, 0, 0, true, true, "", fmt, ap);
+	FILE* out = EmitToStderr(errors_to_stderr) ? stderr : nullptr;
+	DoLog("runtime error", reporter_error, out, nullptr, nullptr, true, true, "", fmt, ap);
 	va_end(ap);
 	PopLocation();
 	throw InterpreterException();
@@ -179,7 +179,7 @@ void Reporter::InternalError(const char* fmt, ...)
 	va_start(ap, fmt);
 
 	// Always log to stderr.
-	DoLog("internal error", 0, stderr, 0, 0, true, false, 0, fmt, ap);
+	DoLog("internal error", nullptr, stderr, nullptr, nullptr, true, false, nullptr, fmt, ap);
 
 	va_end(ap);
 
@@ -197,7 +197,7 @@ void Reporter::AnalyzerError(analyzer::Analyzer* a, const char* fmt,
 	va_start(ap, fmt);
 	// Always log to stderr.
 	// TODO: would be nice to also log a call stack.
-	DoLog("analyzer error", reporter_error, stderr, 0, 0, true, true, 0, fmt,
+	DoLog("analyzer error", reporter_error, stderr, nullptr, nullptr, true, true, nullptr, fmt,
 	      ap);
 	va_end(ap);
 	}
@@ -206,9 +206,9 @@ void Reporter::InternalWarning(const char* fmt, ...)
 	{
 	va_list ap;
 	va_start(ap, fmt);
-	FILE* out = EmitToStderr(warnings_to_stderr) ? stderr : 0;
+	FILE* out = EmitToStderr(warnings_to_stderr) ? stderr : nullptr;
 	// TODO: would be nice to also log a call stack.
-	DoLog("internal warning", reporter_warning, out, 0, 0, true, true, 0, fmt,
+	DoLog("internal warning", reporter_warning, out, nullptr, nullptr, true, true, nullptr, fmt,
 	      ap);
 	va_end(ap);
 	}
@@ -228,7 +228,7 @@ void Reporter::WeirdHelper(EventHandlerPtr event, val_list vl, const char* fmt_n
 	{
 	va_list ap;
 	va_start(ap, fmt_name);
-	DoLog("weird", event, 0, 0, &vl, false, false, 0, fmt_name, ap);
+	DoLog("weird", event, nullptr, nullptr, &vl, false, false, nullptr, fmt_name, ap);
 	va_end(ap);
 	}
 
@@ -382,7 +382,7 @@ void Reporter::DoLog(const char* prefix, EventHandlerPtr event, FILE* out,
 
 	int size = sizeof(tmp);
 	char* buffer  = tmp;
-	char* alloced = 0;
+	char* alloced = nullptr;
 
 	string loc_str;
 

--- a/src/Rule.cc
+++ b/src/Rule.cc
@@ -87,7 +87,7 @@ void Rule::AddRequires(const char* id, bool opposite_direction, bool negate)
 	{
 	Precond* p = new Precond;
 	p->id = copy_string(id);
-	p->rule = 0;
+	p->rule = nullptr;
 	p->opposite_dir = opposite_direction;
 	p->negate = negate;
 

--- a/src/Rule.h
+++ b/src/Rule.h
@@ -25,7 +25,7 @@ public:
 		idx = rule_counter++;
 		location = arg_location;
 		active = true;
-		next = 0;
+		next = nullptr;
 		}
 
 	~Rule();

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -48,10 +48,10 @@ RuleHdrTest::RuleHdrTest(Prot arg_prot, uint32_t arg_offset, uint32_t arg_size,
 	size = arg_size;
 	comp = arg_comp;
 	vals = arg_vals;
-	sibling = 0;
-	child = 0;
-	pattern_rules = 0;
-	pure_rules = 0;
+	sibling = nullptr;
+	child = nullptr;
+	pattern_rules = nullptr;
+	pure_rules = nullptr;
 	ruleset = new IntSet;
 	id = ++idcounter;
 	level = 0;
@@ -65,10 +65,10 @@ RuleHdrTest::RuleHdrTest(Prot arg_prot, Comp arg_comp, vector<IPPrefix> arg_v)
 	comp = arg_comp;
 	vals = new maskedvalue_list;
 	prefix_vals = std::move(arg_v);
-	sibling = 0;
-	child = 0;
-	pattern_rules = 0;
-	pure_rules = 0;
+	sibling = nullptr;
+	child = nullptr;
+	pattern_rules = nullptr;
+	pure_rules = nullptr;
 	ruleset = new IntSet;
 	id = ++idcounter;
 	level = 0;
@@ -103,7 +103,7 @@ RuleHdrTest::RuleHdrTest(RuleHdrTest& h)
 		for ( PatternSet* orig_set : h.psets[j] )
 			{
 			PatternSet* copied_set = new PatternSet;
-			copied_set->re = 0;
+			copied_set->re = nullptr;
 			copied_set->ids = orig_set->ids;
 			for ( const auto& pattern : orig_set->patterns )
 				copied_set->patterns.push_back(copy_string(pattern));
@@ -113,10 +113,10 @@ RuleHdrTest::RuleHdrTest(RuleHdrTest& h)
 			}
 		}
 
-	sibling = 0;
-	child = 0;
-	pattern_rules = 0;
-	pure_rules = 0;
+	sibling = nullptr;
+	child = nullptr;
+	pattern_rules = nullptr;
+	pure_rules = nullptr;
 	ruleset = new IntSet;
 	id = ++idcounter;
 	level = 0;
@@ -758,8 +758,8 @@ RuleEndpointState* RuleMatcher::InitEndpoint(analyzer::Analyzer* analyzer,
 		// Evaluate all rules on this node which don't contain
 		// any patterns.
 		for ( Rule* r = hdr_test->pure_rules; r; r = r->next )
-			if ( EvalRuleConditions(r, state, 0, 0, false) )
-				ExecRuleActions(r, state, 0, 0, false);
+			if ( EvalRuleConditions(r, state, nullptr, 0, false) )
+				ExecRuleActions(r, state, nullptr, 0, false);
 
 		// If we're on or above the RE_level, we may have some
 		// pattern matching to do.
@@ -989,7 +989,7 @@ void RuleMatcher::ExecPureRules(RuleEndpointState* state, bool eos)
 	for ( const auto& hdr_test : state->hdr_tests )
 		{
 		for ( Rule* r = hdr_test->pure_rules; r; r = r->next )
-			ExecRulePurely(r, 0, state, eos);
+			ExecRulePurely(r, nullptr, state, eos);
 		}
 	}
 
@@ -1001,14 +1001,14 @@ bool RuleMatcher::ExecRulePurely(Rule* r, BroString* s,
 
 	DBG_LOG(DBG_RULES, "Checking rule %s purely", r->ID());
 
-	if ( EvalRuleConditions(r, state, 0, 0, eos) )
+	if ( EvalRuleConditions(r, state, nullptr, 0, eos) )
 		{
 		DBG_LOG(DBG_RULES, "MATCH!");
 
 		if ( s )
 			ExecRuleActions(r, state, s->Bytes(), s->Len(), eos);
 		else
-			ExecRuleActions(r, state, 0, 0, eos);
+			ExecRuleActions(r, state, nullptr, 0, eos);
 
 		return true;
 		}
@@ -1098,7 +1098,7 @@ void RuleMatcher::ExecRule(Rule* rule, RuleEndpointState* state, bool eos)
 		for ( Rule* r = h->pure_rules; r; r = r->next )
 			if ( r == rule )
 				{ // found, so let's evaluate it
-				ExecRulePurely(rule, 0, state, eos);
+				ExecRulePurely(rule, nullptr, state, eos);
 				return;
 				}
 
@@ -1273,7 +1273,7 @@ static Val* get_bro_val(const char* label)
 	if ( ! id )
 		{
 		rules_error("unknown script-level identifier", label);
-		return 0;
+		return nullptr;
 		}
 
 	return id->ID_Val();
@@ -1464,7 +1464,7 @@ void RuleMatcherState::FinishEndpointMatcher()
 	delete orig_match_state;
 	delete resp_match_state;
 
-	orig_match_state = resp_match_state = 0;
+	orig_match_state = resp_match_state = nullptr;
 	}
 
 void RuleMatcherState::Match(Rule::PatternType type, const u_char* data,

--- a/src/RuleMatcher.h
+++ b/src/RuleMatcher.h
@@ -67,7 +67,7 @@ typedef PList<BroString> bstr_list;
 
 // Get values from Bro's script-level variables.
 extern void id_to_maskedvallist(const char* id, maskedvalue_list* append_to,
-                                vector<IPPrefix>* prefix_vector = 0);
+                                vector<IPPrefix>* prefix_vector = nullptr);
 extern char* id_to_str(const char* id);
 extern uint32_t id_to_uint(const char* id);
 
@@ -256,7 +256,7 @@ public:
 	 * @return The results of the signature matching.
 	 */
 	MIME_Matches* Match(RuleFileMagicState* state, const u_char* data,
-	                   uint64_t len, MIME_Matches* matches = 0) const;
+	                   uint64_t len, MIME_Matches* matches = nullptr) const;
 
 
 	/**
@@ -313,7 +313,7 @@ public:
 	Val* BuildRuleStateValue(const Rule* rule,
 					const RuleEndpointState* state) const;
 
-	void GetStats(Stats* stats, RuleHdrTest* hdr_test = 0);
+	void GetStats(Stats* stats, RuleHdrTest* hdr_test = nullptr);
 	void DumpStats(BroFile* f);
 
 private:
@@ -373,13 +373,13 @@ private:
 // Keeps bi-directional matching-state.
 class RuleMatcherState {
 public:
-	RuleMatcherState()	{ orig_match_state = resp_match_state = 0; }
+	RuleMatcherState()	{ orig_match_state = resp_match_state = nullptr; }
 	~RuleMatcherState()
 		{ delete orig_match_state; delete resp_match_state; }
 
 	// ip may be nil.
 	void InitEndpointMatcher(analyzer::Analyzer* analyzer, const IP_Hdr* ip,
-				 int caplen, bool from_orig, analyzer::pia::PIA* pia = 0);
+				 int caplen, bool from_orig, analyzer::pia::PIA* pia = nullptr);
 
 	// bol/eol should be set to false for type Rule::PAYLOAD; they're
 	// deduced automatically.

--- a/src/Scope.cc
+++ b/src/Scope.cc
@@ -20,7 +20,7 @@ Scope::Scope(IntrusivePtr<ID> id, attr_list* al)
 	: scope_id(std::move(id))
 	{
 	attrs = al;
-	return_type = 0;
+	return_type = nullptr;
 
 	inits = new id_list;
 
@@ -65,7 +65,7 @@ ID* Scope::GenerateTemporary(const char* name)
 id_list* Scope::GetInits()
 	{
 	id_list* ids = inits;
-	inits = 0;
+	inits = nullptr;
 	return ids;
 	}
 
@@ -76,9 +76,9 @@ void Scope::Describe(ODesc* d) const
 
 	else
 		{
-		d->Add(scope_id != 0);
+		d->Add(scope_id != nullptr);
 		d->SP();
-		d->Add(return_type != 0);
+		d->Add(return_type != nullptr);
 		d->SP();
 		d->Add(static_cast<uint64_t>(local.size()));
 		d->SP();
@@ -149,7 +149,7 @@ IntrusivePtr<ID> lookup_ID(const char* name, const char* curr_module,
 			return {NewRef{}, id};
 		}
 
-	return 0;
+	return nullptr;
 	}
 
 IntrusivePtr<ID> install_ID(const char* name, const char* module_name,

--- a/src/SerializationFormat.cc
+++ b/src/SerializationFormat.cc
@@ -29,7 +29,7 @@ void SerializationFormat::StartRead(const char* data, uint32_t arg_len)
 
 void SerializationFormat::EndRead()
 	{
-	input = 0;
+	input = nullptr;
 	}
 
 void SerializationFormat::StartWrite()
@@ -37,7 +37,7 @@ void SerializationFormat::StartWrite()
 	if ( output && output_size > INITIAL_SIZE )
 		{
 		free(output);
-		output = 0;
+		output = nullptr;
 		}
 
 	if ( ! output )
@@ -54,7 +54,7 @@ uint32_t SerializationFormat::EndWrite(char** data)
 	{
 	uint32_t rval = output_pos;
 	*data = output;
-	output = 0;
+	output = nullptr;
 	output_size = 0;
 	output_pos = 0;
 	return rval;
@@ -193,7 +193,7 @@ bool BinarySerializationFormat::Read(char** str, int* len, const char* tag)
 	if ( ! ReadData(s, l) )
 		{
 		delete [] s;
-		*str = 0;
+		*str = nullptr;
 		return false;
 		}
 

--- a/src/Sessions.h
+++ b/src/Sessions.h
@@ -75,9 +75,9 @@ public:
 	void GetStats(SessionStats& s) const;
 
 	void Weird(const char* name, const Packet* pkt,
-	    const EncapsulationStack* encap = 0, const char* addl = "");
+	    const EncapsulationStack* encap = nullptr, const char* addl = "");
 	void Weird(const char* name, const IP_Hdr* ip,
-	    const EncapsulationStack* encap = 0, const char* addl = "");
+	    const EncapsulationStack* encap = nullptr, const char* addl = "");
 
 	PacketFilter* GetPacketFilter()
 		{

--- a/src/SmithWaterman.cc
+++ b/src/SmithWaterman.cc
@@ -61,22 +61,22 @@ VectorVal* BroSubstring::VecToPolicy(Vec* vec)
 	RecordType* sw_substring_type =
 		internal_type("sw_substring")->AsRecordType();
 	if ( ! sw_substring_type )
-		return 0;
+		return nullptr;
 
 	RecordType* sw_align_type =
 		internal_type("sw_align")->AsRecordType();
 	if ( ! sw_align_type )
-		return 0;
+		return nullptr;
 
 	VectorType* sw_align_vec_type =
 		internal_type("sw_align_vec")->AsVectorType();
 	if ( ! sw_align_vec_type )
-		return 0;
+		return nullptr;
 
 	VectorVal* result =
 		new VectorVal(internal_type("sw_substring_vec")->AsVectorType());
 	if ( ! result )
-		return 0;
+		return nullptr;
 
 	if ( vec )
 		{
@@ -235,9 +235,9 @@ public:
 		{
 		// Make sure access is in allowed range.
 		if ( row < 0 || row >= _rows )
-			return 0;
+			return nullptr;
 		if ( col < 0 || col >= _cols )
-			return 0;
+			return nullptr;
 
 		return &(_nodes[row * _cols + col]);
 		}
@@ -359,7 +359,7 @@ static void sw_collect_multiple(BroSubstring::Vec* result,
 				{
 				BroSubstring::Vec* old_al = *it;
 
-				if ( old_al == 0 )
+				if ( old_al == nullptr )
 					continue;
 
 				for ( BroSubstring::VecIt it2 = old_al->begin();
@@ -372,7 +372,7 @@ static void sw_collect_multiple(BroSubstring::Vec* result,
 							{
 							delete_each(new_al);
 							delete new_al;
-							new_al = 0;
+							new_al = nullptr;
 							goto end_loop;
 							}
 
@@ -398,7 +398,7 @@ end_loop:
 		{
 		BroSubstring::Vec* al = *it;
 
-		if ( al == 0 )
+		if ( al == nullptr )
 			continue;
 
 		for ( BroSubstring::VecIt it2 = al->begin();
@@ -432,8 +432,8 @@ BroSubstring::Vec* smith_waterman(const BroString* s1, const BroString* s2,
 	byte_vec string2 = s2->Bytes();
 
 	SWNodeMatrix matrix(s1, s2);	// dynamic programming matrix.
-	SWNode* node_max = 0;	// pointer to the best score's node
-	SWNode* node_br_max = 0;	// pointer to lowest-right matching node
+	SWNode* node_max = nullptr;	// pointer to the best score's node
+	SWNode* node_br_max = nullptr;	// pointer to lowest-right matching node
 
 	// The highest score in the matrix, globally.  We initialize to 1
 	// because we are only interested in real scores (initializing to

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -339,7 +339,7 @@ void ProfileLogger::SegmentProfile(const char* name, const Location* loc,
 
 SampleLogger::SampleLogger()
 	{
-	static TableType* load_sample_info = 0;
+	static TableType* load_sample_info = nullptr;
 
 	if ( ! load_sample_info )
 		load_sample_info = internal_type("load_sample_info")->AsTableType();
@@ -355,14 +355,14 @@ SampleLogger::~SampleLogger()
 void SampleLogger::FunctionSeen(const Func* func)
 	{
 	Val* idx = new StringVal(func->Name());
-	load_samples->Assign(idx, 0);
+	load_samples->Assign(idx, nullptr);
 	Unref(idx);
 	}
 
 void SampleLogger::LocationSeen(const Location* loc)
 	{
 	Val* idx = new StringVal(loc->filename);
-	load_samples->Assign(idx, 0);
+	load_samples->Assign(idx, nullptr);
 	Unref(idx);
 	}
 
@@ -438,7 +438,7 @@ void PacketProfiler::ProfilePkt(double t, unsigned int bytes)
 		getrusage(RUSAGE_SELF, &res);
 		gettimeofday(&ptimestamp, 0);
 
-		get_memory_usage(&last_mem, 0);
+		get_memory_usage(&last_mem, nullptr);
 		last_Utime = res.ru_utime.tv_sec + res.ru_utime.tv_usec / 1e6;
 		last_Stime = res.ru_stime.tv_sec + res.ru_stime.tv_usec / 1e6;
 		last_Rtime = ptimestamp.tv_sec + ptimestamp.tv_usec / 1e6;
@@ -462,7 +462,7 @@ void PacketProfiler::ProfilePkt(double t, unsigned int bytes)
 			ptimestamp.tv_sec + ptimestamp.tv_usec / 1e6;
 
 		uint64_t curr_mem;
-		get_memory_usage(&curr_mem, 0);
+		get_memory_usage(&curr_mem, nullptr);
 
 		file->Write(fmt("%.06f %.03f %" PRIu64 " %" PRIu64 " %.03f %.03f %.03f %" PRIu64 "\n",
 				t, time-last_timestamp, pkt_cnt, byte_cnt,

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -182,7 +182,7 @@ TraversalCode ExprListStmt::Traverse(TraversalCallback* cb) const
 	HANDLE_TC_STMT_POST(tc);
 	}
 
-static BroFile* print_stdout = 0;
+static BroFile* print_stdout = nullptr;
 
 static IntrusivePtr<EnumVal> lookup_enum_val(const char* module_name, const char* name)
 	{
@@ -629,7 +629,7 @@ SwitchStmt::SwitchStmt(IntrusivePtr<Expr> index, case_list* arg_cases)
 						NegExpr* ne = (NegExpr*)(expr);
 
 						if ( ne->Op()->IsConst() )
-							Unref(exprs.replace(j, new ConstExpr(ne->Eval(0))));
+							Unref(exprs.replace(j, new ConstExpr(ne->Eval(nullptr))));
 						}
 						break;
 
@@ -638,7 +638,7 @@ SwitchStmt::SwitchStmt(IntrusivePtr<Expr> index, case_list* arg_cases)
 						PosExpr* pe = (PosExpr*)(expr);
 
 						if ( pe->Op()->IsConst() )
-							Unref(exprs.replace(j, new ConstExpr(pe->Eval(0))));
+							Unref(exprs.replace(j, new ConstExpr(pe->Eval(nullptr))));
 						}
 						break;
 
@@ -648,7 +648,7 @@ SwitchStmt::SwitchStmt(IntrusivePtr<Expr> index, case_list* arg_cases)
 
 						if ( ne->Id()->IsConst() )
 							{
-							auto v = ne->Eval(0);
+							auto v = ne->Eval(nullptr);
 
 							if ( v )
 								Unref(exprs.replace(j, new ConstExpr(std::move(v))));
@@ -757,7 +757,7 @@ bool SwitchStmt::AddCaseLabelTypeMapping(ID* t, int idx)
 std::pair<int, ID*> SwitchStmt::FindCaseLabelMatch(const Val* v) const
 	{
 	int label_idx = -1;
-	ID* label_id = 0;
+	ID* label_id = nullptr;
 
 	// Find matching expression cases.
 	if ( case_label_value_map.Length() )
@@ -1065,7 +1065,7 @@ ForStmt::ForStmt(id_list* arg_loop_vars, IntrusivePtr<Expr> loop_expr)
 	: ExprStmt(STMT_FOR, std::move(loop_expr))
 	{
 	loop_vars = arg_loop_vars;
-	body = 0;
+	body = nullptr;
 
 	if ( e->Type()->Tag() == TYPE_TABLE )
 		{
@@ -1090,7 +1090,7 @@ ForStmt::ForStmt(id_list* arg_loop_vars, IntrusivePtr<Expr> loop_expr)
 				{
 				add_local({NewRef{}, (*loop_vars)[i]},
 						{NewRef{}, ind_type}, INIT_NONE,
-						0, 0, VAR_REGULAR);
+						nullptr, nullptr, VAR_REGULAR);
 				}
 			}
 		}
@@ -1106,7 +1106,7 @@ ForStmt::ForStmt(id_list* arg_loop_vars, IntrusivePtr<Expr> loop_expr)
 		BroType* t = (*loop_vars)[0]->Type();
 		if ( ! t )
 			add_local({NewRef{}, (*loop_vars)[0]}, base_type(TYPE_COUNT),
-						INIT_NONE, 0, 0, VAR_REGULAR);
+						INIT_NONE, nullptr, nullptr, VAR_REGULAR);
 
 		else if ( ! IsIntegral(t->Tag()) )
 			{
@@ -1127,7 +1127,7 @@ ForStmt::ForStmt(id_list* arg_loop_vars, IntrusivePtr<Expr> loop_expr)
 		if ( ! t )
 			add_local({NewRef{}, (*loop_vars)[0]},
 					base_type(TYPE_STRING),
-					INIT_NONE, 0, 0, VAR_REGULAR);
+					INIT_NONE, nullptr, nullptr, VAR_REGULAR);
 
 		else if ( t->Tag() != TYPE_STRING )
 			{
@@ -1158,7 +1158,7 @@ ForStmt::ForStmt(id_list* arg_loop_vars,
 		else
 			{
 			add_local(value_var, {NewRef{}, yield_type}, INIT_NONE,
-			                 0, 0, VAR_REGULAR);
+			                 nullptr, nullptr, VAR_REGULAR);
 			}
 		}
 	else
@@ -1471,7 +1471,7 @@ void ReturnStmt::Describe(ODesc* d) const
 	{
 	Stmt::Describe(d);
 	if ( ! d->IsReadable() )
-		d->Add(e != 0);
+		d->Add(e != nullptr);
 
 	if ( e )
 		{
@@ -1600,7 +1600,7 @@ IntrusivePtr<Val> EventBodyList::Exec(Frame* f, stmt_flow_type& flow) const
 
 	// Simulate a return so the hooks operate properly.
 	stmt_flow_type ft = FLOW_RETURN;
-	(void) post_execute_stmt(f->GetNextStmt(), f, 0, &ft);
+	(void) post_execute_stmt(f->GetNextStmt(), f, nullptr, &ft);
 
 	return nullptr;
 	}
@@ -1656,7 +1656,7 @@ IntrusivePtr<Val> InitStmt::Exec(Frame* f, stmt_flow_type& flow) const
 		{
 		BroType* t = aggr->Type();
 
-		Val* v = 0;
+		Val* v = nullptr;
 
 		switch ( t->Tag() ) {
 		case TYPE_RECORD:

--- a/src/Tag.cc
+++ b/src/Tag.cc
@@ -41,13 +41,13 @@ Tag::Tag()
 	{
 	type = 0;
 	subtype = 0;
-	val = 0;
+	val = nullptr;
 	}
 
 Tag::~Tag()
 	{
 	Unref(val);
-	val = 0;
+	val = nullptr;
 	}
 
 Tag& Tag::operator=(const Tag& other)

--- a/src/Traverse.h
+++ b/src/Traverse.h
@@ -12,7 +12,7 @@ class ID;
 
 class TraversalCallback {
 public:
-	TraversalCallback()	{ current_scope = 0; }
+	TraversalCallback()	{ current_scope = nullptr; }
 	virtual ~TraversalCallback() {}
 
 	virtual TraversalCode PreFunction(const Func*) { return TC_CONTINUE; }

--- a/src/Trigger.cc
+++ b/src/Trigger.cc
@@ -130,10 +130,10 @@ Trigger::Trigger(Expr* arg_cond, Stmt* arg_body, Stmt* arg_timeout_stmts,
 	timeout_stmts = arg_timeout_stmts;
 	timeout = arg_timeout;
 	frame = arg_frame->Clone();
-	timer = 0;
+	timer = nullptr;
 	delayed = false;
 	disabled = false;
-	attached = 0;
+	attached = nullptr;
 	is_return = arg_is_return;
 	location = arg_location;
 	timeout_value = -1;

--- a/src/TunnelEncapsulation.h
+++ b/src/TunnelEncapsulation.h
@@ -129,7 +129,7 @@ protected:
  */
 class EncapsulationStack {
 public:
-	EncapsulationStack() : conns(0)
+	EncapsulationStack() : conns(nullptr)
 		{}
 
 	EncapsulationStack(const EncapsulationStack& other)
@@ -137,7 +137,7 @@ public:
 		if ( other.conns )
 			conns = new vector<EncapsulatingConn>(*(other.conns));
 		else
-			conns = 0;
+			conns = nullptr;
 		}
 
 	EncapsulationStack& operator=(const EncapsulationStack& other)
@@ -150,7 +150,7 @@ public:
 		if ( other.conns )
 			conns = new vector<EncapsulatingConn>(*(other.conns));
 		else
-			conns = 0;
+			conns = nullptr;
 
 		return *this;
 		}

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -541,7 +541,7 @@ void FuncType::Describe(ODesc* d) const
 		{
 		d->Add(int(Tag()));
 		d->Add(flavor);
-		d->Add(yield != 0);
+		d->Add(yield != nullptr);
 		args->DescribeFields(d);
 		if ( yield )
 			yield->Describe(d);
@@ -648,7 +648,7 @@ bool RecordType::HasField(const char* field) const
 BroType* RecordType::FieldType(const char* field) const
 	{
 	int offset = FieldOffset(field);
-	return offset >= 0 ? FieldType(offset) : 0;
+	return offset >= 0 ? FieldType(offset) : nullptr;
 	}
 
 BroType* RecordType::FieldType(int field) const
@@ -783,7 +783,7 @@ IntrusivePtr<TableVal> RecordType::GetRecordFieldsVal(const RecordVal* rv) const
 		if ( fv )
 			::Ref(fv);
 
-		bool logged = (fd->attrs && fd->FindAttr(ATTR_LOG) != 0);
+		bool logged = (fd->attrs && fd->FindAttr(ATTR_LOG) != nullptr);
 
 		auto nr = make_intrusive<RecordVal>(internal_type("record_field")->AsRecordType());
 
@@ -1575,10 +1575,10 @@ bool same_type(const BroType* t1, const BroType* t2, bool is_init, bool match_re
 bool same_attrs(const Attributes* a1, const Attributes* a2)
 	{
 	if ( ! a1 )
-		return (a2 == 0);
+		return (a2 == nullptr);
 
 	if ( ! a2 )
-		return (a1 == 0);
+		return (a1 == nullptr);
 
 	return (*a1 == *a2);
 	}
@@ -2023,7 +2023,7 @@ IntrusivePtr<BroType> init_type(Expr* init)
 	// Could be a record, a set, or a list of table elements.
 	Expr* e0 = el[0];
 
-	if ( e0->IsRecordElement(0) )
+	if ( e0->IsRecordElement(nullptr) )
 		// ListExpr's know how to build a record from their
 		// components.
 		return init_list->InitType();
@@ -2039,7 +2039,7 @@ IntrusivePtr<BroType> init_type(Expr* init)
 	for ( int i = 1; t && i < el.length(); ++i )
 		{
 		auto el_t = el[i]->InitType();
-		BroType* ti = el_t ? reduce_type(el_t.get()) : 0;
+		BroType* ti = el_t ? reduce_type(el_t.get()) : nullptr;
 
 		if ( ! ti )
 			return nullptr;

--- a/src/Type.h
+++ b/src/Type.h
@@ -304,12 +304,12 @@ public:
 
 	bool IsSet() const
 		{
-		return tag == TYPE_TABLE && (YieldType() == 0);
+		return tag == TYPE_TABLE && (YieldType() == nullptr);
 		}
 
 	bool IsTable() const
 		{
-		return tag == TYPE_TABLE && (YieldType() != 0);
+		return tag == TYPE_TABLE && (YieldType() != nullptr);
 		}
 
 	BroType* Ref()		{ ::Ref(this); return this; }
@@ -357,7 +357,7 @@ public:
 	const type_list* Types() const	{ return &types; }
 	type_list* Types()		{ return &types; }
 
-	bool IsPure() const		{ return pure_type != 0; }
+	bool IsPure() const		{ return pure_type != nullptr; }
 
 	// Returns the underlying pure type, or nil if the list
 	// is not pure or is empty.
@@ -485,12 +485,12 @@ protected:
 
 class TypeDecl final {
 public:
-	TypeDecl(IntrusivePtr<BroType> t, const char* i, attr_list* attrs = 0, bool in_record = false);
+	TypeDecl(IntrusivePtr<BroType> t, const char* i, attr_list* attrs = nullptr, bool in_record = false);
 	TypeDecl(const TypeDecl& other);
 	~TypeDecl();
 
 	const Attr* FindAttr(attr_tag a) const
-		{ return attrs ? attrs->FindAttr(a) : 0; }
+		{ return attrs ? attrs->FindAttr(a) : nullptr; }
 
 	void DescribeReST(ODesc* d, bool roles_only = false) const;
 
@@ -547,19 +547,19 @@ public:
 	bool IsFieldDeprecated(int field) const
 		{
 		const TypeDecl* decl = FieldDecl(field);
-		return decl && decl->FindAttr(ATTR_DEPRECATED) != 0;
+		return decl && decl->FindAttr(ATTR_DEPRECATED) != nullptr;
 		}
 
 	bool FieldHasAttr(int field, attr_tag at) const
 		{
 		const TypeDecl* decl = FieldDecl(field);
-		return decl && decl->FindAttr(at) != 0;
+		return decl && decl->FindAttr(at) != nullptr;
 		}
 
 	std::string GetFieldDeprecationWarning(int field, bool has_check) const;
 
 protected:
-	RecordType() { types = 0; }
+	RecordType() { types = nullptr; }
 
 	int num_fields;
 	type_decl_list* types;

--- a/src/UID.h
+++ b/src/UID.h
@@ -28,7 +28,7 @@ public:
 	 * Construct a UID of a given bit-length, optionally from given values.
 	 * @see UID::Set
 	 */
-	explicit UID(bro_uint_t bits, const uint64_t* v = 0, size_t n = 0)
+	explicit UID(bro_uint_t bits, const uint64_t* v = nullptr, size_t n = 0)
 		{ Set(bits, v, n); }
 
 	/**
@@ -47,7 +47,7 @@ public:
 	 *          64, then a value is truncated to bit in desired bit-length.
 	 * @param n number of 64-bit elements in array pointed to by \a v.
 	 */
-	void Set(bro_uint_t bits, const uint64_t* v = 0, size_t n = 0);
+	void Set(bro_uint_t bits, const uint64_t* v = nullptr, size_t n = 0);
 
 	/**
 	 * Returns a base62 (characters 0-9, A-Z, a-z) representation of the UID.

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -48,7 +48,7 @@ Val::Val(Func* f)
 
 static FileType* GetStringFileType() noexcept
 	{
-	static FileType* string_file_type = 0;
+	static FileType* string_file_type = nullptr;
 	if ( ! string_file_type )
 		string_file_type = new FileType(base_type(TYPE_STRING));
 	return string_file_type;
@@ -366,13 +366,13 @@ void Val::ValDescribeReST(ODesc* d) const
 #ifdef DEBUG
 ID* Val::GetID() const
 	{
-	return bound_id ? global_scope()->Lookup(bound_id) : 0;
+	return bound_id ? global_scope()->Lookup(bound_id) : nullptr;
 	}
 
 void Val::SetID(ID* id)
 	{
 	delete [] bound_id;
-	bound_id = id ? copy_string(id->Name()) : 0;
+	bound_id = id ? copy_string(id->Name()) : nullptr;
 	}
 #endif
 
@@ -1233,7 +1233,7 @@ TableVal* ListVal::ConvertToSet() const
 	TableVal* t = new TableVal(std::move(s));
 
 	for ( const auto& val : vals )
-		t->Assign(val, 0);
+		t->Assign(val, nullptr);
 
 	return t;
 	}
@@ -1381,16 +1381,16 @@ TableVal::TableVal(IntrusivePtr<TableType> t, IntrusivePtr<Attributes> a) : Val(
 void TableVal::Init(IntrusivePtr<TableType> t)
 	{
 	table_type = std::move(t);
-	expire_func = 0;
-	expire_time = 0;
-	expire_cookie = 0;
-	timer = 0;
-	def_val = 0;
+	expire_func = nullptr;
+	expire_time = nullptr;
+	expire_cookie = nullptr;
+	timer = nullptr;
+	def_val = nullptr;
 
 	if ( table_type->IsSubNetIndex() )
 		subnets = new PrefixTable;
 	else
-		subnets = 0;
+		subnets = nullptr;
 
 	table_hash = new CompositeHash(IntrusivePtr<TypeList>(NewRef{},
 	                               table_type->Indices()));
@@ -1603,12 +1603,12 @@ bool TableVal::AddTo(Val* val, bool is_first_init, bool propagate_ops) const
 
 		if ( type->IsSet() )
 			{
-			if ( ! t->Assign(v->Value(), k, 0) )
+			if ( ! t->Assign(v->Value(), k, nullptr) )
 				 return false;
 			}
 		else
 			{
-			if ( ! t->Assign(0, k, {NewRef{}, v->Value()}) )
+			if ( ! t->Assign(nullptr, k, {NewRef{}, v->Value()}) )
 				 return false;
 			}
 		}
@@ -1804,11 +1804,11 @@ IntrusivePtr<Val> TableVal::Default(Val* index)
 			auto coerce = make_intrusive<RecordCoerceExpr>(
 			        IntrusivePtr{NewRef{}, def_attr->AttrExpr()},
 			        IntrusivePtr{NewRef{}, ytype->AsRecordType()});
-			def_val = coerce->Eval(0);
+			def_val = coerce->Eval(nullptr);
 			}
 
 		else
-			def_val = def_attr->AttrExpr()->Eval(0);
+			def_val = def_attr->AttrExpr()->Eval(nullptr);
 		}
 
 	if ( ! def_val )
@@ -1942,7 +1942,7 @@ IntrusivePtr<TableVal> TableVal::LookupSubnetValues(const SubNetVal* search)
 		if ( entry && entry->Value() )
 			nt->Assign(s, {NewRef{}, entry->Value()});
 		else
-			nt->Assign(s, 0); // set
+			nt->Assign(s, nullptr); // set
 
 		if ( entry )
 			{
@@ -2050,7 +2050,7 @@ void TableVal::CallChangeFunc(const Val* index, Val* old_value, OnChangeType tpe
 IntrusivePtr<Val> TableVal::Delete(const Val* index)
 	{
 	HashKey* k = ComputeHash(index);
-	TableEntryVal* v = k ? AsNonConstTable()->RemoveEntry(k) : 0;
+	TableEntryVal* v = k ? AsNonConstTable()->RemoveEntry(k) : nullptr;
 	IntrusivePtr<Val> va{NewRef{}, v ? (v->Value() ? v->Value() : this) : nullptr};
 
 	if ( subnets && ! subnets->Remove(index) )
@@ -2128,7 +2128,7 @@ ListVal* TableVal::ConvertToPureList() const
 	if ( tl->length() != 1 )
 		{
 		InternalWarning("bad index type in TableVal::ConvertToPureList");
-		return 0;
+		return nullptr;
 		}
 
 	return ConvertToList((*tl)[0]->Tag());
@@ -2136,7 +2136,7 @@ ListVal* TableVal::ConvertToPureList() const
 
 Attr* TableVal::FindAttr(attr_tag t) const
 	{
-	return attrs ? attrs->FindAttr(t) : 0;
+	return attrs ? attrs->FindAttr(t) : nullptr;
 	}
 
 void TableVal::Describe(ODesc* d) const
@@ -2253,7 +2253,7 @@ bool TableVal::ExpandCompoundAndInit(val_list* vl, int k, IntrusivePtr<Val> new_
 
 bool TableVal::CheckAndAssign(Val* index, IntrusivePtr<Val> new_val)
 	{
-	Val* v = 0;
+	Val* v = nullptr;
 	if ( subnets )
 		// We need an exact match here.
 		v = (Val*) subnets->Lookup(index, true);
@@ -2392,7 +2392,7 @@ void TableVal::DoExpire(double t)
 
 	if ( ! v )
 		{
-		expire_cookie = 0;
+		expire_cookie = nullptr;
 		InitTimer(table_expire_interval);
 		}
 	else
@@ -2419,7 +2419,7 @@ double TableVal::GetExpireTime()
 	if ( interval >= 0 )
 		return interval;
 
-	expire_time = 0;
+	expire_time = nullptr;
 
 	if ( timer )
 		timer_mgr->Cancel(timer);
@@ -2819,7 +2819,7 @@ IntrusivePtr<RecordVal> RecordVal::CoerceTo(RecordType* t, bool allow_orphaning)
 	if ( same_type(Type(), t) )
 		return {NewRef{}, this};
 
-	return CoerceTo(t, 0, allow_orphaning);
+	return CoerceTo(t, nullptr, allow_orphaning);
 	}
 
 IntrusivePtr<TableVal> RecordVal::GetRecordFieldsVal() const
@@ -2975,7 +2975,7 @@ bool VectorVal::Assign(unsigned int index, IntrusivePtr<Val> element)
 	     ! same_type(element->Type(), vector_type->YieldType(), false) )
 		return false;
 
-	Val* val_at_index = 0;
+	Val* val_at_index = nullptr;
 
 	if ( index < val.vector_val->size() )
 		val_at_index = (*val.vector_val)[index];

--- a/src/Val.h
+++ b/src/Val.h
@@ -310,7 +310,7 @@ public:
 
 	// To be overridden by mutable derived class to enable change
 	// notification.
-	virtual notifier::Modifiable* Modifiable()	{ return 0; }
+	virtual notifier::Modifiable* Modifiable()	{ return nullptr; }
 
 #ifdef DEBUG
 	// For debugging, we keep a reference to the global ID to which a
@@ -804,7 +804,7 @@ public:
 	void ClearTimer(Timer* t)
 		{
 		if ( timer == t )
-			timer = 0;
+			timer = nullptr;
 		}
 
 	HashKey* ComputeHash(const Val* index) const;
@@ -843,7 +843,7 @@ protected:
 	IntrusivePtr<Val> Default(Val* index);
 
 	// Returns true if item expiration is enabled.
-	bool ExpirationEnabled()	{ return expire_time != 0; }
+	bool ExpirationEnabled()	{ return expire_time != nullptr; }
 
 	// Returns the expiration time defined by %{create,read,write}_expire
 	// attribute, or -1 for unset/invalid values. In the invalid case, an

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -216,7 +216,7 @@ static void make_var(ID* id, IntrusivePtr<BroType> t, init_class c,
 		// For events, add a function value (without any body) here so that
 		// we can later access the ID even if no implementations have been
 		// defined.
-		Func* f = new BroFunc(id, 0, 0, 0, 0);
+		Func* f = new BroFunc(id, nullptr, nullptr, 0, 0);
 		id->SetVal(make_intrusive<Val>(f));
 		}
 	}
@@ -305,7 +305,7 @@ static void transfer_arg_defaults(RecordType* args, RecordType* recv)
 		TypeDecl* args_i = args->FieldDecl(i);
 		TypeDecl* recv_i = recv->FieldDecl(i);
 
-		Attr* def = args_i->attrs ? args_i->attrs->FindAttr(ATTR_DEFAULT) : 0;
+		Attr* def = args_i->attrs ? args_i->attrs->FindAttr(ATTR_DEFAULT) : nullptr;
 
 		if ( ! def )
 			continue;
@@ -379,7 +379,7 @@ void begin_func(ID* id, const char* module_name, function_flavor flavor,
 		case FUNC_FLAVOR_HOOK:
 			if ( is_redef )
 				// Clear out value so it will be replaced.
-				id->SetVal(0);
+				id->SetVal(nullptr);
 			break;
 
 		case FUNC_FLAVOR_FUNCTION:

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -124,11 +124,11 @@ void Analyzer::CtorInit(const Tag& arg_tag, Connection* arg_conn)
 	skip = false;
 	finished = false;
 	removing = false;
-	parent = 0;
-	orig_supporters = 0;
-	resp_supporters = 0;
-	signature = 0;
-	output_handler = 0;
+	parent = nullptr;
+	orig_supporters = nullptr;
+	resp_supporters = nullptr;
+	signature = nullptr;
+	output_handler = nullptr;
 	}
 
 Analyzer::~Analyzer()
@@ -138,7 +138,7 @@ Analyzer::~Analyzer()
 	LOOP_OVER_CHILDREN(i)
 		delete *i;
 
-	SupportAnalyzer* next = 0;
+	SupportAnalyzer* next = nullptr;
 
 	for ( SupportAnalyzer* a = orig_supporters; a; a = next )
 		{
@@ -501,7 +501,7 @@ Analyzer* Analyzer::FindChild(ID arg_id)
 			return child;
 		}
 
-	return 0;
+	return nullptr;
 	}
 
 Analyzer* Analyzer::FindChild(Tag arg_tag)
@@ -523,13 +523,13 @@ Analyzer* Analyzer::FindChild(Tag arg_tag)
 			return child;
 		}
 
-	return 0;
+	return nullptr;
 	}
 
 Analyzer* Analyzer::FindChild(const char* name)
 	{
 	Tag tag = analyzer_mgr->GetComponentTag(name);
-	return tag ? FindChild(tag) : 0;
+	return tag ? FindChild(tag) : nullptr;
 	}
 
 void Analyzer::DeleteChild(analyzer_list::iterator i)
@@ -570,7 +570,7 @@ void Analyzer::AddSupportAnalyzer(SupportAnalyzer* analyzer)
 		analyzer->IsOrig() ? &orig_supporters : &resp_supporters;
 
 	// Find end of the list.
-	SupportAnalyzer* prev = 0;
+	SupportAnalyzer* prev = nullptr;
 	SupportAnalyzer* s;
 	for ( s = *head; s; prev = s, s = s->sibling )
 		;
@@ -621,7 +621,7 @@ SupportAnalyzer* Analyzer::FirstSupportAnalyzer(bool orig)
 	SupportAnalyzer* sa = orig ? orig_supporters : resp_supporters;
 
 	if ( ! sa )
-		return 0;
+		return nullptr;
 
 	if ( ! sa->Removing() )
 		return sa;
@@ -922,7 +922,7 @@ void TransportLayerAnalyzer::SetContentsFile(unsigned int /* direction */,
 BroFile* TransportLayerAnalyzer::GetContentsFile(unsigned int /* direction */) const
 	{
 	reporter->Error("analyzer type does not support writing to a contents file");
-	return 0;
+	return nullptr;
 	}
 
 void TransportLayerAnalyzer::PacketContents(const u_char* data, int len)

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -152,7 +152,7 @@ public:
 	 * @param caplen The packet's capture length, if available.
 	 */
 	void NextPacket(int len, const u_char* data, bool is_orig,
-			uint64_t seq = -1, const IP_Hdr* ip = 0, int caplen = 0);
+			uint64_t seq = -1, const IP_Hdr* ip = nullptr, int caplen = 0);
 
 	/**
 	 * Passes stream input to the analyzer for processing. The analyzer
@@ -528,7 +528,7 @@ public:
 	 * @param len If \a data is given, the length of it.
 	 */
 	virtual void ProtocolViolation(const char* reason,
-					const char* data = 0, int len = 0);
+					const char* data = nullptr, int len = 0);
 
 	/**
 	 * Returns true if ProtocolConfirmation() has been called at least
@@ -558,13 +558,13 @@ public:
 	 * Convenience function that forwards directly to the corresponding
 	 * Connection::Event().
 	 */
-	void Event(EventHandlerPtr f, const char* name = 0);
+	void Event(EventHandlerPtr f, const char* name = nullptr);
 
 	/**
 	 * Convenience function that forwards directly to the corresponding
 	 * Connection::Event().
 	 */
-	void Event(EventHandlerPtr f, Val* v1, Val* v2 = 0);
+	void Event(EventHandlerPtr f, Val* v1, Val* v2 = nullptr);
 
 	/**
 	 * Convenience function that forwards directly to
@@ -796,7 +796,7 @@ public:
 	 * connection originator side, and otherwise for the responder side.
 	 */
 	SupportAnalyzer(const char* name, Connection* conn, bool arg_orig)
-		: Analyzer(name, conn)	{ orig = arg_orig; sibling = 0; }
+		: Analyzer(name, conn)	{ orig = arg_orig; sibling = nullptr; }
 
 	/**
 	 * Destructor.
@@ -879,7 +879,7 @@ public:
 	 * @param conn The connection the analyzer is associated with.
 	 */
 	TransportLayerAnalyzer(const char* name, Connection* conn)
-		: Analyzer(name, conn)	{ pia = 0; }
+		: Analyzer(name, conn)	{ pia = nullptr; }
 
 	/**
 	 * Overridden from parent class.

--- a/src/analyzer/Manager.cc
+++ b/src/analyzer/Manager.cc
@@ -292,17 +292,17 @@ Analyzer* Manager::InstantiateAnalyzer(const Tag& tag, Connection* conn)
 	if ( ! c )
 		{
 		reporter->InternalWarning("request to instantiate unknown analyzer");
-		return 0;
+		return nullptr;
 		}
 
 	if ( ! c->Enabled() )
-		return 0;
+		return nullptr;
 
 	if ( ! c->Factory() )
 		{
 		reporter->InternalWarning("analyzer %s cannot be instantiated dynamically",
 					  GetComponentName(tag).c_str());
-		return 0;
+		return nullptr;
 		}
 
 	Analyzer* a = c->Factory()(conn);
@@ -310,7 +310,7 @@ Analyzer* Manager::InstantiateAnalyzer(const Tag& tag, Connection* conn)
 	if ( ! a )
 		{
 		reporter->InternalWarning("analyzer instantiation failed");
-		return 0;
+		return nullptr;
 		}
 
 	a->SetAnalyzerTag(tag);
@@ -321,12 +321,12 @@ Analyzer* Manager::InstantiateAnalyzer(const Tag& tag, Connection* conn)
 Analyzer* Manager::InstantiateAnalyzer(const char* name, Connection* conn)
 	{
 	Tag tag = GetComponentTag(name);
-	return tag ? InstantiateAnalyzer(tag, conn) : 0;
+	return tag ? InstantiateAnalyzer(tag, conn) : nullptr;
 	}
 
 Manager::tag_set* Manager::LookupPort(TransportProto proto, uint32_t port, bool add_if_not_found)
 	{
-	analyzer_map_by_port* m = 0;
+	analyzer_map_by_port* m = nullptr;
 
 	switch ( proto ) {
 	case TRANSPORT_TCP:
@@ -339,7 +339,7 @@ Manager::tag_set* Manager::LookupPort(TransportProto proto, uint32_t port, bool 
 
 	default:
 		reporter->InternalWarning("unsupported transport protocol in analyzer::Manager::LookupPort");
-		return 0;
+		return nullptr;
 	}
 
 	analyzer_map_by_port::const_iterator i = m->find(port);
@@ -348,7 +348,7 @@ Manager::tag_set* Manager::LookupPort(TransportProto proto, uint32_t port, bool 
 		return i->second;
 
 	if ( ! add_if_not_found )
-		return 0;
+		return nullptr;
 
 	tag_set* l = new tag_set;
 	m->insert(std::make_pair(port, l));
@@ -362,11 +362,11 @@ Manager::tag_set* Manager::LookupPort(PortVal* val, bool add_if_not_found)
 
 bool Manager::BuildInitialAnalyzerTree(Connection* conn)
 	{
-	tcp::TCP_Analyzer* tcp = 0;
-	udp::UDP_Analyzer* udp = 0;
-	icmp::ICMP_Analyzer* icmp = 0;
-	TransportLayerAnalyzer* root = 0;
-	pia::PIA* pia = 0;
+	tcp::TCP_Analyzer* tcp = nullptr;
+	udp::UDP_Analyzer* udp = nullptr;
+	icmp::ICMP_Analyzer* icmp = nullptr;
+	TransportLayerAnalyzer* root = nullptr;
+	pia::PIA* pia = nullptr;
 	bool check_port = false;
 
 	switch ( conn->ConnTransport() ) {
@@ -628,7 +628,7 @@ bool Manager::ApplyScheduledAnalyzers(Connection* conn, bool init, TransportLaye
 
 		EnumVal* tag = it->AsEnumVal();
 		Ref(tag);
-		conn->Event(scheduled_analyzer_applied, 0, tag);
+		conn->Event(scheduled_analyzer_applied, nullptr, tag);
 
 		DBG_ANALYZER_ARGS(conn, "activated %s analyzer as scheduled",
 		                  analyzer_mgr->GetComponentName(*it).c_str());

--- a/src/analyzer/Manager.h
+++ b/src/analyzer/Manager.h
@@ -311,7 +311,7 @@ public:
 	 *
 	 * @return True if at least one scheduled analyzer was found.
 	 */
-	bool ApplyScheduledAnalyzers(Connection* conn, bool init_and_event = true, TransportLayerAnalyzer* parent = 0);
+	bool ApplyScheduledAnalyzers(Connection* conn, bool init_and_event = true, TransportLayerAnalyzer* parent = nullptr);
 
 	/**
 	 * Schedules a particular analyzer for an upcoming connection. Once

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -15,7 +15,7 @@
 
 using namespace analyzer::bittorrent;
 
-static TableType* bt_tracker_headers = 0;
+static TableType* bt_tracker_headers = nullptr;
 static RecordType* bittorrent_peer;
 static TableType* bittorrent_peer_set;
 static RecordType* bittorrent_benc_value;
@@ -44,7 +44,7 @@ BitTorrentTracker_Analyzer::BitTorrentTracker_Analyzer(Connection* c)
 	req_buf[sizeof(req_buf) - 1] = 0;
 	req_buf_pos = req_buf;
 	req_buf_len = 0;
-	req_val_uri = 0;
+	req_val_uri = nullptr;
 	req_val_headers = new TableVal({NewRef{}, bt_tracker_headers});
 
 	res_state = BTT_RES_STATUS;
@@ -230,16 +230,16 @@ void BitTorrentTracker_Analyzer::InitBencParser(void)
 	benc_count.clear();
 
 	benc_state = BENC_STATE_EMPTY;
-	benc_raw = 0;
+	benc_raw = nullptr;
 	benc_raw_type = BENC_TYPE_NONE;
 	benc_raw_len = 0;
-	benc_key = 0;
+	benc_key = nullptr;
 	benc_key_len = 0;
-	benc_strlen = 0;
-	benc_str = 0;
+	benc_strlen = nullptr;
+	benc_str = nullptr;
 	benc_str_len = 0;
 	benc_str_have = 0;
-	benc_int = 0;
+	benc_int = nullptr;
 	benc_int_val = 0;
 	}
 
@@ -353,8 +353,8 @@ void BitTorrentTracker_Analyzer::EmitRequest(void)
 			IntrusivePtr{AdoptRef{}, req_val_headers}
 		);
 
-	req_val_uri = 0;
-	req_val_headers = 0;
+	req_val_uri = nullptr;
+	req_val_headers = nullptr;
 	}
 
 bool BitTorrentTracker_Analyzer::ParseResponse(char* line)
@@ -406,7 +406,7 @@ bool BitTorrentTracker_Analyzer::ParseResponse(char* line)
 						IntrusivePtr{AdoptRef{}, val_mgr->GetCount(res_status)},
 						IntrusivePtr{AdoptRef{}, res_val_headers}
 					);
-				res_val_headers = 0;
+				res_val_headers = nullptr;
 				res_buf_pos = res_buf + res_buf_len;
 				res_state = BTT_RES_DONE;
 				}
@@ -481,7 +481,7 @@ void BitTorrentTracker_Analyzer::ResponseBenc(int name_len, char* name,
 			RecordVal* peer = new RecordVal(bittorrent_peer);
 			peer->Assign(0, make_intrusive<AddrVal>(ad));
 			peer->Assign(1, val_mgr->GetPort(pt, TRANSPORT_TCP));
-			res_val_peers->Assign(peer, 0);
+			res_val_peers->Assign(peer, nullptr);
 
 			Unref(peer);
 			}
@@ -617,9 +617,9 @@ int BitTorrentTracker_Analyzer::ResponseParseBenc(void)
 					ResponseBenc(benc_key_len, benc_key,
 							benc_raw_type,
 							benc_raw_len, benc_raw);
-					benc_key = 0;
+					benc_key = nullptr;
 					benc_key_len = 0;
-					benc_raw = 0;
+					benc_raw = nullptr;
 					benc_raw_len = 0;
 					benc_raw_type = BENC_TYPE_NONE;
 					}
@@ -686,7 +686,7 @@ int BitTorrentTracker_Analyzer::ResponseParseBenc(void)
 						ResponseBenc(benc_key_len,
 							benc_key, BENC_TYPE_INT,
 							benc_int_val);
-						benc_key = 0;
+						benc_key = nullptr;
 						benc_key_len = 0;
 						}
 					}
@@ -764,7 +764,7 @@ int BitTorrentTracker_Analyzer::ResponseParseBenc(void)
 							BENC_TYPE_STR,
 							benc_str_len, benc_str);
 					benc_key_len = 0;
-					benc_key = 0;
+					benc_key = nullptr;
 					}
 
 				if ( ! benc_str_len )
@@ -796,7 +796,7 @@ void BitTorrentTracker_Analyzer::EmitResponse(void)
 			IntrusivePtr{AdoptRef{}, res_val_benc}
 		);
 
-	res_val_headers = 0;
-	res_val_peers = 0;
-	res_val_benc = 0;
+	res_val_headers = nullptr;
+	res_val_peers = nullptr;
+	res_val_benc = nullptr;
 	}

--- a/src/analyzer/protocol/conn-size/functions.bif
+++ b/src/analyzer/protocol/conn-size/functions.bif
@@ -7,7 +7,7 @@ static analyzer::Analyzer* GetConnsizeAnalyzer(Val* cid)
 	{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return 0;
+		return nullptr;
 
 	analyzer::Analyzer* a = c->FindAnalyzer("CONNSIZE");
 	if ( ! a )

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -545,7 +545,7 @@ bool DNS_Interpreter::ParseRR_Name(DNS_MsgInfo* msg,
 
 		default:
 			analyzer->Conn()->Internal("DNS_RR_bad_name");
-			reply_event = 0;
+			reply_event = nullptr;
 	}
 
 	if ( reply_event && ! msg->skip_event )
@@ -757,7 +757,7 @@ bool DNS_Interpreter::ParseRR_TSIG(DNS_MsgInfo* msg,
 	ExtractOctets(data, len, dns_TSIG_addl ? &request_MAC : nullptr);
 	unsigned int orig_id = ExtractShort(data, len);
 	unsigned int rr_error = ExtractShort(data, len);
-	ExtractOctets(data, len, 0);  // Other Data
+	ExtractOctets(data, len, nullptr);  // Other Data
 
 	if ( dns_TSIG_addl )
 		{
@@ -1256,7 +1256,7 @@ static StringVal* extract_char_string(analyzer::Analyzer* analyzer,
                                       const u_char*& data, int& len, int& rdlen)
 	{
 	if ( rdlen <= 0 )
-		return 0;
+		return nullptr;
 
 	uint8_t str_size = data[0];
 
@@ -1267,7 +1267,7 @@ static StringVal* extract_char_string(analyzer::Analyzer* analyzer,
 	if ( str_size > rdlen )
 		{
 		analyzer->Weird("DNS_TXT_char_str_past_rdlen");
-		return 0;
+		return nullptr;
 		}
 
 	StringVal* rval = new StringVal(str_size,
@@ -1428,7 +1428,7 @@ DNS_MsgInfo::DNS_MsgInfo(DNS_RawMsgHdr* hdr, int arg_is_query)
 	id = ntohs(hdr->id);
 	is_query = arg_is_query;
 
-	query_name = 0;
+	query_name = nullptr;
 	atype = TYPE_ALL;
 	aclass = 0;
 	ttl = 0;
@@ -1612,7 +1612,7 @@ Contents_DNS::Contents_DNS(Connection* conn, bool orig,
 	{
 	interp = arg_interp;
 
-	msg_buf = 0;
+	msg_buf = nullptr;
 	buf_n = buf_len = msg_size = 0;
 	state = DNS_LEN_HI;
 	}
@@ -1685,7 +1685,7 @@ void Contents_DNS::DeliverStream(int len, const u_char* data, bool orig)
 		// Haven't filled up the message buffer yet, no more to do.
 		return;
 
-	ForwardPacket(msg_size, msg_buf, orig, -1, 0, 0);
+	ForwardPacket(msg_size, msg_buf, orig, -1, nullptr, 0);
 
 	buf_n = 0;
 	state = DNS_LEN_HI;
@@ -1699,7 +1699,7 @@ DNS_Analyzer::DNS_Analyzer(Connection* conn)
 : tcp::TCP_ApplicationAnalyzer("DNS", conn)
 	{
 	interp = new DNS_Interpreter(this);
-	contents_dns_orig = contents_dns_resp = 0;
+	contents_dns_orig = contents_dns_resp = nullptr;
 
 	if ( Conn()->ConnTransport() == TRANSPORT_TCP )
 		{

--- a/src/analyzer/protocol/dns/Plugin.cc
+++ b/src/analyzer/protocol/dns/Plugin.cc
@@ -12,7 +12,7 @@ public:
 	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("DNS", ::analyzer::dns::DNS_Analyzer::Instantiate));
-		AddComponent(new ::analyzer::Component("Contents_DNS", 0));
+		AddComponent(new ::analyzer::Component("Contents_DNS", nullptr));
 
 		plugin::Configuration config;
 		config.name = "Zeek::DNS";

--- a/src/analyzer/protocol/finger/Finger.cc
+++ b/src/analyzer/protocol/finger/Finger.cc
@@ -60,7 +60,7 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 		assert(line <= end_of_line);
 		size_t n = end_of_line >= line ? end_of_line - line : 0; // just to be sure if assertions aren't on.
 		const char* at = reinterpret_cast<const char*>(memchr(line, '@', n));
-		const char* host = 0;
+		const char* host = nullptr;
 		if ( ! at )
 			at = host = end_of_line;
 		else

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -204,7 +204,7 @@ void FTP_ADAT_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	const char* line = (const char*) data;
 	const char* end_of_line = line + len;
 
-	BroString* decoded_adat = 0;
+	BroString* decoded_adat = nullptr;
 
 	if ( orig )
 		{
@@ -217,7 +217,7 @@ void FTP_ADAT_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 			{
 			line = skip_whitespace(line + cmd_len, end_of_line);
 			StringVal encoded(end_of_line - line, line);
-			decoded_adat = decode_base64(encoded.AsString(), 0, Conn());
+			decoded_adat = decode_base64(encoded.AsString(), nullptr, Conn());
 
 			if ( first_token )
 				{
@@ -247,7 +247,7 @@ void FTP_ADAT_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 					// Doesn't look like TLS/SSL, so done analyzing.
 					done = true;
 					delete decoded_adat;
-					decoded_adat = 0;
+					decoded_adat = nullptr;
 					}
 				}
 
@@ -292,7 +292,7 @@ void FTP_ADAT_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 				{
 				line += 5;
 				StringVal encoded(end_of_line - line, line);
-				decoded_adat = decode_base64(encoded.AsString(), 0, Conn());
+				decoded_adat = decode_base64(encoded.AsString(), nullptr, Conn());
 				}
 
 			break;

--- a/src/analyzer/protocol/ftp/Plugin.cc
+++ b/src/analyzer/protocol/ftp/Plugin.cc
@@ -12,7 +12,7 @@ public:
 	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("FTP", ::analyzer::ftp::FTP_Analyzer::Instantiate));
-		AddComponent(new ::analyzer::Component("FTP_ADAT", 0));
+		AddComponent(new ::analyzer::Component("FTP_ADAT", nullptr));
 
 		plugin::Configuration config;
 		config.name = "Zeek::FTP";

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -40,7 +40,7 @@ Gnutella_Analyzer::Gnutella_Analyzer(Connection* conn)
 	new_state = 0;
 	sent_establish = 0;
 
-	ms = 0;
+	ms = nullptr;
 
 	orig_msg_state = new GnutellaMsgState();
 	resp_msg_state = new GnutellaMsgState();

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -81,7 +81,7 @@ void ICMP_Analyzer::DeliverPacket(int len, const u_char* data,
 	if ( rule_matcher )
 		{
 		if ( ! matcher_state.MatcherInitialized(is_orig) )
-			matcher_state.InitEndpointMatcher(this, ip, len, is_orig, 0);
+			matcher_state.InitEndpointMatcher(this, ip, len, is_orig, nullptr);
 		}
 
 	type = icmpp->icmp_type;
@@ -497,7 +497,7 @@ void ICMP_Analyzer::Echo(double t, const struct icmp* icmpp, int len,
 					 int caplen, const u_char*& data, const IP_Hdr* ip_hdr)
 	{
 	// For handling all Echo related ICMP messages
-	EventHandlerPtr f = 0;
+	EventHandlerPtr f = nullptr;
 
 	if ( ip_hdr->NextProto() == IPPROTO_ICMPV6 )
 		f = (icmpp->icmp_type == ICMP6_ECHO_REQUEST)
@@ -658,7 +658,7 @@ void ICMP_Analyzer::RouterSolicit(double t, const struct icmp* icmpp, int len,
 void ICMP_Analyzer::Context4(double t, const struct icmp* icmpp,
 		int len, int caplen, const u_char*& data, const IP_Hdr* ip_hdr)
 	{
-	EventHandlerPtr f = 0;
+	EventHandlerPtr f = nullptr;
 
 	switch ( icmpp->icmp_type )
 		{
@@ -684,7 +684,7 @@ void ICMP_Analyzer::Context4(double t, const struct icmp* icmpp,
 void ICMP_Analyzer::Context6(double t, const struct icmp* icmpp,
 		int len, int caplen, const u_char*& data, const IP_Hdr* ip_hdr)
 	{
-	EventHandlerPtr f = 0;
+	EventHandlerPtr f = nullptr;
 
 	switch ( icmpp->icmp_type )
 		{
@@ -720,8 +720,8 @@ void ICMP_Analyzer::Context6(double t, const struct icmp* icmpp,
 
 VectorVal* ICMP_Analyzer::BuildNDOptionsVal(int caplen, const u_char* data)
 	{
-	static RecordType* icmp6_nd_option_type = 0;
-	static RecordType* icmp6_nd_prefix_info_type = 0;
+	static RecordType* icmp6_nd_option_type = nullptr;
+	static RecordType* icmp6_nd_prefix_info_type = nullptr;
 
 	if ( ! icmp6_nd_option_type )
 		{

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -52,7 +52,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 	const char* orig_line = line;
 	const char* end_of_line = line + length;
 
-	tcp::TCP_Endpoint* s = 0;
+	tcp::TCP_Endpoint* s = nullptr;
 
 	if ( TCP() )
 		s = is_orig ? TCP()->Orig() : TCP()->Resp();
@@ -194,17 +194,17 @@ const char* Ident_Analyzer::ParsePair(const char* line, const char* end_of_line,
 	line = ParsePort(line, end_of_line, p1);
 	if ( ! line )
 		{
-		return 0;
+		return nullptr;
 		}
 
 	if ( line >= end_of_line || line[0] != ',' )
-		return 0;
+		return nullptr;
 
 	++line;
 
 	line = ParsePort(line, end_of_line, p2);
 	if ( ! line )
-		return 0;
+		return nullptr;
 
 	return line;
 	}
@@ -216,7 +216,7 @@ const char* Ident_Analyzer::ParsePort(const char* line, const char* end_of_line,
 
 	line = skip_whitespace(line, end_of_line);
 	if ( ! isdigit(*line) )
-		return 0;
+		return nullptr;
 
 	const char* l = line;
 

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -277,7 +277,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				if ( parts[i][0] == '@' )
 					parts[i] = parts[i].substr(1);
 				auto idx = make_intrusive<StringVal>(parts[i].c_str());
-				set->Assign(idx.get(), 0);
+				set->Assign(idx.get(), nullptr);
 				}
 
 			EnqueueConnEvent(irc_names_info,
@@ -468,7 +468,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			for ( unsigned int i = 0; i < parts.size(); ++i )
 				{
 				auto idx = make_intrusive<StringVal>(parts[i].c_str());
-				set->Assign(idx.get(), 0);
+				set->Assign(idx.get(), nullptr);
 				}
 
 			EnqueueConnEvent(irc_whois_channel_line,
@@ -857,7 +857,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				info->Assign(2, make_intrusive<StringVal>(empty_string.c_str()));
 			// User mode.
 			info->Assign(3, make_intrusive<StringVal>(empty_string.c_str()));
-			list->Assign(info, 0);
+			list->Assign(info, nullptr);
 			Unref(info);
 			}
 
@@ -918,7 +918,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			info->Assign(2, make_intrusive<StringVal>(empty_string.c_str()));
 			// User mode:
 			info->Assign(3, make_intrusive<StringVal>(mode.c_str()));
-			list->Assign(info.get(), 0);
+			list->Assign(info.get(), nullptr);
 			}
 
 		EnqueueConnEvent(irc_join_message,
@@ -957,7 +957,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		for ( unsigned int i = 0; i < channelList.size(); ++i )
 			{
 			auto idx = make_intrusive<StringVal>(channelList[i].c_str());
-			set->Assign(idx.get(), 0);
+			set->Assign(idx.get(), nullptr);
 			}
 
 		EnqueueConnEvent(irc_part_message,

--- a/src/analyzer/protocol/login/Login.cc
+++ b/src/analyzer/protocol/login/Login.cc
@@ -16,7 +16,7 @@
 
 using namespace analyzer::login;
 
-static RE_Matcher* re_skip_authentication = 0;
+static RE_Matcher* re_skip_authentication = nullptr;
 static RE_Matcher* re_direct_login_prompts;
 static RE_Matcher* re_login_prompts;
 static RE_Matcher* re_login_non_failure_msgs;
@@ -39,7 +39,7 @@ Login_Analyzer::Login_Analyzer(const char* name, Connection* conn)
 	user_text_first = 0;
 	user_text_last = MAX_USER_TEXT - 1;
 	num_user_text = 0;
-	client_name = username = 0;
+	client_name = username = nullptr;
 	saw_ploy = is_VMS = false;
 
 	if ( ! re_skip_authentication )
@@ -214,7 +214,7 @@ void Login_Analyzer::AuthenticationDialog(bool orig, char* line)
 			 // respect to it (see below).
 			 login_prompt_line != failure_line);
 
-		const char* next_prompt = 0;
+		const char* next_prompt = nullptr;
 		while ( (*prompt != '\0' &&
 			 (next_prompt = IsLoginPrompt(prompt + 1))) ||
 			multi_line_prompt )
@@ -507,7 +507,7 @@ const char* Login_Analyzer::IsLoginPrompt(const char* line) const
 	int prompt_match = re_login_prompts->MatchAnywhere(line);
 	if ( ! prompt_match || IsFailureMsg(line) )
 		// IRIX can report "login: ERROR: Login incorrect"
-		return 0;
+		return nullptr;
 
 	return &line[prompt_match];
 	}
@@ -565,7 +565,7 @@ char* Login_Analyzer::PeekUserText()
 		{
 		reporter->AnalyzerError(this,
 		  "underflow in Login_Analyzer::PeekUserText()");
-		return 0;
+		return nullptr;
 		}
 
 	return user_text[user_text_first];
@@ -576,7 +576,7 @@ char* Login_Analyzer::PopUserText()
 	char* s = PeekUserText();
 
 	if ( ! s )
-		return 0;
+		return nullptr;
 
 	if ( ++user_text_first == MAX_USER_TEXT )
 		user_text_first = 0;

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -320,7 +320,7 @@ char* TelnetEnvironmentOption::ExtractEnv(u_char*& data, int& len, int& code)
 
 	if ( code != ENVIRON_VAR && code != ENVIRON_VAL &&
 	     code != ENVIRON_USERVAR )
-		return 0;
+		return nullptr;
 
 	// Move past code.
 	--len;
@@ -338,7 +338,7 @@ char* TelnetEnvironmentOption::ExtractEnv(u_char*& data, int& len, int& code)
 			{
 			++d;	// move past ESC
 			if ( d >= data_end )
-				return 0;
+				return nullptr;
 			break;
 			}
 		}
@@ -400,7 +400,7 @@ TelnetOption* NVT_Analyzer::FindOption(unsigned int code)
 		if ( options[i]->Code() == code )
 			return options[i];
 
-	TelnetOption* opt = 0;
+	TelnetOption* opt = nullptr;
 	if ( i < NUM_TELNET_OPTIONS )
 		{ // Maybe we haven't created this option yet.
 		switch ( code ) {

--- a/src/analyzer/protocol/login/Plugin.cc
+++ b/src/analyzer/protocol/login/Plugin.cc
@@ -17,10 +17,10 @@ public:
 		AddComponent(new ::analyzer::Component("Telnet", ::analyzer::login::Telnet_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("Rsh", ::analyzer::login::Rsh_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("Rlogin", ::analyzer::login::Rlogin_Analyzer::Instantiate));
-		AddComponent(new ::analyzer::Component("NVT", 0));
-		AddComponent(new ::analyzer::Component("Login", 0));
-		AddComponent(new ::analyzer::Component("Contents_Rsh", 0));
-		AddComponent(new ::analyzer::Component("Contents_Rlogin", 0));
+		AddComponent(new ::analyzer::Component("NVT", nullptr));
+		AddComponent(new ::analyzer::Component("Login", nullptr));
+		AddComponent(new ::analyzer::Component("Contents_Rsh", nullptr));
+		AddComponent(new ::analyzer::Component("Contents_Rlogin", nullptr));
 
 		plugin::Configuration config;
 		config.name = "Zeek::Login";

--- a/src/analyzer/protocol/login/Rlogin.cc
+++ b/src/analyzer/protocol/login/Rlogin.cc
@@ -16,7 +16,7 @@ Contents_Rlogin_Analyzer::Contents_Rlogin_Analyzer(Connection* conn, bool orig, 
 	{
 	num_bytes_to_scan = 0;
 	analyzer = arg_analyzer;
-	peer = 0;
+	peer = nullptr;
 
 	if ( orig )
 		state = save_state = RLOGIN_FIRST_NULL;

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -21,7 +21,7 @@
 
 namespace analyzer { namespace mime {
 
-static const data_chunk_t null_data_chunk = { 0, 0 };
+static const data_chunk_t null_data_chunk = { 0, nullptr };
 
 int mime_header_only = 0;
 int mime_decode_data = 1;
@@ -65,14 +65,14 @@ enum MIME_BOUNDARY_DELIMITER {
 static const char* MIMEHeaderName[] = {
 	"content-type",
 	"content-transfer-encoding",
-	0,
+	nullptr,
 };
 
 static const char* MIMEContentTypeName[] = {
 	"MULTIPART",
 	"MESSAGE",
 	"TEXT",
-	0,
+	nullptr,
 };
 
 static const char* MIMEContentSubtypeName[] = {
@@ -86,7 +86,7 @@ static const char* MIMEContentSubtypeName[] = {
 
 	"PLAIN",		// for text
 
-	0,			// other
+	nullptr,			// other
 };
 
 static const char* MIMEContentEncodingName[] = {
@@ -95,12 +95,12 @@ static const char* MIMEContentEncodingName[] = {
 	"BINARY",
 	"QUOTED-PRINTABLE",
 	"BASE64",
-	0,
+	nullptr,
 };
 
 bool is_null_data_chunk(data_chunk_t b)
 	{
-	return b.data == 0;
+	return b.data == nullptr;
 	}
 
 bool is_lws(char ch)
@@ -437,7 +437,7 @@ using namespace analyzer::mime;
 
 MIME_Multiline::MIME_Multiline()
 	{
-	line = 0;
+	line = nullptr;
 	}
 
 MIME_Multiline::~MIME_Multiline()
@@ -454,7 +454,7 @@ void MIME_Multiline::append(int len, const char* data)
 BroString* MIME_Multiline::get_concatenated_line()
 	{
 	if ( buffer.empty() )
-		return 0;
+		return nullptr;
 
 	delete line;
 	line = concatenate(buffer);
@@ -546,7 +546,7 @@ void MIME_Entity::init()
 	in_header = 1;
 	end_of_data = 0;
 
-	current_header_line = 0;
+	current_header_line = nullptr;
 	current_field_type = MIME_FIELD_OTHER;
 
 	need_to_parse_parameters = 0;
@@ -554,22 +554,22 @@ void MIME_Entity::init()
 	content_type_str = new StringVal("TEXT");
 	content_subtype_str = new StringVal("PLAIN");
 
-	content_encoding_str = 0;
-	multipart_boundary = 0;
+	content_encoding_str = nullptr;
+	multipart_boundary = nullptr;
 	content_type = CONTENT_TYPE_TEXT;
 	content_subtype = CONTENT_SUBTYPE_PLAIN;
 	content_encoding = CONTENT_ENCODING_OTHER;
 
-	parent = 0;
-	current_child_entity = 0;
+	parent = nullptr;
+	current_child_entity = nullptr;
 
-	base64_decoder = 0;
+	base64_decoder = nullptr;
 
 	data_buf_length = 0;
-	data_buf_data = 0;
+	data_buf_data = nullptr;
 	data_buf_offset = -1;
 
-	message = 0;
+	message = nullptr;
 	delay_adding_implicit_CRLF = false;
 	want_all_headers = false;
 	}
@@ -577,7 +577,7 @@ void MIME_Entity::init()
 MIME_Entity::~MIME_Entity()
 	{
 	if ( ! end_of_data )
-		reporter->AnalyzerError(message ? message->GetAnalyzer() : 0,
+		reporter->AnalyzerError(message ? message->GetAnalyzer() : nullptr,
 		            "missing MIME_Entity::EndOfData() before ~MIME_Entity");
 
 	delete current_header_line;
@@ -653,7 +653,7 @@ void MIME_Entity::EndOfData()
 
 	else
 		{
-		if ( current_child_entity != 0 )
+		if ( current_child_entity != nullptr )
 			{
 			if ( content_type == CONTENT_TYPE_MULTIPART )
 				IllegalFormat("multipart closing boundary delimiter missing");
@@ -675,13 +675,13 @@ void MIME_Entity::NewDataLine(int len, const char* data, bool trailing_CRLF)
 		{
 		switch ( CheckBoundaryDelimiter(len, data) ) {
 			case MULTIPART_BOUNDARY:
-				if ( current_child_entity != 0 )
+				if ( current_child_entity != nullptr )
 					EndChildEntity();
 				BeginChildEntity();
 				return;
 
 			case MULTIPART_CLOSING_BOUNDARY:
-				if ( current_child_entity != 0 )
+				if ( current_child_entity != nullptr )
 					EndChildEntity();
 				EndOfData();
 				return;
@@ -695,7 +695,7 @@ void MIME_Entity::NewDataLine(int len, const char* data, bool trailing_CRLF)
 		// binary encoding, and thus do not need to decode
 		// before passing the data to child.
 
-		if ( current_child_entity != 0 )
+		if ( current_child_entity != nullptr )
 			// Data before the first or after the last
 			// boundary delimiter are ignored
 			current_child_entity->Deliver(len, data, trailing_CRLF);
@@ -722,7 +722,7 @@ void MIME_Entity::NewHeader(int len, const char* data)
 
 void MIME_Entity::ContHeader(int len, const char* data)
 	{
-	if ( current_header_line == 0 )
+	if ( current_header_line == nullptr )
 		{
 		IllegalFormat("first header line starts with linear whitespace");
 
@@ -737,11 +737,11 @@ void MIME_Entity::ContHeader(int len, const char* data)
 
 void MIME_Entity::FinishHeader()
 	{
-	if ( current_header_line == 0 )
+	if ( current_header_line == nullptr )
 		return;
 
 	MIME_Header* h = new MIME_Header(current_header_line);
-	current_header_line = 0;
+	current_header_line = nullptr;
 
 	if ( ! is_null_data_chunk(h->get_name()) )
 		{
@@ -762,7 +762,7 @@ int MIME_Entity::LookupMIMEHeaderName(data_chunk_t name)
 	// A linear lookup should be fine for now.
 	// header names are case-insensitive (RFC 822, 2822, 2045).
 
-	for ( int i = 0; MIMEHeaderName[i] != 0; ++i )
+	for ( int i = 0; MIMEHeaderName[i] != nullptr; ++i )
 		if ( istrequal(name, MIMEHeaderName[i]) )
 			return i;
 	return -1;
@@ -770,7 +770,7 @@ int MIME_Entity::LookupMIMEHeaderName(data_chunk_t name)
 
 void MIME_Entity::ParseMIMEHeader(MIME_Header* h)
 	{
-	if ( h == 0 )
+	if ( h == nullptr )
 		return;
 
 	current_field_type = LookupMIMEHeaderName(h->get_name());
@@ -884,7 +884,7 @@ bool MIME_Entity::ParseFieldParameters(int len, const char* data)
 		data += offset;
 		len -= offset;
 
-		BroString* val = 0;
+		BroString* val = nullptr;
 
 		if ( current_field_type == MIME_CONTENT_TYPE &&
 		     content_type == CONTENT_TYPE_MULTIPART &&
@@ -1172,13 +1172,13 @@ void MIME_Entity::FinishDecodeBase64()
 		}
 
 	delete base64_decoder;
-	base64_decoder = 0;
+	base64_decoder = nullptr;
 	}
 
 bool MIME_Entity::GetDataBuffer()
 	{
 	int ret = message->RequestBuffer(&data_buf_length, &data_buf_data);
-	if ( ! ret || data_buf_length == 0 || data_buf_data == 0 )
+	if ( ! ret || data_buf_length == 0 || data_buf_data == nullptr )
 		{
 		// reporter->InternalError("cannot get data buffer from MIME_Message", "");
 		return false;
@@ -1250,18 +1250,18 @@ void MIME_Entity::SubmitAllHeaders()
 
 void MIME_Entity::BeginChildEntity()
 	{
-	ASSERT(current_child_entity == 0);
+	ASSERT(current_child_entity == nullptr);
 	current_child_entity = NewChildEntity();
 	message->BeginEntity(current_child_entity);
 	}
 
 void MIME_Entity::EndChildEntity()
 	{
-	ASSERT(current_child_entity != 0);
+	ASSERT(current_child_entity != nullptr);
 
 	current_child_entity->EndOfData();
 	delete current_child_entity;
-	current_child_entity = 0;
+	current_child_entity = nullptr;
 	}
 
 void MIME_Entity::IllegalFormat(const char* explanation)
@@ -1349,7 +1349,7 @@ MIME_Mail::MIME_Mail(analyzer::Analyzer* mail_analyzer, bool orig, int buf_size)
 
 	content_hash_length = 0;
 
-	top_level = new MIME_Entity(this, 0);	// to be changed to MIME_Mail
+	top_level = new MIME_Entity(this, nullptr);	// to be changed to MIME_Mail
 	BeginEntity(top_level);
 	}
 

--- a/src/analyzer/protocol/mime/MIME.h
+++ b/src/analyzer/protocol/mime/MIME.h
@@ -188,7 +188,7 @@ public:
 		// Cannot initialize top_level entity because we do
 		// not know its type yet (MIME_Entity / MIME_Mail /
 		// etc.).
-		top_level = 0;
+		top_level = nullptr;
 		finished = false;
 		analyzer = arg_analyzer;
 		}

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -83,7 +83,7 @@ void NCP_Session::DeliverFrame(const binpac::NCP::ncp_frame* frame)
 FrameBuffer::FrameBuffer(size_t header_length)
 	{
 	hdr_len = header_length;
-	msg_buf = 0;
+	msg_buf = nullptr;
 	buf_len = 0;
 	Reset();
 	}

--- a/src/analyzer/protocol/ncp/Plugin.cc
+++ b/src/analyzer/protocol/ncp/Plugin.cc
@@ -12,7 +12,7 @@ public:
 	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("NCP", ::analyzer::ncp::NCP_Analyzer::Instantiate));
-		AddComponent(new ::analyzer::Component("Contents_NCP", 0));
+		AddComponent(new ::analyzer::Component("Contents_NCP", nullptr));
 
 		plugin::Configuration config;
 		config.name = "Zeek::NCP";

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -214,7 +214,7 @@ int NetbiosSSN_Interpreter::ConvertName(const u_char* name, int name_len,
 	{
 	// Taken from tcpdump's smbutil.c.
 
-	xname = 0;
+	xname = nullptr;
 
 	if ( name_len < 1 )
 		return 0;
@@ -340,7 +340,7 @@ Contents_NetbiosSSN::Contents_NetbiosSSN(Connection* conn, bool orig,
 	{
 	interp = arg_interp;
 	type = flags = msg_size = 0;
-	msg_buf = 0;
+	msg_buf = nullptr;
 	buf_n = buf_len = msg_size = 0;
 	state = NETBIOS_SSN_TYPE;
 	}
@@ -455,7 +455,7 @@ NetbiosSSN_Analyzer::NetbiosSSN_Analyzer(Connection* conn)
 	{
 	//smb_session = new SMB_Session(this);
 	interp = new NetbiosSSN_Interpreter(this);
-	orig_netbios = resp_netbios = 0;
+	orig_netbios = resp_netbios = nullptr;
 	did_session_done = 0;
 
 	if ( Conn()->ConnTransport() == TRANSPORT_TCP )

--- a/src/analyzer/protocol/netbios/Plugin.cc
+++ b/src/analyzer/protocol/netbios/Plugin.cc
@@ -12,7 +12,7 @@ public:
 	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("NetbiosSSN", ::analyzer::netbios_ssn::NetbiosSSN_Analyzer::Instantiate));
-		AddComponent(new ::analyzer::Component("Contents_NetbiosSSN", 0));
+		AddComponent(new ::analyzer::Component("Contents_NetbiosSSN", nullptr));
 
 		plugin::Configuration config;
 		config.name = "Zeek::NetBIOS";

--- a/src/analyzer/protocol/pia/PIA.cc
+++ b/src/analyzer/protocol/pia/PIA.cc
@@ -22,7 +22,7 @@ PIA::~PIA()
 
 void PIA::ClearBuffer(Buffer* buffer)
 	{
-	DataBlock* next = 0;
+	DataBlock* next = nullptr;
 	for ( DataBlock* b = buffer->head; b; b = next )
 		{
 		next = b->next;
@@ -31,14 +31,14 @@ void PIA::ClearBuffer(Buffer* buffer)
 		delete b;
 		}
 
-	buffer->head = buffer->tail = 0;
+	buffer->head = buffer->tail = nullptr;
 	buffer->size = 0;
 	}
 
 void PIA::AddToBuffer(Buffer* buffer, uint64_t seq, int len, const u_char* data,
 			bool is_orig, const IP_Hdr* ip)
 	{
-	u_char* tmp = 0;
+	u_char* tmp = nullptr;
 
 	if ( data )
 		{
@@ -47,12 +47,12 @@ void PIA::AddToBuffer(Buffer* buffer, uint64_t seq, int len, const u_char* data,
 		}
 
 	DataBlock* b = new DataBlock;
-	b->ip = ip ? ip->Copy() : 0;
+	b->ip = ip ? ip->Copy() : nullptr;
 	b->data = tmp;
 	b->is_orig = is_orig;
 	b->len = len;
 	b->seq = seq;
-	b->next = 0;
+	b->next = nullptr;
 
 	if ( buffer->tail )
 		{
@@ -117,14 +117,14 @@ void PIA::PIA_DeliverPacket(int len, const u_char* data, bool is_orig, uint64_t 
 
 	pkt_buffer.state = new_state;
 
-	current_packet.data = 0;
+	current_packet.data = nullptr;
 	}
 
 void PIA::Match(Rule::PatternType type, const u_char* data, int len,
 		bool is_orig, bool bol, bool eol, bool clear_state)
 	{
 	if ( ! MatcherInitialized(is_orig) )
-		InitEndpointMatcher(AsAnalyzer(), 0, 0, is_orig, this);
+		InitEndpointMatcher(AsAnalyzer(), nullptr, 0, is_orig, this);
 
 	RuleMatcherState::Match(type, data, len, is_orig, bol, eol, clear_state);
 	}
@@ -207,9 +207,9 @@ void PIA_TCP::Init()
 void PIA_TCP::FirstPacket(bool is_orig, const IP_Hdr* ip)
 	{
 	static char dummy_packet[sizeof(struct ip) + sizeof(struct tcphdr)];
-	static struct ip* ip4 = 0;
-	static struct tcphdr* tcp4 = 0;
-	static IP_Hdr* ip4_hdr = 0;
+	static struct ip* ip4 = nullptr;
+	static struct tcphdr* tcp4 = nullptr;
+	static IP_Hdr* ip4_hdr = nullptr;
 
 	DBG_LOG(DBG_ANALYZER, "PIA_TCP[%d] FirstPacket(%s)", GetID(), (is_orig ? "T" : "F"));
 
@@ -277,7 +277,7 @@ void PIA_TCP::DeliverStream(int len, const u_char* data, bool is_orig)
 						SKIPPING : MATCHING_ONLY;
 		}
 
-	DoMatch(data, len, is_orig, false, false, false, 0);
+	DoMatch(data, len, is_orig, false, false, false, nullptr);
 
 	stream_buffer.state = new_state;
 	}
@@ -288,7 +288,7 @@ void PIA_TCP::Undelivered(uint64_t seq, int len, bool is_orig)
 
 	if ( stream_buffer.state == BUFFERING )
 		// We use data=nil to mark an undelivered.
-		AddToBuffer(&stream_buffer, seq, len, 0, is_orig);
+		AddToBuffer(&stream_buffer, seq, len, nullptr, is_orig);
 
 	// No check for buffer overrun here. I think that's ok.
 	}

--- a/src/analyzer/protocol/pia/PIA.h
+++ b/src/analyzer/protocol/pia/PIA.h
@@ -25,7 +25,7 @@ public:
 	// Called when PIA wants to put an Analyzer in charge.  rule is the
 	// signature that triggered the activitation, if any.
 	virtual void ActivateAnalyzer(analyzer::Tag tag,
-					const Rule* rule = 0) = 0;
+					const Rule* rule = nullptr) = 0;
 
 	// Called when PIA wants to remove an Analyzer.
 	virtual void DeactivateAnalyzer(analyzer::Tag tag) = 0;
@@ -58,7 +58,7 @@ protected:
 	};
 
 	struct Buffer {
-		Buffer() { head = tail = 0; size = 0; state = INIT; }
+		Buffer() { head = tail = nullptr; size = 0; state = INIT; }
 
 		DataBlock* head;
 		DataBlock* tail;
@@ -67,15 +67,15 @@ protected:
 	};
 
 	void AddToBuffer(Buffer* buffer, uint64_t seq, int len,
-				const u_char* data, bool is_orig, const IP_Hdr* ip = 0);
+				const u_char* data, bool is_orig, const IP_Hdr* ip = nullptr);
 	void AddToBuffer(Buffer* buffer, int len,
-				const u_char* data, bool is_orig, const IP_Hdr* ip = 0);
+				const u_char* data, bool is_orig, const IP_Hdr* ip = nullptr);
 	void ClearBuffer(Buffer* buffer);
 
 	DataBlock* CurrentPacket()	{ return &current_packet; }
 
 	void DoMatch(const u_char* data, int len, bool is_orig, bool bol,
-			bool eol, bool clear_state, const IP_Hdr* ip = 0);
+			bool eol, bool clear_state, const IP_Hdr* ip = nullptr);
 
 	void SetConn(Connection* c)	{ conn = c; }
 
@@ -161,7 +161,7 @@ protected:
 	void Undelivered(uint64_t seq, int len, bool is_orig) override;
 
 	void ActivateAnalyzer(analyzer::Tag tag,
-					const Rule* rule = 0) override;
+					const Rule* rule = nullptr) override;
 	void DeactivateAnalyzer(analyzer::Tag tag) override;
 
 private:

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -43,7 +43,7 @@ POP3_Analyzer::POP3_Analyzer(Connection* conn)
 	lastRequiredCommand = 0;
 	authLines = 0;
 
-	mail = 0;
+	mail = nullptr;
 
 	cl_orig = new tcp::ContentLine_Analyzer(conn, true);
 	AddSupportAnalyzer(cl_orig);
@@ -136,7 +136,7 @@ void POP3_Analyzer::ProcessRequest(int length, const char* line)
 		++authLines;
 
 		BroString encoded(line);
-		BroString* decoded = decode_base64(&encoded, 0, Conn());
+		BroString* decoded = decode_base64(&encoded, nullptr, Conn());
 
 		if ( ! decoded )
 			{
@@ -854,7 +854,7 @@ void POP3_Analyzer::EndData()
 		{
 		mail->Done();
 		delete mail;
-		mail = 0;
+		mail = nullptr;
 		}
 	}
 

--- a/src/analyzer/protocol/pop3/POP3.h
+++ b/src/analyzer/protocol/pop3/POP3.h
@@ -103,7 +103,7 @@ protected:
 	int ParseCmd(string cmd);
 	void AuthSuccessfull();
 	void POP3Event(EventHandlerPtr event, bool is_orig,
-			const char* arg1 = 0, const char* arg2 = 0);
+			const char* arg1 = nullptr, const char* arg2 = nullptr);
 
 	mime::MIME_Mail* mail;
 	list<string> cmds;

--- a/src/analyzer/protocol/rdp/RDP.cc
+++ b/src/analyzer/protocol/rdp/RDP.cc
@@ -12,7 +12,7 @@ RDP_Analyzer::RDP_Analyzer(Connection* c)
 	interp = new binpac::RDP::RDP_Conn(this);
 
 	had_gap = false;
-	pia = 0;
+	pia = nullptr;
 	}
 
 RDP_Analyzer::~RDP_Analyzer()
@@ -66,8 +66,8 @@ void RDP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 					return;
 					}
 
-				pia->FirstPacket(true, 0);
-				pia->FirstPacket(false, 0);
+				pia->FirstPacket(true, nullptr);
+				pia->FirstPacket(false, nullptr);
 				}
 
 			ForwardStream(len, data, orig);

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -22,7 +22,7 @@ bool MOUNT_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 
 	uint32_t proc = c->Proc();
 	// The call arguments, depends on the call type obviously ...
-	Val *callarg = 0;
+	Val *callarg = nullptr;
 
 	switch ( proc ) {
 		case BifEnum::MOUNT3::PROC_NULL:
@@ -41,7 +41,7 @@ bool MOUNT_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 		break;
 
 	default:
-		callarg = 0;
+		callarg = nullptr;
 		if ( proc < BifEnum::MOUNT3::PROC_END_OF_PROCS )
 			{
 			// We know the procedure but haven't implemented it.
@@ -65,7 +65,7 @@ bool MOUNT_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 		// RecordVal was allocated but we failed to fill it). So we
 		// Unref() the call arguments, and we are fine.
 		Unref(callarg);
-		callarg = 0;
+		callarg = nullptr;
 		return false;
 		}
 
@@ -78,8 +78,8 @@ bool MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_statu
 			       const u_char*& buf, int& n, double start_time,
 			       double last_time, int reply_len)
 	{
-	EventHandlerPtr event = 0;
-	Val* reply = 0;
+	EventHandlerPtr event = nullptr;
+	Val* reply = nullptr;
 	BifEnum::MOUNT3::status_t mount_status = BifEnum::MOUNT3::MNT3_OK;
 	bool rpc_success = ( rpc_status == BifEnum::RPC_SUCCESS );
 
@@ -104,7 +104,7 @@ bool MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_statu
 		// We set the buffer to NULL, the function that extract the
 		// reply from the data stream will then return empty records.
 		//
-		buf = NULL;
+		buf = nullptr;
 		n = 0;
 		}
 
@@ -119,14 +119,14 @@ bool MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_statu
 		break;
 
 	case BifEnum::MOUNT3::PROC_UMNT:
-		reply = 0;
+		reply = nullptr;
 		n = 0;
 		mount_status = BifEnum::MOUNT3::MNT3_OK;
 		event = mount_proc_umnt;
 		break;
 
 	case BifEnum::MOUNT3::PROC_UMNT_ALL:
-		reply = 0;
+		reply = nullptr;
 		n = 0;
 		mount_status = BifEnum::MOUNT3::MNT3_OK;
 		event = mount_proc_umnt;
@@ -151,7 +151,7 @@ bool MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_statu
 		// There was a parse error. We have to unref the reply. (see
 		// also comments in RPC_BuildCall.
 		Unref(reply);
-		reply = 0;
+		reply = nullptr;
 		return false;
 		}
 
@@ -230,7 +230,7 @@ StringVal* MOUNT_Interp::mount3_fh(const u_char*& buf, int& n)
 	const u_char* fh = extract_XDR_opaque(buf, n, fh_n, 64);
 
 	if ( ! fh )
-		return 0;
+		return nullptr;
 
 	return new StringVal(new BroString(fh, fh_n, false));
 	}
@@ -241,7 +241,7 @@ StringVal* MOUNT_Interp::mount3_filename(const u_char*& buf, int& n)
 	const u_char* name = extract_XDR_opaque(buf, n, name_len);
 
 	if ( ! name )
-		return 0;
+		return nullptr;
 
 	return new StringVal(new BroString(name, name_len, false));
 	}
@@ -288,8 +288,8 @@ RecordVal* MOUNT_Interp::mount3_mnt_reply(const u_char*& buf, int& n,
 		}
 	else
 		{
-		rep->Assign(0, 0);
-		rep->Assign(1, 0);
+		rep->Assign(0, nullptr);
+		rep->Assign(1, nullptr);
 		}
 
 	return rep;
@@ -298,7 +298,7 @@ RecordVal* MOUNT_Interp::mount3_mnt_reply(const u_char*& buf, int& n,
 MOUNT_Analyzer::MOUNT_Analyzer(Connection* conn)
 	: RPC_Analyzer("MOUNT", conn, new MOUNT_Interp(this))
 	{
-	orig_rpc = resp_rpc = 0;
+	orig_rpc = resp_rpc = nullptr;
 	}
 
 void MOUNT_Analyzer::Init()

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -22,7 +22,7 @@ bool NFS_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 
 	uint32_t proc = c->Proc();
 	// The call arguments, depends on the call type obviously ...
-	Val *callarg = 0;
+	Val *callarg = nullptr;
 
 	switch ( proc ) {
 	case BifEnum::NFS3::PROC_NULL:
@@ -95,7 +95,7 @@ bool NFS_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 		break;
 
 	default:
-		callarg = 0;
+		callarg = nullptr;
 		if ( proc < BifEnum::NFS3::PROC_END_OF_PROCS )
 			{
 			// We know the procedure but haven't implemented it.
@@ -119,7 +119,7 @@ bool NFS_Interp::RPC_BuildCall(RPC_CallInfo* c, const u_char*& buf, int& n)
 		// RecordVal was allocated but we failed to fill it). So we
 		// Unref() the call arguments, and we are fine.
 		Unref(callarg);
-		callarg = 0;
+		callarg = nullptr;
 		return false;
 		}
 
@@ -132,8 +132,8 @@ bool NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 			       const u_char*& buf, int& n, double start_time,
 			       double last_time, int reply_len)
 	{
-	EventHandlerPtr event = 0;
-	Val *reply = 0;
+	EventHandlerPtr event = nullptr;
+	Val *reply = nullptr;
 	BifEnum::NFS3::status_t nfs_status = BifEnum::NFS3::NFS3ERR_OK;
 	bool rpc_success = ( rpc_status == BifEnum::RPC_SUCCESS );
 
@@ -158,7 +158,7 @@ bool NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 		// We set the buffer to NULL, the function that extract the
 		// reply from the data stream will then return empty records.
 		//
-		buf = NULL;
+		buf = nullptr;
 		n = 0;
 		}
 
@@ -263,7 +263,7 @@ bool NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 		// There was a parse error. We have to unref the reply. (see
 		// also comments in RPC_BuildCall.
 		Unref(reply);
-		reply = 0;
+		reply = nullptr;
 		return false;
 		}
 
@@ -303,10 +303,10 @@ StringVal* NFS_Interp::nfs3_file_data(const u_char*& buf, int& n, uint64_t offse
 
 	// check whether we have to deliver data to the event
 	if ( ! BifConst::NFS3::return_data )
-		return 0;
+		return nullptr;
 
 	if ( BifConst::NFS3::return_data_first_only && offset != 0 )
-		return 0;
+		return nullptr;
 
 	// Ok, so we want to return some data
 	data_n = min(data_n, size);
@@ -315,7 +315,7 @@ StringVal* NFS_Interp::nfs3_file_data(const u_char*& buf, int& n, uint64_t offse
 	if ( data && data_n > 0 )
 		return new StringVal(new BroString(data, data_n, false));
 
-	return 0;
+	return nullptr;
 	}
 
 zeek::Args NFS_Interp::event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_status,
@@ -358,7 +358,7 @@ StringVal* NFS_Interp::nfs3_fh(const u_char*& buf, int& n)
 	const u_char* fh = extract_XDR_opaque(buf, n, fh_n, 64);
 
 	if ( ! fh )
-		return 0;
+		return nullptr;
 
 	return new StringVal(new BroString(fh, fh_n, false));
 	}
@@ -368,22 +368,22 @@ RecordVal* NFS_Interp::nfs3_sattr(const u_char*& buf, int& n)
 	{
 	RecordVal* attrs = new RecordVal(BifType::Record::NFS3::sattr_t);
 
-	attrs->Assign(0, 0); // mode
+	attrs->Assign(0, nullptr); // mode
 	int mode_set_it =  extract_XDR_uint32(buf, n);
 	if ( mode_set_it )
 		attrs->Assign(0, ExtractUint32(buf, n)); // mode
 
-	attrs->Assign(1, 0); // uid
+	attrs->Assign(1, nullptr); // uid
 	int uid_set_it =  extract_XDR_uint32(buf, n);
 	if ( uid_set_it )
 		attrs->Assign(1, ExtractUint32(buf, n)); // uid
 
-	attrs->Assign(2, 0); // gid
+	attrs->Assign(2, nullptr); // gid
 	int gid_set_it =  extract_XDR_uint32(buf, n);
 	if ( gid_set_it )
 		attrs->Assign(2, ExtractUint32(buf, n)); // gid
 
-	attrs->Assign(3, 0); // size
+	attrs->Assign(3, nullptr); // size
 	int size_set_it =  extract_XDR_uint32(buf, n);
 	if ( size_set_it )
 		attrs->Assign(3, ExtractTime(buf, n));	 // size
@@ -406,8 +406,8 @@ RecordVal* NFS_Interp::nfs3_sattr_reply(const u_char*& buf, int& n, BifEnum::NFS
 		}
 	else
 		{
-		rep->Assign(1, 0);
-		rep->Assign(2, 0);
+		rep->Assign(1, nullptr);
+		rep->Assign(2, nullptr);
 		}
 
 	return rep;
@@ -464,7 +464,7 @@ StringVal *NFS_Interp::nfs3_filename(const u_char*& buf, int& n)
 	const u_char* name = extract_XDR_opaque(buf, n, name_len);
 
 	if ( ! name )
-		return 0;
+		return nullptr;
 
 	return new StringVal(new BroString(name, name_len, false));
 	}
@@ -508,7 +508,7 @@ RecordVal* NFS_Interp::nfs3_post_op_attr(const u_char*& buf, int& n)
 	if ( have_attrs )
 		return nfs3_fattr(buf, n);
 
-	return 0;
+	return nullptr;
 	}
 
 StringVal* NFS_Interp::nfs3_post_op_fh(const u_char*& buf, int& n)
@@ -518,7 +518,7 @@ StringVal* NFS_Interp::nfs3_post_op_fh(const u_char*& buf, int& n)
 	if ( have_fh )
 		return nfs3_fh(buf, n);
 
-	return 0;
+	return nullptr;
 	}
 
 RecordVal* NFS_Interp::nfs3_pre_op_attr(const u_char*& buf, int& n)
@@ -527,7 +527,7 @@ RecordVal* NFS_Interp::nfs3_pre_op_attr(const u_char*& buf, int& n)
 
 	if ( have_attrs )
 		return nfs3_wcc_attr(buf, n);
-	return 0;
+	return nullptr;
 	}
 
 EnumVal *NFS_Interp::nfs3_stable_how(const u_char*& buf, int& n)
@@ -548,8 +548,8 @@ RecordVal* NFS_Interp::nfs3_lookup_reply(const u_char*& buf, int& n, BifEnum::NF
 		}
 	else
 		{
-		rep->Assign(0, 0);
-		rep->Assign(1, 0);
+		rep->Assign(0, nullptr);
+		rep->Assign(1, nullptr);
 		rep->Assign(2, nfs3_post_op_attr(buf, n));
 		}
 	return rep;
@@ -710,8 +710,8 @@ RecordVal* NFS_Interp::nfs3_newobj_reply(const u_char*& buf, int& n, BifEnum::NF
 		}
 	else
 		{
-		rep->Assign(0, 0);
-		rep->Assign(1, 0);
+		rep->Assign(0, nullptr);
+		rep->Assign(1, nullptr);
 		rep->Assign(2, nfs3_pre_op_attr(buf, n));
 		rep->Assign(3, nfs3_post_op_attr(buf, n));
 		}
@@ -833,7 +833,7 @@ Val* NFS_Interp::ExtractBool(const u_char*& buf, int& n)
 NFS_Analyzer::NFS_Analyzer(Connection* conn)
 	: RPC_Analyzer("NFS", conn, new NFS_Interp(this))
 	{
-	orig_rpc = resp_rpc = 0;
+	orig_rpc = resp_rpc = nullptr;
 	}
 
 void NFS_Analyzer::Init()

--- a/src/analyzer/protocol/rpc/Plugin.cc
+++ b/src/analyzer/protocol/rpc/Plugin.cc
@@ -17,8 +17,8 @@ public:
 		AddComponent(new ::analyzer::Component("NFS", ::analyzer::rpc::NFS_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("MOUNT", ::analyzer::rpc::MOUNT_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("Portmapper", ::analyzer::rpc::Portmapper_Analyzer::Instantiate));
-		AddComponent(new ::analyzer::Component("Contents_RPC", 0));
-		AddComponent(new ::analyzer::Component("Contents_NFS", 0));
+		AddComponent(new ::analyzer::Component("Contents_RPC", nullptr));
+		AddComponent(new ::analyzer::Component("Contents_NFS", nullptr));
 
 		plugin::Configuration config;
 		config.name = "Zeek::RPC";

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -79,7 +79,7 @@ bool PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status statu
 				     int reply_len)
 	{
 	EventHandlerPtr event;
-	Val *reply = 0;
+	Val *reply = nullptr;
 	int success = (status == BifEnum::RPC_SUCCESS);
 
 	switch ( c->Proc() ) {
@@ -208,7 +208,7 @@ Val* PortmapperInterp::ExtractMapping(const u_char*& buf, int& len)
 	if ( ! buf )
 		{
 		Unref(mapping);
-		return 0;
+		return nullptr;
 		}
 
 	return mapping;
@@ -228,7 +228,7 @@ Val* PortmapperInterp::ExtractPortRequest(const u_char*& buf, int& len)
 	if ( ! buf )
 		{
 		Unref(pr);
-		return 0;
+		return nullptr;
 		}
 
 	return pr;
@@ -249,7 +249,7 @@ Val* PortmapperInterp::ExtractCallItRequest(const u_char*& buf, int& len)
 	if ( ! buf )
 		{
 		Unref(c);
-		return 0;
+		return nullptr;
 		}
 
 	return c;
@@ -307,7 +307,7 @@ void PortmapperInterp::Event(EventHandlerPtr f, Val* request, BifEnum::rpc_statu
 Portmapper_Analyzer::Portmapper_Analyzer(Connection* conn)
 : RPC_Analyzer("PORTMAPPER", conn, new PortmapperInterp(this))
 	{
-	orig_rpc = resp_rpc = 0;
+	orig_rpc = resp_rpc = nullptr;
 	}
 
 Portmapper_Analyzer::~Portmapper_Analyzer()

--- a/src/analyzer/protocol/rpc/RPC.h
+++ b/src/analyzer/protocol/rpc/RPC.h
@@ -54,7 +54,7 @@ public:
 
 	void AddVal(Val* arg_v)		{ Unref(v); v = arg_v; }
 	Val* RequestVal() const		{ return v; }
-	Val* TakeRequestVal()		{ Val* rv = v; v = 0; return rv; }
+	Val* TakeRequestVal()		{ Val* rv = v; v = nullptr; return rv; }
 
 	bool CompareRexmit(const u_char* buf, int n) const;
 
@@ -149,7 +149,7 @@ public:
 	RPC_Reasm_Buffer() {
 		maxsize = expected = 0;
 		fill = processed = 0;
-		buf = 0;
+		buf = nullptr;
 	};
 
 	~RPC_Reasm_Buffer() { if (buf) delete [] buf; }

--- a/src/analyzer/protocol/rpc/XDR.cc
+++ b/src/analyzer/protocol/rpc/XDR.cc
@@ -17,7 +17,7 @@ uint32_t analyzer::rpc::extract_XDR_uint32(const u_char*& buf, int& len)
 
 	if ( len < 4 )
 		{
-		buf = 0;
+		buf = nullptr;
 		return 0;
 		}
 
@@ -36,7 +36,7 @@ uint64_t analyzer::rpc::extract_XDR_uint64(const u_char*& buf, int& len)
 	{
 	if ( ! buf || len < 8 )
 		{
-		buf = 0;
+		buf = nullptr;
 		return 0;
 		}
 
@@ -50,7 +50,7 @@ double analyzer::rpc::extract_XDR_time(const u_char*& buf, int& len)
 	{
 	if ( ! buf || len < 8 )
 		{
-		buf = 0;
+		buf = nullptr;
 		return 0.0;
 		}
 
@@ -64,15 +64,15 @@ const u_char* analyzer::rpc::extract_XDR_opaque(const u_char*& buf, int& len, in
 	{
 	n = int(extract_XDR_uint32(buf, len));
 	if ( ! buf )
-		return 0;
+		return nullptr;
 
 	if ( short_buf_ok )
 		n = std::min(n, len);
 
 	if ( n < 0 || n > len || n > max_len )
 		{ // ### Should really flag this as a different sort of error.
-		buf = 0;
-		return 0;
+		buf = nullptr;
+		return nullptr;
 		}
 
 	int n4 = ((n + 3) >> 2) << 2;	// n rounded up to next multiple of 4
@@ -87,11 +87,11 @@ const u_char* analyzer::rpc::extract_XDR_opaque(const u_char*& buf, int& len, in
 const u_char* analyzer::rpc::extract_XDR_opaque_fixed(const u_char*& buf, int& len, int n)
 	{
 	if ( ! buf )
-		return 0;
+		return nullptr;
 	if ( n < 0 || n > len)
 		{
-		buf = 0;
-		return 0;
+		buf = nullptr;
+		return nullptr;
 		}
 	int n4 = ((n + 3) >> 2) << 2;	// n rounded up to next multiple of 4
 

--- a/src/analyzer/protocol/smb/Plugin.cc
+++ b/src/analyzer/protocol/smb/Plugin.cc
@@ -12,7 +12,7 @@ public:
 	plugin::Configuration Configure() override
 		{
 		AddComponent(new ::analyzer::Component("SMB", ::analyzer::smb::SMB_Analyzer::Instantiate));
-		AddComponent(new ::analyzer::Component("Contents_SMB", 0));
+		AddComponent(new ::analyzer::Component("Contents_SMB", nullptr));
 
 		plugin::Configuration config;
 		config.name = "Zeek::SMB";

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -43,8 +43,8 @@ SMTP_Analyzer::SMTP_Analyzer(Connection* conn)
 
 	skip_data = false;
 	orig_is_sender = true;
-	line_after_gap = 0;
-	mail = 0;
+	line_after_gap = nullptr;
+	mail = nullptr;
 	UpdateState(first_cmd, 0, true);
 	cl_orig = new tcp::ContentLine_Analyzer(conn, true);
 	cl_orig->SetIsNULSensitive(true);
@@ -103,7 +103,7 @@ void SMTP_Analyzer::Undelivered(uint64_t seq, int len, bool is_orig)
 	if ( line_after_gap )
 		{
 		delete line_after_gap;
-		line_after_gap = 0;
+		line_after_gap = nullptr;
 		}
 
 	pending_cmd_q.clear();
@@ -247,7 +247,7 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 			if ( cmd_code == -1 )
 				{
 				Unexpected(true, "unknown command", cmd_len, cmd);
-				cmd = 0;
+				cmd = nullptr;
 				}
 			else
 				NewCmd(cmd_code);
@@ -921,7 +921,7 @@ void SMTP_Analyzer::BeginData(bool orig)
 	{
 	state = SMTP_IN_DATA;
 	skip_data = false; // reset the flag at the beginning of the mail
-	if ( mail != 0 )
+	if ( mail != nullptr )
 		{
 		Weird("smtp_nested_mail_transaction");
 		mail->Done();
@@ -939,6 +939,6 @@ void SMTP_Analyzer::EndData()
 		{
 		mail->Done();
 		delete mail;
-		mail = 0;
+		mail = nullptr;
 		}
 	}

--- a/src/analyzer/protocol/socks/SOCKS.cc
+++ b/src/analyzer/protocol/socks/SOCKS.cc
@@ -11,7 +11,7 @@ SOCKS_Analyzer::SOCKS_Analyzer(Connection* conn)
 	{
 	interp = new binpac::SOCKS::SOCKS_Conn(this);
 	orig_done = resp_done = false;
-	pia = 0;
+	pia = nullptr;
 	}
 
 SOCKS_Analyzer::~SOCKS_Analyzer()
@@ -63,11 +63,11 @@ void SOCKS_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 			pia = new pia::PIA_TCP(Conn());
 			if ( AddChildAnalyzer(pia) )
 				{
-				pia->FirstPacket(true, 0);
-				pia->FirstPacket(false, 0);
+				pia->FirstPacket(true, nullptr);
+				pia->FirstPacket(false, nullptr);
 				}
 			else
-				pia = 0;
+				pia = nullptr;
 			}
 
 		ForwardStream(len, data, orig);

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -158,7 +158,7 @@ SteppingStone_Analyzer::SteppingStone_Analyzer(Connection* c)
 	{
 	stp_manager = sessions->GetSTPManager();
 
-	orig_endp = resp_endp = 0;
+	orig_endp = resp_endp = nullptr;
 	orig_stream_pos = resp_stream_pos = 1;
 	}
 
@@ -179,9 +179,9 @@ void SteppingStone_Analyzer::DeliverPacket(int len, const u_char* data,
 						ip, caplen);
 
 	if ( is_orig )
-		orig_endp->DataSent(network_time, seq, len, caplen, data, 0, 0);
+		orig_endp->DataSent(network_time, seq, len, caplen, data, nullptr, nullptr);
 	else
-		resp_endp->DataSent(network_time, seq, len, caplen, data, 0, 0);
+		resp_endp->DataSent(network_time, seq, len, caplen, data, nullptr, nullptr);
 	}
 
 void SteppingStone_Analyzer::DeliverStream(int len, const u_char* data,
@@ -192,14 +192,14 @@ void SteppingStone_Analyzer::DeliverStream(int len, const u_char* data,
 	if ( is_orig )
 		{
 		orig_endp->DataSent(network_time, orig_stream_pos, len, len,
-					data, 0, 0);
+					data, nullptr, nullptr);
 		orig_stream_pos += len;
 		}
 
 	else
 		{
 		resp_endp->DataSent(network_time, resp_stream_pos, len, len,
-					data, 0, 0);
+					data, nullptr, nullptr);
 		resp_stream_pos += len;
 		}
 	}

--- a/src/analyzer/protocol/tcp/ContentLine.cc
+++ b/src/analyzer/protocol/tcp/ContentLine.cc
@@ -24,7 +24,7 @@ void ContentLine_Analyzer::InitState()
 	CR_LF_as_EOL = (CR_as_EOL | LF_as_EOL);
 	skip_deliveries = false;
 	skip_partial = false;
-	buf = 0;
+	buf = nullptr;
 	seq_delivered_in_lines = 0;
 	skip_pending = 0;
 	seq = 0;

--- a/src/analyzer/protocol/tcp/Plugin.cc
+++ b/src/analyzer/protocol/tcp/Plugin.cc
@@ -13,8 +13,8 @@ public:
 		{
 		AddComponent(new ::analyzer::Component("TCP", ::analyzer::tcp::TCP_Analyzer::Instantiate));
 		AddComponent(new ::analyzer::Component("TCPStats", ::analyzer::tcp::TCPStats_Analyzer::Instantiate));
-		AddComponent(new ::analyzer::Component("CONTENTLINE", 0));
-		AddComponent(new ::analyzer::Component("Contents", 0));
+		AddComponent(new ::analyzer::Component("CONTENTLINE", nullptr));
+		AddComponent(new ::analyzer::Component("Contents", nullptr));
 
 		plugin::Configuration config;
 		config.name = "Zeek::TCP";

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -192,7 +192,7 @@ analyzer::Analyzer* TCP_Analyzer::FindChild(ID arg_id)
 			return child;
 		}
 
-	return 0;
+	return nullptr;
 	}
 
 analyzer::Analyzer* TCP_Analyzer::FindChild(Tag arg_tag)
@@ -209,7 +209,7 @@ analyzer::Analyzer* TCP_Analyzer::FindChild(Tag arg_tag)
 			return child;
 		}
 
-	return 0;
+	return nullptr;
 	}
 
 bool TCP_Analyzer::RemoveChildAnalyzer(ID id)
@@ -253,7 +253,7 @@ const struct tcphdr* TCP_Analyzer::ExtractTCP_Header(const u_char*& data,
 	if ( tcp_hdr_len < sizeof(struct tcphdr) )
 		{
 		Weird("bad_TCP_header_len");
-		return 0;
+		return nullptr;
 		}
 
 	if ( tcp_hdr_len > uint32_t(len) ||
@@ -262,7 +262,7 @@ const struct tcphdr* TCP_Analyzer::ExtractTCP_Header(const u_char*& data,
 		// This can happen even with the above test, due to TCP
 		// options.
 		Weird("truncated_header");
-		return 0;
+		return nullptr;
 		}
 
 	len -= tcp_hdr_len;	// remove TCP header
@@ -1587,8 +1587,8 @@ void TCP_Analyzer::SetContentsFile(unsigned int direction, BroFile* f)
 	{
 	if ( direction == CONTENTS_NONE )
 		{
-		orig->SetContentsFile(0);
-		resp->SetContentsFile(0);
+		orig->SetContentsFile(nullptr);
+		resp->SetContentsFile(nullptr);
 		}
 
 	else
@@ -1604,7 +1604,7 @@ BroFile* TCP_Analyzer::GetContentsFile(unsigned int direction) const
 	{
 	switch ( direction ) {
 	case CONTENTS_NONE:
-		return 0;
+		return nullptr;
 
 	case CONTENTS_ORIG:
 		return orig->GetContentsFile();
@@ -1615,7 +1615,7 @@ BroFile* TCP_Analyzer::GetContentsFile(unsigned int direction) const
 	case CONTENTS_BOTH:
 		if ( orig->GetContentsFile() != resp->GetContentsFile())
 			// This is an "error".
-			return 0;
+			return nullptr;
 		else
 			return orig->GetContentsFile();
 
@@ -1625,7 +1625,7 @@ BroFile* TCP_Analyzer::GetContentsFile(unsigned int direction) const
 
 	reporter->Error("bad direction %u in TCP_Analyzer::GetContentsFile",
 	                direction);
-	return 0;
+	return nullptr;
 	}
 
 void TCP_Analyzer::ConnectionClosed(TCP_Endpoint* endpoint, TCP_Endpoint* peer,
@@ -2127,7 +2127,7 @@ void TCPStats_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 	TCP_ApplicationAnalyzer::DeliverPacket(len, data, is_orig, seq, ip, caplen);
 
 	if ( is_orig )
-		orig_stats->DataSent(network_time, seq, len, caplen, data, ip, 0);
+		orig_stats->DataSent(network_time, seq, len, caplen, data, ip, nullptr);
 	else
-		resp_stats->DataSent(network_time, seq, len, caplen, data, ip, 0);
+		resp_stats->DataSent(network_time, seq, len, caplen, data, ip, nullptr);
 	}

--- a/src/analyzer/protocol/tcp/TCP.h
+++ b/src/analyzer/protocol/tcp/TCP.h
@@ -161,7 +161,7 @@ protected:
 	// A couple utility functions that may also be useful to derived analyzers.
 	static uint64_t get_relative_seq(const TCP_Endpoint* endpoint,
 	                               uint32_t cur_base, uint32_t last,
-	                               uint32_t wraps, bool* underflow = 0);
+	                               uint32_t wraps, bool* underflow = nullptr);
 
 	static int get_segment_len(int payload_len, TCP_Flags flags);
 
@@ -192,12 +192,10 @@ private:
 class TCP_ApplicationAnalyzer : public analyzer::Analyzer {
 public:
 	TCP_ApplicationAnalyzer(const char* name, Connection* conn)
-	: Analyzer(name, conn)
-		{ tcp = 0; }
+		: Analyzer(name, conn), tcp(nullptr) { }
 
 	explicit TCP_ApplicationAnalyzer(Connection* conn)
-	: Analyzer(conn)
-		{ tcp = 0; }
+		: Analyzer(conn), tcp(nullptr) { }
 
 	~TCP_ApplicationAnalyzer() override { }
 
@@ -235,7 +233,7 @@ public:
 	// This suppresses violations if the TCP connection wasn't
 	// fully established.
 	void ProtocolViolation(const char* reason,
-					const char* data = 0, int len = 0) override;
+					const char* data = nullptr, int len = 0) override;
 
 	// "name" and "val" both now belong to this object, which needs to
 	//  delete them when done with them.

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.cc
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.cc
@@ -16,9 +16,9 @@ using namespace analyzer::tcp;
 
 TCP_Endpoint::TCP_Endpoint(TCP_Analyzer* arg_analyzer, bool arg_is_orig)
 	{
-	contents_processor = 0;
+	contents_processor = nullptr;
 	prev_state = state = TCP_ENDPOINT_INACTIVE;
-	peer = 0;
+	peer = nullptr;
 	start_time = last_time = 0.0;
 	start_seq = last_seq = ack_seq = 0;
 	seq_wraps = ack_wraps = 0;
@@ -29,7 +29,7 @@ TCP_Endpoint::TCP_Endpoint(TCP_Analyzer* arg_analyzer, bool arg_is_orig)
 	FIN_seq = 0;
 	SYN_cnt = FIN_cnt = RST_cnt = 0;
 	did_close = false;
-	contents_file = 0;
+	contents_file = nullptr;
 	tcp_analyzer = arg_analyzer;
 	is_orig = arg_is_orig;
 

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.h
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.h
@@ -141,7 +141,7 @@ public:
 
 	Connection* Conn() const;
 
-	bool HasContents() const		{ return contents_processor != 0; }
+	bool HasContents() const		{ return contents_processor != nullptr; }
 	bool HadGap() const;
 
 	inline bool IsOrig() const		{ return is_orig; }

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -30,7 +30,7 @@ TCP_Reassembler::TCP_Reassembler(analyzer::Analyzer* arg_dst_analyzer,
 	type = arg_type;
 	endp = arg_endp;
 	had_gap = false;
-	record_contents_file = 0;
+	record_contents_file = nullptr;
 	deliver_tcp_contents = false;
 	skip_deliveries = false;
 	did_EOF = false;

--- a/src/analyzer/protocol/tcp/functions.bif
+++ b/src/analyzer/protocol/tcp/functions.bif
@@ -121,7 +121,7 @@ function set_contents_file%(cid: conn_id, direction: count, f: file%): bool
 function get_contents_file%(cid: conn_id, direction: count%): file
 	%{
 	Connection* c = sessions->FindConnection(cid);
-	BroFile* f = c ? c->GetRootAnalyzer()->GetContentsFile(direction) : 0;
+	BroFile* f = c ? c->GetRootAnalyzer()->GetContentsFile(direction) : nullptr;
 
 	if ( f )
 		{

--- a/src/analyzer/protocol/teredo/Teredo.cc
+++ b/src/analyzer/protocol/teredo/Teredo.cc
@@ -98,9 +98,9 @@ bool TeredoEncapsulation::DoParse(const u_char* data, int& len,
 
 RecordVal* TeredoEncapsulation::BuildVal(const IP_Hdr* inner) const
 	{
-	static RecordType* teredo_hdr_type = 0;
-	static RecordType* teredo_auth_type = 0;
-	static RecordType* teredo_origin_type = 0;
+	static RecordType* teredo_hdr_type = nullptr;
+	static RecordType* teredo_auth_type = nullptr;
+	static RecordType* teredo_origin_type = nullptr;
 
 	if ( ! teredo_hdr_type )
 		{
@@ -167,7 +167,7 @@ void Teredo_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 		return;
 		}
 
-	IP_Hdr* inner = 0;
+	IP_Hdr* inner = nullptr;
 	int rslt = sessions->ParseIPPacket(len, te.InnerIP(), IPPROTO_IPV6, inner);
 
 	if ( rslt > 0 )
@@ -201,33 +201,33 @@ void Teredo_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 		return;
 		}
 
-	Val* teredo_hdr = 0;
+	Val* teredo_hdr = nullptr;
 
 	if ( teredo_packet )
 		{
 		teredo_hdr = te.BuildVal(inner);
-		Conn()->Event(teredo_packet, 0, teredo_hdr);
+		Conn()->Event(teredo_packet, nullptr, teredo_hdr);
 		}
 
 	if ( te.Authentication() && teredo_authentication )
 		{
 		teredo_hdr = teredo_hdr ? teredo_hdr->Ref() : te.BuildVal(inner);
-		Conn()->Event(teredo_authentication, 0, teredo_hdr);
+		Conn()->Event(teredo_authentication, nullptr, teredo_hdr);
 		}
 
 	if ( te.OriginIndication() && teredo_origin_indication )
 		{
 		teredo_hdr = teredo_hdr ? teredo_hdr->Ref() : te.BuildVal(inner);
-		Conn()->Event(teredo_origin_indication, 0, teredo_hdr);
+		Conn()->Event(teredo_origin_indication, nullptr, teredo_hdr);
 		}
 
 	if ( inner->NextProto() == IPPROTO_NONE && teredo_bubble )
 		{
 		teredo_hdr = teredo_hdr ? teredo_hdr->Ref() : te.BuildVal(inner);
-		Conn()->Event(teredo_bubble, 0, teredo_hdr);
+		Conn()->Event(teredo_bubble, nullptr, teredo_hdr);
 		}
 
 	EncapsulatingConn ec(Conn(), BifEnum::Tunnel::TEREDO);
 
-	sessions->DoNextInnerPacket(network_time, 0, inner, e, ec);
+	sessions->DoNextInnerPacket(network_time, nullptr, inner, e, ec);
 	}

--- a/src/analyzer/protocol/teredo/Teredo.h
+++ b/src/analyzer/protocol/teredo/Teredo.h
@@ -55,7 +55,7 @@ protected:
 class TeredoEncapsulation {
 public:
 	explicit TeredoEncapsulation(const Teredo_Analyzer* ta)
-		: inner_ip(0), origin_indication(0), auth(0), analyzer(ta)
+		: inner_ip(nullptr), origin_indication(nullptr), auth(nullptr), analyzer(ta)
 		{}
 
 	/**

--- a/src/analyzer/protocol/vxlan/VXLAN.cc
+++ b/src/analyzer/protocol/vxlan/VXLAN.cc
@@ -101,7 +101,7 @@ void VXLAN_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 	ProtocolConfirmation();
 
 	if ( vxlan_packet )
-		Conn()->Event(vxlan_packet, 0, inner->BuildPktHdrVal(),
+		Conn()->Event(vxlan_packet, nullptr, inner->BuildPktHdrVal(),
 		              val_mgr->GetCount(vni));
 
 	EncapsulatingConn ec(Conn(), BifEnum::Tunnel::VXLAN);

--- a/src/analyzer/protocol/zip/Plugin.cc
+++ b/src/analyzer/protocol/zip/Plugin.cc
@@ -11,7 +11,7 @@ class Plugin : public plugin::Plugin {
 public:
 	plugin::Configuration Configure() override
 		{
-		AddComponent(new ::analyzer::Component("ZIP", 0));
+		AddComponent(new ::analyzer::Component("ZIP", nullptr));
 
 		plugin::Configuration config;
 		config.name = "Zeek::ZIP";

--- a/src/analyzer/protocol/zip/ZIP.cc
+++ b/src/analyzer/protocol/zip/ZIP.cc
@@ -7,7 +7,7 @@ using namespace analyzer::zip;
 ZIP_Analyzer::ZIP_Analyzer(Connection* conn, bool orig, Method arg_method)
 : tcp::TCP_SupportAnalyzer("ZIP", conn, orig)
 	{
-	zip = 0;
+	zip = nullptr;
 	zip_status = Z_OK;
 	method = arg_method;
 
@@ -26,7 +26,7 @@ ZIP_Analyzer::ZIP_Analyzer(Connection* conn, bool orig, Method arg_method)
 		{
 		Weird("inflate_init_failed");
 		delete zip;
-		zip = 0;
+		zip = nullptr;
 		}
 	}
 

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -695,7 +695,7 @@ RecordVal* Manager::MakeEvent(val_list* args, Frame* frame)
 	auto rval = new RecordVal(BifType::Record::Broker::Event);
 	auto arg_vec = new VectorVal(vector_of_data_type);
 	rval->Assign(1, arg_vec);
-	Func* func = 0;
+	Func* func = nullptr;
 	scoped_reporter_location srl{frame};
 
 	for ( auto i = 0; i < args->length(); ++i )
@@ -738,7 +738,7 @@ RecordVal* Manager::MakeEvent(val_list* args, Frame* frame)
 
 		if ( ! same_type(got_type, expected_type) )
 			{
-			rval->Assign(0, 0);
+			rval->Assign(0, nullptr);
 			Error("event parameter #%d type mismatch, got %s, expect %s", i,
 			      type_name(got_type->Tag()),
 			      type_name(expected_type->Tag()));
@@ -758,7 +758,7 @@ RecordVal* Manager::MakeEvent(val_list* args, Frame* frame)
 		if ( ! data_val->Lookup(0) )
 			{
 			Unref(data_val);
-			rval->Assign(0, 0);
+			rval->Assign(0, nullptr);
 			Error("failed to convert param #%d of type %s to broker data",
 				  i, type_name(got_type->Tag()));
 			return rval;

--- a/src/file_analysis/AnalyzerSet.cc
+++ b/src/file_analysis/AnalyzerSet.cc
@@ -83,7 +83,7 @@ Analyzer* AnalyzerSet::QueueAdd(const file_analysis::Tag& tag, RecordVal* args)
 	if ( ! a )
 		{
 		delete key;
-		return 0;
+		return nullptr;
 		}
 
 	mod_queue.push(new AddMod(a, key));
@@ -184,7 +184,7 @@ file_analysis::Analyzer* AnalyzerSet::InstantiateAnalyzer(const Tag& tag,
 		reporter->Error("[%s] Failed file analyzer %s instantiation",
 		                file->GetID().c_str(),
 		                file_mgr->GetComponentName(tag).c_str());
-		return 0;
+		return nullptr;
 		}
 
 	return a;

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -82,7 +82,7 @@ void File::StaticInit()
 
 File::File(const string& file_id, const string& source_name, Connection* conn,
            analyzer::Tag tag, bool is_orig)
-	: id(file_id), val(0), file_reassembler(0), stream_offset(0),
+	: id(file_id), val(nullptr), file_reassembler(nullptr), stream_offset(0),
 	  reassembly_max_buffer(0), did_metadata_inference(false),
 	  reassembly_enabled(false), postpone_timeout(false), done(false),
 	  analyzers(this)
@@ -260,7 +260,7 @@ bool File::AddAnalyzer(file_analysis::Tag tag, RecordVal* args)
 	if ( done )
 		return false;
 
-	return analyzers.QueueAdd(tag, args) != 0;
+	return analyzers.QueueAdd(tag, args) != nullptr;
 	}
 
 bool File::RemoveAnalyzer(file_analysis::Tag tag, RecordVal* args)
@@ -280,7 +280,7 @@ void File::DisableReassembly()
 	{
 	reassembly_enabled = false;
 	delete file_reassembler;
-	file_reassembler = 0;
+	file_reassembler = nullptr;
 	}
 
 void File::SetReassemblyBuffer(uint64_t max)
@@ -386,7 +386,7 @@ void File::DeliverStream(const u_char* data, uint64_t len)
 	        fmt_bytes((const char*) data, min((uint64_t)40, len)),
 	        len > 40 ? "..." : "");
 
-	file_analysis::Analyzer* a = 0;
+	file_analysis::Analyzer* a = nullptr;
 	IterCookie* c = analyzers.InitForIteration();
 
 	while ( (a = analyzers.NextEntry(c)) )
@@ -490,7 +490,7 @@ void File::DeliverChunk(const u_char* data, uint64_t len, uint64_t offset)
 	        fmt_bytes((const char*) data, min((uint64_t)40, len)),
 	        len > 40 ? "..." : "");
 
-	file_analysis::Analyzer* a = 0;
+	file_analysis::Analyzer* a = nullptr;
 	IterCookie* c = analyzers.InitForIteration();
 
 	while ( (a = analyzers.NextEntry(c)) )
@@ -554,7 +554,7 @@ void File::EndOfFile()
 
 	done = true;
 
-	file_analysis::Analyzer* a = 0;
+	file_analysis::Analyzer* a = nullptr;
 	IterCookie* c = analyzers.InitForIteration();
 
 	while ( (a = analyzers.NextEntry(c)) )
@@ -587,7 +587,7 @@ void File::Gap(uint64_t offset, uint64_t len)
 		DeliverStream((const u_char*) "", 0);
 		}
 
-	file_analysis::Analyzer* a = 0;
+	file_analysis::Analyzer* a = nullptr;
 	IterCookie* c = analyzers.InitForIteration();
 
 	while ( (a = analyzers.NextEntry(c)) )

--- a/src/file_analysis/File.h
+++ b/src/file_analysis/File.h
@@ -236,7 +236,7 @@ protected:
 	 *        of the connection to the responder.  False indicates the other
 	 *        direction.
 	 */
-	File(const string& file_id, const string& source_name, Connection* conn = 0,
+	File(const string& file_id, const string& source_name, Connection* conn = nullptr,
 	     analyzer::Tag tag = analyzer::Tag::Error, bool is_orig = false);
 
 	/**

--- a/src/file_analysis/FileReassembler.cc
+++ b/src/file_analysis/FileReassembler.cc
@@ -13,7 +13,7 @@ FileReassembler::FileReassembler(File *f, uint64_t starting_offset)
 	}
 
 FileReassembler::FileReassembler()
-	: Reassembler(), the_file(0), flushing(false)
+	: Reassembler(), the_file(nullptr), flushing(false)
 	{
 	}
 

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -16,8 +16,8 @@
 
 using namespace file_analysis;
 
-TableVal* Manager::disabled = 0;
-TableType* Manager::tag_set_type = 0;
+TableVal* Manager::disabled = nullptr;
+TableType* Manager::tag_set_type = nullptr;
 string Manager::salt;
 
 Manager::Manager()
@@ -159,7 +159,7 @@ string Manager::DataIn(const u_char* data, uint64_t len, const analyzer::Tag& ta
 void Manager::DataIn(const u_char* data, uint64_t len, const string& file_id,
                      const string& source)
 	{
-	File* file = GetFile(file_id, 0, analyzer::Tag::Error, false, false,
+	File* file = GetFile(file_id, nullptr, analyzer::Tag::Error, false, false,
 	                     source.c_str());
 
 	if ( ! file )
@@ -306,10 +306,10 @@ File* Manager::GetFile(const string& file_id, Connection* conn,
                        const char* source_name)
 	{
 	if ( file_id.empty() )
-		return 0;
+		return nullptr;
 
 	if ( IsIgnored(file_id) )
-		return 0;
+		return nullptr;
 
 	File* rval = LookupFile(file_id);
 
@@ -334,7 +334,7 @@ File* Manager::GetFile(const string& file_id, Connection* conn,
 		rval->RaiseFileOverNewConnection(conn, is_orig);
 
 		if ( IsIgnored(file_id) )
-			return 0;
+			return nullptr;
 		}
 	else
 		{
@@ -466,14 +466,14 @@ Analyzer* Manager::InstantiateAnalyzer(const Tag& tag, RecordVal* args, File* f)
 		reporter->InternalWarning(
 		            "unknown file analyzer instantiation request: %s",
 		            tag.AsString().c_str());
-		return 0;
+		return nullptr;
 		}
 
 	if ( ! c->Factory() )
 		{
 		reporter->InternalWarning("file analyzer %s cannot be instantiated "
 					  "dynamically", c->CanonicalName().c_str());
-		return 0;
+		return nullptr;
 		}
 
 	DBG_LOG(DBG_FILE_ANALYSIS, "[%s] Instantiate analyzer %s",

--- a/src/file_analysis/Manager.h
+++ b/src/file_analysis/Manager.h
@@ -358,10 +358,10 @@ protected:
 	 *         exist, the activity time is refreshed along with any
 	 *         connection-related fields.
 	 */
-	File* GetFile(const string& file_id, Connection* conn = 0,
+	File* GetFile(const string& file_id, Connection* conn = nullptr,
 	              const analyzer::Tag& tag = analyzer::Tag::Error,
 	              bool is_orig = false, bool update_conn = true,
-	              const char* source_name = 0);
+	              const char* source_name = nullptr);
 
 	/**
 	 * Evaluate timeout policy for a file and remove the File object mapped to

--- a/src/file_analysis/analyzer/data_event/DataEvent.cc
+++ b/src/file_analysis/analyzer/data_event/DataEvent.cc
@@ -24,7 +24,7 @@ file_analysis::Analyzer* DataEvent::Instantiate(RecordVal* args, File* file)
 	auto chunk_val = args->Lookup("chunk_event");
 	auto stream_val = args->Lookup("stream_event");
 
-	if ( ! chunk_val && ! stream_val ) return 0;
+	if ( ! chunk_val && ! stream_val ) return nullptr;
 
 	EventHandlerPtr chunk;
 	EventHandlerPtr stream;

--- a/src/file_analysis/analyzer/extract/Extract.cc
+++ b/src/file_analysis/analyzer/extract/Extract.cc
@@ -48,7 +48,7 @@ file_analysis::Analyzer* Extract::Instantiate(RecordVal* args, File* file)
 	auto limit = get_extract_field_val(args, "extract_limit");
 
 	if ( ! fname || ! limit )
-		return 0;
+		return nullptr;
 
 	return new Extract(args, file, fname->AsString()->CheckString(),
 	                   limit->AsCount());

--- a/src/file_analysis/analyzer/hash/Hash.h
+++ b/src/file_analysis/analyzer/hash/Hash.h
@@ -84,7 +84,7 @@ public:
 	 *         handler for the "file_hash" event.
 	 */
 	static file_analysis::Analyzer* Instantiate(RecordVal* args, File* file)
-		{ return file_hash ? new MD5(args, file) : 0; }
+		{ return file_hash ? new MD5(args, file) : nullptr; }
 
 protected:
 
@@ -112,7 +112,7 @@ public:
 	 *         handler for the "file_hash" event.
 	 */
 	static file_analysis::Analyzer* Instantiate(RecordVal* args, File* file)
-		{ return file_hash ? new SHA1(args, file) : 0; }
+		{ return file_hash ? new SHA1(args, file) : nullptr; }
 
 protected:
 
@@ -140,7 +140,7 @@ public:
 	 *         handler for the "file_hash" event.
 	 */
 	static file_analysis::Analyzer* Instantiate(RecordVal* args, File* file)
-		{ return file_hash ? new SHA256(args, file) : 0; }
+		{ return file_hash ? new SHA256(args, file) : nullptr; }
 
 protected:
 

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -257,8 +257,8 @@ X509_STORE* file_analysis::X509::GetRootStore(TableVal* root_certs)
 		::X509* x = d2i_X509(NULL, &data, sv->Len());
 		if ( ! x )
 			{
-			builtin_error(fmt("Root CA error: %s", ERR_error_string(ERR_get_error(),NULL)));
-			return 0;
+			builtin_error(fmt("Root CA error: %s", ERR_error_string(ERR_get_error(), NULL)));
+			return nullptr;
 			}
 
 		X509_STORE_add_cert(ctx, x);
@@ -339,10 +339,10 @@ void file_analysis::X509::ParseSAN(X509_EXTENSION* ext)
 		return;
 		}
 
-	VectorVal* names = 0;
-	VectorVal* emails = 0;
-	VectorVal* uris = 0;
-	VectorVal* ips = 0;
+	VectorVal* names = nullptr;
+	VectorVal* emails = nullptr;
+	VectorVal* uris = nullptr;
+	VectorVal* ips = nullptr;
 
 	bool otherfields = false;
 
@@ -369,21 +369,21 @@ void file_analysis::X509::ParseSAN(X509_EXTENSION* ext)
 			switch ( gen->type )
 				{
 				case GEN_DNS:
-					if ( names == 0 )
+					if ( names == nullptr )
 						names = new VectorVal(internal_type("string_vec")->AsVectorType());
 
 					names->Assign(names->Size(), bs);
 					break;
 
 				case GEN_URI:
-					if ( uris == 0 )
+					if ( uris == nullptr )
 						uris = new VectorVal(internal_type("string_vec")->AsVectorType());
 
 					uris->Assign(uris->Size(), bs);
 					break;
 
 				case GEN_EMAIL:
-					if ( emails == 0 )
+					if ( emails == nullptr )
 						emails = new VectorVal(internal_type("string_vec")->AsVectorType());
 
 					emails->Assign(emails->Size(), bs);
@@ -393,7 +393,7 @@ void file_analysis::X509::ParseSAN(X509_EXTENSION* ext)
 
 		else if ( gen->type == GEN_IPADD )
 			{
-				if ( ips == 0 )
+				if ( ips == nullptr )
 					ips = new VectorVal(internal_type("addr_vec")->AsVectorType());
 
 				uint32_t* addr = (uint32_t*) gen->d.ip->data;
@@ -422,16 +422,16 @@ void file_analysis::X509::ParseSAN(X509_EXTENSION* ext)
 
 		auto sanExt = make_intrusive<RecordVal>(BifType::Record::X509::SubjectAlternativeName);
 
-		if ( names != 0 )
+		if ( names != nullptr )
 			sanExt->Assign(0, names);
 
-		if ( uris != 0 )
+		if ( uris != nullptr )
 			sanExt->Assign(1, uris);
 
-		if ( emails != 0 )
+		if ( emails != nullptr )
 			sanExt->Assign(2, emails);
 
-		if ( ips != 0 )
+		if ( ips != nullptr )
 			sanExt->Assign(3, ips);
 
 		sanExt->Assign(4, val_mgr->GetBool(otherfields));
@@ -453,23 +453,23 @@ StringVal* file_analysis::X509::KeyCurve(EVP_PKEY *key)
 	if ( EVP_PKEY_base_id(key) != EVP_PKEY_EC )
 		{
 		// no EC-key - no curve name
-		return NULL;
+		return nullptr;
 		}
 
 	const EC_GROUP *group;
 	int nid;
 	if ( (group = EC_KEY_get0_group(EVP_PKEY_get0_EC_KEY(key))) == NULL )
 		// I guess we could not parse this
-		return NULL;
+		return nullptr;
 
 	nid = EC_GROUP_get_curve_name(group);
 	if ( nid == 0 )
 		// and an invalid nid...
-		return NULL;
+		return nullptr;
 
 	const char * curve_name = OBJ_nid2sn(nid);
-	if ( curve_name == NULL )
-		return NULL;
+	if ( curve_name == nullptr )
+		return nullptr;
 
 	return new StringVal(curve_name);
 #endif
@@ -560,7 +560,7 @@ IMPLEMENT_OPAQUE_VALUE(X509Val)
 
 broker::expected<broker::data> X509Val::DoSerialize() const
 	{
-	unsigned char *buf = NULL;
+	unsigned char *buf = nullptr;
 	int length = i2d_X509(certificate, &buf);
 
 	if ( length < 0 )

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -86,7 +86,7 @@ public:
 	 * @param Returns the new record value and passes ownership to
 	 * caller.
 	 */
-	static RecordVal* ParseCertificate(X509Val* cert_val, File* file = 0);
+	static RecordVal* ParseCertificate(X509Val* cert_val, File* file = nullptr);
 
 	static file_analysis::Analyzer* Instantiate(RecordVal* args, File* file)
 		{ return new X509(args, file); }

--- a/src/file_analysis/analyzer/x509/X509Common.cc
+++ b/src/file_analysis/analyzer/x509/X509Common.cc
@@ -310,7 +310,7 @@ IntrusivePtr<StringVal> file_analysis::X509Common::GetExtensionFromBIO(BIO* bio,
 		ERR_error_string_n(ERR_get_error(), tmp, sizeof(tmp));
 		EmitWeird("x509_get_ext_from_bio", f, tmp);
 		BIO_free_all(bio);
-		return 0;
+		return nullptr;
 		}
 
 	if ( length == 0 )
@@ -327,7 +327,7 @@ IntrusivePtr<StringVal> file_analysis::X509Common::GetExtensionFromBIO(BIO* bio,
 		// because it's unclear the length value is very reliable.
 		reporter->Error("X509::GetExtensionFromBIO malloc(%d) failed", length);
 		BIO_free_all(bio);
-		return 0;
+		return nullptr;
 		}
 
 	BIO_read(bio, (void*) buffer, length);

--- a/src/file_analysis/analyzer/x509/X509Common.h
+++ b/src/file_analysis/analyzer/x509/X509Common.h
@@ -35,7 +35,7 @@ public:
 	 *
 	 * @return The X509 extension value.
 	 */
-	static IntrusivePtr<StringVal> GetExtensionFromBIO(BIO* bio, File* f = 0);
+	static IntrusivePtr<StringVal> GetExtensionFromBIO(BIO* bio, File* f = nullptr);
 
 	static double GetTimeFromAsn1(const ASN1_TIME* atime, File* f, Reporter* reporter);
 

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -11,7 +11,7 @@
 #include <openssl/err.h>
 
 // construct an error record
-RecordVal* x509_result_record(uint64_t num, const char* reason, Val* chainVector = 0)
+RecordVal* x509_result_record(uint64_t num, const char* reason, Val* chainVector = nullptr)
 	{
 	RecordVal* rrecord = new RecordVal(BifType::Record::X509::Result);
 
@@ -542,7 +542,7 @@ function x509_verify%(certs: x509_opaque_vector, root_certs: table_string_of_str
 
 	int result = X509_verify_cert(csc);
 
-	VectorVal* chainVector = 0;
+	VectorVal* chainVector = nullptr;
 
 	if ( result == 1 ) // we have a valid chain. try to get it...
 		{

--- a/src/input/ReaderBackend.cc
+++ b/src/input/ReaderBackend.cc
@@ -204,7 +204,7 @@ ReaderBackend::ReaderBackend(ReaderFrontend* arg_frontend) : MsgThread()
 	frontend = arg_frontend;
 	info = new ReaderInfo(frontend->Info());
 	num_fields = 0;
-	fields = 0;
+	fields = nullptr;
 
 	SetName(frontend->Name());
 	}
@@ -282,13 +282,13 @@ bool ReaderBackend::OnFinish(double network_time)
 	disabled = true; // frontend disables itself when it gets the Close-message.
 	SendOut(new ReaderClosedMessage(frontend));
 
-	if ( fields != 0 )
+	if ( fields )
 		{
 		for ( unsigned int i = 0; i < num_fields; i++ )
 			delete(fields[i]);
 
 		delete [] (fields);
-		fields = 0;
+		fields = nullptr;
 		}
 
 	return true;

--- a/src/input/ReaderBackend.h
+++ b/src/input/ReaderBackend.h
@@ -104,15 +104,15 @@ public:
 
 		ReaderInfo()
 			{
-			source = 0;
-			name = 0;
+			source = nullptr;
+			name = nullptr;
 			mode = MODE_NONE;
 			}
 
 		ReaderInfo(const ReaderInfo& other)
 			{
-			source = other.source ? copy_string(other.source) : 0;
-			name = other.name ? copy_string(other.name) : 0;
+			source = other.source ? copy_string(other.source) : nullptr;
+			name = other.name ? copy_string(other.name) : nullptr;
 			mode = other.mode;
 
 			for ( config_map::const_iterator i = other.config.begin(); i != other.config.end(); i++ )

--- a/src/input/ReaderFrontend.cc
+++ b/src/input/ReaderFrontend.cc
@@ -52,7 +52,7 @@ void ReaderFrontend::Stop()
 	if ( backend )
 		{
 		backend->SignalStop();
-		backend = 0; // Thread manager will clean it up once it finishes.
+		backend = nullptr; // Thread manager will clean it up once it finishes.
 		}
 	}
 

--- a/src/input/readers/ascii/Ascii.cc
+++ b/src/input/readers/ascii/Ascii.cc
@@ -396,7 +396,7 @@ bool Ascii::DoUpdate()
 
 			Value* val = formatter->ParseValue(stringfields[(*fit).position], (*fit).name, (*fit).type, (*fit).subtype);
 
-			if ( val == 0 )
+			if ( ! val )
 				{
 				Warning(Fmt("Could not convert line '%s' of %s to Val. Ignoring line.", line.c_str(), fname.c_str()));
 				error = true;

--- a/src/input/readers/benchmark/Benchmark.cc
+++ b/src/input/readers/benchmark/Benchmark.cc
@@ -210,11 +210,11 @@ threading::Value* Benchmark::EntryToVal(TypeTag type, TypeTag subtype)
 		for ( unsigned int pos = 0; pos < length; pos++ )
 			{
 			Value* newval = EntryToVal(subtype, TYPE_ENUM);
-			if ( newval == 0 )
+			if ( newval == nullptr )
 				{
 				Error("Error while reading set");
 				delete val;
-				return 0;
+				return nullptr;
 				}
 			lvals[pos] = newval;
 			}
@@ -226,7 +226,7 @@ threading::Value* Benchmark::EntryToVal(TypeTag type, TypeTag subtype)
 	default:
 		Error(Fmt("unsupported field format %d", type));
 		delete val;
-		return 0;
+		return nullptr;
 	}
 
 	return val;
@@ -265,7 +265,7 @@ bool Benchmark::DoHeartbeat(double network_time, double current_time)
 
 			Update(); // call update and not DoUpdate, because update actually checks disabled.
 
-			SendEvent("HeartbeatDone", 0, 0);
+			SendEvent("HeartbeatDone", 0, nullptr);
 			break;
 
 		default:

--- a/src/input/readers/binary/Binary.cc
+++ b/src/input/readers/binary/Binary.cc
@@ -14,7 +14,7 @@ using threading::Field;
 streamsize Binary::chunk_size = 0;
 
 Binary::Binary(ReaderFrontend *frontend)
-	: ReaderBackend(frontend), in(0), mtime(0), ino(0), firstrun(true)
+	: ReaderBackend(frontend), in(nullptr), mtime(0), ino(0), firstrun(true)
 	{
 	if ( ! chunk_size )
 		{
@@ -64,7 +64,7 @@ bool Binary::CloseInput()
 
 	in->close();
 	delete in;
-	in = 0;
+	in = nullptr;
 
 #ifdef DEBUG
 	Debug(DBG_INPUT, "Binary reader finished close");
@@ -76,7 +76,7 @@ bool Binary::CloseInput()
 bool Binary::DoInit(const ReaderInfo& info, int num_fields,
                     const Field* const* fields)
 	{
-	in = 0;
+	in = nullptr;
 	mtime = 0;
 	ino = 0;
 	firstrun = true;
@@ -158,7 +158,7 @@ streamsize Binary::GetChunk(char** chunk)
 	if ( ! bytes_read )
 		{
 		delete [] *chunk;
-		*chunk = 0;
+		*chunk = nullptr;
 		return 0;
 		}
 
@@ -231,7 +231,7 @@ bool Binary::DoUpdate()
 		}
 		}
 
-	char* chunk = 0;
+	char* chunk = nullptr;
 	streamsize size = 0;
 	while ( (size = GetChunk(&chunk)) )
 		{

--- a/src/input/readers/sqlite/SQLite.cc
+++ b/src/input/readers/sqlite/SQLite.cc
@@ -156,7 +156,7 @@ Value* SQLite::EntryToVal(sqlite3_stmt *st, const threading::Field *field, int p
 			{
 			Error("Invalid data type for boolean - expected Integer");
 			delete val;
-			return 0;
+			return nullptr;
 			}
 
 		int res = sqlite3_column_int(st, pos);
@@ -167,7 +167,7 @@ Value* SQLite::EntryToVal(sqlite3_stmt *st, const threading::Field *field, int p
 			{
 			Error(Fmt("Invalid value for boolean: %d", res));
 			delete val;
-			return 0;
+			return nullptr;
 			}
 		break;
 		}
@@ -240,7 +240,7 @@ Value* SQLite::EntryToVal(sqlite3_stmt *st, const threading::Field *field, int p
 	default:
 		Error(Fmt("unsupported field format %d", field->type));
 		delete val;
-		return 0;
+		return nullptr;
 	}
 
 	return val;
@@ -279,7 +279,7 @@ bool SQLite::DoUpdate()
 				mapping[j] = i;
 				}
 
-			if ( fields[j]->secondary_name != 0 && strcmp(fields[j]->secondary_name, name) == 0 )
+			if ( fields[j]->secondary_name != nullptr && strcmp(fields[j]->secondary_name, name) == 0 )
 				{
 				assert(fields[j]->type == TYPE_PORT);
 				if ( submapping[j] != -1 )
@@ -314,7 +314,7 @@ bool SQLite::DoUpdate()
 		for ( unsigned int j = 0; j < num_fields; ++j)
 			{
 			ofields[j] = EntryToVal(st, fields[j], mapping[j], submapping[j]);
-			if ( ofields[j] == 0 )
+			if ( ! ofields[j] )
 				{
 				for ( unsigned int k = 0; k < j; ++k )
 					delete ofields[k];

--- a/src/iosource/BPF_Program.cc
+++ b/src/iosource/BPF_Program.cc
@@ -143,7 +143,7 @@ bool BPF_Program::Compile(int snaplen, int linktype, const char* filter,
 
 bpf_program* BPF_Program::GetProgram()
 	{
-	return m_compiled ? &m_program : 0;
+	return m_compiled ? &m_program : nullptr;
 	}
 
 void BPF_Program::FreeCode()

--- a/src/iosource/BPF_Program.h
+++ b/src/iosource/BPF_Program.h
@@ -22,14 +22,14 @@ public:
 	// Parameters are like in pcap_compile(). Returns true
 	// for successful compilation, false otherwise.
 	bool Compile(pcap_t* pcap, const char* filter, uint32_t netmask,
-		 char* errbuf = 0, unsigned int errbuf_len = 0,
+		 char* errbuf = nullptr, unsigned int errbuf_len = 0,
 		 bool optimize = true);
 
 	// Creates a BPF program when no pcap handle is around,
 	// similarly to pcap_compile_nopcap(). Parameters are
 	// similar. Returns true on success.
 	bool Compile(int snaplen, int linktype, const char* filter,
-		uint32_t netmask, char* errbuf = 0, unsigned int errbuf_len = 0,
+		uint32_t netmask, char* errbuf = nullptr, unsigned int errbuf_len = 0,
 		bool optimize = true);
 
 	// Returns true if this program currently contains compiled

--- a/src/iosource/Manager.cc
+++ b/src/iosource/Manager.cc
@@ -330,7 +330,7 @@ PktSrc* Manager::OpenPktSrc(const std::string& path, bool is_live)
 
 	// Find the component providing packet sources of the requested prefix.
 
-	PktSrcComponent* component = 0;
+	PktSrcComponent* component = nullptr;
 
 	std::list<PktSrcComponent*> all_components = plugin_mgr->Components<PktSrcComponent>();
 	for ( const auto& c : all_components )
@@ -372,7 +372,7 @@ PktDumper* Manager::OpenPktDumper(const string& path, bool append)
 
 	// Find the component providing packet dumpers of the requested prefix.
 
-	PktDumperComponent* component = 0;
+	PktDumperComponent* component = nullptr;
 
 	std::list<PktDumperComponent*> all_components = plugin_mgr->Components<PktDumperComponent>();
 	for ( const auto& c : all_components )

--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -59,7 +59,7 @@ public:
 	Packet(int link_type, pkt_timeval *ts, uint32_t caplen,
 	       uint32_t len, const u_char *data, bool copy = false,
 	       std::string tag = std::string(""))
-	           : data(0), l2_src(0), l2_dst(0)
+	           : data(nullptr), l2_src(nullptr), l2_dst(nullptr)
 	       {
 	       Init(link_type, ts, caplen, len, data, copy, tag);
 	       }
@@ -67,10 +67,10 @@ public:
 	/**
 	 * Default constructor. For internal use only.
 	 */
-	Packet() : data(0), l2_src(0), l2_dst(0)
+	Packet() : data(nullptr), l2_src(nullptr), l2_dst(nullptr)
 		{
 		pkt_timeval ts = {0, 0};
-		Init(0, &ts, 0, 0, 0);
+		Init(0, &ts, 0, 0, nullptr);
 		}
 
 	/**

--- a/src/iosource/PktDumper.cc
+++ b/src/iosource/PktDumper.cc
@@ -45,12 +45,12 @@ double PktDumper::OpenTime() const
 
 bool PktDumper::IsError() const
 	{
-	return errmsg.size();
+	return ! errmsg.empty();
 	}
 
 const char* PktDumper::ErrorMsg() const
 	{
-	return errmsg.size() ? errmsg.c_str() : 0;
+	return errmsg.size() ? errmsg.c_str() : nullptr;
 	}
 
 int PktDumper::HdrSize() const

--- a/src/iosource/PktSrc.cc
+++ b/src/iosource/PktSrc.cc
@@ -51,7 +51,7 @@ const std::string& PktSrc::Path() const
 
 const char* PktSrc::ErrorMsg() const
 	{
-	return errbuf.size() ? errbuf.c_str() : 0;
+	return errbuf.size() ? errbuf.c_str() : nullptr;
 	}
 
 int PktSrc::LinkType() const
@@ -66,7 +66,7 @@ uint32_t PktSrc::Netmask() const
 
 bool PktSrc::IsError() const
 	{
-	return ErrorMsg();
+	return ! errbuf.empty();
 	}
 
 bool PktSrc::IsLive() const
@@ -153,7 +153,7 @@ void PktSrc::Info(const std::string& msg)
 
 void PktSrc::Weird(const std::string& msg, const Packet* p)
 	{
-	sessions->Weird(msg.c_str(), p, 0);
+	sessions->Weird(msg.c_str(), p, nullptr);
 	}
 
 void PktSrc::InternalError(const std::string& msg)
@@ -299,9 +299,9 @@ bool PktSrc::PrecompileBPFFilter(int index, const std::string& filter)
 BPF_Program* PktSrc::GetBPFFilter(int index)
 	{
 	if ( index < 0 )
-		return 0;
+		return nullptr;
 
-	return (static_cast<int>(filters.size()) > index ? filters[index] : 0);
+	return (static_cast<int>(filters.size()) > index ? filters[index] : nullptr);
 	}
 
 bool PktSrc::ApplyBPFFilter(int index, const struct pcap_pkthdr *hdr, const u_char *pkt)

--- a/src/iosource/pcap/Dumper.cc
+++ b/src/iosource/pcap/Dumper.cc
@@ -15,8 +15,8 @@ PcapDumper::PcapDumper(const std::string& path, bool arg_append)
 	{
 	append = arg_append;
 	props.path = path;
-	dumper = 0;
-	pd = 0;
+	dumper = nullptr;
+	pd = nullptr;
 	}
 
 PcapDumper::~PcapDumper()
@@ -93,8 +93,8 @@ void PcapDumper::Close()
 
 	pcap_dump_close(dumper);
 	pcap_close(pd);
-	dumper = 0;
-	pd = 0;
+	dumper = nullptr;
+	pd = nullptr;
 
 	Closed();
 	}

--- a/src/iosource/pcap/Source.h
+++ b/src/iosource/pcap/Source.h
@@ -33,7 +33,7 @@ protected:
 private:
 	void OpenLive();
 	void OpenOffline();
-	void PcapError(const char* where = 0);
+	void PcapError(const char* where = nullptr);
 
 	Properties props;
 	Stats stats;

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -147,7 +147,7 @@ WriterBackend* Manager::CreateBackend(WriterFrontend* frontend, EnumVal* tag)
 	if ( ! c )
 		{
 		reporter->Error("unknown writer type requested");
-		return 0;
+		return nullptr;
 		}
 
 	WriterBackend* backend = (*c->Factory())(frontend);
@@ -161,7 +161,7 @@ Manager::Stream* Manager::FindStream(EnumVal* id)
 	unsigned int idx = id->AsEnum();
 
 	if ( idx >= streams.size() || ! streams[idx] )
-		return 0;
+		return nullptr;
 
 	return streams[idx];
 	}
@@ -182,7 +182,7 @@ Manager::WriterInfo* Manager::FindWriter(WriterFrontend* writer)
 			}
 		}
 
-	return 0;
+	return nullptr;
 	}
 
 bool Manager::CompareFields(const Filter* filter, const WriterFrontend* writer)
@@ -264,7 +264,7 @@ bool Manager::CreateStream(EnumVal* id, RecordVal* sval)
 		}
 
 	auto event_val = sval->Lookup("ev");
-	Func* event = event_val ? event_val->AsFunc() : 0;
+	Func* event = event_val ? event_val->AsFunc() : nullptr;
 
 	if ( event )
 		{
@@ -298,7 +298,7 @@ bool Manager::CreateStream(EnumVal* id, RecordVal* sval)
 	unsigned int idx = id->AsEnum();
 
 	while ( idx >= streams.size() )
-		streams.push_back(0);
+		streams.push_back(nullptr);
 
 	if ( streams[idx] )
 		// We already know this one, delete the previous definition.
@@ -309,7 +309,7 @@ bool Manager::CreateStream(EnumVal* id, RecordVal* sval)
 	streams[idx]->id = id->Ref()->AsEnumVal();
 	streams[idx]->enabled = true;
 	streams[idx]->name = id->Type()->AsEnumType()->Lookup(idx);
-	streams[idx]->event = event ? event_registry->Lookup(event->Name()) : 0;
+	streams[idx]->event = event ? event_registry->Lookup(event->Name()) : nullptr;
 	streams[idx]->columns = columns->Ref()->AsRecordType();
 
 	streams[idx]->enable_remote = internal_val("Log::enable_remote_logging")->AsBool();
@@ -347,7 +347,7 @@ bool Manager::RemoveStream(EnumVal* id)
 	stream->writers.clear();
 	string sname(stream->name);
 	delete stream;
-	streams[idx] = 0;
+	streams[idx] = nullptr;
 
 	DBG_LOG(DBG_LOGGING, "Removed logging stream '%s'", sname.c_str());
 	return true;
@@ -523,7 +523,7 @@ bool Manager::TraverseRecord(Stream* stream, Filter* filter, RecordType* rt,
 
 		bool optional = rtype->FieldDecl(i)->FindAttr(ATTR_OPTIONAL);
 
-		filter->fields[filter->num_fields - 1] = new threading::Field(new_path.c_str(), 0, t->Tag(), st, optional);
+		filter->fields[filter->num_fields - 1] = new threading::Field(new_path.c_str(), nullptr, t->Tag(), st, optional);
 		}
 
 	return true;
@@ -565,18 +565,18 @@ bool Manager::AddFilter(EnumVal* id, RecordVal* fval)
 	filter->fval = fval->Ref();
 	filter->name = name->AsString()->CheckString();
 	filter->id = id->Ref()->AsEnumVal();
-	filter->pred = pred ? pred->AsFunc() : 0;
-	filter->path_func = path_func ? path_func->AsFunc() : 0;
+	filter->pred = pred ? pred->AsFunc() : nullptr;
+	filter->path_func = path_func ? path_func->AsFunc() : nullptr;
 	filter->writer = writer->Ref()->AsEnumVal();
 	filter->local = log_local->AsBool();
 	filter->remote = log_remote->AsBool();
 	filter->interval = interv->AsInterval();
-	filter->postprocessor = postprocessor ? postprocessor->AsFunc() : 0;
+	filter->postprocessor = postprocessor ? postprocessor->AsFunc() : nullptr;
 	filter->config = config->Ref()->AsTableVal();
 	filter->field_name_map = field_name_map->Ref()->AsTableVal();
 	filter->scope_sep = scope_sep->AsString()->CheckString();
 	filter->ext_prefix = ext_prefix->AsString()->CheckString();
-	filter->ext_func = ext_func ? ext_func->AsFunc() : 0;
+	filter->ext_func = ext_func ? ext_func->AsFunc() : nullptr;
 
 	// Build the list of fields that the filter wants included, including
 	// potentially rolling out fields.
@@ -604,7 +604,7 @@ bool Manager::AddFilter(EnumVal* id, RecordVal* fval)
 		}
 
 	filter->num_fields = 0;
-	filter->fields = 0;
+	filter->fields = nullptr;
 	if ( ! TraverseRecord(stream, filter, stream->columns,
 			      include ? include->AsTableVal() : nullptr,
 			      exclude ? exclude->AsTableVal() : nullptr,
@@ -627,7 +627,7 @@ bool Manager::AddFilter(EnumVal* id, RecordVal* fval)
 		{
 		// If no path is given, it's derived based upon the value returned by
 		// the first call to the filter's path_func (during first write).
-		filter->path_val = 0;
+		filter->path_val = nullptr;
 		}
 
 	// Remove any filter with the same name we might already have.
@@ -811,8 +811,8 @@ bool Manager::Write(EnumVal* id, RecordVal* columns_arg)
 			path = filter->path = filter->path_val->AsString()->CheckString();
 			}
 
-		WriterBackend::WriterInfo* info = 0;
-		WriterFrontend* writer = 0;
+		WriterBackend::WriterInfo* info = nullptr;
+		WriterFrontend* writer = nullptr;
 
 		if ( w != stream->writers.end() )
 			{
@@ -1125,7 +1125,7 @@ WriterFrontend* Manager::CreateWriter(EnumVal* id, EnumVal* writer, WriterBacken
 				int num_fields, const threading::Field* const* fields, bool local, bool remote, bool from_remote,
 				const string& instantiating_filter)
 	{
-	WriterFrontend* result = 0;
+	WriterFrontend* result = nullptr;
 
 	Stream* stream = FindStream(id);
 
@@ -1133,7 +1133,7 @@ WriterFrontend* Manager::CreateWriter(EnumVal* id, EnumVal* writer, WriterBacken
 		{
 		// Don't know this stream.
 		delete_info_and_fields(info, num_fields, fields);
-		return 0;
+		return nullptr;
 		}
 
 	Stream::WriterMap::iterator w =
@@ -1149,11 +1149,11 @@ WriterFrontend* Manager::CreateWriter(EnumVal* id, EnumVal* writer, WriterBacken
 
 	WriterInfo* winfo = new WriterInfo;
 	winfo->type = writer->Ref()->AsEnumVal();
-	winfo->writer = 0;
+	winfo->writer = nullptr;
 	winfo->open_time = network_time;
-	winfo->rotation_timer = 0;
+	winfo->rotation_timer = nullptr;
 	winfo->interval = 0;
-	winfo->postprocessor = 0;
+	winfo->postprocessor = nullptr;
 	winfo->info = info;
 	winfo->from_remote = from_remote;
 	winfo->hook_initialized = false;
@@ -1194,7 +1194,7 @@ WriterFrontend* Manager::CreateWriter(EnumVal* id, EnumVal* writer, WriterBacken
 	// Still need to set the WriterInfo's rotation parameters, which we
 	// computed above.
 	const char* base_time = log_rotate_base_time ?
-		log_rotate_base_time->AsString()->CheckString() : 0;
+		log_rotate_base_time->AsString()->CheckString() : nullptr;
 
 	winfo->info->rotation_interval = winfo->interval;
 	winfo->info->rotation_base = parse_rotate_base_time(base_time);
@@ -1411,12 +1411,12 @@ protected:
 RotationTimer::~RotationTimer()
 	{
 	if ( winfo->rotation_timer == this )
-		winfo->rotation_timer = 0;
+		winfo->rotation_timer = nullptr;
 	}
 
 void RotationTimer::Dispatch(double t, bool is_expire)
 	{
-	winfo->rotation_timer = 0;
+	winfo->rotation_timer = nullptr;
 
 	if ( rotate )
 		log_mgr->Rotate(winfo);
@@ -1436,7 +1436,7 @@ void Manager::InstallRotationTimer(WriterInfo* winfo)
 	if ( winfo->rotation_timer )
 		{
 		timer_mgr->Cancel(winfo->rotation_timer);
-		winfo->rotation_timer = 0;
+		winfo->rotation_timer = nullptr;
 		}
 
 	double rotation_interval = winfo->interval;
@@ -1454,7 +1454,7 @@ void Manager::InstallRotationTimer(WriterInfo* winfo)
 				winfo->open_time = network_time;
 
 			const char* base_time = log_rotate_base_time ?
-				log_rotate_base_time->AsString()->CheckString() : 0;
+				log_rotate_base_time->AsString()->CheckString() : nullptr;
 
 			double base = parse_rotate_base_time(base_time);
 			double delta_t =

--- a/src/logging/Manager.h
+++ b/src/logging/Manager.h
@@ -261,7 +261,7 @@ private:
 	threading::Value** RecordToFilterVals(Stream* stream, Filter* filter,
 				    RecordVal* columns);
 
-	threading::Value* ValToLogVal(Val* val, BroType* ty = 0);
+	threading::Value* ValToLogVal(Val* val, BroType* ty = nullptr);
 	Stream* FindStream(EnumVal* id);
 	void RemoveDisabledWriters(Stream* stream);
 	void InstallRotationTimer(WriterInfo* winfo);

--- a/src/logging/WriterBackend.cc
+++ b/src/logging/WriterBackend.cc
@@ -121,7 +121,7 @@ bool WriterBackend::WriterInfo::FromBroker(broker::data d)
 WriterBackend::WriterBackend(WriterFrontend* arg_frontend) : MsgThread()
 	{
 	num_fields = 0;
-	fields = 0;
+	fields = nullptr;
 	buffering = true;
 	frontend = arg_frontend;
 	info = new WriterInfo(frontend->Info());
@@ -168,7 +168,7 @@ bool WriterBackend::FinishedRotation(const char* new_name, const char* old_name,
 bool WriterBackend::FinishedRotation()
 	{
 	--rotation_counter;
-	SendOut(new RotationFinishedMessage(frontend, 0, 0, 0, 0, false, false));
+	SendOut(new RotationFinishedMessage(frontend, nullptr, nullptr, 0, 0, false, false));
 	return true;
 	}
 

--- a/src/logging/WriterBackend.h
+++ b/src/logging/WriterBackend.h
@@ -82,14 +82,14 @@ public:
 		 */
 		config_map config;
 
-		WriterInfo() : path(0), rotation_interval(0.0), rotation_base(0.0),
+		WriterInfo() : path(nullptr), rotation_interval(0.0), rotation_base(0.0),
 		               network_time(0.0)
 			{
 			}
 
 		WriterInfo(const WriterInfo& other)
 			{
-			path = other.path ? copy_string(other.path) : 0;
+			path = other.path ? copy_string(other.path) : nullptr;
 			rotation_interval = other.rotation_interval;
 			rotation_base = other.rotation_base;
 			network_time = other.network_time;

--- a/src/logging/WriterFrontend.cc
+++ b/src/logging/WriterFrontend.cc
@@ -109,12 +109,12 @@ WriterFrontend::WriterFrontend(const WriterBackend::WriterInfo& arg_info, EnumVa
 	buf = true;
 	local = arg_local;
 	remote = arg_remote;
-	write_buffer = 0;
+	write_buffer = nullptr;
 	write_buffer_pos = 0;
 	info = new WriterBackend::WriterInfo(arg_info);
 
 	num_fields = 0;
-	fields = 0;
+	fields = nullptr;
 
 	const char* w = arg_writer->Type()->AsEnumType()->Lookup(arg_writer->InternalInt());
 	name = copy_string(fmt("%s/%s", arg_info.path, w));
@@ -128,7 +128,7 @@ WriterFrontend::WriterFrontend(const WriterBackend::WriterInfo& arg_info, EnumVa
 		}
 
 	else
-		backend = 0;
+		backend = nullptr;
 	}
 
 WriterFrontend::~WriterFrontend()
@@ -152,7 +152,7 @@ void WriterFrontend::Stop()
 	if ( backend )
 		{
 		backend->SignalStop();
-		backend = 0; // Thread manager will clean it up once it finishes.
+		backend = nullptr; // Thread manager will clean it up once it finishes.
 		}
 	}
 
@@ -245,7 +245,7 @@ void WriterFrontend::FlushWriteBuffer()
 		backend->SendIn(new WriteMessage(backend, num_fields, write_buffer_pos, write_buffer));
 
 	// Clear buffer (no delete, we pass ownership to child thread.)
-	write_buffer = 0;
+	write_buffer = nullptr;
 	write_buffer_pos = 0;
 	}
 
@@ -286,7 +286,7 @@ void WriterFrontend::Rotate(const char* rotated_path, double open, double close,
 		backend->SendIn(new RotateMessage(backend, this, rotated_path, open, close, terminating));
 	else
 		// Still signal log manager that we're done.
-		log_mgr->FinishedRotation(this, 0, 0, 0, 0, false, terminating);
+		log_mgr->FinishedRotation(this, nullptr, nullptr, 0, 0, false, terminating);
 	}
 
 void WriterFrontend::DeleteVals(int num_fields, Value** vals)

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -24,7 +24,7 @@ Ascii::Ascii(WriterFrontend* frontend) : WriterBackend(frontend)
 	tsv = false;
 	use_json = false;
 	enable_utf_8 = false;
-	formatter = 0;
+	formatter = nullptr;
 	gzip_level = 0;
 	gzfile = nullptr;
 
@@ -179,7 +179,7 @@ bool Ascii::InitFilterOptions()
 bool Ascii::InitFormatter()
 	{
 	delete formatter;
-	formatter = 0;
+	formatter = nullptr;
 
 	if ( use_json )
 		{

--- a/src/main.cc
+++ b/src/main.cc
@@ -84,44 +84,44 @@ int perftools_profile = 0;
 
 DNS_Mgr* dns_mgr;
 TimerMgr* timer_mgr;
-ValManager* val_mgr = 0;
-logging::Manager* log_mgr = 0;
-threading::Manager* thread_mgr = 0;
-input::Manager* input_mgr = 0;
-plugin::Manager* plugin_mgr = 0;
-analyzer::Manager* analyzer_mgr = 0;
-file_analysis::Manager* file_mgr = 0;
-zeekygen::Manager* zeekygen_mgr = 0;
-iosource::Manager* iosource_mgr = 0;
-bro_broker::Manager* broker_mgr = 0;
-zeek::Supervisor* zeek::supervisor_mgr = 0;
-trigger::Manager* trigger_mgr = 0;
+ValManager* val_mgr = nullptr;
+logging::Manager* log_mgr = nullptr;
+threading::Manager* thread_mgr = nullptr;
+input::Manager* input_mgr = nullptr;
+plugin::Manager* plugin_mgr = nullptr;
+analyzer::Manager* analyzer_mgr = nullptr;
+file_analysis::Manager* file_mgr = nullptr;
+zeekygen::Manager* zeekygen_mgr = nullptr;
+iosource::Manager* iosource_mgr = nullptr;
+bro_broker::Manager* broker_mgr = nullptr;
+zeek::Supervisor* zeek::supervisor_mgr = nullptr;
+trigger::Manager* trigger_mgr = nullptr;
 
 std::vector<std::string> zeek_script_prefixes;
 Stmt* stmts;
-EventHandlerPtr net_done = 0;
-RuleMatcher* rule_matcher = 0;
-EventRegistry* event_registry = 0;
-ProfileLogger* profiling_logger = 0;
-ProfileLogger* segment_logger = 0;
-SampleLogger* sample_logger = 0;
+EventHandlerPtr net_done = nullptr;
+RuleMatcher* rule_matcher = nullptr;
+EventRegistry* event_registry = nullptr;
+ProfileLogger* profiling_logger = nullptr;
+ProfileLogger* segment_logger = nullptr;
+SampleLogger* sample_logger = nullptr;
 int signal_val = 0;
 extern char version[];
-const char* command_line_policy = 0;
+const char* command_line_policy = nullptr;
 vector<string> params;
 set<string> requested_plugins;
-const char* proc_status_file = 0;
+const char* proc_status_file = nullptr;
 
-OpaqueType* md5_type = 0;
-OpaqueType* sha1_type = 0;
-OpaqueType* sha256_type = 0;
-OpaqueType* entropy_type = 0;
-OpaqueType* cardinality_type = 0;
-OpaqueType* topk_type = 0;
-OpaqueType* bloomfilter_type = 0;
-OpaqueType* x509_opaque_type = 0;
-OpaqueType* ocsp_resp_opaque_type = 0;
-OpaqueType* paraglob_type = 0;
+OpaqueType* md5_type = nullptr;
+OpaqueType* sha1_type = nullptr;
+OpaqueType* sha256_type = nullptr;
+OpaqueType* entropy_type = nullptr;
+OpaqueType* cardinality_type = nullptr;
+OpaqueType* topk_type = nullptr;
+OpaqueType* bloomfilter_type = nullptr;
+OpaqueType* x509_opaque_type = nullptr;
+OpaqueType* ocsp_resp_opaque_type = nullptr;
+OpaqueType* paraglob_type = nullptr;
 
 // Keep copy of command line
 int bro_argc;
@@ -130,7 +130,7 @@ char** bro_argv;
 const char* zeek_version()
 	{
 #ifdef DEBUG
-	static char* debug_version = 0;
+	static char* debug_version = nullptr;
 
 	if ( ! debug_version )
 		{
@@ -311,7 +311,7 @@ void terminate_bro()
 	// free the global scope
 	pop_scope();
 
-	reporter = 0;
+	reporter = nullptr;
 	}
 
 void zeek_terminate_loop(const char* reason)
@@ -527,8 +527,8 @@ int main(int argc, char** argv)
 	if ( options.random_seed_input_file )
 		seed_load_file = options.random_seed_input_file->data();
 
-	init_random_seed((seed_load_file && *seed_load_file ? seed_load_file : 0),
-					 options.random_seed_output_file ? options.random_seed_output_file->data() : 0);
+	init_random_seed((seed_load_file && *seed_load_file ? seed_load_file : nullptr),
+					 options.random_seed_output_file ? options.random_seed_output_file->data() : nullptr);
 	// DEBUG_MSG("HMAC key: %s\n", md5_digest_print(shared_hmac_md5_key));
 	init_hash_function();
 
@@ -748,7 +748,7 @@ int main(int argc, char** argv)
 
 	if ( g_policy_debug )
 		// ### Add support for debug command file.
-		dbg_init_debugger(0);
+		dbg_init_debugger(nullptr);
 
 	if ( ! options.pcap_file && ! options.interface )
 		{
@@ -847,7 +847,7 @@ int main(int argc, char** argv)
 	if ( stmts )
 		{
 		stmt_flow_type flow;
-		Frame f(current_scope()->Length(), 0, 0);
+		Frame f(current_scope()->Length(), nullptr, nullptr);
 		g_frame_stack.push_back(&f);
 
 		try

--- a/src/plugin/ComponentManager.h
+++ b/src/plugin/ComponentManager.h
@@ -134,7 +134,7 @@ ComponentManager<T, C>::ComponentManager(const string& arg_module, const string&
 	  tag_enum_type(make_intrusive<EnumType>(module + "::" + local_id))
 	{
 	auto id = install_ID(local_id.c_str(), module.c_str(), true, true);
-	add_type(id.get(), tag_enum_type, 0);
+	add_type(id.get(), tag_enum_type, nullptr);
 	zeekygen_mgr->Identifier(std::move(id));
 	}
 

--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -19,9 +19,9 @@
 
 using namespace plugin;
 
-Plugin* Manager::current_plugin = 0;
-const char* Manager::current_dir = 0;
-const char* Manager::current_sopath = 0;
+Plugin* Manager::current_plugin = nullptr;
+const char* Manager::current_dir = nullptr;
+const char* Manager::current_sopath = nullptr;
 
 Manager::Manager()
 	{
@@ -29,7 +29,7 @@ Manager::Manager()
 	hooks = new hook_list*[NUM_HOOKS];
 
 	for ( int i = 0; i < NUM_HOOKS; i++ )
-		hooks[i] = 0;
+		hooks[i] = nullptr;
 	}
 
 Manager::~Manager()
@@ -238,7 +238,7 @@ bool Manager::ActivateDynamicPluginInternal(const std::string& name, bool ok_if_
 			{
 			const char* path = gl.gl_pathv[i];
 
-			current_plugin = 0;
+			current_plugin = nullptr;
 			current_dir = dir.c_str();
 			current_sopath = path;
 			void* hdl = dlopen(path, RTLD_LAZY | RTLD_GLOBAL);
@@ -270,9 +270,9 @@ bool Manager::ActivateDynamicPluginInternal(const std::string& name, bool ok_if_
 				reporter->FatalError("inconsistent plugin name: %s vs %s",
 						     current_plugin->Name().c_str(), name.c_str());
 
-			current_dir = 0;
-			current_sopath = 0;
-			current_plugin = 0;
+			current_dir = nullptr;
+			current_sopath = nullptr;
+			current_plugin = nullptr;
 
 			DBG_LOG(DBG_PLUGINS, "  Loaded %s", path);
 			}
@@ -461,7 +461,7 @@ Manager::inactive_plugin_list Manager::InactivePlugins() const
 
 Manager::plugin_list* Manager::ActivePluginsInternal()
 	{
-	static plugin_list* plugins = 0;
+	static plugin_list* plugins = nullptr;
 
 	if ( ! plugins )
 		plugins = new plugin_list;
@@ -471,7 +471,7 @@ Manager::plugin_list* Manager::ActivePluginsInternal()
 
 Manager::bif_init_func_map* Manager::BifFilesInternal()
 	{
-	static bif_init_func_map* bifs = 0;
+	static bif_init_func_map* bifs = nullptr;
 
 	if ( ! bifs )
 		bifs = new bif_init_func_map;
@@ -571,7 +571,7 @@ void Manager::DisableHook(HookType hook, Plugin* plugin)
 	if ( l->empty() )
 		{
 		delete l;
-		hooks[hook] = 0;
+		hooks[hook] = nullptr;
 		}
 	}
 

--- a/src/plugin/Manager.h
+++ b/src/plugin/Manager.h
@@ -168,7 +168,7 @@ public:
 	bool HavePluginForHook(HookType hook) const
 		{
 		// Inline to avoid the function call.
-		return hooks[hook] != 0;
+		return hooks[hook] != nullptr;
 		}
 
 	/**

--- a/src/plugin/Plugin.cc
+++ b/src/plugin/Plugin.cc
@@ -475,7 +475,7 @@ void Plugin::Describe(ODesc* d) const
 
 	for ( bif_item_list::const_iterator i = items.begin(); i != items.end(); i++ )
 		{
-		const char* type = 0;
+		const char* type = nullptr;
 
 		switch ( (*i).GetType() ) {
 		case BifItem::FUNCTION:

--- a/src/probabilistic/BloomFilter.cc
+++ b/src/probabilistic/BloomFilter.cc
@@ -17,7 +17,7 @@ using namespace probabilistic;
 
 BloomFilter::BloomFilter()
 	{
-	hasher = 0;
+	hasher = nullptr;
 	}
 
 BloomFilter::BloomFilter(const Hasher* arg_hasher)
@@ -142,7 +142,7 @@ std::string BasicBloomFilter::InternalState() const
 
 BasicBloomFilter::BasicBloomFilter()
 	{
-	bits = 0;
+	bits = nullptr;
 	}
 
 BasicBloomFilter::BasicBloomFilter(const Hasher* hasher, size_t cells)
@@ -195,7 +195,7 @@ bool BasicBloomFilter::DoUnserialize(const broker::data& data)
 
 CountingBloomFilter::CountingBloomFilter()
 	{
-	cells = 0;
+	cells = nullptr;
 	}
 
 CountingBloomFilter::CountingBloomFilter(const Hasher* hasher,

--- a/src/probabilistic/Topk.cc
+++ b/src/probabilistic/Topk.cc
@@ -44,10 +44,10 @@ TopkVal::TopkVal(uint64_t arg_size) : OpaqueVal(topk_type)
 	elementDict = new PDict<Element>;
 	elementDict->SetDeleteFunc(topk_element_hash_delete_func);
 	size = arg_size;
-	type = 0;
+	type = nullptr;
 	numElements = 0;
 	pruned = false;
-	hash = 0;
+	hash = nullptr;
 	}
 
 TopkVal::TopkVal() : OpaqueVal(topk_type)
@@ -55,9 +55,9 @@ TopkVal::TopkVal() : OpaqueVal(topk_type)
 	elementDict = new PDict<Element>;
 	elementDict->SetDeleteFunc(topk_element_hash_delete_func);
 	size = 0;
-	type = 0;
+	type = nullptr;
 	numElements = 0;
-	hash = 0;
+	hash = nullptr;
 	}
 
 TopkVal::~TopkVal()
@@ -86,7 +86,7 @@ void TopkVal::Merge(const TopkVal* value, bool doPrune)
 		return;
 		}
 
-	if ( type == 0 )
+	if ( type == nullptr )
 		{
 		assert(numElements == 0);
 		Typify(value->type);
@@ -115,7 +115,7 @@ void TopkVal::Merge(const TopkVal* value, bool doPrune)
 			HashKey* key = GetHash(e->value);
 			Element* olde = (Element*) elementDict->Lookup(key);
 
-			if ( olde == 0 )
+			if ( olde == nullptr )
 				{
 				olde = new Element();
 				olde->epsilon = 0;
@@ -196,7 +196,7 @@ VectorVal* TopkVal::GetTopK(int k) const // returns vector
 	if ( numElements == 0 )
 		{
 		reporter->Error("Cannot return topk of empty");
-		return 0;
+		return nullptr;
 		}
 
 	auto vector_index = make_intrusive<TypeList>(IntrusivePtr{NewRef{}, type});
@@ -238,7 +238,7 @@ uint64_t TopkVal::GetCount(Val* value) const
 	Element* e = (Element*) elementDict->Lookup(key);
 	delete key;
 
-	if ( e == 0 )
+	if ( e == nullptr )
 		{
 		reporter->Error("GetCount for element that is not in top-k");
 		return 0;
@@ -253,7 +253,7 @@ uint64_t TopkVal::GetEpsilon(Val* value) const
 	Element* e = (Element*) elementDict->Lookup(key);
 	delete key;
 
-	if ( e == 0 )
+	if ( e == nullptr )
 		{
 		reporter->Error("GetEpsilon for element that is not in top-k");
 		return 0;
@@ -297,7 +297,7 @@ void TopkVal::Encountered(Val* encountered)
 	HashKey* key = GetHash(encountered);
 	Element* e = (Element*) elementDict->Lookup(key);
 
-	if ( e == 0 )
+	if ( e == nullptr )
 		{
 		e = new Element();
 		e->epsilon = 0;
@@ -370,7 +370,7 @@ void TopkVal::IncrementCounter(Element* e, unsigned int count)
 	// well, let's test if there is a bucket for currcount++
 	std::list<Bucket*>::iterator bucketIter = currBucket->bucketPos;
 
-	Bucket* nextBucket = 0;
+	Bucket* nextBucket = nullptr;
 
 	bucketIter++;
 
@@ -380,7 +380,7 @@ void TopkVal::IncrementCounter(Element* e, unsigned int count)
 	if ( bucketIter != buckets.end() && (*bucketIter)->count == currcount+count )
 		nextBucket = *bucketIter;
 
-	if ( nextBucket == 0 )
+	if ( nextBucket == nullptr )
 		{
 		// the bucket for the value that we want does not exist.
 		// create it...
@@ -405,7 +405,7 @@ void TopkVal::IncrementCounter(Element* e, unsigned int count)
 		{
 		buckets.remove(currBucket);
 		delete currBucket;
-		currBucket = 0;
+		currBucket = nullptr;
 		}
 	}
 
@@ -519,7 +519,7 @@ bool TopkVal::DoUnserialize(const broker::data& data)
 			b->elements.insert(b->elements.end(), e);
 
 			HashKey* key = GetHash(e->value);
-			assert (elementDict->Lookup(key) == 0);
+			assert (elementDict->Lookup(key) == nullptr);
 
 			elementDict->Insert(key, e);
 			delete key;

--- a/src/threading/BasicThread.cc
+++ b/src/threading/BasicThread.cc
@@ -22,7 +22,7 @@ BasicThread::BasicThread()
 	buf_len = STD_FMT_BUF_LEN;
 	buf = (char*) safe_malloc(buf_len);
 
-	strerr_buffer = 0;
+	strerr_buffer = nullptr;
 
 	name = copy_string(fmt("thread-%" PRIu64, ++thread_counter));
 
@@ -191,5 +191,5 @@ void* BasicThread::launcher(void *arg)
 
 	thread->Done();
 
-	return 0;
+	return nullptr;
 	}

--- a/src/threading/MsgThread.cc
+++ b/src/threading/MsgThread.cc
@@ -172,7 +172,7 @@ bool ReporterMessage::Process()
 	return true;
 	}
 
-MsgThread::MsgThread() : BasicThread(), queue_in(this, 0), queue_out(0, this)
+MsgThread::MsgThread() : BasicThread(), queue_in(this, nullptr), queue_out(nullptr, this)
 	{
 	cnt_sent_in = cnt_sent_out = 0;
 	main_finished = false;
@@ -367,7 +367,7 @@ BasicOutputMessage* MsgThread::RetrieveOut()
 	{
 	BasicOutputMessage* msg = queue_out.Get();
 	if ( ! msg )
-		return 0;
+		return nullptr;
 
 	DBG_LOG(DBG_THREADING, "Retrieved '%s' from %s",  msg->Name(), Name());
 
@@ -379,7 +379,7 @@ BasicInputMessage* MsgThread::RetrieveIn()
 	BasicInputMessage* msg = queue_in.Get();
 
 	if ( ! msg )
-		return 0;
+		return nullptr;
 
 #ifdef DEBUG
 	string s = Fmt("Retrieved '%s' in %s",  msg->Name(), Name());

--- a/src/threading/SerialTypes.cc
+++ b/src/threading/SerialTypes.cc
@@ -26,7 +26,7 @@ bool Field::Read(SerializationFormat* fmt)
 		secondary_name = copy_string(tmp_secondary_name.c_str());
 		}
 	else
-		secondary_name = 0;
+		secondary_name = nullptr;
 
 	bool success = (fmt->Read(&tmp_name, "name")
 			&& fmt->Read(&t, "type")

--- a/src/threading/SerialTypes.h
+++ b/src/threading/SerialTypes.h
@@ -31,16 +31,16 @@ struct Field {
 	 * Constructor.
 	 */
 	Field(const char* name, const char* secondary_name, TypeTag type, TypeTag subtype, bool optional)
-		: name(name ? copy_string(name) : 0),
-		  secondary_name(secondary_name ? copy_string(secondary_name) : 0),
+		: name(name ? copy_string(name) : nullptr),
+		  secondary_name(secondary_name ? copy_string(secondary_name) : nullptr),
 		  type(type), subtype(subtype), optional(optional)	{ }
 
 	/**
 	 * Copy constructor.
 	 */
 	Field(const Field& other)
-		: name(other.name ? copy_string(other.name) : 0),
-		  secondary_name(other.secondary_name ? copy_string(other.secondary_name) : 0),
+		: name(other.name ? copy_string(other.name) : nullptr),
+		  secondary_name(other.secondary_name ? copy_string(other.secondary_name) : nullptr),
 		  type(other.type), subtype(other.subtype), optional(other.optional)	{ }
 
 	~Field()

--- a/src/threading/formatters/Ascii.cc
+++ b/src/threading/formatters/Ascii.cc
@@ -214,7 +214,7 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, TypeTag
 
 	threading::Value* val = new threading::Value(type, subtype, true);
 	const char* start = s.c_str();
-	char* end = 0;
+	char* end = nullptr;
 	errno = 0;
 	size_t pos;
 
@@ -411,7 +411,7 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, TypeTag
 				}
 
 			threading::Value* newval = ParseValue(element, name, subtype);
-			if ( newval == 0 )
+			if ( newval == nullptr )
 				{
 				GetThread()->Warning("Error while reading set or vector");
 				error = true;
@@ -429,7 +429,7 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, TypeTag
 		if ( ! error && (s.empty() || *s.rbegin() == separators.set_separator[0]) )
 			{
 			lvals[pos] = ParseValue("", name, subtype);
-			if ( lvals[pos] == 0 )
+			if ( lvals[pos] == nullptr )
 				{
 				GetThread()->Warning("Error while trying to add empty set element");
 				goto parse_error;
@@ -470,7 +470,7 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, TypeTag
 
 parse_error:
 	delete val;
-	return 0;
+	return nullptr;
 	}
 
 bool Ascii::CheckNumberError(const char* start, const char* end) const

--- a/src/util.cc
+++ b/src/util.cc
@@ -277,7 +277,7 @@ std::string get_escaped_string(const char* str, size_t len, bool escape_all)
 char* copy_string(const char* s)
 	{
 	if ( ! s )
-		return 0;
+		return nullptr;
 
 	char* c = new char[strlen(s)+1];
 	strcpy(c, s);
@@ -558,7 +558,7 @@ const char* strpbrk_n(size_t len, const char* s, const char* charset)
 		if ( strchr(charset, *p) )
 			return p;
 
-	return 0;
+	return nullptr;
 	}
 
 #ifndef HAVE_STRCASESTR
@@ -819,7 +819,7 @@ const char* fmt_bytes(const char* data, int len)
 
 const char* vfmt(const char* format, va_list al)
 	{
-	static char* buf = 0;
+	static char* buf = nullptr;
 	static unsigned int buf_len = 1024;
 
 	if ( ! buf )
@@ -1017,7 +1017,7 @@ void hmac_md5(size_t size, const unsigned char* bytes, unsigned char digest[16])
 static bool read_random_seeds(const char* read_file, uint32_t* seed,
 				uint32_t* buf, int bufsiz)
 	{
-	FILE* f = 0;
+	FILE* f = nullptr;
 
 	if ( ! (f = fopen(read_file, "r")) )
 		{
@@ -1053,7 +1053,7 @@ static bool read_random_seeds(const char* read_file, uint32_t* seed,
 static bool write_random_seeds(const char* write_file, uint32_t seed,
 				uint32_t* buf, int bufsiz)
 	{
-	FILE* f = 0;
+	FILE* f = nullptr;
 
 	if ( ! (f = fopen(write_file, "w+")) )
 		{
@@ -1345,7 +1345,7 @@ bool is_package_loader(const string& path)
 FILE* open_file(const string& path, const string& mode)
 	{
 	if ( path.empty() )
-		return 0;
+		return nullptr;
 
 	FILE* rval = fopen(path.c_str(), mode.c_str());
 
@@ -1384,7 +1384,7 @@ FILE* open_package(string& path, const string& mode)
 	string package_loader = "__load__" + script_extensions[0];
 	reporter->Error("Failed to open package '%s': missing '%s' file",
 	                arg_path.c_str(), package_loader.c_str());
-	return 0;
+	return nullptr;
 	}
 
 TEST_CASE("util path ops")
@@ -1810,7 +1810,7 @@ FILE* rotate_file(const char* name, RecordVal* rotate_info)
 	if ( ! newf )
 		{
 		reporter->Error("rotate_file: can't open %s: %s", tmpname, strerror(errno));
-		return 0;
+		return nullptr;
 		}
 
 	// Then move old file to "<name>.<pid>.<timestamp>" and make sure
@@ -1822,7 +1822,7 @@ FILE* rotate_file(const char* name, RecordVal* rotate_info)
 		fclose(newf);
 		unlink(newname);
 		unlink(tmpname);
-		return 0;
+		return nullptr;
 		}
 
 	// Close current file, and move the tmp to its place.

--- a/src/util.h
+++ b/src/util.h
@@ -139,7 +139,7 @@ inline std::string get_escaped_string(const std::string& str, bool escape_all)
 
 std::vector<std::string>* tokenize_string(std::string_view input,
 					  std::string_view delim,
-					  std::vector<std::string>* rval = 0, int limit = 0);
+					  std::vector<std::string>* rval = nullptr, int limit = 0);
 
 std::vector<std::string_view> tokenize_string(std::string_view input, const char delim) noexcept;
 
@@ -167,7 +167,7 @@ extern char* strcasestr(const char* s, const char* find);
 #endif
 extern const char* strpbrk_n(size_t len, const char* s, const char* charset);
 template<class T> int atoi_n(int len, const char* s, const char** end, int base, T& result);
-extern char* uitoa_n(uint64_t value, char* str, int n, int base, const char* prefix=0);
+extern char* uitoa_n(uint64_t value, char* str, int n, int base, const char* prefix=nullptr);
 int strstr_n(const int big_len, const unsigned char* big,
 		const int little_len, const unsigned char* little);
 extern int fputs(int len, const char* s, FILE* fp);

--- a/src/zeekygen/IdentifierInfo.h
+++ b/src/zeekygen/IdentifierInfo.h
@@ -91,7 +91,7 @@ public:
 	 * comments are correctly associated.
 	 */
 	void CompletedTypeDecl()
-		{ last_field_seen = 0; }
+		{ last_field_seen = nullptr; }
 
 	/**
 	 * @return the script-level ID tracked by this info object.

--- a/src/zeekygen/Manager.cc
+++ b/src/zeekygen/Manager.cc
@@ -288,7 +288,7 @@ void Manager::Identifier(IntrusivePtr<ID> id)
 			{
 			DBG_LOG(DBG_ZEEKYGEN, "Finished document for type %s", id->Name());
 			incomplete_type->CompletedTypeDecl();
-			incomplete_type = 0;
+			incomplete_type = nullptr;
 			return;
 			}
 
@@ -318,7 +318,7 @@ void Manager::Identifier(IntrusivePtr<ID> id)
 		// Handled specially since they don't have a script location.
 		DBG_LOG(DBG_ZEEKYGEN, "Made internal IdentifierInfo %s",
 		        id->Name());
-		CreateIdentifierInfo(id, 0);
+		CreateIdentifierInfo(id, nullptr);
 		return;
 		}
 

--- a/src/zeekygen/Target.cc
+++ b/src/zeekygen/Target.cc
@@ -438,7 +438,7 @@ vector<string> dir_contents_recursive(string dir)
 	char* dir_copy = copy_string(dir.c_str());
 	char** scan_path = new char*[2];
 	scan_path[0] = dir_copy;
-	scan_path[1] = 0;
+	scan_path[1] = NULL;
 
 	FTS* fts = fts_open(scan_path, FTS_NOCHDIR, 0);
 

--- a/src/zeekygen/Target.h
+++ b/src/zeekygen/Target.h
@@ -148,7 +148,7 @@ public:
 		target_creator_map::const_iterator it = target_creators.find(type_name);
 
 		if ( it == target_creators.end() )
-			return 0;
+			return nullptr;
 
 		return it->second(name, pattern);
 		}


### PR DESCRIPTION
This is the last of my eyes-glazing-over changing-the-whole-world PRs for a bit. This one replaces *most* of the uses of `0` or `NULL` to indicate null pointers with `nullptr`. The reason I say "most" is because it doesn't change any calls to syscalls, in the interest of passing what the API for those calls says to pass.

Most of these changes were discovered by clang-tidy's modernize-use-nullptr checker, with hand-checking to make sure that it got all of them correct.

(The branch was originally named shaka-where-the-nulls-fell, but then I remembered that the line I was referencing was an allegory for failure. That just wouldn't do).