### PR TITLE
Small Updates to Frame Class

### DIFF
--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -135,30 +135,6 @@ void ODesc::Add(int64_t i)
 		}
 	}
 
-void ODesc::Add(uint64_t u)
-	{
-	if ( IsBinary() )
-		AddBytes(&u, sizeof(u));
-	else
-		{
-		char tmp[256];
-		modp_ulitoa10(u, tmp);
-		Add(tmp);
-		}
-	}
-
-void ODesc::Add(size_t u)
-    	{
-	if ( IsBinary() )
-		AddBytes(&u, sizeof(u));
-	else
-		{
-		char tmp[256];
-		modp_ulitoa10(u, tmp);
-		Add(tmp);
-		}
-	}
-
 void ODesc::Add(double d, bool no_exp)
 	{
 	if ( IsBinary() )

--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -147,6 +147,18 @@ void ODesc::Add(uint64_t u)
 		}
 	}
 
+void ODesc::Add(size_t u)
+    	{
+	if ( IsBinary() )
+		AddBytes(&u, sizeof(u));
+	else
+		{
+		char tmp[256];
+		modp_ulitoa10(u, tmp);
+		Add(tmp);
+		}
+	}
+
 void ODesc::Add(double d, bool no_exp)
 	{
 	if ( IsBinary() )

--- a/src/Desc.h
+++ b/src/Desc.h
@@ -83,8 +83,28 @@ public:
 	void Add(int i);
 	void Add(uint32_t u);
 	void Add(int64_t i);
-	void Add(uint64_t u);
-	void Add(size_t u);
+
+	// You might be asking, why use an arcane template
+	// specialization rather than just use function overloading?
+	// The answer my friend is that on many platforms uint64_t and
+	// size_t are the same type. This prevents a compiler from
+	// properly handling overloads between those two types and
+	// leads us to this strange looking template.
+	template <class T>
+	typename std::enable_if<
+		std::is_same<T, uint64_t>::value or std::is_same<T, size_t>::value>::type
+	Add(T u)
+		{
+		if ( IsBinary() )
+			AddBytes(&u, sizeof(u));
+		else
+			{
+			char tmp[256];
+			modp_ulitoa10(u, tmp);
+			Add(tmp);
+			}
+		}
+	
 	void Add(double d, bool no_exp=false);
 	void Add(const IPAddr& addr);
 	void Add(const IPPrefix& prefix);

--- a/src/Desc.h
+++ b/src/Desc.h
@@ -84,6 +84,7 @@ public:
 	void Add(uint32_t u);
 	void Add(int64_t i);
 	void Add(uint64_t u);
+	void Add(size_t u);
 	void Add(double d, bool no_exp=false);
 	void Add(const IPAddr& addr);
 	void Add(const IPPrefix& prefix);

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -238,7 +238,7 @@ IntrusivePtr<Val> NameExpr::Eval(Frame* f) const
 		v = {NewRef{}, id->ID_Val()};
 
 	else if ( f )
-		v = {NewRef{}, f->GetElement(id.get())};
+		v = {NewRef{}, f->GetElement(id)};
 
 	else
 		// No frame - evaluating for Simplify() purposes
@@ -272,7 +272,7 @@ void NameExpr::Assign(Frame* f, IntrusivePtr<Val> v)
 	if ( id->IsGlobal() )
 		id->SetVal(std::move(v));
 	else
-		f->SetElement(id.get(), v.release());
+		f->SetElement(id, v.release());
 	}
 
 bool NameExpr::IsPure() const

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -15,9 +15,9 @@
 std::vector<Frame*> g_frame_stack;
 
 Frame::Frame(size_t arg_size, const BroFunc* func, const zeek::Args* fn_args)
+	: frame(new Val*[arg_size])
 	{
 	size = arg_size;
-	frame = new Val*[size];
 	function = func;
 	func_args = fn_args;
 
@@ -150,8 +150,6 @@ void Frame::Release()
 	{
 	for ( size_t i = 0; i < size; ++i )
 		UnrefElement(i);
-
-	delete [] frame;
 	}
 
 void Frame::Describe(ODesc* d) const
@@ -203,7 +201,7 @@ static bool val_is_func(Val* v, BroFunc* func)
 	return v->AsFunc() == func;
 	}
 
-static void clone_if_not_func(Val** frame, size_t offset, BroFunc* func,
+static void clone_if_not_func(const std::unique_ptr<Val*[]>& frame, size_t offset, BroFunc* func,
                               Frame* other)
 	{
 	auto v = frame[offset];

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -601,7 +601,7 @@ Frame::UnserializeIDList(const broker::vector& data)
 
 		std::advance(where, 1);
 
-		auto has_offset = broker::get_if<broker::integer>(*where);
+		auto has_offset = broker::get_if<broker::count>(*where);
 		if ( ! has_offset )
 			{
 			for ( auto& i : rval )
@@ -631,7 +631,7 @@ Frame::UnserializeOffsetMap(const broker::vector& data)
 		if ( ! key )
 			return std::make_pair(false, std::move(rval));
 
-		auto offset = broker::get_if<broker::integer>(data[i+1]);
+		auto offset = broker::get_if<broker::count>(data[i+1]);
 		if ( ! offset )
 			return std::make_pair(false, std::move(rval));
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -89,7 +89,7 @@ void Frame::SetElement(size_t n, Val* v, bool weak_ref)
 		}
 	}
 
-void Frame::SetElement(const IntrusivePtr<ID> id, Val* v)
+void Frame::SetElement(const IntrusivePtr<ID>& id, Val* v)
 	{
 	if ( closure )
 		{
@@ -118,7 +118,7 @@ void Frame::SetElement(const IntrusivePtr<ID> id, Val* v)
 	SetElement(id->Offset(), v);
 	}
 
-Val* Frame::GetElement(const IntrusivePtr<ID> id) const
+Val* Frame::GetElement(const IntrusivePtr<ID>& id) const
 	{
 	if ( closure )
 		{
@@ -544,7 +544,7 @@ void Frame::UnrefElement(size_t n)
 	Unref(frame[n]);
 	}
 
-bool Frame::IsOuterID(const IntrusivePtr<ID> in) const
+bool Frame::IsOuterID(const IntrusivePtr<ID>& in) const
 	{
 	return IsOuterID(in.get());
 	}

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -89,7 +89,7 @@ void Frame::SetElement(size_t n, Val* v, bool weak_ref)
 		}
 	}
 
-void Frame::SetElement(const ID* id, Val* v)
+void Frame::SetElement(const IntrusivePtr<ID> id, Val* v)
 	{
 	if ( closure )
 		{
@@ -100,7 +100,7 @@ void Frame::SetElement(const ID* id, Val* v)
 			}
 		}
 
-	// do we have an offset for it?
+	// Do we have an offset for it?
 	if ( offset_map && ! offset_map->empty() )
 		{
 		auto where = offset_map->find(std::string(id->Name()));
@@ -118,7 +118,7 @@ void Frame::SetElement(const ID* id, Val* v)
 	SetElement(id->Offset(), v);
 	}
 
-Val* Frame::GetElement(const ID* id) const
+Val* Frame::GetElement(const IntrusivePtr<ID> id) const
 	{
 	if ( closure )
 		{
@@ -544,11 +544,17 @@ void Frame::UnrefElement(size_t n)
 	Unref(frame[n]);
 	}
 
+bool Frame::IsOuterID(const IntrusivePtr<ID> in) const
+	{
+	return IsOuterID(in.get());
+	}
+
 bool Frame::IsOuterID(const ID* in) const
 	{
 	return std::any_of(outer_ids.begin(), outer_ids.end(),
 		[&in](ID* id)-> bool { return strcmp(id->Name(), in->Name()) == 0; });
 	}
+
 
 broker::expected<broker::data> Frame::SerializeIDList(const id_list& in)
 	{

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -348,7 +348,7 @@ broker::expected<broker::data> Frame::Serialize(const Frame* target, const id_li
 
 	for ( const auto& id : us )
 		{
-		int location = id->Offset();
+		size_t location = id->Offset();
 
 		auto where = new_map.find(std::string(id->Name()));
 		if (where != new_map.end())

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -269,7 +269,7 @@ private:
 	bool delayed;
 
 	/** Associates ID's offsets with values. */
-	Val** frame;
+	std::unique_ptr<Val*[]> frame;
 
 	/** Values that are weakly referenced by the frame.  Used to
 	 * prevent circular reference memory leaks in lambda/closures */

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -62,7 +62,7 @@ public:
 	 * @param id the ID to associate
 	 * @param v the value to associate it with
 	 */
-	void SetElement(const ID* id, Val* v);
+	void SetElement(const IntrusivePtr<ID> id, Val* v);
 
 	/**
 	 * Gets the value associated with *id* and returns it. Returns
@@ -71,7 +71,7 @@ public:
 	 * @param id the id who's value to retreive
 	 * @return the value associated with *id*
 	 */
-	Val* GetElement(const ID* id) const;
+	Val* GetElement(const IntrusivePtr<ID> id) const;
 
 	/**
 	 * Resets all of the indexes from [*startIdx, frame_size) in
@@ -242,6 +242,7 @@ private:
 	void UnrefElement(size_t n);
 
 	/** Have we captured this id? */
+	bool IsOuterID(const IntrusivePtr<ID> in) const;
 	bool IsOuterID(const ID* in) const;
 
 	/** Serializes an offset_map */

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -29,7 +29,7 @@ public:
 	 * @param func the function that is creating this frame
 	 * @param fn_args the arguments being passed to that function.
 	 */
-	Frame(int size, const BroFunc* func, const zeek::Args* fn_args);
+	Frame(size_t size, const BroFunc* func, const zeek::Args* fn_args);
 
 	/**
 	 * Deletes the frame. Unrefs its trigger, the values that it
@@ -41,7 +41,7 @@ public:
 	 * @param n the index to get.
 	 * @return the value at index *n* of the underlying array.
 	 */
-	Val* NthElement(int n) const	{ return frame[n]; }
+	Val* NthElement(size_t n) const	{ return frame[n]; }
 
 	/**
 	 * Sets the element at index *n* of the underlying array
@@ -53,7 +53,7 @@ public:
 	 * it upon destruction.  Used to break circular references between
 	 * lambda functions and closure frames.
 	 */
-	void SetElement(int n, Val* v, bool weak_ref = false);
+	void SetElement(size_t n, Val* v, bool weak_ref = false);
 
 	/**
 	 * Associates *id* and *v* in the frame. Future lookups of
@@ -79,7 +79,7 @@ public:
 	 *
 	 * @param the first index to unref.
 	 */
-	void Reset(int startIdx);
+	void Reset(size_t startIdx);
 
 	/**
 	 * Resets all of the values in the frame and clears out the
@@ -234,12 +234,12 @@ public:
 
 private:
 
-	using OffsetMap = std::unordered_map<std::string, int>;
+	using OffsetMap = std::unordered_map<std::string, size_t>;
 
 	/**
 	 * Unrefs the value at offset 'n' frame unless it's a weak reference.
 	 */
-	void UnrefElement(int n);
+	void UnrefElement(size_t n);
 
 	/** Have we captured this id? */
 	bool IsOuterID(const ID* in) const;
@@ -253,7 +253,7 @@ private:
 	SerializeIDList(const id_list& in);
 
 	/** Unserializes an offset map. */
-	static std::pair<bool, std::unordered_map<std::string, int>>
+	static std::pair<bool, std::unordered_map<std::string, size_t>>
 	UnserializeOffsetMap(const broker::vector& data);
 
 	/** Unserializes an id_list. */
@@ -261,7 +261,7 @@ private:
 	UnserializeIDList(const broker::vector& data);
 
 	/** The number of vals that can be stored in this frame. */
-	int size;
+	size_t size;
 
 	bool weak_closure_ref = false;
 	bool break_before_next_stmt;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -62,7 +62,7 @@ public:
 	 * @param id the ID to associate
 	 * @param v the value to associate it with
 	 */
-	void SetElement(const IntrusivePtr<ID> id, Val* v);
+	void SetElement(const IntrusivePtr<ID>& id, Val* v);
 
 	/**
 	 * Gets the value associated with *id* and returns it. Returns
@@ -71,7 +71,7 @@ public:
 	 * @param id the id who's value to retreive
 	 * @return the value associated with *id*
 	 */
-	Val* GetElement(const IntrusivePtr<ID> id) const;
+	Val* GetElement(const IntrusivePtr<ID>& id) const;
 
 	/**
 	 * Resets all of the indexes from [*startIdx, frame_size) in
@@ -242,7 +242,7 @@ private:
 	void UnrefElement(size_t n);
 
 	/** Have we captured this id? */
-	bool IsOuterID(const IntrusivePtr<ID> in) const;
+	bool IsOuterID(const IntrusivePtr<ID>& in) const;
 	bool IsOuterID(const ID* in) const;
 
 	/** Serializes an offset_map */

--- a/src/ID.h
+++ b/src/ID.h
@@ -71,8 +71,8 @@ public:
 	void SetEnumConst()		{ is_enum_const = true; }
 	bool IsEnumConst() const		{ return is_enum_const; }
 
-	void SetOffset(int arg_offset)	{ offset = arg_offset; }
-	int Offset() const		{ return offset; }
+	void SetOffset(size_t arg_offset)	{ offset = arg_offset; }
+	size_t Offset() const		{ return offset; }
 
 	bool IsRedefinable() const;
 
@@ -126,7 +126,7 @@ protected:
 	bool weak_ref;
 	IntrusivePtr<BroType> type;
 	bool is_const, is_enum_const, is_type, is_option;
-	int offset;
+	size_t offset;
 	Val* val;
 	IntrusivePtr<Attributes> attrs;
 	// contains list of functions that are called when an option changes

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -816,7 +816,7 @@ IntrusivePtr<Val> SwitchStmt::DoExec(Frame* f, Val* v, stmt_flow_type& flow) con
 		if ( matching_id )
 			{
 			auto cv = cast_value_to_type(v, matching_id->Type());
-			f->SetElement(matching_id, cv.release());
+			f->SetElement({NewRef{}, matching_id}, cv.release());
 			}
 
 		flow = FLOW_NEXT;
@@ -1193,10 +1193,10 @@ IntrusivePtr<Val> ForStmt::DoExec(Frame* f, Val* v, stmt_flow_type& flow) const
 			delete k;
 
 			if ( value_var )
-				f->SetElement(value_var.get(), current_tev->Value()->Ref());
+				f->SetElement(value_var, current_tev->Value()->Ref());
 
 			for ( int i = 0; i < ind_lv->Length(); i++ )
-				f->SetElement((*loop_vars)[i], ind_lv->Index(i)->Ref());
+				f->SetElement({NewRef{}, (*loop_vars)[i]}, ind_lv->Index(i)->Ref());
 
 			flow = FLOW_NEXT;
 
@@ -1232,7 +1232,7 @@ IntrusivePtr<Val> ForStmt::DoExec(Frame* f, Val* v, stmt_flow_type& flow) const
 
 			// Set the loop variable to the current index, and make
 			// another pass over the loop body.
-			f->SetElement((*loop_vars)[0],
+			f->SetElement({NewRef{}, (*loop_vars)[0]},
 					val_mgr->GetCount(i));
 			flow = FLOW_NEXT;
 			ret = body->Exec(f, flow);
@@ -1247,7 +1247,7 @@ IntrusivePtr<Val> ForStmt::DoExec(Frame* f, Val* v, stmt_flow_type& flow) const
 
 		for ( int i = 0; i < sval->Len(); ++i )
 			{
-			f->SetElement((*loop_vars)[0],
+			f->SetElement({NewRef{}, (*loop_vars)[0]},
 					new StringVal(1, (const char*) sval->Bytes() + i));
 			flow = FLOW_NEXT;
 			ret = body->Exec(f, flow);
@@ -1672,7 +1672,7 @@ IntrusivePtr<Val> InitStmt::Exec(Frame* f, stmt_flow_type& flow) const
 			break;
 		}
 
-		f->SetElement(aggr, v);
+		f->SetElement({NewRef{}, aggr}, v);
 		}
 
 	return nullptr;


### PR DESCRIPTION
This makes some small updates to Zeek's Frame class.

- Use `size_t` for ID offsets and indexing into a Frame's array. Previously we were using `int`.
- Use `std::unique_ptr<Val*[]>` for Frame's underlying array rather than managing the memory ourselves.
- Use `IntrusivePtr<ID>` for lookups in a frame. Most places where a lookup was being done we  already had an `IntrusivePtr` and were passing its underlying `ID*` into the `SetElement` method.