### PR TITLE
Some IntrusivePtr migration

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -104,6 +104,9 @@ Deprecated Functionality
   ``analyzer::Analyzer::ConectionEventFast()`` methods are deprecated, use
   ``analyzer::Analyzer::EnqueueConnEvent()`` instead.
 
+- All ``val_mgr`` methods starting with "Get" are deprecated, use the new
+  ``val_mgr`` methods that return ``IntrusivePtr``.
+
 Zeek 3.1.0
 ==========
 

--- a/NEWS
+++ b/NEWS
@@ -117,6 +117,8 @@ Deprecated Functionality
 
 - ``binpac::string_to_val()`` is deprecated, use ``StringVal`` constructor.
 
+- Returning ``Val*`` from BIFs is deprecated, return ``IntrusivePtr`` instead.
+
 Zeek 3.1.0
 ==========
 

--- a/NEWS
+++ b/NEWS
@@ -111,6 +111,8 @@ Deprecated Functionality
 
 - ``Analyzer::BuildConnVal()`` is deprecated, use ``Analyzer::ConnVal()``.
 
+- ``BifEvent::generate_`` functions are deprecated, use ``BifEvent::enqueue_``.
+
 Zeek 3.1.0
 ==========
 

--- a/NEWS
+++ b/NEWS
@@ -113,6 +113,8 @@ Deprecated Functionality
 
 - ``BifEvent::generate_`` functions are deprecated, use ``BifEvent::enqueue_``.
 
+- ``binpac::bytestring_to_val()`` is deprecated, use ``binpac::to_stringval()``.
+
 Zeek 3.1.0
 ==========
 

--- a/NEWS
+++ b/NEWS
@@ -92,7 +92,7 @@ Deprecated Functionality
 - The ``EventMgr::QueueEvent()`` and EventMgr::QueueEventFast()`` methods
   are now deprecated, use ``EventMgr::Enqueue()`` instead.
 
-- The ``Connection::ConnectionEvent()`` and
+- The ``Connection::ConnectionEvent()``, ``Connection::Event()``, and
   ``Connection::ConnectionEventFast()`` methods are now deprecated, use
   ``Connection::EnqueueEvent()`` instead.
 
@@ -100,8 +100,8 @@ Deprecated Functionality
   arguments are now deprecated, use the overload that takes a ``zeek::Args``
   instead.
 
-- The ``analyzer::Analyzer::ConnectionEvent()`` and
-  ``analyzer::Analyzer::ConectionEventFast()`` methods are deprecated, use
+- The ``analyzer::Analyzer::ConnectionEvent()``, ``analyzer::Analyzer::Event``,
+  and ``analyzer::Analyzer::ConectionEventFast()`` methods are deprecated, use
   ``analyzer::Analyzer::EnqueueConnEvent()`` instead.
 
 - All ``val_mgr`` methods starting with "Get" are deprecated, use the new

--- a/NEWS
+++ b/NEWS
@@ -107,6 +107,10 @@ Deprecated Functionality
 - All ``val_mgr`` methods starting with "Get" are deprecated, use the new
   ``val_mgr`` methods that return ``IntrusivePtr``.
 
+- ``Connection::BuildConnVal()`` is deprecated, use ``Connection::ConnVal()``.
+
+- ``Analyzer::BuildConnVal()`` is deprecated, use ``Analyzer::ConnVal()``.
+
 Zeek 3.1.0
 ==========
 

--- a/NEWS
+++ b/NEWS
@@ -115,6 +115,8 @@ Deprecated Functionality
 
 - ``binpac::bytestring_to_val()`` is deprecated, use ``binpac::to_stringval()``.
 
+- ``binpac::string_to_val()`` is deprecated, use ``StringVal`` constructor.
+
 Zeek 3.1.0
 ==========
 

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -770,7 +770,7 @@ const char* CompositeHash::RecoverOneVal(const HashKey* k, const char* kp0,
 		else if ( tag == TYPE_BOOL )
 			*pval = val_mgr->Bool(*kp);
 		else if ( tag == TYPE_INT )
-			*pval = {AdoptRef{}, val_mgr->GetInt(*kp)};
+			*pval = val_mgr->Int(*kp);
 		else
 			{
 			reporter->InternalError("bad internal unsigned int in CompositeHash::RecoverOneVal()");

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -787,7 +787,7 @@ const char* CompositeHash::RecoverOneVal(const HashKey* k, const char* kp0,
 		switch ( tag ) {
 		case TYPE_COUNT:
 		case TYPE_COUNTER:
-			*pval = {AdoptRef{}, val_mgr->GetCount(*kp)};
+			*pval = val_mgr->Count(*kp);
 			break;
 
 		case TYPE_PORT:

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -791,7 +791,7 @@ const char* CompositeHash::RecoverOneVal(const HashKey* k, const char* kp0,
 			break;
 
 		case TYPE_PORT:
-			*pval = {AdoptRef{}, val_mgr->GetPort(*kp)};
+			*pval = val_mgr->Port(*kp);
 			break;
 
 		default:

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -768,7 +768,7 @@ const char* CompositeHash::RecoverOneVal(const HashKey* k, const char* kp0,
 		if ( tag == TYPE_ENUM )
 			*pval = t->AsEnumType()->GetVal(*kp);
 		else if ( tag == TYPE_BOOL )
-			*pval = {AdoptRef{}, val_mgr->GetBool(*kp)};
+			*pval = val_mgr->Bool(*kp);
 		else if ( tag == TYPE_INT )
 			*pval = {AdoptRef{}, val_mgr->GetInt(*kp)};
 		else

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -367,7 +367,7 @@ RecordVal* Connection::BuildConnVal()
 		conn_val->Assign(2, std::move(resp_endp));
 		// 3 and 4 are set below.
 		conn_val->Assign(5, make_intrusive<TableVal>(IntrusivePtr{NewRef{}, string_set}));	// service
-		conn_val->Assign(6, val_mgr->GetEmptyString());	// history
+		conn_val->Assign(6, val_mgr->EmptyString());	// history
 
 		if ( ! uid )
 			uid.Set(bits_per_uid);

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -378,10 +378,10 @@ RecordVal* Connection::BuildConnVal()
 			conn_val->Assign(8, encapsulation->GetVectorVal());
 
 		if ( vlan != 0 )
-			conn_val->Assign(9, val_mgr->GetInt(vlan));
+			conn_val->Assign(9, val_mgr->Int(vlan));
 
 		if ( inner_vlan != 0 )
-			conn_val->Assign(10, val_mgr->GetInt(inner_vlan));
+			conn_val->Assign(10, val_mgr->Int(inner_vlan));
 
 		}
 

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -261,7 +261,7 @@ void Connection::HistoryThresholdEvent(EventHandlerPtr e, bool is_orig,
 
 	EnqueueEvent(e, nullptr,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+		val_mgr->Bool(is_orig),
 		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(threshold)}
 	);
 	}
@@ -391,7 +391,7 @@ RecordVal* Connection::BuildConnVal()
 	conn_val->Assign(3, make_intrusive<Val>(start_time, TYPE_TIME));	// ###
 	conn_val->Assign(4, make_intrusive<Val>(last_time - start_time, TYPE_INTERVAL));
 	conn_val->Assign(6, make_intrusive<StringVal>(history.c_str()));
-	conn_val->Assign(11, val_mgr->GetBool(is_successful));
+	conn_val->Assign(11, val_mgr->Bool(is_successful));
 
 	conn_val->SetOrigin(this);
 
@@ -698,7 +698,7 @@ void Connection::CheckFlowLabel(bool is_orig, uint32_t flow_label)
 			{
 			EnqueueEvent(connection_flow_label_changed, nullptr,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+				val_mgr->Bool(is_orig),
 				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(my_flow_label)},
 				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(flow_label)}
 			);

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -262,7 +262,7 @@ void Connection::HistoryThresholdEvent(EventHandlerPtr e, bool is_orig,
 	EnqueueEvent(e, nullptr,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
 		val_mgr->Bool(is_orig),
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(threshold)}
+		val_mgr->Count(threshold)
 	);
 	}
 
@@ -344,9 +344,9 @@ RecordVal* Connection::BuildConnVal()
 		id_val->Assign(3, val_mgr->GetPort(ntohs(resp_port), prot_type));
 
 		auto orig_endp = make_intrusive<RecordVal>(endpoint);
-		orig_endp->Assign(0, val_mgr->GetCount(0));
-		orig_endp->Assign(1, val_mgr->GetCount(0));
-		orig_endp->Assign(4, val_mgr->GetCount(orig_flow_label));
+		orig_endp->Assign(0, val_mgr->Count(0));
+		orig_endp->Assign(1, val_mgr->Count(0));
+		orig_endp->Assign(4, val_mgr->Count(orig_flow_label));
 
 		const int l2_len = sizeof(orig_l2_addr);
 		char null[l2_len]{};
@@ -355,9 +355,9 @@ RecordVal* Connection::BuildConnVal()
 			orig_endp->Assign(5, make_intrusive<StringVal>(fmt_mac(orig_l2_addr, l2_len)));
 
 		auto resp_endp = make_intrusive<RecordVal>(endpoint);
-		resp_endp->Assign(0, val_mgr->GetCount(0));
-		resp_endp->Assign(1, val_mgr->GetCount(0));
-		resp_endp->Assign(4, val_mgr->GetCount(resp_flow_label));
+		resp_endp->Assign(0, val_mgr->Count(0));
+		resp_endp->Assign(1, val_mgr->Count(0));
+		resp_endp->Assign(4, val_mgr->Count(resp_flow_label));
 
 		if ( memcmp(&resp_l2_addr, &null, l2_len) != 0 )
 			resp_endp->Assign(5, make_intrusive<StringVal>(fmt_mac(resp_l2_addr, l2_len)));
@@ -690,7 +690,7 @@ void Connection::CheckFlowLabel(bool is_orig, uint32_t flow_label)
 		if ( conn_val )
 			{
 			RecordVal *endp = conn_val->Lookup(is_orig ? 1 : 2)->AsRecordVal();
-			endp->Assign(4, val_mgr->GetCount(flow_label));
+			endp->Assign(4, val_mgr->Count(flow_label));
 			}
 
 		if ( connection_flow_label_changed &&
@@ -699,8 +699,8 @@ void Connection::CheckFlowLabel(bool is_orig, uint32_t flow_label)
 			EnqueueEvent(connection_flow_label_changed, nullptr,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
 				val_mgr->Bool(is_orig),
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(my_flow_label)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(flow_label)}
+				val_mgr->Count(my_flow_label),
+				val_mgr->Count(flow_label)
 			);
 			}
 

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -144,7 +144,10 @@ void Connection::CheckEncapsulation(const EncapsulationStack* arg_encap)
 		{
 		if ( *encapsulation != *arg_encap )
 			{
-			Event(tunnel_changed, nullptr, arg_encap->GetVectorVal());
+			if ( tunnel_changed )
+				EnqueueEvent(tunnel_changed, nullptr, ConnVal(),
+				             IntrusivePtr{AdoptRef{}, arg_encap->GetVectorVal()});
+
 			delete encapsulation;
 			encapsulation = new EncapsulationStack(*arg_encap);
 			}
@@ -152,15 +155,23 @@ void Connection::CheckEncapsulation(const EncapsulationStack* arg_encap)
 
 	else if ( encapsulation )
 		{
-		EncapsulationStack empty;
-		Event(tunnel_changed, nullptr, empty.GetVectorVal());
+		if ( tunnel_changed )
+			{
+			EncapsulationStack empty;
+			EnqueueEvent(tunnel_changed, nullptr, ConnVal(),
+			             IntrusivePtr{AdoptRef{}, empty.GetVectorVal()});
+			}
+
 		delete encapsulation;
 		encapsulation = nullptr;
 		}
 
 	else if ( arg_encap )
 		{
-		Event(tunnel_changed, nullptr, arg_encap->GetVectorVal());
+		if ( tunnel_changed )
+			EnqueueEvent(tunnel_changed, nullptr, ConnVal(),
+			             IntrusivePtr{AdoptRef{}, arg_encap->GetVectorVal()});
+
 		encapsulation = new EncapsulationStack(*arg_encap);
 		}
 	}

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -339,9 +339,9 @@ RecordVal* Connection::BuildConnVal()
 
 		auto id_val = make_intrusive<RecordVal>(conn_id);
 		id_val->Assign(0, make_intrusive<AddrVal>(orig_addr));
-		id_val->Assign(1, val_mgr->GetPort(ntohs(orig_port), prot_type));
+		id_val->Assign(1, val_mgr->Port(ntohs(orig_port), prot_type));
 		id_val->Assign(2, make_intrusive<AddrVal>(resp_addr));
-		id_val->Assign(3, val_mgr->GetPort(ntohs(resp_port), prot_type));
+		id_val->Assign(3, val_mgr->Port(ntohs(resp_port), prot_type));
 
 		auto orig_endp = make_intrusive<RecordVal>(endpoint);
 		orig_endp->Assign(0, val_mgr->Count(0));

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -163,7 +163,14 @@ public:
 	// Activate connection_status_update timer.
 	void EnableStatusUpdateTimer();
 
+	[[deprecated("Remove in v4.1.  Use ConnVal() instead.")]]
 	RecordVal* BuildConnVal();
+
+	/**
+	 * Returns the associated "connection" record.
+	 */
+	const IntrusivePtr<RecordVal>& ConnVal();
+
 	void AppendAddl(const char* str);
 
 	LoginConn* AsLoginConn()		{ return login_conn; }
@@ -316,8 +323,6 @@ public:
 
 protected:
 
-	Connection()	{ }
-
 	// Add the given timer to expire at time t.  If do_expire
 	// is true, then the timer is also evaluated when Bro terminates,
 	// otherwise not.
@@ -349,7 +354,7 @@ protected:
 	u_char resp_l2_addr[Packet::l2_addr_len];	// Link-layer responder address, if available
 	double start_time, last_time;
 	double inactivity_timeout;
-	RecordVal* conn_val;
+	IntrusivePtr<RecordVal> conn_val;
 	LoginConn* login_conn;	// either nil, or this
 	const EncapsulationStack* encapsulation; // tunnels
 	int suppress_event;	// suppress certain events to once per conn.

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -193,6 +193,7 @@ public:
 	// 'v1' and 'v2' reference counts get decremented.  The event's first
 	// argument is the connection value, second argument is 'v1', and if 'v2'
 	// is given that will be it's third argument.
+	[[deprecated("Remove in v4.1.  Use EnqueueEvent() instead (note it doesn't automatically add the connection argument).")]]
 	void Event(EventHandlerPtr f, analyzer::Analyzer* analyzer, Val* v1, Val* v2 = nullptr);
 
 	// If a handler exists for 'f', an event will be generated.  In any case,

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -738,7 +738,7 @@ IntrusivePtr<Val> DNS_Mgr::BuildMappingVal(DNS_Mapping* dm)
 	r->Assign(0, make_intrusive<Val>(dm->CreationTime(), TYPE_TIME));
 	r->Assign(1, make_intrusive<StringVal>(dm->ReqHost() ? dm->ReqHost() : ""));
 	r->Assign(2, make_intrusive<AddrVal>(dm->ReqAddr()));
-	r->Assign(3, val_mgr->GetBool(dm->Valid()));
+	r->Assign(3, val_mgr->Bool(dm->Valid()));
 
 	auto h = dm->Host();
 	r->Assign(4, h ? h.release() : new StringVal("<none>"));

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -686,7 +686,7 @@ IntrusivePtr<Val> BinaryExpr::Fold(Val* v1, Val* v2) const
 	else if ( ret_type->Tag() == TYPE_BOOL )
 		return val_mgr->Bool(i3);
 	else
-		return {AdoptRef{}, val_mgr->GetInt(i3)};
+		return val_mgr->Int(i3);
 	}
 
 IntrusivePtr<Val> BinaryExpr::StringFold(Val* v1, Val* v2) const
@@ -958,7 +958,7 @@ IntrusivePtr<Val> IncrExpr::DoSingleEval(Frame* f, Val* v) const
 		ret_type = Type()->YieldType();
 
 	if ( ret_type->Tag() == TYPE_INT )
-		return {AdoptRef{}, val_mgr->GetInt(k)};
+		return val_mgr->Int(k);
 	else
 		return {AdoptRef{}, val_mgr->GetCount(k)};
 	}
@@ -1075,7 +1075,7 @@ IntrusivePtr<Val> PosExpr::Fold(Val* v) const
 	if ( t == TYPE_DOUBLE || t == TYPE_INTERVAL || t == TYPE_INT )
 		return {NewRef{}, v};
 	else
-		return {AdoptRef{}, val_mgr->GetInt(v->CoerceToInt())};
+		return val_mgr->Int(v->CoerceToInt());
 	}
 
 NegExpr::NegExpr(IntrusivePtr<Expr> arg_op)
@@ -1113,7 +1113,7 @@ IntrusivePtr<Val> NegExpr::Fold(Val* v) const
 	else if ( v->Type()->Tag() == TYPE_INTERVAL )
 		return make_intrusive<IntervalVal>(- v->InternalDouble(), 1.0);
 	else
-		return {AdoptRef{}, val_mgr->GetInt(- v->CoerceToInt())};
+		return val_mgr->Int(- v->CoerceToInt());
 	}
 
 SizeExpr::SizeExpr(IntrusivePtr<Expr> arg_op)
@@ -3485,7 +3485,7 @@ IntrusivePtr<Val> ArithCoerceExpr::FoldSingleVal(Val* v, InternalTypeTag t) cons
 		return make_intrusive<Val>(v->CoerceToDouble(), TYPE_DOUBLE);
 
 	case TYPE_INTERNAL_INT:
-		return {AdoptRef{}, val_mgr->GetInt(v->CoerceToInt())};
+		return val_mgr->Int(v->CoerceToInt());
 
 	case TYPE_INTERNAL_UNSIGNED:
 		return {AdoptRef{}, val_mgr->GetCount(v->CoerceToUnsigned())};

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -682,7 +682,7 @@ IntrusivePtr<Val> BinaryExpr::Fold(Val* v1, Val* v2) const
 	else if ( ret_type->InternalType() == TYPE_INTERNAL_DOUBLE )
 		return make_intrusive<Val>(d3, ret_type->Tag());
 	else if ( ret_type->InternalType() == TYPE_INTERNAL_UNSIGNED )
-		return {AdoptRef{}, val_mgr->GetCount(u3)};
+		return val_mgr->Count(u3);
 	else if ( ret_type->Tag() == TYPE_BOOL )
 		return val_mgr->Bool(i3);
 	else
@@ -960,7 +960,7 @@ IntrusivePtr<Val> IncrExpr::DoSingleEval(Frame* f, Val* v) const
 	if ( ret_type->Tag() == TYPE_INT )
 		return val_mgr->Int(k);
 	else
-		return {AdoptRef{}, val_mgr->GetCount(k)};
+		return val_mgr->Count(k);
 	}
 
 
@@ -1018,7 +1018,7 @@ ComplementExpr::ComplementExpr(IntrusivePtr<Expr> arg_op)
 
 IntrusivePtr<Val> ComplementExpr::Fold(Val* v) const
 	{
-	return {AdoptRef{}, val_mgr->GetCount(~ v->InternalUnsigned())};
+	return val_mgr->Count(~ v->InternalUnsigned());
 	}
 
 NotExpr::NotExpr(IntrusivePtr<Expr> arg_op)
@@ -3488,7 +3488,7 @@ IntrusivePtr<Val> ArithCoerceExpr::FoldSingleVal(Val* v, InternalTypeTag t) cons
 		return val_mgr->Int(v->CoerceToInt());
 
 	case TYPE_INTERNAL_UNSIGNED:
-		return {AdoptRef{}, val_mgr->GetCount(v->CoerceToUnsigned())};
+		return val_mgr->Count(v->CoerceToUnsigned());
 
 	default:
 		RuntimeErrorWithCallStack("bad type in CoerceExpr::Fold");

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -684,7 +684,7 @@ IntrusivePtr<Val> BinaryExpr::Fold(Val* v1, Val* v2) const
 	else if ( ret_type->InternalType() == TYPE_INTERNAL_UNSIGNED )
 		return {AdoptRef{}, val_mgr->GetCount(u3)};
 	else if ( ret_type->Tag() == TYPE_BOOL )
-		return {AdoptRef{}, val_mgr->GetBool(i3)};
+		return val_mgr->Bool(i3);
 	else
 		return {AdoptRef{}, val_mgr->GetInt(i3)};
 	}
@@ -720,7 +720,7 @@ IntrusivePtr<Val> BinaryExpr::StringFold(Val* v1, Val* v2) const
 		BadTag("BinaryExpr::StringFold", expr_name(tag));
 	}
 
-	return {AdoptRef{}, val_mgr->GetBool(result)};
+	return val_mgr->Bool(result);
 	}
 
 
@@ -796,7 +796,7 @@ IntrusivePtr<Val> BinaryExpr::SetFold(Val* v1, Val* v2) const
 		return nullptr;
 	}
 
-	return {AdoptRef{}, val_mgr->GetBool(res)};
+	return val_mgr->Bool(res);
 	}
 
 IntrusivePtr<Val> BinaryExpr::AddrFold(Val* v1, Val* v2) const
@@ -830,7 +830,7 @@ IntrusivePtr<Val> BinaryExpr::AddrFold(Val* v1, Val* v2) const
 		BadTag("BinaryExpr::AddrFold", expr_name(tag));
 	}
 
-	return {AdoptRef{}, val_mgr->GetBool(result)};
+	return val_mgr->Bool(result);
 	}
 
 IntrusivePtr<Val> BinaryExpr::SubNetFold(Val* v1, Val* v2) const
@@ -843,7 +843,7 @@ IntrusivePtr<Val> BinaryExpr::SubNetFold(Val* v1, Val* v2) const
 	if ( tag == EXPR_NE )
 		result = ! result;
 
-	return {AdoptRef{}, val_mgr->GetBool(result)};
+	return val_mgr->Bool(result);
 	}
 
 void BinaryExpr::SwapOps()
@@ -1037,7 +1037,7 @@ NotExpr::NotExpr(IntrusivePtr<Expr> arg_op)
 
 IntrusivePtr<Val> NotExpr::Fold(Val* v) const
 	{
-	return {AdoptRef{}, val_mgr->GetBool(! v->InternalInt())};
+	return val_mgr->Bool(! v->InternalInt());
 	}
 
 PosExpr::PosExpr(IntrusivePtr<Expr> arg_op)
@@ -1620,7 +1620,7 @@ IntrusivePtr<Val> BoolExpr::Eval(Frame* f) const
 				(! op1->IsZero() && ! op2->IsZero()) :
 				(! op1->IsZero() || ! op2->IsZero());
 
-			result->Assign(i, val_mgr->GetBool(local_result));
+			result->Assign(i, val_mgr->Bool(local_result));
 			}
 		else
 			result->Assign(i, nullptr);
@@ -1775,9 +1775,9 @@ IntrusivePtr<Val> EqExpr::Fold(Val* v1, Val* v2) const
 		RE_Matcher* re = v1->AsPattern();
 		const BroString* s = v2->AsString();
 		if ( tag == EXPR_EQ )
-			return {AdoptRef{}, val_mgr->GetBool(re->MatchExactly(s))};
+			return val_mgr->Bool(re->MatchExactly(s));
 		else
-			return {AdoptRef{}, val_mgr->GetBool(! re->MatchExactly(s))};
+			return val_mgr->Bool(! re->MatchExactly(s));
 		}
 
 	else
@@ -2972,7 +2972,7 @@ HasFieldExpr::~HasFieldExpr()
 IntrusivePtr<Val> HasFieldExpr::Fold(Val* v) const
 	{
 	auto rv = v->AsRecordVal();
-	return {AdoptRef{}, val_mgr->GetBool(rv->Lookup(field))};
+	return val_mgr->Bool(rv->Lookup(field));
 	}
 
 void HasFieldExpr::ExprDescribe(ODesc* d) const
@@ -4024,7 +4024,7 @@ IntrusivePtr<Val> InExpr::Fold(Val* v1, Val* v2) const
 		{
 		RE_Matcher* re = v1->AsPattern();
 		const BroString* s = v2->AsString();
-		return {AdoptRef{}, val_mgr->GetBool(re->MatchAnywhere(s) != 0)};
+		return val_mgr->Bool(re->MatchAnywhere(s) != 0);
 		}
 
 	if ( v2->Type()->Tag() == TYPE_STRING )
@@ -4035,12 +4035,12 @@ IntrusivePtr<Val> InExpr::Fold(Val* v1, Val* v2) const
 		// Could do better here e.g. Boyer-Moore if done repeatedly.
 		auto s = reinterpret_cast<const unsigned char*>(s1->CheckString());
 		auto res = strstr_n(s2->Len(), s2->Bytes(), s1->Len(), s) != -1;
-		return {AdoptRef{}, val_mgr->GetBool(res)};
+		return val_mgr->Bool(res);
 		}
 
 	if ( v1->Type()->Tag() == TYPE_ADDR &&
 	     v2->Type()->Tag() == TYPE_SUBNET )
-		return {AdoptRef{}, val_mgr->GetBool(v2->AsSubNetVal()->Contains(v1->AsAddr()))};
+		return val_mgr->Bool(v2->AsSubNetVal()->Contains(v1->AsAddr()));
 
 	bool res;
 
@@ -4049,7 +4049,7 @@ IntrusivePtr<Val> InExpr::Fold(Val* v1, Val* v2) const
 	else
 		res = (bool)v2->AsTableVal()->Lookup(v1, false);
 
-	return {AdoptRef{}, val_mgr->GetBool(res)};
+	return val_mgr->Bool(res);
 	}
 
 CallExpr::CallExpr(IntrusivePtr<Expr> arg_func,
@@ -4906,7 +4906,7 @@ IntrusivePtr<Val> IsExpr::Fold(Val* v) const
 	if ( IsError() )
 		return nullptr;
 
-	return {AdoptRef{}, val_mgr->GetBool(can_cast_value_to_type(v, t.get()))};
+	return val_mgr->Bool(can_cast_value_to_type(v, t.get()));
 	}
 
 void IsExpr::ExprDescribe(ODesc* d) const

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -633,7 +633,7 @@ IntrusivePtr<Val> BuiltinFunc::Call(const zeek::Args& args, Frame* parent) const
 
 	const CallExpr* call_expr = parent ? parent->GetCall() : nullptr;
 	call_stack.emplace_back(CallInfo{call_expr, this, args});
-	IntrusivePtr<Val> result{AdoptRef{}, func(parent, &args)};
+	auto result = std::move(func(parent, &args).rval);
 	call_stack.pop_back();
 
 	if ( result && g_trace_state.DoTrace() )
@@ -890,3 +890,7 @@ function_ingredients::~function_ingredients()
 
 	delete inits;
 	}
+
+BifReturnVal::BifReturnVal(Val* v) noexcept
+	: rval(AdoptRef{}, v)
+	{ }

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -891,6 +891,9 @@ function_ingredients::~function_ingredients()
 	delete inits;
 	}
 
+BifReturnVal::BifReturnVal(std::nullptr_t) noexcept
+	{ }
+
 BifReturnVal::BifReturnVal(Val* v) noexcept
 	: rval(AdoptRef{}, v)
 	{ }

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -321,7 +321,7 @@ IntrusivePtr<Val> BroFunc::Call(const zeek::Args& args, Frame* parent) const
 		{
 		// Can only happen for events and hooks.
 		assert(Flavor() == FUNC_FLAVOR_EVENT || Flavor() == FUNC_FLAVOR_HOOK);
-		return Flavor() == FUNC_FLAVOR_HOOK ? IntrusivePtr{AdoptRef{}, val_mgr->GetTrue()} : nullptr;
+		return Flavor() == FUNC_FLAVOR_HOOK ? val_mgr->True() : nullptr;
 		}
 
 	auto f = make_intrusive<Frame>(frame_size, this, &args);
@@ -407,7 +407,7 @@ IntrusivePtr<Val> BroFunc::Call(const zeek::Args& args, Frame* parent) const
 			if ( flow == FLOW_BREAK )
 				{
 				// Short-circuit execution of remaining hook handler bodies.
-				result = {AdoptRef{}, val_mgr->GetFalse()};
+				result = val_mgr->False();
 				break;
 				}
 			}
@@ -418,7 +418,7 @@ IntrusivePtr<Val> BroFunc::Call(const zeek::Args& args, Frame* parent) const
 	if ( Flavor() == FUNC_FLAVOR_HOOK )
 		{
 		if ( ! result )
-			result = {AdoptRef{}, val_mgr->GetTrue()};
+			result = val_mgr->True();
 		}
 
 	// Warn if the function returns something, but we returned from

--- a/src/Func.h
+++ b/src/Func.h
@@ -201,6 +201,9 @@ public:
 		: rval(AdoptRef{}, v.release())
 		{ }
 
+	BifReturnVal(std::nullptr_t) noexcept;
+
+	[[deprecated("Remove in v4.1.  Return an IntrusivePtr instead.")]]
 	BifReturnVal(Val* v) noexcept;
 
 private:

--- a/src/Func.h
+++ b/src/Func.h
@@ -188,7 +188,29 @@ private:
 	bool weak_closure_ref = false;
 };
 
-using built_in_func = Val* (*)(Frame* frame, const zeek::Args* args);
+/**
+ * A simple wrapper class to use for the return value of BIFs so that
+ * they may return either a Val* or IntrusivePtr<Val> (the former could
+ * potentially be deprecated).
+ */
+class BifReturnVal {
+public:
+
+	template <typename T>
+	BifReturnVal(IntrusivePtr<T> v) noexcept
+		: rval(AdoptRef{}, v.release())
+		{ }
+
+	BifReturnVal(Val* v) noexcept;
+
+private:
+
+	friend class BuiltinFunc;
+
+	IntrusivePtr<Val> rval;
+};
+
+using built_in_func = BifReturnVal (*)(Frame* frame, const zeek::Args* args);
 
 class BuiltinFunc final : public Func {
 public:

--- a/src/IP.cc
+++ b/src/IP.cc
@@ -56,7 +56,7 @@ static VectorVal* BuildOptionsVal(const u_char* data, int len)
 			{
 			// Pad1 option
 			rv->Assign(1, val_mgr->Count(0));
-			rv->Assign(2, val_mgr->GetEmptyString());
+			rv->Assign(2, val_mgr->EmptyString());
 			data += sizeof(uint8_t);
 			len -= sizeof(uint8_t);
 			}

--- a/src/IP.cc
+++ b/src/IP.cc
@@ -394,8 +394,8 @@ RecordVal* IP_Hdr::BuildPktHdrVal(RecordVal* pkt_hdr, int sindex) const
 		int tcp_hdr_len = tp->th_off * 4;
 		int data_len = PayloadLen() - tcp_hdr_len;
 
-		tcp_hdr->Assign(0, val_mgr->GetPort(ntohs(tp->th_sport), TRANSPORT_TCP));
-		tcp_hdr->Assign(1, val_mgr->GetPort(ntohs(tp->th_dport), TRANSPORT_TCP));
+		tcp_hdr->Assign(0, val_mgr->Port(ntohs(tp->th_sport), TRANSPORT_TCP));
+		tcp_hdr->Assign(1, val_mgr->Port(ntohs(tp->th_dport), TRANSPORT_TCP));
 		tcp_hdr->Assign(2, val_mgr->Count(uint32_t(ntohl(tp->th_seq))));
 		tcp_hdr->Assign(3, val_mgr->Count(uint32_t(ntohl(tp->th_ack))));
 		tcp_hdr->Assign(4, val_mgr->Count(tcp_hdr_len));
@@ -413,8 +413,8 @@ RecordVal* IP_Hdr::BuildPktHdrVal(RecordVal* pkt_hdr, int sindex) const
 		const struct udphdr* up = (const struct udphdr*) data;
 		RecordVal* udp_hdr = new RecordVal(udp_hdr_type);
 
-		udp_hdr->Assign(0, val_mgr->GetPort(ntohs(up->uh_sport), TRANSPORT_UDP));
-		udp_hdr->Assign(1, val_mgr->GetPort(ntohs(up->uh_dport), TRANSPORT_UDP));
+		udp_hdr->Assign(0, val_mgr->Port(ntohs(up->uh_sport), TRANSPORT_UDP));
+		udp_hdr->Assign(1, val_mgr->Port(ntohs(up->uh_dport), TRANSPORT_UDP));
 		udp_hdr->Assign(2, val_mgr->Count(ntohs(up->uh_ulen)));
 
 		pkt_hdr->Assign(sindex + 3, udp_hdr);

--- a/src/IP.cc
+++ b/src/IP.cc
@@ -144,7 +144,7 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		rv->Assign(1, val_mgr->GetCount(frag->ip6f_reserved));
 		rv->Assign(2, val_mgr->GetCount((ntohs(frag->ip6f_offlg) & 0xfff8)>>3));
 		rv->Assign(3, val_mgr->GetCount((ntohs(frag->ip6f_offlg) & 0x0006)>>1));
-		rv->Assign(4, val_mgr->GetBool(ntohs(frag->ip6f_offlg) & 0x0001));
+		rv->Assign(4, val_mgr->Bool(ntohs(frag->ip6f_offlg) & 0x0001));
 		rv->Assign(5, val_mgr->GetCount(ntohl(frag->ip6f_ident)));
 		}
 		break;
@@ -255,10 +255,10 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_bu"));
 			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
-			m->Assign(1, val_mgr->GetBool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x8000));
-			m->Assign(2, val_mgr->GetBool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x4000));
-			m->Assign(3, val_mgr->GetBool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x2000));
-			m->Assign(4, val_mgr->GetBool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x1000));
+			m->Assign(1, val_mgr->Bool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x8000));
+			m->Assign(2, val_mgr->Bool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x4000));
+			m->Assign(3, val_mgr->Bool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x2000));
+			m->Assign(4, val_mgr->Bool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x1000));
 			m->Assign(5, val_mgr->GetCount(ntohs(*((uint16_t*)(msg_data + 2*sizeof(uint16_t))))));
 			off += 3 * sizeof(uint16_t);
 			m->Assign(6, BuildOptionsVal(data + off, Length() - off));
@@ -270,7 +270,7 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_back"));
 			m->Assign(0, val_mgr->GetCount(*((uint8_t*)msg_data)));
-			m->Assign(1, val_mgr->GetBool(*((uint8_t*)(msg_data + sizeof(uint8_t))) & 0x80));
+			m->Assign(1, val_mgr->Bool(*((uint8_t*)(msg_data + sizeof(uint8_t))) & 0x80));
 			m->Assign(2, val_mgr->GetCount(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t))))));
 			m->Assign(3, val_mgr->GetCount(ntohs(*((uint16_t*)(msg_data + 2*sizeof(uint16_t))))));
 			off += 3 * sizeof(uint16_t);

--- a/src/IP.cc
+++ b/src/IP.cc
@@ -50,12 +50,12 @@ static VectorVal* BuildOptionsVal(const u_char* data, int len)
 		{
 		const struct ip6_opt* opt = (const struct ip6_opt*) data;
 		RecordVal* rv = new RecordVal(hdrType(ip6_option_type, "ip6_option"));
-		rv->Assign(0, val_mgr->GetCount(opt->ip6o_type));
+		rv->Assign(0, val_mgr->Count(opt->ip6o_type));
 
 		if ( opt->ip6o_type == 0 )
 			{
 			// Pad1 option
-			rv->Assign(1, val_mgr->GetCount(0));
+			rv->Assign(1, val_mgr->Count(0));
 			rv->Assign(2, val_mgr->GetEmptyString());
 			data += sizeof(uint8_t);
 			len -= sizeof(uint8_t);
@@ -64,7 +64,7 @@ static VectorVal* BuildOptionsVal(const u_char* data, int len)
 			{
 			// PadN or other option
 			uint16_t off = 2 * sizeof(uint8_t);
-			rv->Assign(1, val_mgr->GetCount(opt->ip6o_len));
+			rv->Assign(1, val_mgr->Count(opt->ip6o_len));
 			rv->Assign(2, make_intrusive<StringVal>(
 			        new BroString(data + off, opt->ip6o_len, true)));
 			data += opt->ip6o_len + off;
@@ -86,11 +86,11 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		{
 		rv = new RecordVal(hdrType(ip6_hdr_type, "ip6_hdr"));
 		const struct ip6_hdr* ip6 = (const struct ip6_hdr*)data;
-		rv->Assign(0, val_mgr->GetCount((ntohl(ip6->ip6_flow) & 0x0ff00000)>>20));
-		rv->Assign(1, val_mgr->GetCount(ntohl(ip6->ip6_flow) & 0x000fffff));
-		rv->Assign(2, val_mgr->GetCount(ntohs(ip6->ip6_plen)));
-		rv->Assign(3, val_mgr->GetCount(ip6->ip6_nxt));
-		rv->Assign(4, val_mgr->GetCount(ip6->ip6_hlim));
+		rv->Assign(0, val_mgr->Count((ntohl(ip6->ip6_flow) & 0x0ff00000)>>20));
+		rv->Assign(1, val_mgr->Count(ntohl(ip6->ip6_flow) & 0x000fffff));
+		rv->Assign(2, val_mgr->Count(ntohs(ip6->ip6_plen)));
+		rv->Assign(3, val_mgr->Count(ip6->ip6_nxt));
+		rv->Assign(4, val_mgr->Count(ip6->ip6_hlim));
 		rv->Assign(5, make_intrusive<AddrVal>(IPAddr(ip6->ip6_src)));
 		rv->Assign(6, make_intrusive<AddrVal>(IPAddr(ip6->ip6_dst)));
 		if ( ! chain )
@@ -104,8 +104,8 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		{
 		rv = new RecordVal(hdrType(ip6_hopopts_type, "ip6_hopopts"));
 		const struct ip6_hbh* hbh = (const struct ip6_hbh*)data;
-		rv->Assign(0, val_mgr->GetCount(hbh->ip6h_nxt));
-		rv->Assign(1, val_mgr->GetCount(hbh->ip6h_len));
+		rv->Assign(0, val_mgr->Count(hbh->ip6h_nxt));
+		rv->Assign(1, val_mgr->Count(hbh->ip6h_len));
 		uint16_t off = 2 * sizeof(uint8_t);
 		rv->Assign(2, BuildOptionsVal(data + off, Length() - off));
 
@@ -116,8 +116,8 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		{
 		rv = new RecordVal(hdrType(ip6_dstopts_type, "ip6_dstopts"));
 		const struct ip6_dest* dst = (const struct ip6_dest*)data;
-		rv->Assign(0, val_mgr->GetCount(dst->ip6d_nxt));
-		rv->Assign(1, val_mgr->GetCount(dst->ip6d_len));
+		rv->Assign(0, val_mgr->Count(dst->ip6d_nxt));
+		rv->Assign(1, val_mgr->Count(dst->ip6d_len));
 		uint16_t off = 2 * sizeof(uint8_t);
 		rv->Assign(2, BuildOptionsVal(data + off, Length() - off));
 		}
@@ -127,10 +127,10 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		{
 		rv = new RecordVal(hdrType(ip6_routing_type, "ip6_routing"));
 		const struct ip6_rthdr* rt = (const struct ip6_rthdr*)data;
-		rv->Assign(0, val_mgr->GetCount(rt->ip6r_nxt));
-		rv->Assign(1, val_mgr->GetCount(rt->ip6r_len));
-		rv->Assign(2, val_mgr->GetCount(rt->ip6r_type));
-		rv->Assign(3, val_mgr->GetCount(rt->ip6r_segleft));
+		rv->Assign(0, val_mgr->Count(rt->ip6r_nxt));
+		rv->Assign(1, val_mgr->Count(rt->ip6r_len));
+		rv->Assign(2, val_mgr->Count(rt->ip6r_type));
+		rv->Assign(3, val_mgr->Count(rt->ip6r_segleft));
 		uint16_t off = 4 * sizeof(uint8_t);
 		rv->Assign(4, make_intrusive<StringVal>(new BroString(data + off, Length() - off, true)));
 		}
@@ -140,28 +140,28 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		{
 		rv = new RecordVal(hdrType(ip6_fragment_type, "ip6_fragment"));
 		const struct ip6_frag* frag = (const struct ip6_frag*)data;
-		rv->Assign(0, val_mgr->GetCount(frag->ip6f_nxt));
-		rv->Assign(1, val_mgr->GetCount(frag->ip6f_reserved));
-		rv->Assign(2, val_mgr->GetCount((ntohs(frag->ip6f_offlg) & 0xfff8)>>3));
-		rv->Assign(3, val_mgr->GetCount((ntohs(frag->ip6f_offlg) & 0x0006)>>1));
+		rv->Assign(0, val_mgr->Count(frag->ip6f_nxt));
+		rv->Assign(1, val_mgr->Count(frag->ip6f_reserved));
+		rv->Assign(2, val_mgr->Count((ntohs(frag->ip6f_offlg) & 0xfff8)>>3));
+		rv->Assign(3, val_mgr->Count((ntohs(frag->ip6f_offlg) & 0x0006)>>1));
 		rv->Assign(4, val_mgr->Bool(ntohs(frag->ip6f_offlg) & 0x0001));
-		rv->Assign(5, val_mgr->GetCount(ntohl(frag->ip6f_ident)));
+		rv->Assign(5, val_mgr->Count(ntohl(frag->ip6f_ident)));
 		}
 		break;
 
 	case IPPROTO_AH:
 		{
 		rv = new RecordVal(hdrType(ip6_ah_type, "ip6_ah"));
-		rv->Assign(0, val_mgr->GetCount(((ip6_ext*)data)->ip6e_nxt));
-		rv->Assign(1, val_mgr->GetCount(((ip6_ext*)data)->ip6e_len));
-		rv->Assign(2, val_mgr->GetCount(ntohs(((uint16_t*)data)[1])));
-		rv->Assign(3, val_mgr->GetCount(ntohl(((uint32_t*)data)[1])));
+		rv->Assign(0, val_mgr->Count(((ip6_ext*)data)->ip6e_nxt));
+		rv->Assign(1, val_mgr->Count(((ip6_ext*)data)->ip6e_len));
+		rv->Assign(2, val_mgr->Count(ntohs(((uint16_t*)data)[1])));
+		rv->Assign(3, val_mgr->Count(ntohl(((uint32_t*)data)[1])));
 
 		if ( Length() >= 12 )
 			{
 			// Sequence Number and ICV fields can only be extracted if
 			// Payload Len was non-zero for this header.
-			rv->Assign(4, val_mgr->GetCount(ntohl(((uint32_t*)data)[2])));
+			rv->Assign(4, val_mgr->Count(ntohl(((uint32_t*)data)[2])));
 			uint16_t off = 3 * sizeof(uint32_t);
 			rv->Assign(5, make_intrusive<StringVal>(new BroString(data + off, Length() - off, true)));
 			}
@@ -172,8 +172,8 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		{
 		rv = new RecordVal(hdrType(ip6_esp_type, "ip6_esp"));
 		const uint32_t* esp = (const uint32_t*)data;
-		rv->Assign(0, val_mgr->GetCount(ntohl(esp[0])));
-		rv->Assign(1, val_mgr->GetCount(ntohl(esp[1])));
+		rv->Assign(0, val_mgr->Count(ntohl(esp[0])));
+		rv->Assign(1, val_mgr->Count(ntohl(esp[1])));
 		}
 		break;
 
@@ -182,14 +182,14 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		{
 		rv = new RecordVal(hdrType(ip6_mob_type, "ip6_mobility_hdr"));
 		const struct ip6_mobility* mob = (const struct ip6_mobility*) data;
-		rv->Assign(0, val_mgr->GetCount(mob->ip6mob_payload));
-		rv->Assign(1, val_mgr->GetCount(mob->ip6mob_len));
-		rv->Assign(2, val_mgr->GetCount(mob->ip6mob_type));
-		rv->Assign(3, val_mgr->GetCount(mob->ip6mob_rsv));
-		rv->Assign(4, val_mgr->GetCount(ntohs(mob->ip6mob_chksum)));
+		rv->Assign(0, val_mgr->Count(mob->ip6mob_payload));
+		rv->Assign(1, val_mgr->Count(mob->ip6mob_len));
+		rv->Assign(2, val_mgr->Count(mob->ip6mob_type));
+		rv->Assign(3, val_mgr->Count(mob->ip6mob_rsv));
+		rv->Assign(4, val_mgr->Count(ntohs(mob->ip6mob_chksum)));
 
 		RecordVal* msg = new RecordVal(hdrType(ip6_mob_msg_type, "ip6_mobility_msg"));
-		msg->Assign(0, val_mgr->GetCount(mob->ip6mob_type));
+		msg->Assign(0, val_mgr->Count(mob->ip6mob_type));
 
 		uint16_t off = sizeof(ip6_mobility);
 		const u_char* msg_data = data + off;
@@ -198,7 +198,7 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 0:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_brr"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(0, val_mgr->Count(ntohs(*((uint16_t*)msg_data))));
 			off += sizeof(uint16_t);
 			m->Assign(1, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(1, m);
@@ -208,8 +208,8 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 1:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_hoti"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
-			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
+			m->Assign(0, val_mgr->Count(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(1, val_mgr->Count(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
 			off += sizeof(uint16_t) + sizeof(uint64_t);
 			m->Assign(2, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(2, m);
@@ -219,8 +219,8 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 2:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_coti"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
-			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
+			m->Assign(0, val_mgr->Count(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(1, val_mgr->Count(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
 			off += sizeof(uint16_t) + sizeof(uint64_t);
 			m->Assign(2, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(3, m);
@@ -230,9 +230,9 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 3:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_hot"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
-			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
-			m->Assign(2, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t) + sizeof(uint64_t))))));
+			m->Assign(0, val_mgr->Count(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(1, val_mgr->Count(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
+			m->Assign(2, val_mgr->Count(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t) + sizeof(uint64_t))))));
 			off += sizeof(uint16_t) + 2 * sizeof(uint64_t);
 			m->Assign(3, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(4, m);
@@ -242,9 +242,9 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 4:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_cot"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
-			m->Assign(1, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
-			m->Assign(2, val_mgr->GetCount(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t) + sizeof(uint64_t))))));
+			m->Assign(0, val_mgr->Count(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(1, val_mgr->Count(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t))))));
+			m->Assign(2, val_mgr->Count(ntohll(*((uint64_t*)(msg_data + sizeof(uint16_t) + sizeof(uint64_t))))));
 			off += sizeof(uint16_t) + 2 * sizeof(uint64_t);
 			m->Assign(3, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(5, m);
@@ -254,12 +254,12 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 5:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_bu"));
-			m->Assign(0, val_mgr->GetCount(ntohs(*((uint16_t*)msg_data))));
+			m->Assign(0, val_mgr->Count(ntohs(*((uint16_t*)msg_data))));
 			m->Assign(1, val_mgr->Bool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x8000));
 			m->Assign(2, val_mgr->Bool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x4000));
 			m->Assign(3, val_mgr->Bool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x2000));
 			m->Assign(4, val_mgr->Bool(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t)))) & 0x1000));
-			m->Assign(5, val_mgr->GetCount(ntohs(*((uint16_t*)(msg_data + 2*sizeof(uint16_t))))));
+			m->Assign(5, val_mgr->Count(ntohs(*((uint16_t*)(msg_data + 2*sizeof(uint16_t))))));
 			off += 3 * sizeof(uint16_t);
 			m->Assign(6, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(6, m);
@@ -269,10 +269,10 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 6:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_back"));
-			m->Assign(0, val_mgr->GetCount(*((uint8_t*)msg_data)));
+			m->Assign(0, val_mgr->Count(*((uint8_t*)msg_data)));
 			m->Assign(1, val_mgr->Bool(*((uint8_t*)(msg_data + sizeof(uint8_t))) & 0x80));
-			m->Assign(2, val_mgr->GetCount(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t))))));
-			m->Assign(3, val_mgr->GetCount(ntohs(*((uint16_t*)(msg_data + 2*sizeof(uint16_t))))));
+			m->Assign(2, val_mgr->Count(ntohs(*((uint16_t*)(msg_data + sizeof(uint16_t))))));
+			m->Assign(3, val_mgr->Count(ntohs(*((uint16_t*)(msg_data + 2*sizeof(uint16_t))))));
 			off += 3 * sizeof(uint16_t);
 			m->Assign(4, BuildOptionsVal(data + off, Length() - off));
 			msg->Assign(7, m);
@@ -282,7 +282,7 @@ RecordVal* IPv6_Hdr::BuildRecordVal(VectorVal* chain) const
 		case 7:
 			{
 			RecordVal* m = new RecordVal(hdrType(ip6_mob_brr_type, "ip6_mobility_be"));
-			m->Assign(0, val_mgr->GetCount(*((uint8_t*)msg_data)));
+			m->Assign(0, val_mgr->Count(*((uint8_t*)msg_data)));
 			const in6_addr* hoa = (const in6_addr*)(msg_data + sizeof(uint16_t));
 			m->Assign(1, make_intrusive<AddrVal>(IPAddr(*hoa)));
 			off += sizeof(uint16_t) + sizeof(in6_addr);
@@ -335,12 +335,12 @@ RecordVal* IP_Hdr::BuildIPHdrVal() const
 	if ( ip4 )
 		{
 		rval = new RecordVal(hdrType(ip4_hdr_type, "ip4_hdr"));
-		rval->Assign(0, val_mgr->GetCount(ip4->ip_hl * 4));
-		rval->Assign(1, val_mgr->GetCount(ip4->ip_tos));
-		rval->Assign(2, val_mgr->GetCount(ntohs(ip4->ip_len)));
-		rval->Assign(3, val_mgr->GetCount(ntohs(ip4->ip_id)));
-		rval->Assign(4, val_mgr->GetCount(ip4->ip_ttl));
-		rval->Assign(5, val_mgr->GetCount(ip4->ip_p));
+		rval->Assign(0, val_mgr->Count(ip4->ip_hl * 4));
+		rval->Assign(1, val_mgr->Count(ip4->ip_tos));
+		rval->Assign(2, val_mgr->Count(ntohs(ip4->ip_len)));
+		rval->Assign(3, val_mgr->Count(ntohs(ip4->ip_id)));
+		rval->Assign(4, val_mgr->Count(ip4->ip_ttl));
+		rval->Assign(5, val_mgr->Count(ip4->ip_p));
 		rval->Assign(6, make_intrusive<AddrVal>(ip4->ip_src.s_addr));
 		rval->Assign(7, make_intrusive<AddrVal>(ip4->ip_dst.s_addr));
 		}
@@ -396,13 +396,13 @@ RecordVal* IP_Hdr::BuildPktHdrVal(RecordVal* pkt_hdr, int sindex) const
 
 		tcp_hdr->Assign(0, val_mgr->GetPort(ntohs(tp->th_sport), TRANSPORT_TCP));
 		tcp_hdr->Assign(1, val_mgr->GetPort(ntohs(tp->th_dport), TRANSPORT_TCP));
-		tcp_hdr->Assign(2, val_mgr->GetCount(uint32_t(ntohl(tp->th_seq))));
-		tcp_hdr->Assign(3, val_mgr->GetCount(uint32_t(ntohl(tp->th_ack))));
-		tcp_hdr->Assign(4, val_mgr->GetCount(tcp_hdr_len));
-		tcp_hdr->Assign(5, val_mgr->GetCount(data_len));
-		tcp_hdr->Assign(6, val_mgr->GetCount(tp->th_x2));
-		tcp_hdr->Assign(7, val_mgr->GetCount(tp->th_flags));
-		tcp_hdr->Assign(8, val_mgr->GetCount(ntohs(tp->th_win)));
+		tcp_hdr->Assign(2, val_mgr->Count(uint32_t(ntohl(tp->th_seq))));
+		tcp_hdr->Assign(3, val_mgr->Count(uint32_t(ntohl(tp->th_ack))));
+		tcp_hdr->Assign(4, val_mgr->Count(tcp_hdr_len));
+		tcp_hdr->Assign(5, val_mgr->Count(data_len));
+		tcp_hdr->Assign(6, val_mgr->Count(tp->th_x2));
+		tcp_hdr->Assign(7, val_mgr->Count(tp->th_flags));
+		tcp_hdr->Assign(8, val_mgr->Count(ntohs(tp->th_win)));
 
 		pkt_hdr->Assign(sindex + 2, tcp_hdr);
 		break;
@@ -415,7 +415,7 @@ RecordVal* IP_Hdr::BuildPktHdrVal(RecordVal* pkt_hdr, int sindex) const
 
 		udp_hdr->Assign(0, val_mgr->GetPort(ntohs(up->uh_sport), TRANSPORT_UDP));
 		udp_hdr->Assign(1, val_mgr->GetPort(ntohs(up->uh_dport), TRANSPORT_UDP));
-		udp_hdr->Assign(2, val_mgr->GetCount(ntohs(up->uh_ulen)));
+		udp_hdr->Assign(2, val_mgr->Count(ntohs(up->uh_ulen)));
 
 		pkt_hdr->Assign(sindex + 3, udp_hdr);
 		break;
@@ -426,7 +426,7 @@ RecordVal* IP_Hdr::BuildPktHdrVal(RecordVal* pkt_hdr, int sindex) const
 		const struct icmp* icmpp = (const struct icmp *) data;
 		RecordVal* icmp_hdr = new RecordVal(icmp_hdr_type);
 
-		icmp_hdr->Assign(0, val_mgr->GetCount(icmpp->icmp_type));
+		icmp_hdr->Assign(0, val_mgr->Count(icmpp->icmp_type));
 
 		pkt_hdr->Assign(sindex + 4, icmp_hdr);
 		break;
@@ -437,7 +437,7 @@ RecordVal* IP_Hdr::BuildPktHdrVal(RecordVal* pkt_hdr, int sindex) const
 		const struct icmp6_hdr* icmpp = (const struct icmp6_hdr*) data;
 		RecordVal* icmp_hdr = new RecordVal(icmp_hdr_type);
 
-		icmp_hdr->Assign(0, val_mgr->GetCount(icmpp->icmp6_type));
+		icmp_hdr->Assign(0, val_mgr->Count(icmpp->icmp6_type));
 
 		pkt_hdr->Assign(sindex + 4, icmp_hdr);
 		break;
@@ -696,7 +696,7 @@ VectorVal* IPv6_Hdr_Chain::BuildVal() const
 		RecordVal* v = chain[i]->BuildRecordVal();
 		RecordVal* ext_hdr = new RecordVal(ip6_ext_hdr_type);
 		uint8_t type = chain[i]->Type();
-		ext_hdr->Assign(0, val_mgr->GetCount(type));
+		ext_hdr->Assign(0, val_mgr->Count(type));
 
 		switch (type) {
 		case IPPROTO_HOPOPTS:

--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -171,8 +171,7 @@ bool HashVal::Init()
 IntrusivePtr<StringVal> HashVal::Get()
 	{
 	if ( ! valid )
-		return IntrusivePtr<StringVal>(AdoptRef{},
-					       val_mgr->GetEmptyString());
+		return val_mgr->EmptyString();
 
 	auto result = DoGet();
 	valid = false;
@@ -203,7 +202,7 @@ bool HashVal::DoFeed(const void*, size_t)
 IntrusivePtr<StringVal> HashVal::DoGet()
 	{
 	assert(! "missing implementation of DoGet()");
-	return IntrusivePtr<StringVal>(AdoptRef{}, val_mgr->GetEmptyString());
+	return val_mgr->EmptyString();
 	}
 
 HashVal::HashVal(OpaqueType* t) : OpaqueVal(t)
@@ -275,7 +274,7 @@ bool MD5Val::DoFeed(const void* data, size_t size)
 IntrusivePtr<StringVal> MD5Val::DoGet()
 	{
 	if ( ! IsValid() )
-		return IntrusivePtr<StringVal>(AdoptRef{}, val_mgr->GetEmptyString());
+		return val_mgr->EmptyString();
 
 	u_char digest[MD5_DIGEST_LENGTH];
 	hash_final(ctx, digest);
@@ -395,8 +394,7 @@ bool SHA1Val::DoFeed(const void* data, size_t size)
 IntrusivePtr<StringVal> SHA1Val::DoGet()
 	{
 	if ( ! IsValid() )
-		return IntrusivePtr<StringVal>(AdoptRef{},
-		                               val_mgr->GetEmptyString());
+		return val_mgr->EmptyString();
 
 	u_char digest[SHA_DIGEST_LENGTH];
 	hash_final(ctx, digest);
@@ -519,8 +517,7 @@ bool SHA256Val::DoFeed(const void* data, size_t size)
 IntrusivePtr<StringVal> SHA256Val::DoGet()
 	{
 	if ( ! IsValid() )
-		return IntrusivePtr<StringVal>(AdoptRef{},
-		                               val_mgr->GetEmptyString());
+		return val_mgr->EmptyString();
 
 	u_char digest[SHA256_DIGEST_LENGTH];
 	hash_final(ctx, digest);

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -355,7 +355,7 @@ void Reporter::Weird(Connection* conn, const char* name, const char* addl)
 			return;
 		}
 
-	WeirdHelper(conn_weird, {conn->BuildConnVal(), new StringVal(addl)},
+	WeirdHelper(conn_weird, {conn->ConnVal()->Ref(), new StringVal(addl)},
 	            "%s", name);
 	}
 
@@ -492,7 +492,7 @@ void Reporter::DoLog(const char* prefix, EventHandlerPtr event, FILE* out,
 			vl.emplace_back(make_intrusive<StringVal>(loc_str.c_str()));
 
 		if ( conn )
-			vl.emplace_back(AdoptRef{}, conn->BuildConnVal());
+			vl.emplace_back(conn->ConnVal());
 
 		if ( addl )
 			for ( auto v : *addl )

--- a/src/RuleAction.cc
+++ b/src/RuleAction.cc
@@ -24,7 +24,7 @@ void RuleActionEvent::DoAction(const Rule* parent, RuleEndpointState* state,
 		mgr.Enqueue(signature_match,
 			IntrusivePtr{AdoptRef{}, rule_matcher->BuildRuleStateValue(parent, state)},
 			make_intrusive<StringVal>(msg),
-			data ? make_intrusive<StringVal>(len, (const char*)data) : IntrusivePtr{AdoptRef{}, val_mgr->GetEmptyString()}
+			data ? make_intrusive<StringVal>(len, (const char*)data) : val_mgr->EmptyString()
 		);
 	}
 

--- a/src/RuleCondition.cc
+++ b/src/RuleCondition.cc
@@ -174,7 +174,7 @@ bool RuleConditionEval::DoMatch(Rule* rule, RuleEndpointState* state,
 	if ( data )
 		args.emplace_back(make_intrusive<StringVal>(len, (const char*) data));
 	else
-		args.emplace_back(AdoptRef{}, val_mgr->GetEmptyString());
+		args.emplace_back(val_mgr->EmptyString());
 
 	bool result = false;
 

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -82,7 +82,7 @@ Val* RuleMatcher::BuildRuleStateValue(const Rule* rule,
 	RecordVal* val = new RecordVal(signature_state);
 	val->Assign(0, make_intrusive<StringVal>(rule->ID()));
 	val->Assign(1, state->GetAnalyzer()->BuildConnVal());
-	val->Assign(2, val_mgr->GetBool(state->is_orig));
+	val->Assign(2, val_mgr->Bool(state->is_orig));
 	val->Assign(3, val_mgr->GetCount(state->payload_size));
 	return val;
 	}

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -83,7 +83,7 @@ Val* RuleMatcher::BuildRuleStateValue(const Rule* rule,
 	val->Assign(0, make_intrusive<StringVal>(rule->ID()));
 	val->Assign(1, state->GetAnalyzer()->BuildConnVal());
 	val->Assign(2, val_mgr->Bool(state->is_orig));
-	val->Assign(3, val_mgr->GetCount(state->payload_size));
+	val->Assign(3, val_mgr->Count(state->payload_size));
 	return val;
 	}
 

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -81,7 +81,7 @@ Val* RuleMatcher::BuildRuleStateValue(const Rule* rule,
 	{
 	RecordVal* val = new RecordVal(signature_state);
 	val->Assign(0, make_intrusive<StringVal>(rule->ID()));
-	val->Assign(1, state->GetAnalyzer()->BuildConnVal());
+	val->Assign(1, state->GetAnalyzer()->ConnVal());
 	val->Assign(2, val_mgr->Bool(state->is_orig));
 	val->Assign(3, val_mgr->Count(state->payload_size));
 	return val;

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -691,12 +691,14 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 	if ( ipv6_ext_headers && ip_hdr->NumHeaders() > 1 )
 		{
 		pkt_hdr_val = ip_hdr->BuildPktHdrVal();
-		conn->Event(ipv6_ext_headers, nullptr, pkt_hdr_val);
+		conn->EnqueueEvent(ipv6_ext_headers, nullptr, conn->ConnVal(),
+		                   IntrusivePtr{AdoptRef{}, pkt_hdr_val});
 		}
 
 	if ( new_packet )
-		conn->Event(new_packet, nullptr,
-		        pkt_hdr_val ? pkt_hdr_val->Ref() : ip_hdr->BuildPktHdrVal());
+		conn->EnqueueEvent(new_packet, nullptr, conn->ConnVal(), pkt_hdr_val ?
+		                   IntrusivePtr{NewRef{}, pkt_hdr_val} :
+		                   IntrusivePtr{AdoptRef{}, ip_hdr->BuildPktHdrVal()});
 
 	conn->NextPacket(t, is_orig, ip_hdr, len, caplen, data,
 				record_packet, record_content, pkt);

--- a/src/SmithWaterman.cc
+++ b/src/SmithWaterman.cc
@@ -95,7 +95,7 @@ VectorVal* BroSubstring::VecToPolicy(Vec* vec)
 
 				auto align_val = make_intrusive<RecordVal>(sw_align_type);
 				align_val->Assign(0, make_intrusive<StringVal>(new BroString(*align.string)));
-				align_val->Assign(1, val_mgr->GetCount(align.index));
+				align_val->Assign(1, val_mgr->Count(align.index));
 
 				aligns->Assign(j + 1, std::move(align_val));
 				}

--- a/src/SmithWaterman.cc
+++ b/src/SmithWaterman.cc
@@ -101,7 +101,7 @@ VectorVal* BroSubstring::VecToPolicy(Vec* vec)
 				}
 
 			st_val->Assign(1, std::move(aligns));
-			st_val->Assign(2, val_mgr->GetBool(bst->IsNewAlignment()));
+			st_val->Assign(2, val_mgr->Bool(bst->IsNewAlignment()));
 			result->Assign(i + 1, std::move(st_val));
 			}
 		}

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -314,7 +314,7 @@ void ProfileLogger::Log()
 		Ref(file);
 		mgr.Dispatch(new Event(profiling_update, {
 			make_intrusive<Val>(file),
-			{AdoptRef{}, val_mgr->GetBool(expensive)},
+			val_mgr->Bool(expensive),
 		}));
 		}
 	}

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -374,7 +374,7 @@ void SampleLogger::SegmentProfile(const char* /* name */,
 		mgr.Enqueue(load_sample,
 			IntrusivePtr{NewRef{}, load_samples},
 			make_intrusive<IntervalVal>(dtime, Seconds),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetInt(dmem)}
+			val_mgr->Int(dmem)
 		);
 	}
 

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -1232,8 +1232,7 @@ IntrusivePtr<Val> ForStmt::DoExec(Frame* f, Val* v, stmt_flow_type& flow) const
 
 			// Set the loop variable to the current index, and make
 			// another pass over the loop body.
-			f->SetElement((*loop_vars)[0],
-					val_mgr->GetCount(i));
+			f->SetElement((*loop_vars)[0], val_mgr->Count(i).release());
 			flow = FLOW_NEXT;
 			ret = body->Exec(f, flow);
 

--- a/src/TunnelEncapsulation.cc
+++ b/src/TunnelEncapsulation.cc
@@ -22,9 +22,9 @@ RecordVal* EncapsulatingConn::GetRecordVal() const
 
 	auto id_val = make_intrusive<RecordVal>(conn_id);
 	id_val->Assign(0, make_intrusive<AddrVal>(src_addr));
-	id_val->Assign(1, val_mgr->GetPort(ntohs(src_port), proto));
+	id_val->Assign(1, val_mgr->Port(ntohs(src_port), proto));
 	id_val->Assign(2, make_intrusive<AddrVal>(dst_addr));
-	id_val->Assign(3, val_mgr->GetPort(ntohs(dst_port), proto));
+	id_val->Assign(3, val_mgr->Port(ntohs(dst_port), proto));
 	rv->Assign(0, std::move(id_val));
 	rv->Assign(1, BifType::Enum::Tunnel::Type->GetVal(type));
 

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -840,7 +840,7 @@ IntrusivePtr<TableVal> RecordType::GetRecordFieldsVal(const RecordVal* rv) const
 
 		string s = container_type_name(ft);
 		nr->Assign(0, make_intrusive<StringVal>(s));
-		nr->Assign(1, val_mgr->GetBool(logged));
+		nr->Assign(1, val_mgr->Bool(logged));
 		nr->Assign(2, fv);
 		nr->Assign(3, FieldDefault(i));
 		Val* field_name = new StringVal(FieldName(i));

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -250,19 +250,19 @@ IntrusivePtr<Val> Val::SizeVal() const
 		// Return abs value. However abs() only works on ints and llabs
 		// doesn't work on Mac OS X 10.5. So we do it by hand
 		if ( val.int_val < 0 )
-			return {AdoptRef{}, val_mgr->GetCount(-val.int_val)};
+			return val_mgr->Count(-val.int_val);
 		else
-			return {AdoptRef{}, val_mgr->GetCount(val.int_val)};
+			return val_mgr->Count(val.int_val);
 
 	case TYPE_INTERNAL_UNSIGNED:
-		return {AdoptRef{}, val_mgr->GetCount(val.uint_val)};
+		return val_mgr->Count(val.uint_val);
 
 	case TYPE_INTERNAL_DOUBLE:
 		return make_intrusive<Val>(fabs(val.double_val), TYPE_DOUBLE);
 
 	case TYPE_INTERNAL_OTHER:
 		if ( type->Tag() == TYPE_FUNC )
-			return {AdoptRef{}, val_mgr->GetCount(val.func_val->FType()->ArgTypes()->Types()->length())};
+			return val_mgr->Count(val.func_val->FType()->ArgTypes()->Types()->length());
 
 		if ( type->Tag() == TYPE_FILE )
 			return make_intrusive<Val>(val.file_val->Size(), TYPE_DOUBLE);
@@ -272,7 +272,7 @@ IntrusivePtr<Val> Val::SizeVal() const
 		break;
 	}
 
-	return {AdoptRef{}, val_mgr->GetCount(0)};
+	return val_mgr->Count(0);
 	}
 
 unsigned int Val::MemoryAllocation() const
@@ -851,9 +851,9 @@ unsigned int AddrVal::MemoryAllocation() const
 IntrusivePtr<Val> AddrVal::SizeVal() const
 	{
 	if ( val.addr_val->GetFamily() == IPv4 )
-		return {AdoptRef{}, val_mgr->GetCount(32)};
+		return val_mgr->Count(32);
 	else
-		return {AdoptRef{}, val_mgr->GetCount(128)};
+		return val_mgr->Count(128);
 	}
 
 IntrusivePtr<Val> AddrVal::DoClone(CloneState* state)
@@ -979,7 +979,7 @@ StringVal::StringVal(const string& s) : StringVal(s.length(), s.data())
 
 IntrusivePtr<Val> StringVal::SizeVal() const
 	{
-	return {AdoptRef{}, val_mgr->GetCount(val.string_val->Len())};
+	return val_mgr->Count(val.string_val->Len());
 	}
 
 int StringVal::Len()
@@ -1193,7 +1193,7 @@ ListVal::~ListVal()
 
 IntrusivePtr<Val> ListVal::SizeVal() const
 	{
-	return {AdoptRef{}, val_mgr->GetCount(vals.length())};
+	return val_mgr->Count(vals.length());
 	}
 
 RE_Matcher* ListVal::BuildRE() const
@@ -1564,7 +1564,7 @@ bool TableVal::Assign(Val* index, HashKey* k, Val* new_val)
 
 IntrusivePtr<Val> TableVal::SizeVal() const
 	{
-	return {AdoptRef{}, val_mgr->GetCount(Size())};
+	return val_mgr->Count(Size());
 	}
 
 bool TableVal::AddTo(Val* val, bool is_first_init) const
@@ -2683,7 +2683,7 @@ RecordVal::~RecordVal()
 
 IntrusivePtr<Val> RecordVal::SizeVal() const
 	{
-	return {AdoptRef{}, val_mgr->GetCount(Type()->AsRecordType()->NumFields())};
+	return val_mgr->Count(Type()->AsRecordType()->NumFields());
 	}
 
 void RecordVal::Assign(int field, IntrusivePtr<Val> new_val)
@@ -2968,7 +2968,7 @@ VectorVal::~VectorVal()
 
 IntrusivePtr<Val> VectorVal::SizeVal() const
 	{
-	return {AdoptRef{}, val_mgr->GetCount(uint32_t(val.vector_val->size()))};
+	return val_mgr->Count(uint32_t(val.vector_val->size()));
 	}
 
 bool VectorVal::Assign(unsigned int index, IntrusivePtr<Val> element)
@@ -3221,7 +3221,7 @@ IntrusivePtr<Val> check_and_promote(IntrusivePtr<Val> v, const BroType* t,
 			return nullptr;
 			}
 		else if ( t_tag == TYPE_COUNT || t_tag == TYPE_COUNTER )
-			promoted_v = {AdoptRef{}, val_mgr->GetCount(v->CoerceToUnsigned())};
+			promoted_v = val_mgr->Count(v->CoerceToUnsigned());
 		else // port
 			{
 			reporter->InternalError("bad internal type in check_and_promote()");

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -732,7 +732,7 @@ void IntervalVal::ValDescribe(ODesc* d) const
 
 IntrusivePtr<Val> PortVal::SizeVal() const
 	{
-	return {AdoptRef{}, val_mgr->GetInt(val.uint_val)};
+	return val_mgr->Int(val.uint_val);
 	}
 
 uint32_t PortVal::Mask(uint32_t port_num, TransportProto port_type)
@@ -2931,7 +2931,7 @@ unsigned int RecordVal::MemoryAllocation() const
 
 IntrusivePtr<Val> EnumVal::SizeVal() const
 	{
-	return {AdoptRef{}, val_mgr->GetInt(val.int_val)};
+	return val_mgr->Int(val.int_val);
 	}
 
 void EnumVal::ValDescribe(ODesc* d) const
@@ -3205,7 +3205,7 @@ IntrusivePtr<Val> check_and_promote(IntrusivePtr<Val> v, const BroType* t,
 			return nullptr;
 			}
 		else if ( t_tag == TYPE_INT )
-			promoted_v = {AdoptRef{}, val_mgr->GetInt(v->CoerceToInt())};
+			promoted_v = val_mgr->Int(v->CoerceToInt());
 		else // enum
 			{
 			reporter->InternalError("bad internal type in check_and_promote()");

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -583,9 +583,8 @@ static void BuildJSON(threading::formatter::JSON::NullDoubleWriter& writer, Val*
 						{
 						auto blank = make_intrusive<StringVal>("");
 						auto fn_val = make_intrusive<StringVal>(field_name);
-						auto key_val = fn_val->Substitute(re, blank.get(), false)->AsStringVal();
+						auto key_val = fn_val->Substitute(re, blank.get(), false);
 						key_str = key_val->ToStdString();
-						Unref(key_val);
 						}
 					else
 						key_str = field_name;
@@ -1024,7 +1023,7 @@ unsigned int StringVal::MemoryAllocation() const
 	return padded_sizeof(*this) + val.string_val->MemoryAllocation();
 	}
 
-Val* StringVal::Substitute(RE_Matcher* re, StringVal* repl, bool do_all)
+IntrusivePtr<StringVal> StringVal::Substitute(RE_Matcher* re, StringVal* repl, bool do_all)
 	{
 	const u_char* s = Bytes();
 	int offset = 0;
@@ -1105,7 +1104,7 @@ Val* StringVal::Substitute(RE_Matcher* re, StringVal* repl, bool do_all)
 	// the NUL.
 	r[0] = '\0';
 
-	return new StringVal(new BroString(true, result, r - result));
+	return make_intrusive<StringVal>(new BroString(true, result, r - result));
 	}
 
 IntrusivePtr<Val> StringVal::DoClone(CloneState* state)

--- a/src/Val.h
+++ b/src/Val.h
@@ -593,7 +593,7 @@ public:
 
 	unsigned int MemoryAllocation() const override;
 
-	Val* Substitute(RE_Matcher* re, StringVal* repl, bool do_all);
+	IntrusivePtr<StringVal> Substitute(RE_Matcher* re, StringVal* repl, bool do_all);
 
 protected:
 	void ValDescribe(ODesc* d) const override;

--- a/src/Val.h
+++ b/src/Val.h
@@ -335,20 +335,9 @@ protected:
 	virtual void ValDescribe(ODesc* d) const;
 	virtual void ValDescribeReST(ODesc* d) const;
 
-	static Val* MakeBool(bool b)
-		{
-		return new Val(bro_int_t(b), TYPE_BOOL);
-		}
-
-	static Val* MakeInt(bro_int_t i)
-		{
-		return new Val(i, TYPE_INT);
-		}
-
-	static Val* MakeCount(bro_uint_t u)
-		{
-		return new Val(u, TYPE_COUNT);
-		}
+	static IntrusivePtr<Val> MakeBool(bool b);
+	static IntrusivePtr<Val> MakeInt(bro_int_t i);
+	static IntrusivePtr<Val> MakeCount(bro_uint_t u);
 
 	template<typename V>
 	Val(V &&v, TypeTag t) noexcept
@@ -406,44 +395,79 @@ public:
 
 	ValManager();
 
-	~ValManager();
-
+	[[deprecated("Remove in v4.1.  Use val_mgr->True() instead.")]]
 	inline Val* GetTrue() const
 		{ return b_true->Ref(); }
 
+	inline const IntrusivePtr<Val>& True() const
+		{ return b_true; }
+
+	[[deprecated("Remove in v4.1.  Use val_mgr->False() instead.")]]
 	inline Val* GetFalse() const
 		{ return b_false->Ref(); }
 
+	inline const IntrusivePtr<Val>& False() const
+		{ return b_false; }
+
+	[[deprecated("Remove in v4.1.  Use val_mgr->Bool() instead.")]]
 	inline Val* GetBool(bool b) const
 		{ return b ? b_true->Ref() : b_false->Ref(); }
 
+	inline const IntrusivePtr<Val>& Bool(bool b) const
+		{ return b ? b_true : b_false; }
+
+	[[deprecated("Remove in v4.1.  Use val_mgr->Int() instead.")]]
 	inline Val* GetInt(int64_t i) const
 		{
 		return i < PREALLOCATED_INT_LOWEST || i > PREALLOCATED_INT_HIGHEST ?
-		    Val::MakeInt(i) : ints[i - PREALLOCATED_INT_LOWEST]->Ref();
+		    Val::MakeInt(i).release() : ints[i - PREALLOCATED_INT_LOWEST]->Ref();
 		}
 
+	inline IntrusivePtr<Val> Int(int64_t i) const
+		{
+		return i < PREALLOCATED_INT_LOWEST || i > PREALLOCATED_INT_HIGHEST ?
+		    Val::MakeInt(i) : ints[i - PREALLOCATED_INT_LOWEST];
+		}
+
+	[[deprecated("Remove in v4.1.  Use val_mgr->Count() instead.")]]
 	inline Val* GetCount(uint64_t i) const
 		{
-		return i >= PREALLOCATED_COUNTS ? Val::MakeCount(i) : counts[i]->Ref();
+		return i >= PREALLOCATED_COUNTS ? Val::MakeCount(i).release() : counts[i]->Ref();
 		}
 
+	inline IntrusivePtr<Val> Count(uint64_t i) const
+		{
+		return i >= PREALLOCATED_COUNTS ? Val::MakeCount(i) : counts[i];
+		}
+
+	[[deprecated("Remove in v4.1.  Use val_mgr->EmptyString() instead.")]]
 	StringVal* GetEmptyString() const;
 
+	inline const IntrusivePtr<StringVal>& EmptyString() const
+		{ return empty_string; }
+
 	// Port number given in host order.
+	[[deprecated("Remove in v4.1.  Use val_mgr->Port() instead.")]]
 	PortVal* GetPort(uint32_t port_num, TransportProto port_type) const;
 
+	// Port number given in host order.
+	const IntrusivePtr<PortVal>& Port(uint32_t port_num, TransportProto port_type) const;
+
 	// Host-order port number already masked with port space protocol mask.
+	[[deprecated("Remove in v4.1.  Use val_mgr->Port() instead.")]]
 	PortVal* GetPort(uint32_t port_num) const;
+
+	// Host-order port number already masked with port space protocol mask.
+	const IntrusivePtr<PortVal>& Port(uint32_t port_num) const;
 
 private:
 
-	std::array<std::array<PortVal*, 65536>, NUM_PORT_SPACES> ports;
-	StringVal* empty_string;
-	Val* b_true;
-	Val* b_false;
-	Val** counts;
-	Val** ints;
+	std::array<std::array<IntrusivePtr<PortVal>, 65536>, NUM_PORT_SPACES> ports;
+	std::array<IntrusivePtr<Val>, PREALLOCATED_COUNTS> counts;
+	std::array<IntrusivePtr<Val>, PREALLOCATED_INTS> ints;
+	IntrusivePtr<StringVal> empty_string;
+	IntrusivePtr<Val> b_true;
+	IntrusivePtr<Val> b_false;
 };
 
 extern ValManager* val_mgr;

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -692,7 +692,7 @@ void Analyzer::ProtocolConfirmation(Tag arg_tag)
 	mgr.Enqueue(protocol_confirmation,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
 		IntrusivePtr{NewRef{}, tval},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(id)}
+		val_mgr->Count(id)
 	);
 	}
 
@@ -719,7 +719,7 @@ void Analyzer::ProtocolViolation(const char* reason, const char* data, int len)
 	mgr.Enqueue(protocol_violation,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
 		IntrusivePtr{NewRef{}, tval},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(id)},
+		val_mgr->Count(id),
 		IntrusivePtr{AdoptRef{}, r}
 	);
 	}

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -690,7 +690,7 @@ void Analyzer::ProtocolConfirmation(Tag arg_tag)
 	EnumVal* tval = arg_tag ? arg_tag.AsEnumVal() : tag.AsEnumVal();
 
 	mgr.Enqueue(protocol_confirmation,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		IntrusivePtr{NewRef{}, tval},
 		val_mgr->Count(id)
 	);
@@ -717,7 +717,7 @@ void Analyzer::ProtocolViolation(const char* reason, const char* data, int len)
 	EnumVal* tval = tag.AsEnumVal();
 
 	mgr.Enqueue(protocol_violation,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		IntrusivePtr{NewRef{}, tval},
 		val_mgr->Count(id),
 		IntrusivePtr{AdoptRef{}, r}
@@ -788,7 +788,12 @@ void Analyzer::UpdateConnVal(RecordVal *conn_val)
 
 RecordVal* Analyzer::BuildConnVal()
 	{
-	return conn->BuildConnVal();
+	return conn->ConnVal()->Ref()->AsRecordVal();
+	}
+
+const IntrusivePtr<RecordVal>& Analyzer::ConnVal()
+	{
+	return conn->ConnVal();
 	}
 
 void Analyzer::Event(EventHandlerPtr f, const char* name)

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -549,7 +549,14 @@ public:
 	 * Convenience function that forwards directly to
 	 * Connection::BuildConnVal().
 	 */
+	[[deprecated("Remove in v4.1.  Use ConnVal() instead.")]]
 	RecordVal* BuildConnVal();
+
+	/**
+	 * Convenience function that forwards directly to
+	 * Connection::ConnVal().
+	 */
+	const IntrusivePtr<RecordVal>& ConnVal();
 
 	/**
 	 * Convenience function that forwards directly to the corresponding

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -568,6 +568,7 @@ public:
 	 * Convenience function that forwards directly to the corresponding
 	 * Connection::Event().
 	 */
+	[[deprecated("Remove in v4.1.  Use EnqueueConnEvent() instead (note it doesn't automatically ad the connection argument).")]]
 	void Event(EventHandlerPtr f, Val* v1, Val* v2 = nullptr);
 
 	/**

--- a/src/analyzer/Manager.cc
+++ b/src/analyzer/Manager.cc
@@ -624,9 +624,10 @@ bool Manager::ApplyScheduledAnalyzers(Connection* conn, bool init, TransportLaye
 
 		parent->AddChildAnalyzer(analyzer, init);
 
-		EnumVal* tag = it->AsEnumVal();
-		Ref(tag);
-		conn->Event(scheduled_analyzer_applied, nullptr, tag);
+		if ( scheduled_analyzer_applied )
+			conn->EnqueueEvent(scheduled_analyzer_applied, nullptr,
+			                   conn->ConnVal(),
+			                   IntrusivePtr{NewRef{}, it->AsEnumVal()});
 
 		DBG_ANALYZER_ARGS(conn, "activated %s analyzer as scheduled",
 		                  analyzer_mgr->GetComponentName(*it).c_str());

--- a/src/analyzer/Manager.cc
+++ b/src/analyzer/Manager.cc
@@ -440,15 +440,13 @@ bool Manager::BuildInitialAnalyzerTree(Connection* conn)
 
 		if ( tcp_contents && ! reass )
 			{
-			auto dport = val_mgr->GetPort(ntohs(conn->RespPort()), TRANSPORT_TCP);
+			const auto& dport = val_mgr->Port(ntohs(conn->RespPort()), TRANSPORT_TCP);
 
 			if ( ! reass )
-				reass = (bool)tcp_content_delivery_ports_orig->Lookup(dport);
+				reass = (bool)tcp_content_delivery_ports_orig->Lookup(dport.get());
 
 			if ( ! reass )
-				reass = (bool)tcp_content_delivery_ports_resp->Lookup(dport);
-
-			Unref(dport);
+				reass = (bool)tcp_content_delivery_ports_resp->Lookup(dport.get());
 			}
 
 		if ( reass )

--- a/src/analyzer/analyzer.bif
+++ b/src/analyzer/analyzer.bif
@@ -36,7 +36,7 @@ function Analyzer::__schedule_analyzer%(orig: addr, resp: addr, resp_p: port,
 					analyzer: Analyzer::Tag, tout: interval%) : bool
 	%{
 	analyzer_mgr->ScheduleAnalyzer(orig->AsAddr(), resp->AsAddr(), resp_p, analyzer->AsEnumVal(), tout);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function __name%(atype: Analyzer::Tag%) : string

--- a/src/analyzer/analyzer.bif
+++ b/src/analyzer/analyzer.bif
@@ -11,13 +11,13 @@ module Analyzer;
 function Analyzer::__enable_analyzer%(id: Analyzer::Tag%) : bool
 	%{
 	bool result = analyzer_mgr->EnableAnalyzer(id->AsEnumVal());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Analyzer::__disable_analyzer%(id: Analyzer::Tag%) : bool
 	%{
 	bool result = analyzer_mgr->DisableAnalyzer(id->AsEnumVal());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Analyzer::__disable_all_analyzers%(%) : any
@@ -29,7 +29,7 @@ function Analyzer::__disable_all_analyzers%(%) : any
 function Analyzer::__register_for_port%(id: Analyzer::Tag, p: port%) : bool
 	%{
 	bool result = analyzer_mgr->RegisterAnalyzerForPort(id->AsEnumVal(), p);
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Analyzer::__schedule_analyzer%(orig: addr, resp: addr, resp_p: port,

--- a/src/analyzer/analyzer.bif
+++ b/src/analyzer/analyzer.bif
@@ -23,7 +23,7 @@ function Analyzer::__disable_analyzer%(id: Analyzer::Tag%) : bool
 function Analyzer::__disable_all_analyzers%(%) : any
 	%{
 	analyzer_mgr->DisableAllAnalyzers();
-	return 0;
+	return nullptr;
 	%}
 
 function Analyzer::__register_for_port%(id: Analyzer::Tag, p: port%) : bool
@@ -41,11 +41,11 @@ function Analyzer::__schedule_analyzer%(orig: addr, resp: addr, resp_p: port,
 
 function __name%(atype: Analyzer::Tag%) : string
 	%{
-	return new StringVal(analyzer_mgr->GetComponentName(atype));
+	return make_intrusive<StringVal>(analyzer_mgr->GetComponentName(atype));
 	%}
 
 function __tag%(name: string%) : Analyzer::Tag
 	%{
 	analyzer::Tag t = analyzer_mgr->GetComponentTag(name->CheckString());
-	return t.AsEnumVal()->Ref();
+	return IntrusivePtr{NewRef{}, t.AsEnumVal()};
 	%}

--- a/src/analyzer/protocol/asn1/asn1.pac
+++ b/src/analyzer/protocol/asn1/asn1.pac
@@ -113,7 +113,7 @@ Val* asn1_integer_to_val(const ASN1Encoding* i, TypeTag t)
 
 	switch ( t ) {
 	case TYPE_BOOL:
-		return val_mgr->GetBool(v);
+		return val_mgr->Bool(v)->Ref();
 	case TYPE_INT:
 		return val_mgr->GetInt(v);
 	case TYPE_COUNT:

--- a/src/analyzer/protocol/asn1/asn1.pac
+++ b/src/analyzer/protocol/asn1/asn1.pac
@@ -118,10 +118,10 @@ Val* asn1_integer_to_val(const ASN1Encoding* i, TypeTag t)
 		return val_mgr->Int(v).release();
 	case TYPE_COUNT:
 	case TYPE_COUNTER:
-		return val_mgr->GetCount(v);
+		return val_mgr->Count(v).release();
 	default:
 		reporter->Error("bad asn1_integer_to_val tag: %s", type_name(t));
-		return val_mgr->GetCount(v);
+		return val_mgr->Count(v).release();
 	}
 	}
 

--- a/src/analyzer/protocol/asn1/asn1.pac
+++ b/src/analyzer/protocol/asn1/asn1.pac
@@ -115,7 +115,7 @@ Val* asn1_integer_to_val(const ASN1Encoding* i, TypeTag t)
 	case TYPE_BOOL:
 		return val_mgr->Bool(v)->Ref();
 	case TYPE_INT:
-		return val_mgr->GetInt(v);
+		return val_mgr->Int(v).release();
 	case TYPE_COUNT:
 	case TYPE_COUNTER:
 		return val_mgr->GetCount(v);

--- a/src/analyzer/protocol/asn1/asn1.pac
+++ b/src/analyzer/protocol/asn1/asn1.pac
@@ -152,7 +152,7 @@ StringVal* asn1_oid_to_val(const ASN1Encoding* oid)
 
 	if ( ! subidentifier.empty() || subidentifiers.size() < 1 )
 		// Underflow.
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString()->Ref()->AsStringVal();
 
 	for ( size_t i = 0; i < subidentifiers.size(); ++i )
 		{

--- a/src/analyzer/protocol/bittorrent/BitTorrent.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrent.cc
@@ -120,7 +120,7 @@ void BitTorrent_Analyzer::DeliverWeird(const char* msg, bool orig)
 	{
 	if ( bittorrent_peer_weird )
 		EnqueueConnEvent(bittorrent_peer_weird,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(msg)
 		);

--- a/src/analyzer/protocol/bittorrent/BitTorrent.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrent.cc
@@ -121,7 +121,7 @@ void BitTorrent_Analyzer::DeliverWeird(const char* msg, bool orig)
 	if ( bittorrent_peer_weird )
 		EnqueueConnEvent(bittorrent_peer_weird,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(msg)
 		);
 	}

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -503,7 +503,7 @@ void BitTorrentTracker_Analyzer::ResponseBenc(int name_len, char* name,
 	RecordVal* benc_value = new RecordVal(bittorrent_benc_value);
 	StringVal* name_ = new StringVal(name_len, name);
 
-	benc_value->Assign(type, val_mgr->GetInt(value));
+	benc_value->Assign(type, val_mgr->Int(value));
 	res_val_benc->Assign(name_, benc_value);
 
 	Unref(name_);

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -247,7 +247,7 @@ void BitTorrentTracker_Analyzer::DeliverWeird(const char* msg, bool orig)
 	{
 	if ( bt_tracker_weird )
 		EnqueueConnEvent(bt_tracker_weird,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(msg)
 		);
@@ -348,7 +348,7 @@ void BitTorrentTracker_Analyzer::EmitRequest(void)
 
 	if ( bt_tracker_request )
 		EnqueueConnEvent(bt_tracker_request,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			IntrusivePtr{AdoptRef{}, req_val_uri},
 			IntrusivePtr{AdoptRef{}, req_val_headers}
 		);
@@ -402,7 +402,7 @@ bool BitTorrentTracker_Analyzer::ParseResponse(char* line)
 				{
 				if ( bt_tracker_response_not_ok )
 					EnqueueConnEvent(bt_tracker_response_not_ok,
-						IntrusivePtr{AdoptRef{}, BuildConnVal()},
+						ConnVal(),
 						val_mgr->Count(res_status),
 						IntrusivePtr{AdoptRef{}, res_val_headers}
 					);
@@ -789,7 +789,7 @@ void BitTorrentTracker_Analyzer::EmitResponse(void)
 
 	if ( bt_tracker_response )
 		EnqueueConnEvent(bt_tracker_response,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Count(res_status),
 			IntrusivePtr{AdoptRef{}, res_val_headers},
 			IntrusivePtr{AdoptRef{}, res_val_peers},

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -480,7 +480,7 @@ void BitTorrentTracker_Analyzer::ResponseBenc(int name_len, char* name,
 
 			RecordVal* peer = new RecordVal(bittorrent_peer);
 			peer->Assign(0, make_intrusive<AddrVal>(ad));
-			peer->Assign(1, val_mgr->GetPort(pt, TRANSPORT_TCP));
+			peer->Assign(1, val_mgr->Port(pt, TRANSPORT_TCP));
 			res_val_peers->Assign(peer, nullptr);
 
 			Unref(peer);

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -403,7 +403,7 @@ bool BitTorrentTracker_Analyzer::ParseResponse(char* line)
 				if ( bt_tracker_response_not_ok )
 					EnqueueConnEvent(bt_tracker_response_not_ok,
 						IntrusivePtr{AdoptRef{}, BuildConnVal()},
-						IntrusivePtr{AdoptRef{}, val_mgr->GetCount(res_status)},
+						val_mgr->Count(res_status),
 						IntrusivePtr{AdoptRef{}, res_val_headers}
 					);
 				res_val_headers = nullptr;
@@ -790,7 +790,7 @@ void BitTorrentTracker_Analyzer::EmitResponse(void)
 	if ( bt_tracker_response )
 		EnqueueConnEvent(bt_tracker_response,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(res_status)},
+			val_mgr->Count(res_status),
 			IntrusivePtr{AdoptRef{}, res_val_headers},
 			IntrusivePtr{AdoptRef{}, res_val_peers},
 			IntrusivePtr{AdoptRef{}, res_val_benc}

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -248,7 +248,7 @@ void BitTorrentTracker_Analyzer::DeliverWeird(const char* msg, bool orig)
 	if ( bt_tracker_weird )
 		EnqueueConnEvent(bt_tracker_weird,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(msg)
 		);
 	}

--- a/src/analyzer/protocol/bittorrent/bittorrent-analyzer.pac
+++ b/src/analyzer/protocol/bittorrent/bittorrent-analyzer.pac
@@ -221,7 +221,7 @@ flow BitTorrent_Flow(is_orig: bool) {
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
-				val_mgr->GetPort(listen_port, TRANSPORT_TCP));
+				val_mgr->Port(listen_port, TRANSPORT_TCP)->Ref()->AsPortVal());
 			}
 
 		return true;

--- a/src/analyzer/protocol/bittorrent/bittorrent-analyzer.pac
+++ b/src/analyzer/protocol/bittorrent/bittorrent-analyzer.pac
@@ -61,13 +61,13 @@ flow BitTorrent_Flow(is_orig: bool) {
 		handshake_ok = true;
 		if ( ::bittorrent_peer_handshake )
 			{
-			BifEvent::generate_bittorrent_peer_handshake(
+			BifEvent::enqueue_bittorrent_peer_handshake(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
-				bytestring_to_val(reserved),
-				bytestring_to_val(info_hash),
-				bytestring_to_val(peer_id));
+				to_stringval(reserved),
+				to_stringval(info_hash),
+				to_stringval(peer_id));
 			}
 
 		connection()->bro_analyzer()->ProtocolConfirmation();
@@ -79,7 +79,7 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_keep_alive )
 			{
-			BifEvent::generate_bittorrent_peer_keep_alive(
+			BifEvent::enqueue_bittorrent_peer_keep_alive(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig());
@@ -92,7 +92,7 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_choke )
 			{
-			BifEvent::generate_bittorrent_peer_choke(
+			BifEvent::enqueue_bittorrent_peer_choke(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig());
@@ -105,7 +105,7 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_unchoke )
 			{
-			BifEvent::generate_bittorrent_peer_unchoke(
+			BifEvent::enqueue_bittorrent_peer_unchoke(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig());
@@ -118,7 +118,7 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_interested )
 			{
-			BifEvent::generate_bittorrent_peer_interested(
+			BifEvent::enqueue_bittorrent_peer_interested(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig());
@@ -131,7 +131,7 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_not_interested )
 			{
-			BifEvent::generate_bittorrent_peer_not_interested(
+			BifEvent::enqueue_bittorrent_peer_not_interested(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig());
@@ -144,7 +144,7 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_have )
 			{
-			BifEvent::generate_bittorrent_peer_have(
+			BifEvent::enqueue_bittorrent_peer_have(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
@@ -158,11 +158,11 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_bitfield )
 			{
-			BifEvent::generate_bittorrent_peer_bitfield(
+			BifEvent::enqueue_bittorrent_peer_bitfield(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
-				bytestring_to_val(bitfield));
+				to_stringval(bitfield));
 			}
 
 		return true;
@@ -173,7 +173,7 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_request )
 			{
-			BifEvent::generate_bittorrent_peer_request(
+			BifEvent::enqueue_bittorrent_peer_request(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
@@ -188,7 +188,7 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_piece )
 			{
-			BifEvent::generate_bittorrent_peer_piece(
+			BifEvent::enqueue_bittorrent_peer_piece(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
@@ -203,7 +203,7 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_cancel )
 			{
-			BifEvent::generate_bittorrent_peer_cancel(
+			BifEvent::enqueue_bittorrent_peer_cancel(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
@@ -217,11 +217,11 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_port )
 			{
-			BifEvent::generate_bittorrent_peer_port(
+			BifEvent::enqueue_bittorrent_peer_port(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
-				val_mgr->Port(listen_port, TRANSPORT_TCP)->Ref()->AsPortVal());
+				val_mgr->Port(listen_port, TRANSPORT_TCP));
 			}
 
 		return true;
@@ -231,12 +231,12 @@ flow BitTorrent_Flow(is_orig: bool) {
 		%{
 		if ( ::bittorrent_peer_unknown )
 			{
-			BifEvent::generate_bittorrent_peer_unknown(
+			BifEvent::enqueue_bittorrent_peer_unknown(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
 				id,
-				bytestring_to_val(data));
+				to_stringval(data));
 			}
 
 		return true;

--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -52,7 +52,7 @@ void ConnSize_Analyzer::ThresholdEvent(EventHandlerPtr f, uint64_t threshold, bo
 
 	EnqueueConnEvent(f,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(threshold)},
+		val_mgr->Count(threshold),
 		val_mgr->Bool(is_orig)
 	);
 	}
@@ -183,10 +183,10 @@ void ConnSize_Analyzer::UpdateConnVal(RecordVal *conn_val)
 	if ( bytesidx < 0 )
 		reporter->InternalError("'endpoint' record missing 'num_bytes_ip' field");
 
-	orig_endp->Assign(pktidx, val_mgr->GetCount(orig_pkts));
-	orig_endp->Assign(bytesidx, val_mgr->GetCount(orig_bytes));
-	resp_endp->Assign(pktidx, val_mgr->GetCount(resp_pkts));
-	resp_endp->Assign(bytesidx, val_mgr->GetCount(resp_bytes));
+	orig_endp->Assign(pktidx, val_mgr->Count(orig_pkts));
+	orig_endp->Assign(bytesidx, val_mgr->Count(orig_bytes));
+	resp_endp->Assign(pktidx, val_mgr->Count(resp_pkts));
+	resp_endp->Assign(bytesidx, val_mgr->Count(resp_bytes));
 
 	Analyzer::UpdateConnVal(conn_val);
 	}

--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -53,7 +53,7 @@ void ConnSize_Analyzer::ThresholdEvent(EventHandlerPtr f, uint64_t threshold, bo
 	EnqueueConnEvent(f,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
 		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(threshold)},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)}
+		val_mgr->Bool(is_orig)
 	);
 	}
 
@@ -95,7 +95,7 @@ void ConnSize_Analyzer::CheckThresholds(bool is_orig)
 			EnqueueConnEvent(conn_duration_threshold_crossed,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
 					make_intrusive<Val>(duration_thresh, TYPE_INTERVAL),
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)}
+					val_mgr->Bool(is_orig)
 			);
 			duration_thresh = 0;
 			}

--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -51,7 +51,7 @@ void ConnSize_Analyzer::ThresholdEvent(EventHandlerPtr f, uint64_t threshold, bo
 		return;
 
 	EnqueueConnEvent(f,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		val_mgr->Count(threshold),
 		val_mgr->Bool(is_orig)
 	);
@@ -93,7 +93,7 @@ void ConnSize_Analyzer::CheckThresholds(bool is_orig)
 		if ( ( network_time - start_time ) > duration_thresh && conn_duration_threshold_crossed )
 			{
 			EnqueueConnEvent(conn_duration_threshold_crossed,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					make_intrusive<Val>(duration_thresh, TYPE_INTERVAL),
 					val_mgr->Bool(is_orig)
 			);

--- a/src/analyzer/protocol/conn-size/functions.bif
+++ b/src/analyzer/protocol/conn-size/functions.bif
@@ -139,7 +139,7 @@ function get_current_conn_duration_threshold%(cid: conn_id%): interval
 	%{
 	analyzer::Analyzer* a = GetConnsizeAnalyzer(cid);
 	if ( ! a )
-		return new Val(0.0, TYPE_INTERVAL);
+		return make_intrusive<Val>(0.0, TYPE_INTERVAL);
 
-	return new Val(static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->GetDurationThreshold(), TYPE_INTERVAL);
+	return make_intrusive<Val>(static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->GetDurationThreshold(), TYPE_INTERVAL);
 	%}

--- a/src/analyzer/protocol/conn-size/functions.bif
+++ b/src/analyzer/protocol/conn-size/functions.bif
@@ -35,11 +35,11 @@ function set_current_conn_bytes_threshold%(cid: conn_id, threshold: count, is_or
 	%{
 	analyzer::Analyzer* a = GetConnsizeAnalyzer(cid);
 	if ( ! a )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->SetByteAndPacketThreshold(threshold, true, is_orig);
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Sets a threshold for connection packets, overwtiting any potential old thresholds.
@@ -59,11 +59,11 @@ function set_current_conn_packets_threshold%(cid: conn_id, threshold: count, is_
 	%{
 	analyzer::Analyzer* a = GetConnsizeAnalyzer(cid);
 	if ( ! a )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->SetByteAndPacketThreshold(threshold, false, is_orig);
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Sets the current duration threshold for connection, overwriting any potential old
@@ -81,11 +81,11 @@ function set_current_conn_duration_threshold%(cid: conn_id, threshold: interval%
 	%{
 	analyzer::Analyzer* a = GetConnsizeAnalyzer(cid);
 	if ( ! a )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->SetDurationThreshold(threshold);
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 # Gets the current byte threshold size for a connection.

--- a/src/analyzer/protocol/conn-size/functions.bif
+++ b/src/analyzer/protocol/conn-size/functions.bif
@@ -103,9 +103,9 @@ function get_current_conn_bytes_threshold%(cid: conn_id, is_orig: bool%): count
 	%{
 	analyzer::Analyzer* a = GetConnsizeAnalyzer(cid);
 	if ( ! a )
-		return val_mgr->GetCount(0);
+		return val_mgr->Count(0);
 
-	return val_mgr->GetCount(static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->GetByteAndPacketThreshold(true, is_orig));
+	return val_mgr->Count(static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->GetByteAndPacketThreshold(true, is_orig));
 	%}
 
 ## Gets the current packet threshold size for a connection.
@@ -122,9 +122,9 @@ function get_current_conn_packets_threshold%(cid: conn_id, is_orig: bool%): coun
 	%{
 	analyzer::Analyzer* a = GetConnsizeAnalyzer(cid);
 	if ( ! a )
-		return val_mgr->GetCount(0);
+		return val_mgr->Count(0);
 
-	return val_mgr->GetCount(static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->GetByteAndPacketThreshold(false, is_orig));
+	return val_mgr->Count(static_cast<analyzer::conn_size::ConnSize_Analyzer*>(a)->GetByteAndPacketThreshold(false, is_orig));
 	%}
 
 ## Gets the current duration threshold size for a connection.

--- a/src/analyzer/protocol/dce-rpc/dce_rpc-analyzer.pac
+++ b/src/analyzer/protocol/dce-rpc/dce_rpc-analyzer.pac
@@ -37,12 +37,12 @@ refine connection DCE_RPC_Conn += {
 		%{
 		if ( dce_rpc_message )
 			{
-			BifEvent::generate_dce_rpc_message(bro_analyzer(),
-			                                   bro_analyzer()->Conn(),
-			                                   ${header.is_orig},
-			                                   fid,
-			                                   ${header.PTYPE},
-			                                   BifType::Enum::DCE_RPC::PType->GetVal(${header.PTYPE}).release());
+			BifEvent::enqueue_dce_rpc_message(bro_analyzer(),
+			                                  bro_analyzer()->Conn(),
+			                                  ${header.is_orig},
+			                                  fid,
+			                                  ${header.PTYPE},
+			                                  BifType::Enum::DCE_RPC::PType->GetVal(${header.PTYPE}));
 			}
 		return true;
 		%}
@@ -51,13 +51,13 @@ refine connection DCE_RPC_Conn += {
 		%{
 		if ( dce_rpc_bind )
 			{
-			BifEvent::generate_dce_rpc_bind(bro_analyzer(),
-			                                bro_analyzer()->Conn(),
-			                                fid,
-			                                ${req.id},
-			                                bytestring_to_val(${req.abstract_syntax.uuid}),
-			                                ${req.abstract_syntax.ver_major},
-			                                ${req.abstract_syntax.ver_minor});
+			BifEvent::enqueue_dce_rpc_bind(bro_analyzer(),
+			                               bro_analyzer()->Conn(),
+			                               fid,
+			                               ${req.id},
+			                               to_stringval(${req.abstract_syntax.uuid}),
+			                               ${req.abstract_syntax.ver_major},
+			                               ${req.abstract_syntax.ver_minor});
 			}
 
 		return true;
@@ -67,13 +67,13 @@ refine connection DCE_RPC_Conn += {
 		%{
 		if ( dce_rpc_alter_context )
 			{
-			BifEvent::generate_dce_rpc_alter_context(bro_analyzer(),
-			                                         bro_analyzer()->Conn(),
-			                                         fid,
-			                                         ${req.id},
-			                                         bytestring_to_val(${req.abstract_syntax.uuid}),
-			                                         ${req.abstract_syntax.ver_major},
-			                                         ${req.abstract_syntax.ver_minor});
+			BifEvent::enqueue_dce_rpc_alter_context(bro_analyzer(),
+			                                        bro_analyzer()->Conn(),
+			                                        fid,
+			                                        ${req.id},
+			                                        to_stringval(${req.abstract_syntax.uuid}),
+			                                        ${req.abstract_syntax.ver_major},
+			                                        ${req.abstract_syntax.ver_minor});
 			}
 
 		return true;
@@ -83,22 +83,19 @@ refine connection DCE_RPC_Conn += {
 		%{
 		if ( dce_rpc_bind_ack )
 			{
-			StringVal *sec_addr;
+			IntrusivePtr<StringVal> sec_addr;
+
 			// Remove the null from the end of the string if it's there.
 			if ( ${bind.sec_addr}.length() > 0 &&
 			     *(${bind.sec_addr}.begin() + ${bind.sec_addr}.length()) == 0 )
-				{
-				sec_addr = new StringVal(${bind.sec_addr}.length()-1, (const char*) ${bind.sec_addr}.begin());
-				}
+				sec_addr = make_intrusive<StringVal>(${bind.sec_addr}.length()-1, (const char*) ${bind.sec_addr}.begin());
 			else
-				{
-				sec_addr = new StringVal(${bind.sec_addr}.length(), (const char*) ${bind.sec_addr}.begin());
-				}
+				sec_addr = make_intrusive<StringVal>(${bind.sec_addr}.length(), (const char*) ${bind.sec_addr}.begin());
 
-			BifEvent::generate_dce_rpc_bind_ack(bro_analyzer(),
-			                                    bro_analyzer()->Conn(),
-			                                    fid,
-			                                    sec_addr);
+			BifEvent::enqueue_dce_rpc_bind_ack(bro_analyzer(),
+			                                   bro_analyzer()->Conn(),
+			                                   fid,
+			                                   std::move(sec_addr));
 			}
 		return true;
 		%}
@@ -107,9 +104,9 @@ refine connection DCE_RPC_Conn += {
 		%{
 		if ( dce_rpc_alter_context_resp )
 			{
-			BifEvent::generate_dce_rpc_alter_context_resp(bro_analyzer(),
-			                                              bro_analyzer()->Conn(),
-			                                              fid);
+			BifEvent::enqueue_dce_rpc_alter_context_resp(bro_analyzer(),
+			                                             bro_analyzer()->Conn(),
+			                                             fid);
 			}
 		return true;
 		%}
@@ -118,12 +115,12 @@ refine connection DCE_RPC_Conn += {
 		%{
 		if ( dce_rpc_request )
 			{
-			BifEvent::generate_dce_rpc_request(bro_analyzer(),
-			                                   bro_analyzer()->Conn(),
-			                                   fid,
-			                                   ${req.context_id},
-			                                   ${req.opnum},
-			                                   ${req.stub}.length());
+			BifEvent::enqueue_dce_rpc_request(bro_analyzer(),
+			                                  bro_analyzer()->Conn(),
+			                                  fid,
+			                                  ${req.context_id},
+			                                  ${req.opnum},
+			                                  ${req.stub}.length());
 			}
 
 		set_cont_id_opnum_map(${req.context_id},
@@ -135,12 +132,12 @@ refine connection DCE_RPC_Conn += {
 		%{
 		if ( dce_rpc_response )
 			{
-			BifEvent::generate_dce_rpc_response(bro_analyzer(),
-			                                    bro_analyzer()->Conn(),
-			                                    fid,
-			                                    ${resp.context_id},
-			                                    get_cont_id_opnum_map(${resp.context_id}),
-			                                    ${resp.stub}.length());
+			BifEvent::enqueue_dce_rpc_response(bro_analyzer(),
+			                                   bro_analyzer()->Conn(),
+			                                   fid,
+			                                   ${resp.context_id},
+			                                   get_cont_id_opnum_map(${resp.context_id}),
+			                                   ${resp.stub}.length());
 			}
 
 		return true;

--- a/src/analyzer/protocol/dhcp/dhcp-analyzer.pac
+++ b/src/analyzer/protocol/dhcp/dhcp-analyzer.pac
@@ -35,8 +35,7 @@ refine flow DHCP_Flow += {
 		init_options();
 
 		if ( code != 255 )
-			all_options->Assign(all_options->Size(),
-			                    val_mgr->GetCount(code));
+			all_options->Assign(all_options->Size(), val_mgr->Count(code));
 
 		return true;
 		%}
@@ -58,11 +57,11 @@ refine flow DHCP_Flow += {
 			double secs = static_cast<double>(${msg.secs});
 
 			auto dhcp_msg_val = new RecordVal(BifType::Record::DHCP::Msg);
-			dhcp_msg_val->Assign(0, val_mgr->GetCount(${msg.op}));
-			dhcp_msg_val->Assign(1, val_mgr->GetCount(${msg.type}));
-			dhcp_msg_val->Assign(2, val_mgr->GetCount(${msg.xid}));
+			dhcp_msg_val->Assign(0, val_mgr->Count(${msg.op}));
+			dhcp_msg_val->Assign(1, val_mgr->Count(${msg.type}));
+			dhcp_msg_val->Assign(2, val_mgr->Count(${msg.xid}));
 			dhcp_msg_val->Assign(3, make_intrusive<Val>(secs, TYPE_INTERVAL));
-			dhcp_msg_val->Assign(4, val_mgr->GetCount(${msg.flags}));
+			dhcp_msg_val->Assign(4, val_mgr->Count(${msg.flags}));
 			dhcp_msg_val->Assign(5, make_intrusive<AddrVal>(htonl(${msg.ciaddr})));
 			dhcp_msg_val->Assign(6, make_intrusive<AddrVal>(htonl(${msg.yiaddr})));
 			dhcp_msg_val->Assign(7, make_intrusive<AddrVal>(htonl(${msg.siaddr})));

--- a/src/analyzer/protocol/dhcp/dhcp-options.pac
+++ b/src/analyzer/protocol/dhcp/dhcp-options.pac
@@ -469,7 +469,7 @@ refine flow DHCP_Flow += {
 		for ( int i = 0; i < num_parms; ++i )
 			{
 			uint8 param = (*plist)[i];
-			params->Assign(i, val_mgr->GetCount(param));
+			params->Assign(i, val_mgr->Count(param));
 			}
 
 		${context.flow}->options->Assign(13, params);
@@ -521,7 +521,7 @@ refine casetype OptionValue += {
 refine flow DHCP_Flow += {
 	function process_max_message_size_option(v: OptionValue): bool
 		%{
-		${context.flow}->options->Assign(15, val_mgr->GetCount(${v.max_msg_size}));
+		${context.flow}->options->Assign(15, val_mgr->Count(${v.max_msg_size}));
 
 		return true;
 		%}
@@ -626,7 +626,7 @@ refine flow DHCP_Flow += {
 	function process_client_id_option(v: OptionValue): bool
 		%{
 		RecordVal* client_id = new RecordVal(BifType::Record::DHCP::ClientID);
-		client_id->Assign(0, val_mgr->GetCount(${v.client_id.hwtype}));
+		client_id->Assign(0, val_mgr->Count(${v.client_id.hwtype}));
 		client_id->Assign(1, make_intrusive<StringVal>(fmt_mac(${v.client_id.hwaddr}.begin(), ${v.client_id.hwaddr}.length())));
 
 		${context.flow}->options->Assign(19, client_id);
@@ -686,9 +686,9 @@ refine flow DHCP_Flow += {
 	function process_client_fqdn_option(v: OptionValue): bool
 		%{
 		RecordVal* client_fqdn = new RecordVal(BifType::Record::DHCP::ClientFQDN);
-		client_fqdn->Assign(0, val_mgr->GetCount(${v.client_fqdn.flags}));
-		client_fqdn->Assign(1, val_mgr->GetCount(${v.client_fqdn.rcode1}));
-		client_fqdn->Assign(2, val_mgr->GetCount(${v.client_fqdn.rcode2}));
+		client_fqdn->Assign(0, val_mgr->Count(${v.client_fqdn.flags}));
+		client_fqdn->Assign(1, val_mgr->Count(${v.client_fqdn.rcode1}));
+		client_fqdn->Assign(2, val_mgr->Count(${v.client_fqdn.rcode2}));
 		const char* domain_name = reinterpret_cast<const char*>(${v.client_fqdn.domain_name}.begin());
 		client_fqdn->Assign(3, make_intrusive<StringVal>(${v.client_fqdn.domain_name}.length(), domain_name));
 
@@ -751,7 +751,7 @@ refine flow DHCP_Flow += {
 		      ptrsubopt != ${v.relay_agent_inf}->end(); ++ptrsubopt )
 			{
 			auto r = new RecordVal(BifType::Record::DHCP::SubOpt);
-			r->Assign(0, val_mgr->GetCount((*ptrsubopt)->code()));
+			r->Assign(0, val_mgr->Count((*ptrsubopt)->code()));
 			r->Assign(1, bytestring_to_val((*ptrsubopt)->value()));
 
 			relay_agent_sub_opt->Assign(i, r);

--- a/src/analyzer/protocol/dhcp/dhcp-options.pac
+++ b/src/analyzer/protocol/dhcp/dhcp-options.pac
@@ -250,7 +250,7 @@ refine casetype OptionValue += {
 refine flow DHCP_Flow += {
 	function process_forwarding_option(v: OptionValue): bool
 		%{
-		${context.flow}->options->Assign(6, val_mgr->GetBool(${v.forwarding} == 0 ? false : true));
+		${context.flow}->options->Assign(6, val_mgr->Bool(${v.forwarding} == 0 ? false : true));
 
 		return true;
 		%}
@@ -781,7 +781,7 @@ refine casetype OptionValue += {
 refine flow DHCP_Flow += {
 	function process_auto_config_option(v: OptionValue): bool
 		%{
-		${context.flow}->options->Assign(23, val_mgr->GetBool(${v.auto_config} == 0 ? false : true));
+		${context.flow}->options->Assign(23, val_mgr->Bool(${v.auto_config} == 0 ? false : true));
 
 		return true;
 		%}

--- a/src/analyzer/protocol/dhcp/dhcp-options.pac
+++ b/src/analyzer/protocol/dhcp/dhcp-options.pac
@@ -34,7 +34,7 @@ refine casetype OptionValue += {
 refine flow DHCP_Flow += {
 	function process_time_offset_option(v: OptionValue): bool
 		%{
-		${context.flow}->options->Assign(25, val_mgr->GetInt(${v.time_offset}));
+		${context.flow}->options->Assign(25, val_mgr->Int(${v.time_offset}));
 		return true;
 		%}
 };

--- a/src/analyzer/protocol/dhcp/dhcp-options.pac
+++ b/src/analyzer/protocol/dhcp/dhcp-options.pac
@@ -752,7 +752,7 @@ refine flow DHCP_Flow += {
 			{
 			auto r = new RecordVal(BifType::Record::DHCP::SubOpt);
 			r->Assign(0, val_mgr->Count((*ptrsubopt)->code()));
-			r->Assign(1, bytestring_to_val((*ptrsubopt)->value()));
+			r->Assign(1, to_stringval((*ptrsubopt)->value()));
 
 			relay_agent_sub_opt->Assign(i, r);
 			++i;

--- a/src/analyzer/protocol/dnp3/dnp3-analyzer.pac
+++ b/src/analyzer/protocol/dnp3/dnp3-analyzer.pac
@@ -29,7 +29,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_header_block )
 			{
-			BifEvent::generate_dnp3_header_block(
+			BifEvent::enqueue_dnp3_header_block(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), len, ctrl, dest_addr, src_addr);
@@ -42,11 +42,11 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_application_request_header )
 			{
-			BifEvent::generate_dnp3_application_request_header(
+			BifEvent::enqueue_dnp3_application_request_header(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
-				application_control, 
+				application_control,
 				fc
 				);
 			}
@@ -57,7 +57,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_application_response_header )
 			{
-			BifEvent::generate_dnp3_application_response_header(
+			BifEvent::enqueue_dnp3_application_response_header(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(),
@@ -73,7 +73,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_object_header )
 			{
-			BifEvent::generate_dnp3_object_header(
+			BifEvent::enqueue_dnp3_object_header(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), obj_type, qua_field, number, rf_low, rf_high);
@@ -86,7 +86,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_object_prefix )
 			{
-			BifEvent::generate_dnp3_object_prefix(
+			BifEvent::enqueue_dnp3_object_prefix(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), prefix_value);
@@ -99,7 +99,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_response_data_object )
 			{
-			BifEvent::generate_dnp3_response_data_object(
+			BifEvent::enqueue_dnp3_response_data_object(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), data_value);
@@ -113,10 +113,10 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_attribute_common )
 			{
-			BifEvent::generate_dnp3_attribute_common(
+			BifEvent::enqueue_dnp3_attribute_common(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
-				is_orig(), data_type_code, leng, bytestring_to_val(attribute_obj) );
+				is_orig(), data_type_code, leng, to_stringval(attribute_obj) );
 			}
 
 		return true;
@@ -127,7 +127,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_crob )
 			{
-			BifEvent::generate_dnp3_crob(
+			BifEvent::enqueue_dnp3_crob(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), control_code, count8, on_time, off_time, status_code);
@@ -141,7 +141,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_pcb )
 			{
-			BifEvent::generate_dnp3_pcb(
+			BifEvent::enqueue_dnp3_pcb(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), control_code, count8, on_time, off_time, status_code);
@@ -155,7 +155,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_counter_32wFlag )
 			{
-			BifEvent::generate_dnp3_counter_32wFlag(
+			BifEvent::enqueue_dnp3_counter_32wFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, count_value);
@@ -169,7 +169,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_counter_16wFlag )
 			{
-			BifEvent::generate_dnp3_counter_16wFlag(
+			BifEvent::enqueue_dnp3_counter_16wFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, count_value);
@@ -183,7 +183,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_counter_32woFlag )
 			{
-			BifEvent::generate_dnp3_counter_32woFlag(
+			BifEvent::enqueue_dnp3_counter_32woFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), count_value);
@@ -197,7 +197,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_counter_16woFlag )
 			{
-			BifEvent::generate_dnp3_counter_16woFlag(
+			BifEvent::enqueue_dnp3_counter_16woFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), count_value);
@@ -211,7 +211,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_counter_32wFlag )
 			{
-			BifEvent::generate_dnp3_frozen_counter_32wFlag(
+			BifEvent::enqueue_dnp3_frozen_counter_32wFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, count_value);
@@ -225,7 +225,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_counter_16wFlag )
 			{
-			BifEvent::generate_dnp3_frozen_counter_16wFlag(
+			BifEvent::enqueue_dnp3_frozen_counter_16wFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, count_value);
@@ -239,7 +239,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_counter_32wFlagTime )
 			{
-			BifEvent::generate_dnp3_frozen_counter_32wFlagTime(
+			BifEvent::enqueue_dnp3_frozen_counter_32wFlagTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, count_value, bytestring_to_time(time48));
@@ -253,7 +253,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_counter_16wFlagTime )
 			{
-			BifEvent::generate_dnp3_frozen_counter_16wFlagTime(
+			BifEvent::enqueue_dnp3_frozen_counter_16wFlagTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, count_value, bytestring_to_time(time48));
@@ -267,7 +267,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_counter_32woFlag )
 			{
-			BifEvent::generate_dnp3_frozen_counter_32woFlag(
+			BifEvent::enqueue_dnp3_frozen_counter_32woFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), count_value);
@@ -281,7 +281,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_counter_16woFlag )
 			{
-			BifEvent::generate_dnp3_frozen_counter_16woFlag(
+			BifEvent::enqueue_dnp3_frozen_counter_16woFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), count_value);
@@ -295,7 +295,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_32wFlag )
 			{
-			BifEvent::generate_dnp3_analog_input_32wFlag(
+			BifEvent::enqueue_dnp3_analog_input_32wFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value);
@@ -309,7 +309,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_16wFlag )
 			{
-			BifEvent::generate_dnp3_analog_input_16wFlag(
+			BifEvent::enqueue_dnp3_analog_input_16wFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value);
@@ -323,7 +323,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_32woFlag )
 			{
-			BifEvent::generate_dnp3_analog_input_32woFlag(
+			BifEvent::enqueue_dnp3_analog_input_32woFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), value);
@@ -337,7 +337,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_16woFlag )
 			{
-			BifEvent::generate_dnp3_analog_input_16woFlag(
+			BifEvent::enqueue_dnp3_analog_input_16woFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), value);
@@ -351,7 +351,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_SPwFlag )
 			{
-			BifEvent::generate_dnp3_analog_input_SPwFlag(
+			BifEvent::enqueue_dnp3_analog_input_SPwFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value);
@@ -365,7 +365,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_DPwFlag )
 			{
-			BifEvent::generate_dnp3_analog_input_DPwFlag(
+			BifEvent::enqueue_dnp3_analog_input_DPwFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value_low, value_high);
@@ -379,7 +379,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_32wFlag )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_32wFlag(
+			BifEvent::enqueue_dnp3_frozen_analog_input_32wFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value);
@@ -393,7 +393,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_16wFlag )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_16wFlag(
+			BifEvent::enqueue_dnp3_frozen_analog_input_16wFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value);
@@ -407,7 +407,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_32wTime )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_32wTime(
+			BifEvent::enqueue_dnp3_frozen_analog_input_32wTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value, bytestring_to_time(time48));
@@ -421,7 +421,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_16wTime )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_16wTime(
+			BifEvent::enqueue_dnp3_frozen_analog_input_16wTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value, bytestring_to_time(time48));
@@ -435,7 +435,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_32woFlag )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_32woFlag(
+			BifEvent::enqueue_dnp3_frozen_analog_input_32woFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), frozen_value);
@@ -449,7 +449,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_16woFlag )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_16woFlag(
+			BifEvent::enqueue_dnp3_frozen_analog_input_16woFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), frozen_value);
@@ -463,7 +463,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_SPwFlag )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_SPwFlag(
+			BifEvent::enqueue_dnp3_frozen_analog_input_SPwFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value);
@@ -477,7 +477,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_DPwFlag )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_DPwFlag(
+			BifEvent::enqueue_dnp3_frozen_analog_input_DPwFlag(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value_low, frozen_value_high);
@@ -491,7 +491,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_event_32woTime )
 			{
-			BifEvent::generate_dnp3_analog_input_event_32woTime(
+			BifEvent::enqueue_dnp3_analog_input_event_32woTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value);
@@ -505,7 +505,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_event_16woTime )
 			{
-			BifEvent::generate_dnp3_analog_input_event_16woTime(
+			BifEvent::enqueue_dnp3_analog_input_event_16woTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value);
@@ -519,7 +519,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_event_32wTime )
 			{
-			BifEvent::generate_dnp3_analog_input_event_32wTime(
+			BifEvent::enqueue_dnp3_analog_input_event_32wTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value, bytestring_to_time(time48));
@@ -533,7 +533,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_event_16wTime )
 			{
-			BifEvent::generate_dnp3_analog_input_event_16wTime(
+			BifEvent::enqueue_dnp3_analog_input_event_16wTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value, bytestring_to_time(time48));
@@ -547,7 +547,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_event_SPwoTime )
 			{
-			BifEvent::generate_dnp3_analog_input_event_SPwoTime(
+			BifEvent::enqueue_dnp3_analog_input_event_SPwoTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value);
@@ -561,7 +561,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_event_DPwoTime )
 			{
-			BifEvent::generate_dnp3_analog_input_event_DPwoTime(
+			BifEvent::enqueue_dnp3_analog_input_event_DPwoTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value_low, value_high);
@@ -575,7 +575,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_event_SPwTime )
 			{
-			BifEvent::generate_dnp3_analog_input_event_SPwTime(
+			BifEvent::enqueue_dnp3_analog_input_event_SPwTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value, bytestring_to_time(time48));
@@ -589,7 +589,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_analog_input_event_DPwTime )
 			{
-			BifEvent::generate_dnp3_analog_input_event_DPwTime(
+			BifEvent::enqueue_dnp3_analog_input_event_DPwTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, value_low, value_high, bytestring_to_time(time48));
@@ -603,7 +603,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_event_32woTime )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_event_32woTime(
+			BifEvent::enqueue_dnp3_frozen_analog_input_event_32woTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value);
@@ -617,7 +617,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_event_16woTime )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_event_16woTime(
+			BifEvent::enqueue_dnp3_frozen_analog_input_event_16woTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value);
@@ -631,7 +631,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_event_32wTime )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_event_32wTime(
+			BifEvent::enqueue_dnp3_frozen_analog_input_event_32wTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value, bytestring_to_time(time48));
@@ -645,7 +645,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_event_16wTime )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_event_16wTime(
+			BifEvent::enqueue_dnp3_frozen_analog_input_event_16wTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value, bytestring_to_time(time48));
@@ -659,7 +659,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_event_SPwoTime )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_event_SPwoTime(
+			BifEvent::enqueue_dnp3_frozen_analog_input_event_SPwoTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value);
@@ -673,7 +673,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_event_DPwoTime )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_event_DPwoTime(
+			BifEvent::enqueue_dnp3_frozen_analog_input_event_DPwoTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value_low, frozen_value_high);
@@ -687,7 +687,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_event_SPwTime )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_event_SPwTime(
+			BifEvent::enqueue_dnp3_frozen_analog_input_event_SPwTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value, bytestring_to_time(time48));
@@ -701,7 +701,7 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_frozen_analog_input_event_DPwTime )
 			{
-			BifEvent::generate_dnp3_frozen_analog_input_event_DPwTime(
+			BifEvent::enqueue_dnp3_frozen_analog_input_event_DPwTime(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				is_orig(), flag, frozen_value_low, frozen_value_high, bytestring_to_time(time48));
@@ -715,10 +715,10 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_file_transport )
 			{
-			BifEvent::generate_dnp3_file_transport(
+			BifEvent::enqueue_dnp3_file_transport(
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
-				is_orig(), file_handle, block_num, bytestring_to_val(file_data));
+				is_orig(), file_handle, block_num, to_stringval(file_data));
 			}
 
 		return true;
@@ -729,10 +729,10 @@ flow DNP3_Flow(is_orig: bool) {
 		%{
 		if ( ::dnp3_debug_byte )
 			{
-			BifEvent::generate_dnp3_debug_byte (
+			BifEvent::enqueue_dnp3_debug_byte (
 				connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
-				is_orig(), bytestring_to_val(debug));
+				is_orig(), to_stringval(debug));
 			}
 
 		return true;

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -52,7 +52,7 @@ void DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
 			val_mgr->Bool(is_query),
 			IntrusivePtr{AdoptRef{}, msg.BuildHdrVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)}
+			val_mgr->Count(len)
 		);
 
 	// There is a great deal of non-DNS traffic that runs on port 53.
@@ -596,7 +596,7 @@ bool DNS_Interpreter::ParseRR_SOA(DNS_MsgInfo* msg,
 		auto r = make_intrusive<RecordVal>(dns_soa);
 		r->Assign(0, make_intrusive<StringVal>(new BroString(mname, mname_end - mname, true)));
 		r->Assign(1, make_intrusive<StringVal>(new BroString(rname, rname_end - rname, true)));
-		r->Assign(2, val_mgr->GetCount(serial));
+		r->Assign(2, val_mgr->Count(serial));
 		r->Assign(3, make_intrusive<IntervalVal>(double(refresh), Seconds));
 		r->Assign(4, make_intrusive<IntervalVal>(double(retry), Seconds));
 		r->Assign(5, make_intrusive<IntervalVal>(double(expire), Seconds));
@@ -637,7 +637,7 @@ bool DNS_Interpreter::ParseRR_MX(DNS_MsgInfo* msg,
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(preference)}
+			val_mgr->Count(preference)
 		);
 
 	return true;
@@ -678,9 +678,9 @@ bool DNS_Interpreter::ParseRR_SRV(DNS_MsgInfo* msg,
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(priority)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(weight)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(port)}
+			val_mgr->Count(priority),
+			val_mgr->Count(weight),
+			val_mgr->Count(port)
 		);
 
 	return true;
@@ -1371,7 +1371,7 @@ bool DNS_Interpreter::ParseRR_CAA(DNS_MsgInfo* msg,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(flags)},
+			val_mgr->Count(flags),
 			make_intrusive<StringVal>(tag),
 			make_intrusive<StringVal>(value)
 		);
@@ -1399,8 +1399,8 @@ void DNS_Interpreter::SendReplyOrRejectEvent(DNS_MsgInfo* msg,
 		IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
 		IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 		make_intrusive<StringVal>(question_name),
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(qtype)},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(qclass)}
+		val_mgr->Count(qtype),
+		val_mgr->Count(qclass)
 	);
 	}
 
@@ -1446,19 +1446,19 @@ Val* DNS_MsgInfo::BuildHdrVal()
 	{
 	RecordVal* r = new RecordVal(dns_msg);
 
-	r->Assign(0, val_mgr->GetCount(id));
-	r->Assign(1, val_mgr->GetCount(opcode));
-	r->Assign(2, val_mgr->GetCount(rcode));
+	r->Assign(0, val_mgr->Count(id));
+	r->Assign(1, val_mgr->Count(opcode));
+	r->Assign(2, val_mgr->Count(rcode));
 	r->Assign(3, val_mgr->Bool(QR));
 	r->Assign(4, val_mgr->Bool(AA));
 	r->Assign(5, val_mgr->Bool(TC));
 	r->Assign(6, val_mgr->Bool(RD));
 	r->Assign(7, val_mgr->Bool(RA));
-	r->Assign(8, val_mgr->GetCount(Z));
-	r->Assign(9, val_mgr->GetCount(qdcount));
-	r->Assign(10, val_mgr->GetCount(ancount));
-	r->Assign(11, val_mgr->GetCount(nscount));
-	r->Assign(12, val_mgr->GetCount(arcount));
+	r->Assign(8, val_mgr->Count(Z));
+	r->Assign(9, val_mgr->Count(qdcount));
+	r->Assign(10, val_mgr->Count(ancount));
+	r->Assign(11, val_mgr->Count(nscount));
+	r->Assign(12, val_mgr->Count(arcount));
 
 	return r;
 	}
@@ -1468,10 +1468,10 @@ Val* DNS_MsgInfo::BuildAnswerVal()
 	RecordVal* r = new RecordVal(dns_answer);
 
 	Ref(query_name);
-	r->Assign(0, val_mgr->GetCount(int(answer_type)));
+	r->Assign(0, val_mgr->Count(int(answer_type)));
 	r->Assign(1, query_name);
-	r->Assign(2, val_mgr->GetCount(atype));
-	r->Assign(3, val_mgr->GetCount(aclass));
+	r->Assign(2, val_mgr->Count(atype));
+	r->Assign(3, val_mgr->Count(aclass));
 	r->Assign(4, make_intrusive<IntervalVal>(double(ttl), Seconds));
 
 	return r;
@@ -1484,14 +1484,14 @@ Val* DNS_MsgInfo::BuildEDNS_Val()
 	RecordVal* r = new RecordVal(dns_edns_additional);
 
 	Ref(query_name);
-	r->Assign(0, val_mgr->GetCount(int(answer_type)));
+	r->Assign(0, val_mgr->Count(int(answer_type)));
 	r->Assign(1, query_name);
 
 	// type = 0x29 or 41 = EDNS
-	r->Assign(2, val_mgr->GetCount(atype));
+	r->Assign(2, val_mgr->Count(atype));
 
 	// sender's UDP payload size, per RFC 2671 4.3
-	r->Assign(3, val_mgr->GetCount(aclass));
+	r->Assign(3, val_mgr->Count(aclass));
 
 	// Need to break the TTL field into three components:
 	// initial: [------------- ttl (32) ---------------------]
@@ -1504,11 +1504,11 @@ Val* DNS_MsgInfo::BuildEDNS_Val()
 
 	unsigned int return_error = (ercode << 8) | rcode;
 
-	r->Assign(4, val_mgr->GetCount(return_error));
-	r->Assign(5, val_mgr->GetCount(version));
-	r->Assign(6, val_mgr->GetCount(z));
+	r->Assign(4, val_mgr->Count(return_error));
+	r->Assign(5, val_mgr->Count(version));
+	r->Assign(6, val_mgr->Count(z));
 	r->Assign(7, make_intrusive<IntervalVal>(double(ttl), Seconds));
-	r->Assign(8, val_mgr->GetCount(is_query));
+	r->Assign(8, val_mgr->Count(is_query));
 
 	return r;
 	}
@@ -1519,16 +1519,16 @@ Val* DNS_MsgInfo::BuildTSIG_Val(struct TSIG_DATA* tsig)
 	double rtime = tsig->time_s + tsig->time_ms / 1000.0;
 
 	Ref(query_name);
-	// r->Assign(0, val_mgr->GetCount(int(answer_type)));
+	// r->Assign(0, val_mgr->Count(int(answer_type)));
 	r->Assign(0, query_name);
-	r->Assign(1, val_mgr->GetCount(int(answer_type)));
+	r->Assign(1, val_mgr->Count(int(answer_type)));
 	r->Assign(2, make_intrusive<StringVal>(tsig->alg_name));
 	r->Assign(3, make_intrusive<StringVal>(tsig->sig));
 	r->Assign(4, make_intrusive<Val>(rtime, TYPE_TIME));
 	r->Assign(5, make_intrusive<Val>(double(tsig->fudge), TYPE_TIME));
-	r->Assign(6, val_mgr->GetCount(tsig->orig_id));
-	r->Assign(7, val_mgr->GetCount(tsig->rr_error));
-	r->Assign(8, val_mgr->GetCount(is_query));
+	r->Assign(6, val_mgr->Count(tsig->orig_id));
+	r->Assign(7, val_mgr->Count(tsig->rr_error));
+	r->Assign(8, val_mgr->Count(is_query));
 
 	return r;
 	}
@@ -1539,17 +1539,17 @@ Val* DNS_MsgInfo::BuildRRSIG_Val(RRSIG_DATA* rrsig)
 
 	Ref(query_name);
 	r->Assign(0, query_name);
-	r->Assign(1, val_mgr->GetCount(int(answer_type)));
-	r->Assign(2, val_mgr->GetCount(rrsig->type_covered));
-	r->Assign(3, val_mgr->GetCount(rrsig->algorithm));
-	r->Assign(4, val_mgr->GetCount(rrsig->labels));
+	r->Assign(1, val_mgr->Count(int(answer_type)));
+	r->Assign(2, val_mgr->Count(rrsig->type_covered));
+	r->Assign(3, val_mgr->Count(rrsig->algorithm));
+	r->Assign(4, val_mgr->Count(rrsig->labels));
 	r->Assign(5, make_intrusive<IntervalVal>(double(rrsig->orig_ttl), Seconds));
 	r->Assign(6, make_intrusive<Val>(double(rrsig->sig_exp), TYPE_TIME));
 	r->Assign(7, make_intrusive<Val>(double(rrsig->sig_incep), TYPE_TIME));
-	r->Assign(8, val_mgr->GetCount(rrsig->key_tag));
+	r->Assign(8, val_mgr->Count(rrsig->key_tag));
 	r->Assign(9, make_intrusive<StringVal>(rrsig->signer_name));
 	r->Assign(10, make_intrusive<StringVal>(rrsig->signature));
-	r->Assign(11, val_mgr->GetCount(is_query));
+	r->Assign(11, val_mgr->Count(is_query));
 
 	return r;
 	}
@@ -1560,12 +1560,12 @@ Val* DNS_MsgInfo::BuildDNSKEY_Val(DNSKEY_DATA* dnskey)
 
 	Ref(query_name);
 	r->Assign(0, query_name);
-	r->Assign(1, val_mgr->GetCount(int(answer_type)));
-	r->Assign(2, val_mgr->GetCount(dnskey->dflags));
-	r->Assign(3, val_mgr->GetCount(dnskey->dprotocol));
-	r->Assign(4, val_mgr->GetCount(dnskey->dalgorithm));
+	r->Assign(1, val_mgr->Count(int(answer_type)));
+	r->Assign(2, val_mgr->Count(dnskey->dflags));
+	r->Assign(3, val_mgr->Count(dnskey->dprotocol));
+	r->Assign(4, val_mgr->Count(dnskey->dalgorithm));
 	r->Assign(5, make_intrusive<StringVal>(dnskey->public_key));
-	r->Assign(6, val_mgr->GetCount(is_query));
+	r->Assign(6, val_mgr->Count(is_query));
 
 	return r;
 	}
@@ -1576,16 +1576,16 @@ Val* DNS_MsgInfo::BuildNSEC3_Val(NSEC3_DATA* nsec3)
 
 	Ref(query_name);
 	r->Assign(0, query_name);
-	r->Assign(1, val_mgr->GetCount(int(answer_type)));
-	r->Assign(2, val_mgr->GetCount(nsec3->nsec_flags));
-	r->Assign(3, val_mgr->GetCount(nsec3->nsec_hash_algo));
-	r->Assign(4, val_mgr->GetCount(nsec3->nsec_iter));
-	r->Assign(5, val_mgr->GetCount(nsec3->nsec_salt_len));
+	r->Assign(1, val_mgr->Count(int(answer_type)));
+	r->Assign(2, val_mgr->Count(nsec3->nsec_flags));
+	r->Assign(3, val_mgr->Count(nsec3->nsec_hash_algo));
+	r->Assign(4, val_mgr->Count(nsec3->nsec_iter));
+	r->Assign(5, val_mgr->Count(nsec3->nsec_salt_len));
 	r->Assign(6, make_intrusive<StringVal>(nsec3->nsec_salt));
-	r->Assign(7, val_mgr->GetCount(nsec3->nsec_hlen));
+	r->Assign(7, val_mgr->Count(nsec3->nsec_hlen));
 	r->Assign(8, make_intrusive<StringVal>(nsec3->nsec_hash));
 	r->Assign(9, nsec3->bitmaps);
-	r->Assign(10, val_mgr->GetCount(is_query));
+	r->Assign(10, val_mgr->Count(is_query));
 
 	return r;
 	}
@@ -1596,12 +1596,12 @@ Val* DNS_MsgInfo::BuildDS_Val(DS_DATA* ds)
 
 	Ref(query_name);
 	r->Assign(0, query_name);
-	r->Assign(1, val_mgr->GetCount(int(answer_type)));
-	r->Assign(2, val_mgr->GetCount(ds->key_tag));
-	r->Assign(3, val_mgr->GetCount(ds->algorithm));
-	r->Assign(4, val_mgr->GetCount(ds->digest_type));
+	r->Assign(1, val_mgr->Count(int(answer_type)));
+	r->Assign(2, val_mgr->Count(ds->key_tag));
+	r->Assign(3, val_mgr->Count(ds->algorithm));
+	r->Assign(4, val_mgr->Count(ds->digest_type));
 	r->Assign(5, make_intrusive<StringVal>(ds->digest_val));
-	r->Assign(6, val_mgr->GetCount(is_query));
+	r->Assign(6, val_mgr->Count(is_query));
 
 	return r;
 	}

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -50,7 +50,7 @@ void DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
 	if ( dns_message )
 		analyzer->EnqueueConnEvent(dns_message,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_query)},
+			val_mgr->Bool(is_query),
 			IntrusivePtr{AdoptRef{}, msg.BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)}
 		);
@@ -1449,11 +1449,11 @@ Val* DNS_MsgInfo::BuildHdrVal()
 	r->Assign(0, val_mgr->GetCount(id));
 	r->Assign(1, val_mgr->GetCount(opcode));
 	r->Assign(2, val_mgr->GetCount(rcode));
-	r->Assign(3, val_mgr->GetBool(QR));
-	r->Assign(4, val_mgr->GetBool(AA));
-	r->Assign(5, val_mgr->GetBool(TC));
-	r->Assign(6, val_mgr->GetBool(RD));
-	r->Assign(7, val_mgr->GetBool(RA));
+	r->Assign(3, val_mgr->Bool(QR));
+	r->Assign(4, val_mgr->Bool(AA));
+	r->Assign(5, val_mgr->Bool(TC));
+	r->Assign(6, val_mgr->Bool(RD));
+	r->Assign(7, val_mgr->Bool(RA));
 	r->Assign(8, val_mgr->GetCount(Z));
 	r->Assign(9, val_mgr->GetCount(qdcount));
 	r->Assign(10, val_mgr->GetCount(ancount));

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -49,7 +49,7 @@ void DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
 
 	if ( dns_message )
 		analyzer->EnqueueConnEvent(dns_message,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Bool(is_query),
 			IntrusivePtr{AdoptRef{}, msg.BuildHdrVal()},
 			val_mgr->Count(len)
@@ -134,7 +134,7 @@ void DNS_Interpreter::EndMessage(DNS_MsgInfo* msg)
 	{
 	if ( dns_end )
 		analyzer->EnqueueConnEvent(dns_end,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()}
 		);
 	}
@@ -337,7 +337,7 @@ bool DNS_Interpreter::ParseAnswer(DNS_MsgInfo* msg,
 
 			if ( dns_unknown_reply && ! msg->skip_event )
 				analyzer->EnqueueConnEvent(dns_unknown_reply,
-					IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+					analyzer->ConnVal(),
 					IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 					IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()}
 				);
@@ -550,7 +550,7 @@ bool DNS_Interpreter::ParseRR_Name(DNS_MsgInfo* msg,
 
 	if ( reply_event && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(reply_event,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			make_intrusive<StringVal>(new BroString(name, name_end - name, true))
@@ -603,7 +603,7 @@ bool DNS_Interpreter::ParseRR_SOA(DNS_MsgInfo* msg,
 		r->Assign(6, make_intrusive<IntervalVal>(double(minimum), Seconds));
 
 		analyzer->EnqueueConnEvent(dns_SOA_reply,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			std::move(r)
@@ -633,7 +633,7 @@ bool DNS_Interpreter::ParseRR_MX(DNS_MsgInfo* msg,
 
 	if ( dns_MX_reply && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(dns_MX_reply,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
@@ -674,7 +674,7 @@ bool DNS_Interpreter::ParseRR_SRV(DNS_MsgInfo* msg,
 
 	if ( dns_SRV_reply && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(dns_SRV_reply,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
@@ -695,7 +695,7 @@ bool DNS_Interpreter::ParseRR_EDNS(DNS_MsgInfo* msg,
 
 	if ( dns_EDNS_addl && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(dns_EDNS_addl,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildEDNS_Val()}
 		);
@@ -772,7 +772,7 @@ bool DNS_Interpreter::ParseRR_TSIG(DNS_MsgInfo* msg,
 		tsig.rr_error = rr_error;
 
 		analyzer->EnqueueConnEvent(dns_TSIG_addl,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildTSIG_Val(&tsig)}
 		);
@@ -873,7 +873,7 @@ bool DNS_Interpreter::ParseRR_RRSIG(DNS_MsgInfo* msg,
 		rrsig.signature = sign;
 
 		analyzer->EnqueueConnEvent(dns_RRSIG,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildRRSIG_Val(&rrsig)}
@@ -968,7 +968,7 @@ bool DNS_Interpreter::ParseRR_DNSKEY(DNS_MsgInfo* msg,
 		dnskey.public_key = key;
 
 		analyzer->EnqueueConnEvent(dns_DNSKEY,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildDNSKEY_Val(&dnskey)}
@@ -1020,7 +1020,7 @@ bool DNS_Interpreter::ParseRR_NSEC(DNS_MsgInfo* msg,
 
 	if ( dns_NSEC )
 		analyzer->EnqueueConnEvent(dns_NSEC,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
@@ -1106,7 +1106,7 @@ bool DNS_Interpreter::ParseRR_NSEC3(DNS_MsgInfo* msg,
 		nsec3.bitmaps = char_strings;
 
 		analyzer->EnqueueConnEvent(dns_NSEC3,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildNSEC3_Val(&nsec3)}
@@ -1166,7 +1166,7 @@ bool DNS_Interpreter::ParseRR_DS(DNS_MsgInfo* msg,
 		ds.digest_val = ds_digest;
 
 		analyzer->EnqueueConnEvent(dns_DS,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildDS_Val(&ds)}
@@ -1189,7 +1189,7 @@ bool DNS_Interpreter::ParseRR_A(DNS_MsgInfo* msg,
 
 	if ( dns_A_reply && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(dns_A_reply,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			make_intrusive<AddrVal>(htonl(addr))
@@ -1225,7 +1225,7 @@ bool DNS_Interpreter::ParseRR_AAAA(DNS_MsgInfo* msg,
 
 	if ( event && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(event,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			make_intrusive<AddrVal>(addr)
@@ -1299,7 +1299,7 @@ bool DNS_Interpreter::ParseRR_TXT(DNS_MsgInfo* msg,
 
 	if ( dns_TXT_reply )
 		analyzer->EnqueueConnEvent(dns_TXT_reply,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			std::move(char_strings)
@@ -1327,7 +1327,7 @@ bool DNS_Interpreter::ParseRR_SPF(DNS_MsgInfo* msg,
 
 	if ( dns_SPF_reply )
 		analyzer->EnqueueConnEvent(dns_SPF_reply,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			std::move(char_strings)
@@ -1368,7 +1368,7 @@ bool DNS_Interpreter::ParseRR_CAA(DNS_MsgInfo* msg,
 
 	if ( dns_CAA_reply )
 		analyzer->EnqueueConnEvent(dns_CAA_reply,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 			IntrusivePtr{AdoptRef{}, msg->BuildAnswerVal()},
 			val_mgr->Count(flags),
@@ -1396,7 +1396,7 @@ void DNS_Interpreter::SendReplyOrRejectEvent(DNS_MsgInfo* msg,
 	assert(event);
 
 	analyzer->EnqueueConnEvent(event,
-		IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+		analyzer->ConnVal(),
 		IntrusivePtr{AdoptRef{}, msg->BuildHdrVal()},
 		make_intrusive<StringVal>(question_name),
 		val_mgr->Count(qtype),

--- a/src/analyzer/protocol/file/File.cc
+++ b/src/analyzer/protocol/file/File.cc
@@ -80,7 +80,7 @@ void File_Analyzer::Identify()
 
 	if ( file_transferred )
 		EnqueueConnEvent(file_transferred,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			make_intrusive<StringVal>(buffer_len, buffer),
 			make_intrusive<StringVal>("<unknown>"),
 			make_intrusive<StringVal>(match)

--- a/src/analyzer/protocol/finger/Finger.cc
+++ b/src/analyzer/protocol/finger/Finger.cc
@@ -69,7 +69,7 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 		if ( finger_request )
 			EnqueueConnEvent(finger_request,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(long_cnt)},
+				val_mgr->Bool(long_cnt),
 				make_intrusive<StringVal>(at - line, line),
 				make_intrusive<StringVal>(end_of_line - host, host)
 			);

--- a/src/analyzer/protocol/finger/Finger.cc
+++ b/src/analyzer/protocol/finger/Finger.cc
@@ -68,7 +68,7 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 
 		if ( finger_request )
 			EnqueueConnEvent(finger_request,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(long_cnt),
 				make_intrusive<StringVal>(at - line, line),
 				make_intrusive<StringVal>(end_of_line - host, host)
@@ -86,7 +86,7 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 			return;
 
 		EnqueueConnEvent(finger_reply,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			make_intrusive<StringVal>(end_of_line - line, line)
 		);
 		}

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -97,7 +97,7 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 			cmd_str = (new StringVal(cmd_len, cmd))->ToUpper();
 
 		vl = {
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			IntrusivePtr{AdoptRef{}, cmd_str},
 			make_intrusive<StringVal>(end_of_line - line, line),
 		};
@@ -176,7 +176,7 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 			}
 
 		vl = {
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Count(reply_code),
 			make_intrusive<StringVal>(end_of_line - line, line),
 			val_mgr->Bool(cont_resp)

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -177,7 +177,7 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 
 		vl = {
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(reply_code)},
+			val_mgr->Count(reply_code),
 			make_intrusive<StringVal>(end_of_line - line, line),
 			val_mgr->Bool(cont_resp)
 		};

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -179,7 +179,7 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(reply_code)},
 			make_intrusive<StringVal>(end_of_line - line, line),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(cont_resp)}
+			val_mgr->Bool(cont_resp)
 		};
 
 		f = ftp_reply;

--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -4,9 +4,9 @@ type ftp_port: record;
 %%{
 #include "Reporter.h"
 
-static Val* parse_port(const char* line)
+static IntrusivePtr<Val> parse_port(const char* line)
 	{
-	RecordVal* r = new RecordVal(BifType::Record::ftp_port);
+	auto r = make_intrusive<RecordVal>(BifType::Record::ftp_port);
 
 	int bytes[6];
 	if ( line && sscanf(line, "%d,%d,%d,%d,%d,%d",
@@ -47,9 +47,9 @@ static Val* parse_port(const char* line)
 	return r;
 	}
 
-static Val* parse_eftp(const char* line)
+static IntrusivePtr<Val> parse_eftp(const char* line)
 	{
-	RecordVal* r = new RecordVal(BifType::Record::ftp_port);
+	auto r = make_intrusive<RecordVal>(BifType::Record::ftp_port);
 
 	int net_proto = 0;	// currently not used
 	IPAddr addr;	// unspecified IPv6 address (all 128 bits zero)
@@ -206,7 +206,7 @@ function fmt_ftp_port%(a: addr, p: port%): string
 		{
 		uint32_t a = ntohl(addr[0]);
 		uint32_t pn = p->Port();
-		return new StringVal(fmt("%d,%d,%d,%d,%d,%d",
+		return make_intrusive<StringVal>(fmt("%d,%d,%d,%d,%d,%d",
 						a >> 24, (a >> 16) & 0xff,
 						(a >> 8) & 0xff, a & 0xff,
 						pn >> 8, pn & 0xff));

--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -35,7 +35,7 @@ static Val* parse_port(const char* line)
 
 		r->Assign(0, make_intrusive<AddrVal>(htonl(addr)));
 		r->Assign(1, val_mgr->GetPort(port, TRANSPORT_TCP));
-		r->Assign(2, val_mgr->GetBool(good));
+		r->Assign(2, val_mgr->Bool(good));
 		}
 	else
 		{
@@ -111,7 +111,7 @@ static Val* parse_eftp(const char* line)
 
 	r->Assign(0, make_intrusive<AddrVal>(addr));
 	r->Assign(1, val_mgr->GetPort(port, TRANSPORT_TCP));
-	r->Assign(2, val_mgr->GetBool(good));
+	r->Assign(2, val_mgr->Bool(good));
 
 	return r;
 	}

--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -34,13 +34,13 @@ static Val* parse_port(const char* line)
 			}
 
 		r->Assign(0, make_intrusive<AddrVal>(htonl(addr)));
-		r->Assign(1, val_mgr->GetPort(port, TRANSPORT_TCP));
+		r->Assign(1, val_mgr->Port(port, TRANSPORT_TCP));
 		r->Assign(2, val_mgr->Bool(good));
 		}
 	else
 		{
 		r->Assign(0, make_intrusive<AddrVal>(uint32_t(0)));
-		r->Assign(1, val_mgr->GetPort(0, TRANSPORT_TCP));
+		r->Assign(1, val_mgr->Port(0, TRANSPORT_TCP));
 		r->Assign(2, val_mgr->False());
 		}
 
@@ -110,7 +110,7 @@ static Val* parse_eftp(const char* line)
 		}
 
 	r->Assign(0, make_intrusive<AddrVal>(addr));
-	r->Assign(1, val_mgr->GetPort(port, TRANSPORT_TCP));
+	r->Assign(1, val_mgr->Port(port, TRANSPORT_TCP));
 	r->Assign(2, val_mgr->Bool(good));
 
 	return r;

--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -41,7 +41,7 @@ static Val* parse_port(const char* line)
 		{
 		r->Assign(0, make_intrusive<AddrVal>(uint32_t(0)));
 		r->Assign(1, val_mgr->GetPort(0, TRANSPORT_TCP));
-		r->Assign(2, val_mgr->GetFalse());
+		r->Assign(2, val_mgr->False());
 		}
 
 	return r;

--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -215,6 +215,6 @@ function fmt_ftp_port%(a: addr, p: port%): string
 		{
 		builtin_error("conversion of non-IPv4 address in fmt_ftp_port",
 		              @ARG@[0]);
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 	%}

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -74,7 +74,7 @@ void Gnutella_Analyzer::Done()
 				EnqueueConnEvent(gnutella_partial_binary_msg,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
 					make_intrusive<StringVal>(p->msg),
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool((i == 0))},
+					val_mgr->Bool((i == 0)),
 					IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->msg_pos)}
 				);
 
@@ -178,7 +178,7 @@ void Gnutella_Analyzer::DeliverLines(int len, const u_char* data, bool orig)
 			if ( gnutella_text_msg )
 				EnqueueConnEvent(gnutella_text_msg,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(ms->headers.data())
 				);
 
@@ -216,15 +216,15 @@ void Gnutella_Analyzer::SendEvents(GnutellaMsgState* p, bool is_orig)
 	if ( gnutella_binary_msg )
 		EnqueueConnEvent(gnutella_binary_msg,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+			val_mgr->Bool(is_orig),
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->msg_type)},
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->msg_ttl)},
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->msg_hops)},
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->msg_len)},
 			make_intrusive<StringVal>(p->payload),
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->payload_len)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool((p->payload_len < std::min(p->msg_len, (unsigned int)GNUTELLA_MAX_PAYLOAD)))},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool((p->payload_left == 0))}
+			val_mgr->Bool((p->payload_len < std::min(p->msg_len, (unsigned int)GNUTELLA_MAX_PAYLOAD))),
+			val_mgr->Bool((p->payload_left == 0))
 		);
 	}
 

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -75,7 +75,7 @@ void Gnutella_Analyzer::Done()
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
 					make_intrusive<StringVal>(p->msg),
 					val_mgr->Bool((i == 0)),
-					IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->msg_pos)}
+					val_mgr->Count(p->msg_pos)
 				);
 
 			else if ( ! p->msg_sent && p->payload_left )
@@ -217,12 +217,12 @@ void Gnutella_Analyzer::SendEvents(GnutellaMsgState* p, bool is_orig)
 		EnqueueConnEvent(gnutella_binary_msg,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
 			val_mgr->Bool(is_orig),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->msg_type)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->msg_ttl)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->msg_hops)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->msg_len)},
+			val_mgr->Count(p->msg_type),
+			val_mgr->Count(p->msg_ttl),
+			val_mgr->Count(p->msg_hops),
+			val_mgr->Count(p->msg_len),
 			make_intrusive<StringVal>(p->payload),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(p->payload_len)},
+			val_mgr->Count(p->payload_len),
 			val_mgr->Bool((p->payload_len < std::min(p->msg_len, (unsigned int)GNUTELLA_MAX_PAYLOAD))),
 			val_mgr->Bool((p->payload_left == 0))
 		);

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -59,9 +59,9 @@ void Gnutella_Analyzer::Done()
 	if ( ! sent_establish && (gnutella_establish || gnutella_not_establish) )
 		{
 		if ( Established() && gnutella_establish )
-			EnqueueConnEvent(gnutella_establish, IntrusivePtr{AdoptRef{}, BuildConnVal()});
+			EnqueueConnEvent(gnutella_establish, ConnVal());
 		else if ( ! Established () && gnutella_not_establish )
-			EnqueueConnEvent(gnutella_not_establish, IntrusivePtr{AdoptRef{}, BuildConnVal()});
+			EnqueueConnEvent(gnutella_not_establish, ConnVal());
 		}
 
 	if ( gnutella_partial_binary_msg )
@@ -72,7 +72,7 @@ void Gnutella_Analyzer::Done()
 			{
 			if ( ! p->msg_sent && p->msg_pos )
 				EnqueueConnEvent(gnutella_partial_binary_msg,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					make_intrusive<StringVal>(p->msg),
 					val_mgr->Bool((i == 0)),
 					val_mgr->Count(p->msg_pos)
@@ -118,7 +118,7 @@ bool Gnutella_Analyzer::IsHTTP(std::string header)
 		return false;
 
 	if ( gnutella_http_notify )
-		EnqueueConnEvent(gnutella_http_notify, IntrusivePtr{AdoptRef{}, BuildConnVal()});
+		EnqueueConnEvent(gnutella_http_notify, ConnVal());
 
 	analyzer::Analyzer* a = analyzer_mgr->InstantiateAnalyzer("HTTP", Conn());
 
@@ -177,7 +177,7 @@ void Gnutella_Analyzer::DeliverLines(int len, const u_char* data, bool orig)
 			{
 			if ( gnutella_text_msg )
 				EnqueueConnEvent(gnutella_text_msg,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(ms->headers.data())
 				);
@@ -189,7 +189,7 @@ void Gnutella_Analyzer::DeliverLines(int len, const u_char* data, bool orig)
 				{
 				sent_establish = 1;
 
-				EnqueueConnEvent(gnutella_establish, IntrusivePtr{AdoptRef{}, BuildConnVal()});
+				EnqueueConnEvent(gnutella_establish, ConnVal());
 				}
 			}
 		}
@@ -215,7 +215,7 @@ void Gnutella_Analyzer::SendEvents(GnutellaMsgState* p, bool is_orig)
 
 	if ( gnutella_binary_msg )
 		EnqueueConnEvent(gnutella_binary_msg,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(is_orig),
 			val_mgr->Count(p->msg_type),
 			val_mgr->Count(p->msg_ttl),

--- a/src/analyzer/protocol/gssapi/gssapi-analyzer.pac
+++ b/src/analyzer/protocol/gssapi/gssapi-analyzer.pac
@@ -61,9 +61,9 @@ refine connection GSSAPI_Conn += {
 		%{
 		if ( gssapi_neg_result )
 			{
-			BifEvent::generate_gssapi_neg_result(bro_analyzer(),
-			                                     bro_analyzer()->Conn(),
-			                                     binary_to_int64(${val.neg_state.encoding.content}));
+			BifEvent::enqueue_gssapi_neg_result(bro_analyzer(),
+			                                    bro_analyzer()->Conn(),
+			                                    binary_to_int64(${val.neg_state.encoding.content}));
 			}
 
 		return true;

--- a/src/analyzer/protocol/gtpv1/gtpv1-analyzer.pac
+++ b/src/analyzer/protocol/gtpv1/gtpv1-analyzer.pac
@@ -9,11 +9,11 @@ RecordVal* BuildGTPv1Hdr(const GTPv1_Header* pdu)
 	RecordVal* rv = new RecordVal(BifType::Record::gtpv1_hdr);
 
 	rv->Assign(0, val_mgr->GetCount(pdu->version()));
-	rv->Assign(1, val_mgr->GetBool(pdu->pt_flag()));
-	rv->Assign(2, val_mgr->GetBool(pdu->rsv()));
-	rv->Assign(3, val_mgr->GetBool(pdu->e_flag()));
-	rv->Assign(4, val_mgr->GetBool(pdu->s_flag()));
-	rv->Assign(5, val_mgr->GetBool(pdu->pn_flag()));
+	rv->Assign(1, val_mgr->Bool(pdu->pt_flag()));
+	rv->Assign(2, val_mgr->Bool(pdu->rsv()));
+	rv->Assign(3, val_mgr->Bool(pdu->e_flag()));
+	rv->Assign(4, val_mgr->Bool(pdu->s_flag()));
+	rv->Assign(5, val_mgr->Bool(pdu->pn_flag()));
 	rv->Assign(6, val_mgr->GetCount(pdu->msg_type()));
 	rv->Assign(7, val_mgr->GetCount(pdu->length()));
 	rv->Assign(8, val_mgr->GetCount(pdu->teid()));
@@ -206,9 +206,9 @@ Val* BuildCause(const InformationElement* ie)
 	return val_mgr->GetCount(ie->cause()->value());
 	}
 
-Val* BuildReorderReq(const InformationElement* ie)
+static IntrusivePtr<Val> BuildReorderReq(const InformationElement* ie)
 	{
-	return val_mgr->GetBool(ie->reorder_req()->req());
+	return val_mgr->Bool(ie->reorder_req()->req());
 	}
 
 Val* BuildChargingID(const InformationElement* ie)
@@ -228,9 +228,9 @@ Val* BuildChargingGatewayAddr(const InformationElement* ie)
 		return 0;
 	}
 
-Val* BuildTeardownInd(const InformationElement* ie)
+static IntrusivePtr<Val> BuildTeardownInd(const InformationElement* ie)
 	{
-	return val_mgr->GetBool(ie->teardown_ind()->ind());
+	return val_mgr->Bool(ie->teardown_ind()->ind());
 	}
 
 void CreatePDP_Request(const BroAnalyzer& a, const GTPv1_Header* pdu)

--- a/src/analyzer/protocol/gtpv1/gtpv1-analyzer.pac
+++ b/src/analyzer/protocol/gtpv1/gtpv1-analyzer.pac
@@ -8,86 +8,86 @@ RecordVal* BuildGTPv1Hdr(const GTPv1_Header* pdu)
 	{
 	RecordVal* rv = new RecordVal(BifType::Record::gtpv1_hdr);
 
-	rv->Assign(0, val_mgr->GetCount(pdu->version()));
+	rv->Assign(0, val_mgr->Count(pdu->version()));
 	rv->Assign(1, val_mgr->Bool(pdu->pt_flag()));
 	rv->Assign(2, val_mgr->Bool(pdu->rsv()));
 	rv->Assign(3, val_mgr->Bool(pdu->e_flag()));
 	rv->Assign(4, val_mgr->Bool(pdu->s_flag()));
 	rv->Assign(5, val_mgr->Bool(pdu->pn_flag()));
-	rv->Assign(6, val_mgr->GetCount(pdu->msg_type()));
-	rv->Assign(7, val_mgr->GetCount(pdu->length()));
-	rv->Assign(8, val_mgr->GetCount(pdu->teid()));
+	rv->Assign(6, val_mgr->Count(pdu->msg_type()));
+	rv->Assign(7, val_mgr->Count(pdu->length()));
+	rv->Assign(8, val_mgr->Count(pdu->teid()));
 
 	if ( pdu->has_opt() )
 		{
-		rv->Assign(9, val_mgr->GetCount(pdu->opt_hdr()->seq()));
-		rv->Assign(10, val_mgr->GetCount(pdu->opt_hdr()->n_pdu()));
-		rv->Assign(11, val_mgr->GetCount(pdu->opt_hdr()->next_type()));
+		rv->Assign(9, val_mgr->Count(pdu->opt_hdr()->seq()));
+		rv->Assign(10, val_mgr->Count(pdu->opt_hdr()->n_pdu()));
+		rv->Assign(11, val_mgr->Count(pdu->opt_hdr()->next_type()));
 		}
 
 	return rv;
 	}
 
-Val* BuildIMSI(const InformationElement* ie)
+static IntrusivePtr<Val> BuildIMSI(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->imsi()->value());
+	return val_mgr->Count(ie->imsi()->value());
 	}
 
-Val* BuildRAI(const InformationElement* ie)
+static IntrusivePtr<Val> BuildRAI(const InformationElement* ie)
 	{
-	RecordVal* ev = new RecordVal(BifType::Record::gtp_rai);
-	ev->Assign(0, val_mgr->GetCount(ie->rai()->mcc()));
-	ev->Assign(1, val_mgr->GetCount(ie->rai()->mnc()));
-	ev->Assign(2, val_mgr->GetCount(ie->rai()->lac()));
-	ev->Assign(3, val_mgr->GetCount(ie->rai()->rac()));
+	auto ev = make_intrusive<RecordVal>(BifType::Record::gtp_rai);
+	ev->Assign(0, val_mgr->Count(ie->rai()->mcc()));
+	ev->Assign(1, val_mgr->Count(ie->rai()->mnc()));
+	ev->Assign(2, val_mgr->Count(ie->rai()->lac()));
+	ev->Assign(3, val_mgr->Count(ie->rai()->rac()));
 	return ev;
 	}
 
-Val* BuildRecovery(const InformationElement* ie)
+static IntrusivePtr<Val> BuildRecovery(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->recovery()->restart_counter());
+	return val_mgr->Count(ie->recovery()->restart_counter());
 	}
 
-Val* BuildSelectionMode(const InformationElement* ie)
+static IntrusivePtr<Val> BuildSelectionMode(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->selection_mode()->mode());
+	return val_mgr->Count(ie->selection_mode()->mode());
 	}
 
-Val* BuildTEID1(const InformationElement* ie)
+static IntrusivePtr<Val> BuildTEID1(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->teid1()->value());
+	return val_mgr->Count(ie->teid1()->value());
 	}
 
-Val* BuildTEID_ControlPlane(const InformationElement* ie)
+static IntrusivePtr<Val> BuildTEID_ControlPlane(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->teidcp()->value());
+	return val_mgr->Count(ie->teidcp()->value());
 	}
 
-Val* BuildNSAPI(const InformationElement* ie)
+static IntrusivePtr<Val> BuildNSAPI(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->nsapi()->nsapi());
+	return val_mgr->Count(ie->nsapi()->nsapi());
 	}
 
-Val* BuildChargingCharacteristics(const InformationElement* ie)
+static IntrusivePtr<Val> BuildChargingCharacteristics(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->charging_characteristics()->value());
+	return val_mgr->Count(ie->charging_characteristics()->value());
 	}
 
-Val* BuildTraceReference(const InformationElement* ie)
+static IntrusivePtr<Val> BuildTraceReference(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->trace_reference()->value());
+	return val_mgr->Count(ie->trace_reference()->value());
 	}
 
-Val* BuildTraceType(const InformationElement* ie)
+static IntrusivePtr<Val> BuildTraceType(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->trace_type()->value());
+	return val_mgr->Count(ie->trace_type()->value());
 	}
 
 Val* BuildEndUserAddr(const InformationElement* ie)
 	{
 	RecordVal* ev = new RecordVal(BifType::Record::gtp_end_user_addr);
-	ev->Assign(0, val_mgr->GetCount(ie->end_user_addr()->pdp_type_org()));
-	ev->Assign(1, val_mgr->GetCount(ie->end_user_addr()->pdp_type_num()));
+	ev->Assign(0, val_mgr->Count(ie->end_user_addr()->pdp_type_org()));
+	ev->Assign(1, val_mgr->Count(ie->end_user_addr()->pdp_type_num()));
 
 	int len = ie->end_user_addr()->pdp_addr().length();
 
@@ -161,7 +161,7 @@ Val* BuildQoS_Profile(const InformationElement* ie)
 	const u_char* d = (const u_char*) ie->qos_profile()->data().data();
 	int len = ie->qos_profile()->data().length();
 
-	ev->Assign(0, val_mgr->GetCount(ie->qos_profile()->alloc_retention_priority()));
+	ev->Assign(0, val_mgr->Count(ie->qos_profile()->alloc_retention_priority()));
 	ev->Assign(1, make_intrusive<StringVal>(new BroString(d, len, false)));
 
 	return ev;
@@ -195,15 +195,15 @@ Val* BuildPrivateExt(const InformationElement* ie)
 	const uint8* d = ie->private_ext()->value().data();
 	int len = ie->private_ext()->value().length();
 
-	ev->Assign(0, val_mgr->GetCount(ie->private_ext()->id()));
+	ev->Assign(0, val_mgr->Count(ie->private_ext()->id()));
 	ev->Assign(1, make_intrusive<StringVal>(new BroString((const u_char*) d, len, false)));
 
 	return ev;
 	}
 
-Val* BuildCause(const InformationElement* ie)
+static IntrusivePtr<Val> BuildCause(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->cause()->value());
+	return val_mgr->Count(ie->cause()->value());
 	}
 
 static IntrusivePtr<Val> BuildReorderReq(const InformationElement* ie)
@@ -211,9 +211,9 @@ static IntrusivePtr<Val> BuildReorderReq(const InformationElement* ie)
 	return val_mgr->Bool(ie->reorder_req()->req());
 	}
 
-Val* BuildChargingID(const InformationElement* ie)
+static IntrusivePtr<Val> BuildChargingID(const InformationElement* ie)
 	{
-	return val_mgr->GetCount(ie->charging_id()->value());;
+	return val_mgr->Count(ie->charging_id()->value());;
 	}
 
 Val* BuildChargingGatewayAddr(const InformationElement* ie)

--- a/src/analyzer/protocol/gtpv1/gtpv1-analyzer.pac
+++ b/src/analyzer/protocol/gtpv1/gtpv1-analyzer.pac
@@ -4,9 +4,9 @@
 %}
 
 %code{
-RecordVal* BuildGTPv1Hdr(const GTPv1_Header* pdu)
+IntrusivePtr<RecordVal> BuildGTPv1Hdr(const GTPv1_Header* pdu)
 	{
-	RecordVal* rv = new RecordVal(BifType::Record::gtpv1_hdr);
+	auto rv = make_intrusive<RecordVal>(BifType::Record::gtpv1_hdr);
 
 	rv->Assign(0, val_mgr->Count(pdu->version()));
 	rv->Assign(1, val_mgr->Bool(pdu->pt_flag()));
@@ -237,7 +237,7 @@ void CreatePDP_Request(const BroAnalyzer& a, const GTPv1_Header* pdu)
 	{
 	if ( ! ::gtpv1_create_pdp_ctx_request ) return;
 
-	RecordVal* rv = new RecordVal(
+	auto rv = make_intrusive<RecordVal>(
 	  BifType::Record::gtp_create_pdp_ctx_request_elements);
 
 	const vector<InformationElement *> * v = pdu->create_pdp_ctx_request();
@@ -328,8 +328,8 @@ void CreatePDP_Request(const BroAnalyzer& a, const GTPv1_Header* pdu)
 		}
 		}
 
-	BifEvent::generate_gtpv1_create_pdp_ctx_request(a, a->Conn(),
-	                                                BuildGTPv1Hdr(pdu), rv);
+	BifEvent::enqueue_gtpv1_create_pdp_ctx_request(a, a->Conn(),
+	                                               BuildGTPv1Hdr(pdu), std::move(rv));
 	}
 
 void CreatePDP_Response(const BroAnalyzer& a, const GTPv1_Header* pdu)
@@ -337,7 +337,7 @@ void CreatePDP_Response(const BroAnalyzer& a, const GTPv1_Header* pdu)
 	if ( ! ::gtpv1_create_pdp_ctx_response )
 	    return;
 
-	RecordVal* rv = new RecordVal(
+	auto rv = make_intrusive<RecordVal>(
 	  BifType::Record::gtp_create_pdp_ctx_response_elements);
 
 	const vector<InformationElement *> * v = pdu->create_pdp_ctx_response();
@@ -397,8 +397,8 @@ void CreatePDP_Response(const BroAnalyzer& a, const GTPv1_Header* pdu)
 		}
 		}
 
-	BifEvent::generate_gtpv1_create_pdp_ctx_response(a, a->Conn(),
-	                                                 BuildGTPv1Hdr(pdu), rv);
+	BifEvent::enqueue_gtpv1_create_pdp_ctx_response(a, a->Conn(),
+	                                                BuildGTPv1Hdr(pdu), std::move(rv));
 	}
 
 void UpdatePDP_Request(const BroAnalyzer& a, const GTPv1_Header* pdu)
@@ -406,7 +406,7 @@ void UpdatePDP_Request(const BroAnalyzer& a, const GTPv1_Header* pdu)
 	if ( ! ::gtpv1_update_pdp_ctx_request )
 	    return;
 
-	RecordVal* rv = new RecordVal(
+	auto rv = make_intrusive<RecordVal>(
 	  BifType::Record::gtp_update_pdp_ctx_request_elements);
 
 	const vector<InformationElement *> * v = pdu->update_pdp_ctx_request();
@@ -475,8 +475,8 @@ void UpdatePDP_Request(const BroAnalyzer& a, const GTPv1_Header* pdu)
 		}
 		}
 
-	BifEvent::generate_gtpv1_update_pdp_ctx_request(a, a->Conn(),
-	                                                BuildGTPv1Hdr(pdu), rv);
+	BifEvent::enqueue_gtpv1_update_pdp_ctx_request(a, a->Conn(),
+	                                               BuildGTPv1Hdr(pdu), std::move(rv));
 	}
 
 void UpdatePDP_Response(const BroAnalyzer& a, const GTPv1_Header* pdu)
@@ -484,7 +484,7 @@ void UpdatePDP_Response(const BroAnalyzer& a, const GTPv1_Header* pdu)
 	if ( ! ::gtpv1_update_pdp_ctx_response )
 	    return;
 
-	RecordVal* rv = new RecordVal(
+	auto rv = make_intrusive<RecordVal>(
 	  BifType::Record::gtp_update_pdp_ctx_response_elements);
 
 	const vector<InformationElement *> * v = pdu->update_pdp_ctx_response();
@@ -535,8 +535,8 @@ void UpdatePDP_Response(const BroAnalyzer& a, const GTPv1_Header* pdu)
 		}
 		}
 
-	BifEvent::generate_gtpv1_update_pdp_ctx_response(a, a->Conn(),
-	                                                 BuildGTPv1Hdr(pdu), rv);
+	BifEvent::enqueue_gtpv1_update_pdp_ctx_response(a, a->Conn(),
+	                                                BuildGTPv1Hdr(pdu), std::move(rv));
 	}
 
 void DeletePDP_Request(const BroAnalyzer& a, const GTPv1_Header* pdu)
@@ -544,7 +544,7 @@ void DeletePDP_Request(const BroAnalyzer& a, const GTPv1_Header* pdu)
 	if ( ! ::gtpv1_delete_pdp_ctx_request )
 	    return;
 
-	RecordVal* rv = new RecordVal(
+	auto rv = make_intrusive<RecordVal>(
 	  BifType::Record::gtp_delete_pdp_ctx_request_elements);
 
 	const vector<InformationElement *> * v = pdu->delete_pdp_ctx_request();
@@ -569,8 +569,8 @@ void DeletePDP_Request(const BroAnalyzer& a, const GTPv1_Header* pdu)
 		}
 		}
 
-	BifEvent::generate_gtpv1_delete_pdp_ctx_request(a, a->Conn(),
-	                                                BuildGTPv1Hdr(pdu), rv);
+	BifEvent::enqueue_gtpv1_delete_pdp_ctx_request(a, a->Conn(),
+	                                               BuildGTPv1Hdr(pdu), std::move(rv));
 	}
 
 void DeletePDP_Response(const BroAnalyzer& a, const GTPv1_Header* pdu)
@@ -578,7 +578,7 @@ void DeletePDP_Response(const BroAnalyzer& a, const GTPv1_Header* pdu)
 	if ( ! ::gtpv1_delete_pdp_ctx_response )
 	    return;
 
-	RecordVal* rv = new RecordVal(
+	auto rv = make_intrusive<RecordVal>(
 	  BifType::Record::gtp_delete_pdp_ctx_response_elements);
 
 	const vector<InformationElement *> * v = pdu->delete_pdp_ctx_response();
@@ -600,8 +600,8 @@ void DeletePDP_Response(const BroAnalyzer& a, const GTPv1_Header* pdu)
 		}
 		}
 
-	BifEvent::generate_gtpv1_delete_pdp_ctx_response(a, a->Conn(),
-	                                                 BuildGTPv1Hdr(pdu), rv);
+	BifEvent::enqueue_gtpv1_delete_pdp_ctx_response(a, a->Conn(),
+	                                                BuildGTPv1Hdr(pdu), std::move(rv));
 	}
 %}
 
@@ -679,7 +679,7 @@ flow GTPv1_Flow(is_orig: bool)
 			}
 
 		if ( ::gtpv1_message )
-			BifEvent::generate_gtpv1_message(a, c, BuildGTPv1Hdr(pdu));
+			BifEvent::enqueue_gtpv1_message(a, c, BuildGTPv1Hdr(pdu));
 
 		switch ( ${pdu.msg_type} ) {
 		case 16:
@@ -759,8 +759,8 @@ flow GTPv1_Flow(is_orig: bool)
 			}
 
 		if ( ::gtpv1_g_pdu_packet )
-			BifEvent::generate_gtpv1_g_pdu_packet(a, c, BuildGTPv1Hdr(pdu),
-			                                      inner->BuildPktHdrVal());
+			BifEvent::enqueue_gtpv1_g_pdu_packet(a, c, BuildGTPv1Hdr(pdu),
+			                                     {AdoptRef{}, inner->BuildPktHdrVal()});
 
 		EncapsulatingConn ec(c, BifEnum::Tunnel::GTPv1);
 

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -620,9 +620,9 @@ Val* HTTP_Message::BuildMessageStat(bool interrupted, const char* msg)
 	stat->Assign(field++, make_intrusive<Val>(start_time, TYPE_TIME));
 	stat->Assign(field++, val_mgr->Bool(interrupted));
 	stat->Assign(field++, make_intrusive<StringVal>(msg));
-	stat->Assign(field++, val_mgr->GetCount(body_length));
-	stat->Assign(field++, val_mgr->GetCount(content_gap_length));
-	stat->Assign(field++, val_mgr->GetCount(header_length));
+	stat->Assign(field++, val_mgr->Count(body_length));
+	stat->Assign(field++, val_mgr->Count(content_gap_length));
+	stat->Assign(field++, val_mgr->Count(header_length));
 	return stat;
 	}
 
@@ -1172,8 +1172,8 @@ void HTTP_Analyzer::GenStats()
 	if ( http_stats )
 		{
 		auto r = make_intrusive<RecordVal>(http_stats_rec);
-		r->Assign(0, val_mgr->GetCount(num_requests));
-		r->Assign(1, val_mgr->GetCount(num_replies));
+		r->Assign(0, val_mgr->Count(num_requests));
+		r->Assign(1, val_mgr->Count(num_replies));
 		r->Assign(2, make_intrusive<Val>(request_version.ToDouble(), TYPE_DOUBLE));
 		r->Assign(3, make_intrusive<Val>(reply_version.ToDouble(), TYPE_DOUBLE));
 
@@ -1431,7 +1431,7 @@ void HTTP_Analyzer::HTTP_Reply()
 		EnqueueConnEvent(http_reply,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
 			make_intrusive<StringVal>(fmt("%.1f", reply_version.ToDouble())),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(reply_code)},
+			val_mgr->Count(reply_code),
 			reply_reason_phrase ?
 				IntrusivePtr{NewRef{}, reply_reason_phrase} :
 				make_intrusive<StringVal>("<empty>")
@@ -1684,7 +1684,7 @@ void HTTP_Analyzer::HTTP_EntityData(bool is_orig, BroString* entity_data)
 		EnqueueConnEvent(http_entity_data,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
 			val_mgr->Bool(is_orig),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(entity_data->Len())},
+			val_mgr->Count(entity_data->Len()),
 			make_intrusive<StringVal>(entity_data)
 		);
 	else

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -650,7 +650,7 @@ void HTTP_Message::Done(bool interrupted, const char* detail)
 
 	if ( http_message_done )
 		GetAnalyzer()->EnqueueConnEvent(http_message_done,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Bool(is_orig),
 			IntrusivePtr{AdoptRef{}, BuildMessageStat(interrupted, detail)}
 		);
@@ -681,7 +681,7 @@ void HTTP_Message::BeginEntity(mime::MIME_Entity* entity)
 
 	if ( http_begin_entity )
 		analyzer->EnqueueConnEvent(http_begin_entity,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Bool(is_orig)
 		);
 	}
@@ -696,7 +696,7 @@ void HTTP_Message::EndEntity(mime::MIME_Entity* entity)
 
 	if ( http_end_entity )
 		analyzer->EnqueueConnEvent(http_end_entity,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Bool(is_orig)
 		);
 
@@ -735,7 +735,7 @@ void HTTP_Message::SubmitAllHeaders(mime::MIME_HeaderList& hlist)
 	{
 	if ( http_all_headers )
 		analyzer->EnqueueConnEvent(http_all_headers,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Bool(is_orig),
 			IntrusivePtr{AdoptRef{}, BuildHeaderTable(hlist)}
 		);
@@ -746,7 +746,7 @@ void HTTP_Message::SubmitAllHeaders(mime::MIME_HeaderList& hlist)
 		StringVal* subty = current_entity->ContentSubType();
 
 		analyzer->EnqueueConnEvent(http_content_type,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Bool(is_orig),
 			IntrusivePtr{NewRef{}, ty},
 			IntrusivePtr{NewRef{}, subty}
@@ -1178,7 +1178,7 @@ void HTTP_Analyzer::GenStats()
 		r->Assign(3, make_intrusive<Val>(reply_version.ToDouble(), TYPE_DOUBLE));
 
 		// DEBUG_MSG("%.6f http_stats\n", network_time);
-		EnqueueConnEvent(http_stats, IntrusivePtr{AdoptRef{}, BuildConnVal()}, std::move(r));
+		EnqueueConnEvent(http_stats, ConnVal(), std::move(r));
 		}
 	}
 
@@ -1378,7 +1378,7 @@ void HTTP_Analyzer::HTTP_Event(const char* category, StringVal* detail)
 	if ( http_event )
 		// DEBUG_MSG("%.6f http_event\n", network_time);
 		EnqueueConnEvent(http_event,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			make_intrusive<StringVal>(category),
 			IntrusivePtr{AdoptRef{}, detail}
 		);
@@ -1417,7 +1417,7 @@ void HTTP_Analyzer::HTTP_Request()
 	if ( http_request )
 		// DEBUG_MSG("%.6f http_request\n", network_time);
 		EnqueueConnEvent(http_request,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			IntrusivePtr{NewRef{}, request_method},
 			IntrusivePtr{AdoptRef{}, TruncateURI(request_URI->AsStringVal())},
 			IntrusivePtr{AdoptRef{}, TruncateURI(unescaped_URI->AsStringVal())},
@@ -1429,7 +1429,7 @@ void HTTP_Analyzer::HTTP_Reply()
 	{
 	if ( http_reply )
 		EnqueueConnEvent(http_reply,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			make_intrusive<StringVal>(fmt("%.1f", reply_version.ToDouble())),
 			val_mgr->Count(reply_code),
 			reply_reason_phrase ?
@@ -1506,7 +1506,7 @@ void HTTP_Analyzer::ReplyMade(bool interrupted, const char* msg)
 
 		if ( http_connection_upgrade )
 			EnqueueConnEvent(http_connection_upgrade,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				make_intrusive<StringVal>(upgrade_protocol)
 			);
 		}
@@ -1670,7 +1670,7 @@ void HTTP_Analyzer::HTTP_Header(bool is_orig, mime::MIME_Header* h)
 			DEBUG_MSG("%.6f http_header\n", network_time);
 
 		EnqueueConnEvent(http_header,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(is_orig),
 			IntrusivePtr{AdoptRef{}, mime::new_string_val(h->get_name())->ToUpper()},
 			IntrusivePtr{AdoptRef{}, mime::new_string_val(h->get_value())}
@@ -1682,7 +1682,7 @@ void HTTP_Analyzer::HTTP_EntityData(bool is_orig, BroString* entity_data)
 	{
 	if ( http_entity_data )
 		EnqueueConnEvent(http_entity_data,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(is_orig),
 			val_mgr->Count(entity_data->Len()),
 			make_intrusive<StringVal>(entity_data)

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -618,7 +618,7 @@ Val* HTTP_Message::BuildMessageStat(bool interrupted, const char* msg)
 	RecordVal* stat = new RecordVal(http_message_stat);
 	int field = 0;
 	stat->Assign(field++, make_intrusive<Val>(start_time, TYPE_TIME));
-	stat->Assign(field++, val_mgr->GetBool(interrupted));
+	stat->Assign(field++, val_mgr->Bool(interrupted));
 	stat->Assign(field++, make_intrusive<StringVal>(msg));
 	stat->Assign(field++, val_mgr->GetCount(body_length));
 	stat->Assign(field++, val_mgr->GetCount(content_gap_length));
@@ -651,7 +651,7 @@ void HTTP_Message::Done(bool interrupted, const char* detail)
 	if ( http_message_done )
 		GetAnalyzer()->EnqueueConnEvent(http_message_done,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+			val_mgr->Bool(is_orig),
 			IntrusivePtr{AdoptRef{}, BuildMessageStat(interrupted, detail)}
 		);
 
@@ -682,7 +682,7 @@ void HTTP_Message::BeginEntity(mime::MIME_Entity* entity)
 	if ( http_begin_entity )
 		analyzer->EnqueueConnEvent(http_begin_entity,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)}
+			val_mgr->Bool(is_orig)
 		);
 	}
 
@@ -697,7 +697,7 @@ void HTTP_Message::EndEntity(mime::MIME_Entity* entity)
 	if ( http_end_entity )
 		analyzer->EnqueueConnEvent(http_end_entity,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)}
+			val_mgr->Bool(is_orig)
 		);
 
 	current_entity = (HTTP_Entity*) entity->Parent();
@@ -736,7 +736,7 @@ void HTTP_Message::SubmitAllHeaders(mime::MIME_HeaderList& hlist)
 	if ( http_all_headers )
 		analyzer->EnqueueConnEvent(http_all_headers,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+			val_mgr->Bool(is_orig),
 			IntrusivePtr{AdoptRef{}, BuildHeaderTable(hlist)}
 		);
 
@@ -747,7 +747,7 @@ void HTTP_Message::SubmitAllHeaders(mime::MIME_HeaderList& hlist)
 
 		analyzer->EnqueueConnEvent(http_content_type,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+			val_mgr->Bool(is_orig),
 			IntrusivePtr{NewRef{}, ty},
 			IntrusivePtr{NewRef{}, subty}
 		);
@@ -1671,7 +1671,7 @@ void HTTP_Analyzer::HTTP_Header(bool is_orig, mime::MIME_Header* h)
 
 		EnqueueConnEvent(http_header,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+			val_mgr->Bool(is_orig),
 			IntrusivePtr{AdoptRef{}, mime::new_string_val(h->get_name())->ToUpper()},
 			IntrusivePtr{AdoptRef{}, mime::new_string_val(h->get_value())}
 		);
@@ -1683,7 +1683,7 @@ void HTTP_Analyzer::HTTP_EntityData(bool is_orig, BroString* entity_data)
 	if ( http_entity_data )
 		EnqueueConnEvent(http_entity_data,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+			val_mgr->Bool(is_orig),
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(entity_data->Len())},
 			make_intrusive<StringVal>(entity_data)
 		);

--- a/src/analyzer/protocol/http/functions.bif
+++ b/src/analyzer/protocol/http/functions.bif
@@ -31,7 +31,7 @@ function skip_http_entity_data%(c: connection, is_orig: bool%): any
 	else
 		reporter->Error("no analyzer associated with connection record");
 
-	return 0;
+	return nullptr;
 	%}
 
 ## Unescapes all characters in a URI (decode every ``%xx`` group).
@@ -52,5 +52,5 @@ function unescape_URI%(URI: string%): string
 	const u_char* line = URI->Bytes();
 	const u_char* const line_end = line + URI->Len();
 
-	return new StringVal(analyzer::http::unescape_URI(line, line_end, 0));
+	return make_intrusive<StringVal>(analyzer::http::unescape_URI(line, line_end, 0));
 	%}

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -228,10 +228,10 @@ RecordVal* ICMP_Analyzer::BuildICMPVal(const struct icmp* icmpp, int len,
 
 		icmp_conn_val->Assign(0, make_intrusive<AddrVal>(Conn()->OrigAddr()));
 		icmp_conn_val->Assign(1, make_intrusive<AddrVal>(Conn()->RespAddr()));
-		icmp_conn_val->Assign(2, val_mgr->GetCount(icmpp->icmp_type));
-		icmp_conn_val->Assign(3, val_mgr->GetCount(icmpp->icmp_code));
-		icmp_conn_val->Assign(4, val_mgr->GetCount(len));
-		icmp_conn_val->Assign(5, val_mgr->GetCount(ip_hdr->TTL()));
+		icmp_conn_val->Assign(2, val_mgr->Count(icmpp->icmp_type));
+		icmp_conn_val->Assign(3, val_mgr->Count(icmpp->icmp_code));
+		icmp_conn_val->Assign(4, val_mgr->Count(len));
+		icmp_conn_val->Assign(5, val_mgr->Count(ip_hdr->TTL()));
 		icmp_conn_val->Assign(6, val_mgr->Bool(icmpv6));
 		}
 
@@ -360,9 +360,9 @@ RecordVal* ICMP_Analyzer::ExtractICMP4Context(int len, const u_char*& data)
 	id_val->Assign(3, val_mgr->GetPort(dst_port, proto));
 
 	iprec->Assign(0, id_val);
-	iprec->Assign(1, val_mgr->GetCount(ip_len));
-	iprec->Assign(2, val_mgr->GetCount(proto));
-	iprec->Assign(3, val_mgr->GetCount(frag_offset));
+	iprec->Assign(1, val_mgr->Count(ip_len));
+	iprec->Assign(2, val_mgr->Count(proto));
+	iprec->Assign(3, val_mgr->Count(frag_offset));
 	iprec->Assign(4, val_mgr->Bool(bad_hdr_len));
 	iprec->Assign(5, val_mgr->Bool(bad_checksum));
 	iprec->Assign(6, val_mgr->Bool(MF));
@@ -419,9 +419,9 @@ RecordVal* ICMP_Analyzer::ExtractICMP6Context(int len, const u_char*& data)
 	id_val->Assign(3, val_mgr->GetPort(dst_port, proto));
 
 	iprec->Assign(0, id_val);
-	iprec->Assign(1, val_mgr->GetCount(ip_len));
-	iprec->Assign(2, val_mgr->GetCount(proto));
-	iprec->Assign(3, val_mgr->GetCount(frag_offset));
+	iprec->Assign(1, val_mgr->Count(ip_len));
+	iprec->Assign(2, val_mgr->Count(proto));
+	iprec->Assign(3, val_mgr->Count(frag_offset));
 	iprec->Assign(4, val_mgr->Bool(bad_hdr_len));
 	// bad_checksum is always false since IPv6 layer doesn't have a checksum.
 	iprec->Assign(5, val_mgr->False());
@@ -474,14 +474,14 @@ void ICMP_Analyzer::UpdateEndpointVal(RecordVal* endp, bool is_orig)
 	int size = is_orig ? request_len : reply_len;
 	if ( size < 0 )
 		{
-		endp->Assign(0, val_mgr->GetCount(0));
-		endp->Assign(1, val_mgr->GetCount(int(ICMP_INACTIVE)));
+		endp->Assign(0, val_mgr->Count(0));
+		endp->Assign(1, val_mgr->Count(int(ICMP_INACTIVE)));
 		}
 
 	else
 		{
-		endp->Assign(0, val_mgr->GetCount(size));
-		endp->Assign(1, val_mgr->GetCount(int(ICMP_ACTIVE)));
+		endp->Assign(0, val_mgr->Count(size));
+		endp->Assign(1, val_mgr->Count(int(ICMP_ACTIVE)));
 		}
 	}
 
@@ -517,8 +517,8 @@ void ICMP_Analyzer::Echo(double t, const struct icmp* icmpp, int len,
 	EnqueueConnEvent(f,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
 		IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, ip_hdr->NextProto() != IPPROTO_ICMP, ip_hdr)},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(iid)},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(iseq)},
+		val_mgr->Count(iid),
+		val_mgr->Count(iseq),
 		make_intrusive<StringVal>(payload)
 	);
 	}
@@ -545,13 +545,13 @@ void ICMP_Analyzer::RouterAdvert(double t, const struct icmp* icmpp, int len,
 	EnqueueConnEvent(f,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
 		IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 1, ip_hdr)},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(icmpp->icmp_num_addrs)}, // Cur Hop Limit
+		val_mgr->Count(icmpp->icmp_num_addrs), // Cur Hop Limit
 		val_mgr->Bool(icmpp->icmp_wpa & 0x80), // Managed
 		val_mgr->Bool(icmpp->icmp_wpa & 0x40), // Other
 		val_mgr->Bool(icmpp->icmp_wpa & 0x20), // Home Agent
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount((icmpp->icmp_wpa & 0x18)>>3)}, // Pref
+		val_mgr->Count((icmpp->icmp_wpa & 0x18)>>3), // Pref
 		val_mgr->Bool(icmpp->icmp_wpa & 0x04), // Proxy
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(icmpp->icmp_wpa & 0x02)}, // Reserved
+		val_mgr->Count(icmpp->icmp_wpa & 0x02), // Reserved
 		make_intrusive<IntervalVal>((double)ntohs(icmpp->icmp_lifetime), Seconds),
 		make_intrusive<IntervalVal>((double)ntohl(reachable), Milliseconds),
 		make_intrusive<IntervalVal>((double)ntohl(retrans), Milliseconds),
@@ -675,7 +675,7 @@ void ICMP_Analyzer::Context4(double t, const struct icmp* icmpp,
 		EnqueueConnEvent(f,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
 			IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 0, ip_hdr)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(icmpp->icmp_code)},
+			val_mgr->Count(icmpp->icmp_code),
 			IntrusivePtr{AdoptRef{}, ExtractICMP4Context(caplen, data)}
 		);
 	}
@@ -713,7 +713,7 @@ void ICMP_Analyzer::Context6(double t, const struct icmp* icmpp,
 		EnqueueConnEvent(f,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
 			IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 1, ip_hdr)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(icmpp->icmp_code)},
+			val_mgr->Count(icmpp->icmp_code),
 			IntrusivePtr{AdoptRef{}, ExtractICMP6Context(caplen, data)}
 		);
 	}
@@ -752,8 +752,8 @@ VectorVal* ICMP_Analyzer::BuildNDOptionsVal(int caplen, const u_char* data)
 			}
 
 		RecordVal* rv = new RecordVal(icmp6_nd_option_type);
-		rv->Assign(0, val_mgr->GetCount(type));
-		rv->Assign(1, val_mgr->GetCount(length));
+		rv->Assign(0, val_mgr->Count(type));
+		rv->Assign(1, val_mgr->Count(length));
 
 		// Adjust length to be in units of bytes, exclude type/length fields.
 		length = length * 8 - 2;
@@ -792,7 +792,7 @@ VectorVal* ICMP_Analyzer::BuildNDOptionsVal(int caplen, const u_char* data)
 				uint32_t valid_life = *((const uint32_t*)(data + 2));
 				uint32_t prefer_life = *((const uint32_t*)(data + 6));
 				in6_addr prefix = *((const in6_addr*)(data + 14));
-				info->Assign(0, val_mgr->GetCount(prefix_len));
+				info->Assign(0, val_mgr->Count(prefix_len));
 				info->Assign(1, val_mgr->Bool(L_flag));
 				info->Assign(2, val_mgr->Bool(A_flag));
 				info->Assign(3, make_intrusive<IntervalVal>((double)ntohl(valid_life), Seconds));
@@ -825,7 +825,7 @@ VectorVal* ICMP_Analyzer::BuildNDOptionsVal(int caplen, const u_char* data)
 			// MTU option
 			{
 			if ( caplen >= 6 )
-				rv->Assign(5, val_mgr->GetCount(ntohl(*((const uint32_t*)(data + 2)))));
+				rv->Assign(5, val_mgr->Count(ntohl(*((const uint32_t*)(data + 2)))));
 			else
 				set_payload_field = true;
 

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -203,7 +203,7 @@ void ICMP_Analyzer::ICMP_Sent(const struct icmp* icmpp, int len, int caplen,
     {
 	if ( icmp_sent )
 		EnqueueConnEvent(icmp_sent,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, icmpv6, ip_hdr)}
 		);
 
@@ -212,7 +212,7 @@ void ICMP_Analyzer::ICMP_Sent(const struct icmp* icmpp, int len, int caplen,
 		BroString* payload = new BroString(data, std::min(len, caplen), false);
 
 		EnqueueConnEvent(icmp_sent_payload,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, icmpv6, ip_hdr)},
 			make_intrusive<StringVal>(payload)
 		);
@@ -515,7 +515,7 @@ void ICMP_Analyzer::Echo(double t, const struct icmp* icmpp, int len,
 	BroString* payload = new BroString(data, caplen, false);
 
 	EnqueueConnEvent(f,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, ip_hdr->NextProto() != IPPROTO_ICMP, ip_hdr)},
 		val_mgr->Count(iid),
 		val_mgr->Count(iseq),
@@ -543,7 +543,7 @@ void ICMP_Analyzer::RouterAdvert(double t, const struct icmp* icmpp, int len,
 	int opt_offset = sizeof(reachable) + sizeof(retrans);
 
 	EnqueueConnEvent(f,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 1, ip_hdr)},
 		val_mgr->Count(icmpp->icmp_num_addrs), // Cur Hop Limit
 		val_mgr->Bool(icmpp->icmp_wpa & 0x80), // Managed
@@ -576,7 +576,7 @@ void ICMP_Analyzer::NeighborAdvert(double t, const struct icmp* icmpp, int len,
 	int opt_offset = sizeof(in6_addr);
 
 	EnqueueConnEvent(f,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 1, ip_hdr)},
 		val_mgr->Bool(icmpp->icmp_num_addrs & 0x80), // Router
 		val_mgr->Bool(icmpp->icmp_num_addrs & 0x40), // Solicited
@@ -603,7 +603,7 @@ void ICMP_Analyzer::NeighborSolicit(double t, const struct icmp* icmpp, int len,
 	int opt_offset = sizeof(in6_addr);
 
 	EnqueueConnEvent(f,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 1, ip_hdr)},
 		make_intrusive<AddrVal>(tgtaddr),
 		IntrusivePtr{AdoptRef{}, BuildNDOptionsVal(caplen - opt_offset, data + opt_offset)}
@@ -630,7 +630,7 @@ void ICMP_Analyzer::Redirect(double t, const struct icmp* icmpp, int len,
 	int opt_offset = 2 * sizeof(in6_addr);
 
 	EnqueueConnEvent(f,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 1, ip_hdr)},
 		make_intrusive<AddrVal>(tgtaddr),
 		make_intrusive<AddrVal>(dstaddr),
@@ -648,7 +648,7 @@ void ICMP_Analyzer::RouterSolicit(double t, const struct icmp* icmpp, int len,
 		return;
 
 	EnqueueConnEvent(f,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 1, ip_hdr)},
 		IntrusivePtr{AdoptRef{}, BuildNDOptionsVal(caplen, data)}
 	);
@@ -673,7 +673,7 @@ void ICMP_Analyzer::Context4(double t, const struct icmp* icmpp,
 
 	if ( f )
 		EnqueueConnEvent(f,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 0, ip_hdr)},
 			val_mgr->Count(icmpp->icmp_code),
 			IntrusivePtr{AdoptRef{}, ExtractICMP4Context(caplen, data)}
@@ -711,7 +711,7 @@ void ICMP_Analyzer::Context6(double t, const struct icmp* icmpp,
 
 	if ( f )
 		EnqueueConnEvent(f,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 1, ip_hdr)},
 			val_mgr->Count(icmpp->icmp_code),
 			IntrusivePtr{AdoptRef{}, ExtractICMP6Context(caplen, data)}

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -355,9 +355,9 @@ RecordVal* ICMP_Analyzer::ExtractICMP4Context(int len, const u_char*& data)
 	RecordVal* id_val = new RecordVal(conn_id);
 
 	id_val->Assign(0, make_intrusive<AddrVal>(src_addr));
-	id_val->Assign(1, val_mgr->GetPort(src_port, proto));
+	id_val->Assign(1, val_mgr->Port(src_port, proto));
 	id_val->Assign(2, make_intrusive<AddrVal>(dst_addr));
-	id_val->Assign(3, val_mgr->GetPort(dst_port, proto));
+	id_val->Assign(3, val_mgr->Port(dst_port, proto));
 
 	iprec->Assign(0, id_val);
 	iprec->Assign(1, val_mgr->Count(ip_len));
@@ -414,9 +414,9 @@ RecordVal* ICMP_Analyzer::ExtractICMP6Context(int len, const u_char*& data)
 	RecordVal* id_val = new RecordVal(conn_id);
 
 	id_val->Assign(0, make_intrusive<AddrVal>(src_addr));
-	id_val->Assign(1, val_mgr->GetPort(src_port, proto));
+	id_val->Assign(1, val_mgr->Port(src_port, proto));
 	id_val->Assign(2, make_intrusive<AddrVal>(dst_addr));
-	id_val->Assign(3, val_mgr->GetPort(dst_port, proto));
+	id_val->Assign(3, val_mgr->Port(dst_port, proto));
 
 	iprec->Assign(0, id_val);
 	iprec->Assign(1, val_mgr->Count(ip_len));

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -232,7 +232,7 @@ RecordVal* ICMP_Analyzer::BuildICMPVal(const struct icmp* icmpp, int len,
 		icmp_conn_val->Assign(3, val_mgr->GetCount(icmpp->icmp_code));
 		icmp_conn_val->Assign(4, val_mgr->GetCount(len));
 		icmp_conn_val->Assign(5, val_mgr->GetCount(ip_hdr->TTL()));
-		icmp_conn_val->Assign(6, val_mgr->GetBool(icmpv6));
+		icmp_conn_val->Assign(6, val_mgr->Bool(icmpv6));
 		}
 
 	Ref(icmp_conn_val);
@@ -363,10 +363,10 @@ RecordVal* ICMP_Analyzer::ExtractICMP4Context(int len, const u_char*& data)
 	iprec->Assign(1, val_mgr->GetCount(ip_len));
 	iprec->Assign(2, val_mgr->GetCount(proto));
 	iprec->Assign(3, val_mgr->GetCount(frag_offset));
-	iprec->Assign(4, val_mgr->GetBool(bad_hdr_len));
-	iprec->Assign(5, val_mgr->GetBool(bad_checksum));
-	iprec->Assign(6, val_mgr->GetBool(MF));
-	iprec->Assign(7, val_mgr->GetBool(DF));
+	iprec->Assign(4, val_mgr->Bool(bad_hdr_len));
+	iprec->Assign(5, val_mgr->Bool(bad_checksum));
+	iprec->Assign(6, val_mgr->Bool(MF));
+	iprec->Assign(7, val_mgr->Bool(DF));
 
 	return iprec;
 	}
@@ -422,11 +422,11 @@ RecordVal* ICMP_Analyzer::ExtractICMP6Context(int len, const u_char*& data)
 	iprec->Assign(1, val_mgr->GetCount(ip_len));
 	iprec->Assign(2, val_mgr->GetCount(proto));
 	iprec->Assign(3, val_mgr->GetCount(frag_offset));
-	iprec->Assign(4, val_mgr->GetBool(bad_hdr_len));
+	iprec->Assign(4, val_mgr->Bool(bad_hdr_len));
 	// bad_checksum is always false since IPv6 layer doesn't have a checksum.
 	iprec->Assign(5, val_mgr->False());
-	iprec->Assign(6, val_mgr->GetBool(MF));
-	iprec->Assign(7, val_mgr->GetBool(DF));
+	iprec->Assign(6, val_mgr->Bool(MF));
+	iprec->Assign(7, val_mgr->Bool(DF));
 
 	return iprec;
 	}
@@ -546,11 +546,11 @@ void ICMP_Analyzer::RouterAdvert(double t, const struct icmp* icmpp, int len,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
 		IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 1, ip_hdr)},
 		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(icmpp->icmp_num_addrs)}, // Cur Hop Limit
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(icmpp->icmp_wpa & 0x80)}, // Managed
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(icmpp->icmp_wpa & 0x40)}, // Other
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(icmpp->icmp_wpa & 0x20)}, // Home Agent
+		val_mgr->Bool(icmpp->icmp_wpa & 0x80), // Managed
+		val_mgr->Bool(icmpp->icmp_wpa & 0x40), // Other
+		val_mgr->Bool(icmpp->icmp_wpa & 0x20), // Home Agent
 		IntrusivePtr{AdoptRef{}, val_mgr->GetCount((icmpp->icmp_wpa & 0x18)>>3)}, // Pref
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(icmpp->icmp_wpa & 0x04)}, // Proxy
+		val_mgr->Bool(icmpp->icmp_wpa & 0x04), // Proxy
 		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(icmpp->icmp_wpa & 0x02)}, // Reserved
 		make_intrusive<IntervalVal>((double)ntohs(icmpp->icmp_lifetime), Seconds),
 		make_intrusive<IntervalVal>((double)ntohl(reachable), Milliseconds),
@@ -578,9 +578,9 @@ void ICMP_Analyzer::NeighborAdvert(double t, const struct icmp* icmpp, int len,
 	EnqueueConnEvent(f,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
 		IntrusivePtr{AdoptRef{}, BuildICMPVal(icmpp, len, 1, ip_hdr)},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(icmpp->icmp_num_addrs & 0x80)}, // Router
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(icmpp->icmp_num_addrs & 0x40)}, // Solicited
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(icmpp->icmp_num_addrs & 0x20)}, // Override
+		val_mgr->Bool(icmpp->icmp_num_addrs & 0x80), // Router
+		val_mgr->Bool(icmpp->icmp_num_addrs & 0x40), // Solicited
+		val_mgr->Bool(icmpp->icmp_num_addrs & 0x20), // Override
 		make_intrusive<AddrVal>(tgtaddr),
 		IntrusivePtr{AdoptRef{}, BuildNDOptionsVal(caplen - opt_offset, data + opt_offset)}
 	);
@@ -793,8 +793,8 @@ VectorVal* ICMP_Analyzer::BuildNDOptionsVal(int caplen, const u_char* data)
 				uint32_t prefer_life = *((const uint32_t*)(data + 6));
 				in6_addr prefix = *((const in6_addr*)(data + 14));
 				info->Assign(0, val_mgr->GetCount(prefix_len));
-				info->Assign(1, val_mgr->GetBool(L_flag));
-				info->Assign(2, val_mgr->GetBool(A_flag));
+				info->Assign(1, val_mgr->Bool(L_flag));
+				info->Assign(2, val_mgr->Bool(A_flag));
 				info->Assign(3, make_intrusive<IntervalVal>((double)ntohl(valid_life), Seconds));
 				info->Assign(4, make_intrusive<IntervalVal>((double)ntohl(prefer_life), Seconds));
 				info->Assign(5, make_intrusive<AddrVal>(IPAddr(prefix)));

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -424,7 +424,7 @@ RecordVal* ICMP_Analyzer::ExtractICMP6Context(int len, const u_char*& data)
 	iprec->Assign(3, val_mgr->GetCount(frag_offset));
 	iprec->Assign(4, val_mgr->GetBool(bad_hdr_len));
 	// bad_checksum is always false since IPv6 layer doesn't have a checksum.
-	iprec->Assign(5, val_mgr->GetFalse());
+	iprec->Assign(5, val_mgr->False());
 	iprec->Assign(6, val_mgr->GetBool(MF));
 	iprec->Assign(7, val_mgr->GetBool(DF));
 

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -85,7 +85,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 			}
 
 		EnqueueConnEvent(ident_request,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Port(local_port, TRANSPORT_TCP),
 			val_mgr->Port(remote_port, TRANSPORT_TCP)
 		);
@@ -146,7 +146,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 			{
 			if ( ident_error )
 				EnqueueConnEvent(ident_error,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					val_mgr->Port(local_port, TRANSPORT_TCP),
 					val_mgr->Port(remote_port, TRANSPORT_TCP),
 					make_intrusive<StringVal>(end_of_line - line, line)
@@ -179,7 +179,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 			line = skip_whitespace(colon + 1, end_of_line);
 
 			EnqueueConnEvent(ident_reply,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Port(local_port, TRANSPORT_TCP),
 				val_mgr->Port(remote_port, TRANSPORT_TCP),
 				make_intrusive<StringVal>(end_of_line - line, line),

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -86,8 +86,8 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 
 		EnqueueConnEvent(ident_request,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetPort(local_port, TRANSPORT_TCP)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetPort(remote_port, TRANSPORT_TCP)}
+			val_mgr->Port(local_port, TRANSPORT_TCP),
+			val_mgr->Port(remote_port, TRANSPORT_TCP)
 		);
 
 		did_deliver = true;
@@ -147,8 +147,8 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 			if ( ident_error )
 				EnqueueConnEvent(ident_error,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetPort(local_port, TRANSPORT_TCP)},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetPort(remote_port, TRANSPORT_TCP)},
+					val_mgr->Port(local_port, TRANSPORT_TCP),
+					val_mgr->Port(remote_port, TRANSPORT_TCP),
 					make_intrusive<StringVal>(end_of_line - line, line)
 				);
 			}
@@ -180,8 +180,8 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 
 			EnqueueConnEvent(ident_reply,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetPort(local_port, TRANSPORT_TCP)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetPort(remote_port, TRANSPORT_TCP)},
+				val_mgr->Port(local_port, TRANSPORT_TCP),
+				val_mgr->Port(remote_port, TRANSPORT_TCP),
 				make_intrusive<StringVal>(end_of_line - line, line),
 				make_intrusive<StringVal>(sys_type_s)
 			);

--- a/src/analyzer/protocol/imap/imap-analyzer.pac
+++ b/src/analyzer/protocol/imap/imap-analyzer.pac
@@ -45,7 +45,7 @@ refine connection IMAP_Conn += {
 				bro_analyzer()->StartTLS();
 
 				if ( imap_starttls )
-					BifEvent::generate_imap_starttls(bro_analyzer(), bro_analyzer()->Conn());
+					BifEvent::enqueue_imap_starttls(bro_analyzer(), bro_analyzer()->Conn());
 				}
 			else
 				reporter->Weird(bro_analyzer()->Conn(), "IMAP: server refused StartTLS");
@@ -59,14 +59,15 @@ refine connection IMAP_Conn += {
 		if ( ! imap_capabilities )
 			return true;
 
-		VectorVal* capv = new VectorVal(internal_type("string_vec")->AsVectorType());
+		auto capv = make_intrusive<VectorVal>(internal_type("string_vec")->AsVectorType());
+
 		for ( unsigned int i = 0; i< capabilities->size(); i++ )
 			{
 			const bytestring& capability = (*capabilities)[i]->cap();
 			capv->Assign(i, make_intrusive<StringVal>(capability.length(), (const char*)capability.data()));
 			}
 
-		BifEvent::generate_imap_capabilities(bro_analyzer(), bro_analyzer()->Conn(), capv);
+		BifEvent::enqueue_imap_capabilities(bro_analyzer(), bro_analyzer()->Conn(), std::move(capv));
 		return true;
 		%}
 

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -235,7 +235,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_network_info,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				val_mgr->Int(users),
 				val_mgr->Int(services),
@@ -282,7 +282,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_names_info,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(type.c_str()),
 				make_intrusive<StringVal>(channel.c_str()),
@@ -316,7 +316,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_server_info,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				val_mgr->Int(users),
 				val_mgr->Int(services),
@@ -338,7 +338,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 					channels = atoi(parts[i - 1].c_str());
 
 			EnqueueConnEvent(irc_channel_info,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				val_mgr->Int(channels)
 			);
@@ -370,7 +370,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_global_users,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(eop - prefix, prefix),
 				make_intrusive<StringVal>(++msg)
@@ -396,7 +396,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			zeek::Args vl;
 			vl.reserve(6);
-			vl.emplace_back(AdoptRef{}, BuildConnVal());
+			vl.emplace_back(ConnVal());
 			vl.emplace_back(val_mgr->Bool(orig));
 			vl.emplace_back(make_intrusive<StringVal>(parts[0].c_str()));
 			vl.emplace_back(make_intrusive<StringVal>(parts[1].c_str()));
@@ -435,7 +435,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_whois_operator_line,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(parts[0].c_str())
 			);
@@ -473,7 +473,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_whois_channel_line,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(nick.c_str()),
 				std::move(set)
@@ -504,7 +504,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 					++t;
 
 				EnqueueConnEvent(irc_channel_topic,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(parts[1].c_str()),
 					make_intrusive<StringVal>(t)
@@ -538,7 +538,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				parts[7] = parts[7].substr(1);
 
 			EnqueueConnEvent(irc_who_line,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(parts[0].c_str()),
 				make_intrusive<StringVal>(parts[1].c_str()),
@@ -560,7 +560,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		case 436:
 			if ( irc_invalid_nick )
 				EnqueueConnEvent(irc_invalid_nick,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					val_mgr->Bool(orig)
 				);
 			break;
@@ -570,7 +570,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		case 491:  // user is not operator
 			if ( irc_oper_response )
 				EnqueueConnEvent(irc_oper_response,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					val_mgr->Bool(orig),
 					val_mgr->Bool(code == 381)
 				);
@@ -585,7 +585,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		default:
 			if ( irc_reply )
 				EnqueueConnEvent(irc_reply,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(prefix.c_str()),
 					val_mgr->Count(code),
@@ -656,7 +656,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			if ( irc_dcc_message )
 				EnqueueConnEvent(irc_dcc_message,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(prefix.c_str()),
 					make_intrusive<StringVal>(target.c_str()),
@@ -672,7 +672,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			{
 			if ( irc_privmsg_message )
 				EnqueueConnEvent(irc_privmsg_message,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(prefix.c_str()),
 					make_intrusive<StringVal>(target.c_str()),
@@ -697,7 +697,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			message = message.substr(1);
 
 		EnqueueConnEvent(irc_notice_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(target.c_str()),
@@ -721,7 +721,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			message = message.substr(1);
 
 		EnqueueConnEvent(irc_squery_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(target.c_str()),
@@ -735,7 +735,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		vector<string> parts = SplitWords(params, ' ');
 		zeek::Args vl;
 		vl.reserve(6);
-		vl.emplace_back(AdoptRef{}, BuildConnVal());
+		vl.emplace_back(ConnVal());
 		vl.emplace_back(val_mgr->Bool(orig));
 
 		if ( parts.size() > 0 )
@@ -770,7 +770,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		vector<string> parts = SplitWords(params, ' ');
 		if ( parts.size() == 2 )
 			EnqueueConnEvent(irc_oper_message,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(parts[0].c_str()),
 				make_intrusive<StringVal>(parts[1].c_str())
@@ -792,7 +792,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		zeek::Args vl;
 		vl.reserve(6);
-		vl.emplace_back(AdoptRef{}, BuildConnVal());
+		vl.emplace_back(ConnVal());
 		vl.emplace_back(val_mgr->Bool(orig));
 		vl.emplace_back(make_intrusive<StringVal>(prefix.c_str()));
 		vl.emplace_back(make_intrusive<StringVal>(parts[0].c_str()));
@@ -861,7 +861,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		EnqueueConnEvent(irc_join_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			std::move(list)
 		);
@@ -921,7 +921,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		EnqueueConnEvent(irc_join_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			std::move(list)
 		);
@@ -960,7 +960,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		EnqueueConnEvent(irc_part_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(nick.c_str()),
 			std::move(set),
@@ -983,7 +983,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		EnqueueConnEvent(irc_quit_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(nickname.c_str()),
 			make_intrusive<StringVal>(message.c_str())
@@ -997,7 +997,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			nick = nick.substr(1);
 
 		EnqueueConnEvent(irc_nick_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(nick.c_str())
@@ -1022,7 +1022,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			parts[0] = parts[0].substr(1);
 
 		EnqueueConnEvent(irc_who_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			parts.size() > 0 ?
 				make_intrusive<StringVal>(parts[0].c_str()) :
@@ -1052,7 +1052,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			users = parts[0];
 
 		EnqueueConnEvent(irc_whois_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(server.c_str()),
 			make_intrusive<StringVal>(users.c_str())
@@ -1065,7 +1065,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			params = params.substr(1);
 
 		EnqueueConnEvent(irc_error_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(params.c_str())
@@ -1081,7 +1081,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				parts[1] = parts[1].substr(1);
 
 			EnqueueConnEvent(irc_invite_message,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(parts[0].c_str()),
@@ -1096,7 +1096,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		{
 		if ( params.size() > 0 )
 			EnqueueConnEvent(irc_mode_message,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(params.c_str())
@@ -1109,7 +1109,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 	else if ( irc_password_message && command == "PASS" )
 		{
 		EnqueueConnEvent(irc_password_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(params.c_str())
 		);
@@ -1131,7 +1131,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		EnqueueConnEvent(irc_squit_message,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(server.c_str()),
@@ -1145,7 +1145,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( irc_request )
 			{
 			EnqueueConnEvent(irc_request,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(command.c_str()),
@@ -1159,7 +1159,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( irc_message )
 			{
 			EnqueueConnEvent(irc_message,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(command.c_str()),
@@ -1194,7 +1194,7 @@ void IRC_Analyzer::StartTLS()
 		AddChildAnalyzer(ssl);
 
 	if ( irc_starttls )
-		EnqueueConnEvent(irc_starttls, IntrusivePtr{AdoptRef{}, BuildConnVal()});
+		EnqueueConnEvent(irc_starttls, ConnVal());
 	}
 
 vector<string> IRC_Analyzer::SplitWords(const string& input, char split)

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -237,9 +237,9 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			EnqueueConnEvent(irc_network_info,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
 				val_mgr->Bool(orig),
-				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(users)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(services)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(servers)}
+				val_mgr->Int(users),
+				val_mgr->Int(services),
+				val_mgr->Int(servers)
 			);
 			}
 			break;
@@ -318,9 +318,9 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			EnqueueConnEvent(irc_server_info,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
 				val_mgr->Bool(orig),
-				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(users)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(services)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(servers)}
+				val_mgr->Int(users),
+				val_mgr->Int(services),
+				val_mgr->Int(servers)
 			);
 			}
 			break;
@@ -340,7 +340,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			EnqueueConnEvent(irc_channel_info,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
 				val_mgr->Bool(orig),
-				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(channels)}
+				val_mgr->Int(channels)
 			);
 			}
 			break;
@@ -547,7 +547,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				make_intrusive<StringVal>(parts[4].c_str()),
 				make_intrusive<StringVal>(parts[5].c_str()),
 				make_intrusive<StringVal>(parts[6].c_str()),
-				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(atoi(parts[7].c_str()))},
+				val_mgr->Int(atoi(parts[7].c_str())),
 				make_intrusive<StringVal>(parts[8].c_str())
 			);
 			}

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -588,7 +588,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(prefix.c_str()),
-					IntrusivePtr{AdoptRef{}, val_mgr->GetCount(code)},
+					val_mgr->Count(code),
 					make_intrusive<StringVal>(params.c_str())
 				);
 			break;
@@ -663,10 +663,8 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 					make_intrusive<StringVal>(parts[1].c_str()),
 					make_intrusive<StringVal>(parts[2].c_str()),
 					make_intrusive<AddrVal>(htonl(raw_ip)),
-					IntrusivePtr{AdoptRef{}, val_mgr->GetCount(atoi(parts[4].c_str()))},
-					IntrusivePtr{AdoptRef{}, parts.size() >= 6 ?
-						val_mgr->GetCount(atoi(parts[5].c_str())) :
-						val_mgr->GetCount(0)}
+					val_mgr->Count(atoi(parts[4].c_str())),
+					parts.size() >= 6 ? val_mgr->Count(atoi(parts[5].c_str())) : val_mgr->Count(0)
 				);
 			}
 

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -236,7 +236,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			EnqueueConnEvent(irc_network_info,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(users)},
 				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(services)},
 				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(servers)}
@@ -283,7 +283,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			EnqueueConnEvent(irc_names_info,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(type.c_str()),
 				make_intrusive<StringVal>(channel.c_str()),
 				std::move(set)
@@ -317,7 +317,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			EnqueueConnEvent(irc_server_info,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(users)},
 				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(services)},
 				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(servers)}
@@ -339,7 +339,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			EnqueueConnEvent(irc_channel_info,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				IntrusivePtr{AdoptRef{}, val_mgr->GetInt(channels)}
 			);
 			}
@@ -371,7 +371,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			EnqueueConnEvent(irc_global_users,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(eop - prefix, prefix),
 				make_intrusive<StringVal>(++msg)
 			);
@@ -397,7 +397,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			zeek::Args vl;
 			vl.reserve(6);
 			vl.emplace_back(AdoptRef{}, BuildConnVal());
-			vl.emplace_back(AdoptRef{}, val_mgr->GetBool(orig));
+			vl.emplace_back(val_mgr->Bool(orig));
 			vl.emplace_back(make_intrusive<StringVal>(parts[0].c_str()));
 			vl.emplace_back(make_intrusive<StringVal>(parts[1].c_str()));
 			vl.emplace_back(make_intrusive<StringVal>(parts[2].c_str()));
@@ -436,7 +436,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			EnqueueConnEvent(irc_whois_operator_line,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(parts[0].c_str())
 			);
 			}
@@ -474,7 +474,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			EnqueueConnEvent(irc_whois_channel_line,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(nick.c_str()),
 				std::move(set)
 			);
@@ -505,7 +505,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 				EnqueueConnEvent(irc_channel_topic,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(parts[1].c_str()),
 					make_intrusive<StringVal>(t)
 				);
@@ -539,7 +539,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			EnqueueConnEvent(irc_who_line,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(parts[0].c_str()),
 				make_intrusive<StringVal>(parts[1].c_str()),
 				make_intrusive<StringVal>(parts[2].c_str()),
@@ -561,7 +561,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( irc_invalid_nick )
 				EnqueueConnEvent(irc_invalid_nick,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)}
+					val_mgr->Bool(orig)
 				);
 			break;
 
@@ -571,8 +571,8 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( irc_oper_response )
 				EnqueueConnEvent(irc_oper_response,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(code == 381)}
+					val_mgr->Bool(orig),
+					val_mgr->Bool(code == 381)
 				);
 			break;
 
@@ -586,7 +586,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( irc_reply )
 				EnqueueConnEvent(irc_reply,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(prefix.c_str()),
 					IntrusivePtr{AdoptRef{}, val_mgr->GetCount(code)},
 					make_intrusive<StringVal>(params.c_str())
@@ -657,7 +657,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( irc_dcc_message )
 				EnqueueConnEvent(irc_dcc_message,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(prefix.c_str()),
 					make_intrusive<StringVal>(target.c_str()),
 					make_intrusive<StringVal>(parts[1].c_str()),
@@ -675,7 +675,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			if ( irc_privmsg_message )
 				EnqueueConnEvent(irc_privmsg_message,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(prefix.c_str()),
 					make_intrusive<StringVal>(target.c_str()),
 					make_intrusive<StringVal>(message.c_str())
@@ -700,7 +700,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_notice_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(target.c_str()),
 			make_intrusive<StringVal>(message.c_str())
@@ -724,7 +724,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_squery_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(target.c_str()),
 			make_intrusive<StringVal>(message.c_str())
@@ -738,7 +738,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		zeek::Args vl;
 		vl.reserve(6);
 		vl.emplace_back(AdoptRef{}, BuildConnVal());
-		vl.emplace_back(AdoptRef{}, val_mgr->GetBool(orig));
+		vl.emplace_back(val_mgr->Bool(orig));
 
 		if ( parts.size() > 0 )
 			vl.emplace_back(make_intrusive<StringVal>(parts[0].c_str()));
@@ -773,7 +773,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( parts.size() == 2 )
 			EnqueueConnEvent(irc_oper_message,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(parts[0].c_str()),
 				make_intrusive<StringVal>(parts[1].c_str())
 			);
@@ -795,7 +795,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		zeek::Args vl;
 		vl.reserve(6);
 		vl.emplace_back(AdoptRef{}, BuildConnVal());
-		vl.emplace_back(AdoptRef{}, val_mgr->GetBool(orig));
+		vl.emplace_back(val_mgr->Bool(orig));
 		vl.emplace_back(make_intrusive<StringVal>(prefix.c_str()));
 		vl.emplace_back(make_intrusive<StringVal>(parts[0].c_str()));
 		vl.emplace_back(make_intrusive<StringVal>(parts[1].c_str()));
@@ -864,7 +864,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_join_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			std::move(list)
 		);
 		}
@@ -924,7 +924,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_join_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			std::move(list)
 		);
 		}
@@ -963,7 +963,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_part_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(nick.c_str()),
 			std::move(set),
 			make_intrusive<StringVal>(message.c_str())
@@ -986,7 +986,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_quit_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(nickname.c_str()),
 			make_intrusive<StringVal>(message.c_str())
 		);
@@ -1000,7 +1000,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_nick_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(nick.c_str())
 		);
@@ -1025,11 +1025,11 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_who_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			parts.size() > 0 ?
 				make_intrusive<StringVal>(parts[0].c_str()) :
 				IntrusivePtr{AdoptRef{}, val_mgr->GetEmptyString()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(oper)}
+			val_mgr->Bool(oper)
 		);
 		}
 
@@ -1055,7 +1055,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_whois_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(server.c_str()),
 			make_intrusive<StringVal>(users.c_str())
 		);
@@ -1068,7 +1068,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_error_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(params.c_str())
 		);
@@ -1084,7 +1084,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			EnqueueConnEvent(irc_invite_message,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(parts[0].c_str()),
 				make_intrusive<StringVal>(parts[1].c_str())
@@ -1099,7 +1099,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( params.size() > 0 )
 			EnqueueConnEvent(irc_mode_message,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(params.c_str())
 			);
@@ -1112,7 +1112,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		{
 		EnqueueConnEvent(irc_password_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(params.c_str())
 		);
 		}
@@ -1134,7 +1134,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		EnqueueConnEvent(irc_squit_message,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(server.c_str()),
 			make_intrusive<StringVal>(message.c_str())
@@ -1148,7 +1148,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			{
 			EnqueueConnEvent(irc_request,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(command.c_str()),
 				make_intrusive<StringVal>(params.c_str())
@@ -1162,7 +1162,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			{
 			EnqueueConnEvent(irc_message,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(command.c_str()),
 				make_intrusive<StringVal>(params.c_str())

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -740,15 +740,15 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		if ( parts.size() > 0 )
 			vl.emplace_back(make_intrusive<StringVal>(parts[0].c_str()));
-		else vl.emplace_back(AdoptRef{}, val_mgr->GetEmptyString());
+		else vl.emplace_back(val_mgr->EmptyString());
 
 		if ( parts.size() > 1 )
 			vl.emplace_back(make_intrusive<StringVal>(parts[1].c_str()));
-		else vl.emplace_back(AdoptRef{}, val_mgr->GetEmptyString());
+		else vl.emplace_back(val_mgr->EmptyString());
 
 		if ( parts.size() > 2 )
 			vl.emplace_back(make_intrusive<StringVal>(parts[2].c_str()));
-		else vl.emplace_back(AdoptRef{}, val_mgr->GetEmptyString());
+		else vl.emplace_back(val_mgr->EmptyString());
 
 		string realname;
 		for ( unsigned int i = 3; i < parts.size(); i++ )
@@ -810,7 +810,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			vl.emplace_back(make_intrusive<StringVal>(comment.c_str()));
 			}
 		else
-			vl.emplace_back(AdoptRef{}, val_mgr->GetEmptyString());
+			vl.emplace_back(val_mgr->EmptyString());
 
 		EnqueueConnEvent(irc_kick_message, std::move(vl));
 		}
@@ -1026,7 +1026,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			val_mgr->Bool(orig),
 			parts.size() > 0 ?
 				make_intrusive<StringVal>(parts[0].c_str()) :
-				IntrusivePtr{AdoptRef{}, val_mgr->GetEmptyString()},
+				val_mgr->EmptyString(),
 			val_mgr->Bool(oper)
 		);
 		}

--- a/src/analyzer/protocol/krb/KRB.cc
+++ b/src/analyzer/protocol/krb/KRB.cc
@@ -87,7 +87,9 @@ void KRB_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 		}
 	}
 
-StringVal* KRB_Analyzer::GetAuthenticationInfo(const BroString* principal, const BroString* ciphertext, const bro_uint_t enctype)
+IntrusivePtr<StringVal> KRB_Analyzer::GetAuthenticationInfo(const BroString* principal,
+                                                            const BroString* ciphertext,
+                                                            const bro_uint_t enctype)
 	{
 #ifdef USE_KRB5
 	if ( !krb_available )
@@ -145,7 +147,7 @@ StringVal* KRB_Analyzer::GetAuthenticationInfo(const BroString* principal, const
 		return nullptr;
 		}
 
-	StringVal* ret = new StringVal(cp);
+	auto ret = make_intrusive<StringVal>(cp);
 
 	krb5_free_unparsed_name(krb_context, cp);
 	krb5_free_ticket(krb_context, tkt);

--- a/src/analyzer/protocol/krb/KRB.h
+++ b/src/analyzer/protocol/krb/KRB.h
@@ -25,7 +25,9 @@ public:
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new KRB_Analyzer(conn); }
 
-	StringVal* GetAuthenticationInfo(const BroString* principal, const BroString* ciphertext, const bro_uint_t enctype);
+	IntrusivePtr<StringVal> GetAuthenticationInfo(const BroString* principal,
+	                                              const BroString* ciphertext,
+	                                              const bro_uint_t enctype);
 
 protected:
 

--- a/src/analyzer/protocol/krb/KRB_TCP.h
+++ b/src/analyzer/protocol/krb/KRB_TCP.h
@@ -21,7 +21,10 @@ public:
 	// Overriden from tcp::TCP_ApplicationAnalyzer.
 	void EndpointEOF(bool is_orig) override;
 
-	StringVal* GetAuthenticationInfo(const BroString* principal, const BroString* ciphertext, const bro_uint_t enctype) { return val_mgr->GetEmptyString(); }
+	IntrusivePtr<StringVal> GetAuthenticationInfo(const BroString* principal,
+	                                              const BroString* ciphertext,
+	                                              const bro_uint_t enctype)
+		{ return val_mgr->EmptyString(); }
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)
 		{ return new KRB_Analyzer(conn); }

--- a/src/analyzer/protocol/krb/krb-analyzer.pac
+++ b/src/analyzer/protocol/krb/krb-analyzer.pac
@@ -263,7 +263,7 @@ refine connection KRB_Conn += {
 			rv->Assign(1, val_mgr->Bool(${msg.ap_options.mutual_required}));
 
 			RecordVal* rvticket = proc_ticket(${msg.ticket});
-			StringVal* authenticationinfo = bro_analyzer()->GetAuthenticationInfo(rvticket->Lookup(2)->AsString(), rvticket->Lookup(4)->AsString(), rvticket->Lookup(3)->AsCount());
+			auto authenticationinfo = bro_analyzer()->GetAuthenticationInfo(rvticket->Lookup(2)->AsString(), rvticket->Lookup(4)->AsString(), rvticket->Lookup(3)->AsCount());
 			if ( authenticationinfo )
 				rvticket->Assign(5, authenticationinfo);
 			BifEvent::generate_krb_ap_request(bro_analyzer(), bro_analyzer()->Conn(),

--- a/src/analyzer/protocol/krb/krb-analyzer.pac
+++ b/src/analyzer/protocol/krb/krb-analyzer.pac
@@ -49,7 +49,7 @@ RecordVal* proc_krb_kdc_req_arguments(KRB_KDC_REQ* msg, const BroAnalyzer bro_an
 				rv->Assign(4, GetStringFromPrincipalName(element->data()->principal()));
 				break;
 			case 2:
-				rv->Assign(5, bytestring_to_val(element->data()->realm()->encoding()->content()));
+				rv->Assign(5, to_stringval(element->data()->realm()->encoding()->content()));
 				break;
 			case 3:
 				rv->Assign(6, GetStringFromPrincipalName(element->data()->sname()));
@@ -139,19 +139,19 @@ bool proc_error_arguments(RecordVal* rv, const std::vector<KRB_ERROR_Arg*>* args
 				break;
 			// ctime/stime handled above
 			case 7:
-				rv->Assign(5, bytestring_to_val((*args)[i]->args()->crealm()->encoding()->content()));
+				rv->Assign(5, to_stringval((*args)[i]->args()->crealm()->encoding()->content()));
 				break;
 			case 8:
 				rv->Assign(6, GetStringFromPrincipalName((*args)[i]->args()->cname()));
 				break;
 			case 9:
-				rv->Assign(7, bytestring_to_val((*args)[i]->args()->realm()->encoding()->content()));
+				rv->Assign(7, to_stringval((*args)[i]->args()->realm()->encoding()->content()));
 				break;
 			case 10:
 				rv->Assign(8, GetStringFromPrincipalName((*args)[i]->args()->sname()));
 				break;
 			case 11:
-				rv->Assign(9, bytestring_to_val((*args)[i]->args()->e_text()->encoding()->content()));
+				rv->Assign(9, to_stringval((*args)[i]->args()->e_text()->encoding()->content()));
 				break;
 			case 12:
 				if ( error_code == KDC_ERR_PREAUTH_REQUIRED )
@@ -211,7 +211,7 @@ refine connection KRB_Conn += {
 			if ( ${msg.padata.has_padata} )
 				rv->Assign(2, proc_padata(${msg.padata.padata.padata}, bro_analyzer(), false));
 
-			rv->Assign(3, bytestring_to_val(${msg.client_realm.encoding.content}));
+			rv->Assign(3, to_stringval(${msg.client_realm.encoding.content}));
 			rv->Assign(4, GetStringFromPrincipalName(${msg.client_name}));
 
 			rv->Assign(5, proc_ticket(${msg.ticket}));
@@ -322,7 +322,7 @@ refine connection KRB_Conn += {
 				switch ( ${msg.safe_body.args[i].seq_meta.index} )
 					{
 					case 0:
-						rv->Assign(3, bytestring_to_val(${msg.safe_body.args[i].args.user_data.encoding.content}));
+						rv->Assign(3, to_stringval(${msg.safe_body.args[i].args.user_data.encoding.content}));
 						break;
 					case 3:
 						rv->Assign(5, asn1_integer_to_val(${msg.safe_body.args[i].args.seq_number}, TYPE_COUNT));

--- a/src/analyzer/protocol/krb/krb-analyzer.pac
+++ b/src/analyzer/protocol/krb/krb-analyzer.pac
@@ -10,19 +10,19 @@ RecordVal* proc_krb_kdc_options(const KRB_KDC_Options* opts)
 {
 	RecordVal* rv = new RecordVal(BifType::Record::KRB::KDC_Options);
 
-	rv->Assign(0, val_mgr->GetBool(opts->forwardable()));
-	rv->Assign(1, val_mgr->GetBool(opts->forwarded()));
-	rv->Assign(2, val_mgr->GetBool(opts->proxiable()));
-	rv->Assign(3, val_mgr->GetBool(opts->proxy()));
-	rv->Assign(4, val_mgr->GetBool(opts->allow_postdate()));
-	rv->Assign(5, val_mgr->GetBool(opts->postdated()));
-	rv->Assign(6, val_mgr->GetBool(opts->renewable()));
-	rv->Assign(7, val_mgr->GetBool(opts->opt_hardware_auth()));
-	rv->Assign(8, val_mgr->GetBool(opts->disable_transited_check()));
-	rv->Assign(9, val_mgr->GetBool(opts->renewable_ok()));
-	rv->Assign(10, val_mgr->GetBool(opts->enc_tkt_in_skey()));
-	rv->Assign(11, val_mgr->GetBool(opts->renew()));
-	rv->Assign(12, val_mgr->GetBool(opts->validate()));
+	rv->Assign(0, val_mgr->Bool(opts->forwardable()));
+	rv->Assign(1, val_mgr->Bool(opts->forwarded()));
+	rv->Assign(2, val_mgr->Bool(opts->proxiable()));
+	rv->Assign(3, val_mgr->Bool(opts->proxy()));
+	rv->Assign(4, val_mgr->Bool(opts->allow_postdate()));
+	rv->Assign(5, val_mgr->Bool(opts->postdated()));
+	rv->Assign(6, val_mgr->Bool(opts->renewable()));
+	rv->Assign(7, val_mgr->Bool(opts->opt_hardware_auth()));
+	rv->Assign(8, val_mgr->Bool(opts->disable_transited_check()));
+	rv->Assign(9, val_mgr->Bool(opts->renewable_ok()));
+	rv->Assign(10, val_mgr->Bool(opts->enc_tkt_in_skey()));
+	rv->Assign(11, val_mgr->Bool(opts->renew()));
+	rv->Assign(12, val_mgr->Bool(opts->validate()));
 
 	return rv;
 }
@@ -259,8 +259,8 @@ refine connection KRB_Conn += {
 		if ( krb_ap_request )
 			{
 			RecordVal* rv = new RecordVal(BifType::Record::KRB::AP_Options);
-			rv->Assign(0, val_mgr->GetBool(${msg.ap_options.use_session_key}));
-			rv->Assign(1, val_mgr->GetBool(${msg.ap_options.mutual_required}));
+			rv->Assign(0, val_mgr->Bool(${msg.ap_options.use_session_key}));
+			rv->Assign(1, val_mgr->Bool(${msg.ap_options.mutual_required}));
 
 			RecordVal* rvticket = proc_ticket(${msg.ticket});
 			StringVal* authenticationinfo = bro_analyzer()->GetAuthenticationInfo(rvticket->Lookup(2)->AsString(), rvticket->Lookup(4)->AsString(), rvticket->Lookup(3)->AsCount());

--- a/src/analyzer/protocol/krb/krb-asn1.pac
+++ b/src/analyzer/protocol/krb/krb-asn1.pac
@@ -2,21 +2,20 @@
 %include ../asn1/asn1.pac
 
 %header{
-    Val* GetTimeFromAsn1(const KRB_Time* atime, int64 usecs);
-    Val* GetTimeFromAsn1(StringVal* atime, int64 usecs);
+    IntrusivePtr<Val> GetTimeFromAsn1(const KRB_Time* atime, int64 usecs);
+    IntrusivePtr<Val> GetTimeFromAsn1(StringVal* atime, int64 usecs);
 %}
 
 %code{
 
-Val* GetTimeFromAsn1(const KRB_Time* atime, int64 usecs)
+IntrusivePtr<Val> GetTimeFromAsn1(const KRB_Time* atime, int64 usecs)
 	{
-	StringVal* atime_bytestring = bytestring_to_val(atime->time());
-	Val* result = GetTimeFromAsn1(atime_bytestring, usecs);
-	Unref(atime_bytestring);
+	auto atime_bytestring = to_stringval(atime->time());
+	auto result = GetTimeFromAsn1(atime_bytestring.get(), usecs);
 	return result;
 	}
 
-Val* GetTimeFromAsn1(StringVal* atime, int64 usecs)
+IntrusivePtr<Val> GetTimeFromAsn1(StringVal* atime, int64 usecs)
 	{
 	time_t lResult = 0;
 
@@ -27,7 +26,7 @@ Val* GetTimeFromAsn1(StringVal* atime, int64 usecs)
 	char * pString = (char *) atime->Bytes();
 
 	if ( lTimeLength != 15 && lTimeLength != 17 )
-		return 0;
+		return nullptr;
 
 	if (lTimeLength == 17 )
 		pString = pString + 2;
@@ -52,7 +51,7 @@ Val* GetTimeFromAsn1(StringVal* atime, int64 usecs)
 	if ( !lResult )
 		lResult = 0;
 
-	return new Val(double(lResult + double(usecs/100000.0)), TYPE_TIME);
+	return make_intrusive<Val>(double(lResult + double(usecs/100000.0)), TYPE_TIME);
 	}
 
 %}

--- a/src/analyzer/protocol/krb/krb-padata.pac
+++ b/src/analyzer/protocol/krb/krb-padata.pac
@@ -37,7 +37,7 @@ VectorVal* proc_padata(const KRB_PA_Data_Sequence* data, const BroAnalyzer bro_a
 			case PA_PW_SALT:
 				{
 				RecordVal * type_val = new RecordVal(BifType::Record::KRB::Type_Value);
-				type_val->Assign(0, val_mgr->GetCount(element->data_type()));
+				type_val->Assign(0, val_mgr->Count(element->data_type()));
 				type_val->Assign(1, bytestring_to_val(element->pa_data_element()->pa_pw_salt()->encoding()->content()));
 				vv->Assign(vv->Size(), type_val);
 				break;
@@ -45,7 +45,7 @@ VectorVal* proc_padata(const KRB_PA_Data_Sequence* data, const BroAnalyzer bro_a
 			case PA_ENCTYPE_INFO:
 				{
 				RecordVal * type_val = new RecordVal(BifType::Record::KRB::Type_Value);
-				type_val->Assign(0, val_mgr->GetCount(element->data_type()));
+				type_val->Assign(0, val_mgr->Count(element->data_type()));
 				type_val->Assign(1, bytestring_to_val(element->pa_data_element()->pf_enctype_info()->salt()));
 				vv->Assign(vv->Size(), type_val);
 				break;
@@ -53,7 +53,7 @@ VectorVal* proc_padata(const KRB_PA_Data_Sequence* data, const BroAnalyzer bro_a
 			case PA_ENCTYPE_INFO2:
 				{
 				RecordVal * type_val = new RecordVal(BifType::Record::KRB::Type_Value);
-				type_val->Assign(0, val_mgr->GetCount(element->data_type()));
+				type_val->Assign(0, val_mgr->Count(element->data_type()));
 				type_val->Assign(1, bytestring_to_val(element->pa_data_element()->pf_enctype_info2()->salt()));
 				vv->Assign(vv->Size(), type_val);
 				break;
@@ -111,7 +111,7 @@ VectorVal* proc_padata(const KRB_PA_Data_Sequence* data, const BroAnalyzer bro_a
 				if ( ! is_error && element->pa_data_element()->unknown()->meta()->length() > 0 )
 					{
 					RecordVal * type_val = new RecordVal(BifType::Record::KRB::Type_Value);
-					type_val->Assign(0, val_mgr->GetCount(element->data_type()));
+					type_val->Assign(0, val_mgr->Count(element->data_type()));
 					type_val->Assign(1, bytestring_to_val(element->pa_data_element()->unknown()->content()));
 					vv->Assign(vv->Size(), type_val);
 					}

--- a/src/analyzer/protocol/krb/krb-padata.pac
+++ b/src/analyzer/protocol/krb/krb-padata.pac
@@ -38,7 +38,7 @@ VectorVal* proc_padata(const KRB_PA_Data_Sequence* data, const BroAnalyzer bro_a
 				{
 				RecordVal * type_val = new RecordVal(BifType::Record::KRB::Type_Value);
 				type_val->Assign(0, val_mgr->Count(element->data_type()));
-				type_val->Assign(1, bytestring_to_val(element->pa_data_element()->pa_pw_salt()->encoding()->content()));
+				type_val->Assign(1, to_stringval(element->pa_data_element()->pa_pw_salt()->encoding()->content()));
 				vv->Assign(vv->Size(), type_val);
 				break;
 				}
@@ -46,7 +46,7 @@ VectorVal* proc_padata(const KRB_PA_Data_Sequence* data, const BroAnalyzer bro_a
 				{
 				RecordVal * type_val = new RecordVal(BifType::Record::KRB::Type_Value);
 				type_val->Assign(0, val_mgr->Count(element->data_type()));
-				type_val->Assign(1, bytestring_to_val(element->pa_data_element()->pf_enctype_info()->salt()));
+				type_val->Assign(1, to_stringval(element->pa_data_element()->pf_enctype_info()->salt()));
 				vv->Assign(vv->Size(), type_val);
 				break;
 				}
@@ -54,7 +54,7 @@ VectorVal* proc_padata(const KRB_PA_Data_Sequence* data, const BroAnalyzer bro_a
 				{
 				RecordVal * type_val = new RecordVal(BifType::Record::KRB::Type_Value);
 				type_val->Assign(0, val_mgr->Count(element->data_type()));
-				type_val->Assign(1, bytestring_to_val(element->pa_data_element()->pf_enctype_info2()->salt()));
+				type_val->Assign(1, to_stringval(element->pa_data_element()->pf_enctype_info2()->salt()));
 				vv->Assign(vv->Size(), type_val);
 				break;
 				}
@@ -112,7 +112,7 @@ VectorVal* proc_padata(const KRB_PA_Data_Sequence* data, const BroAnalyzer bro_a
 					{
 					RecordVal * type_val = new RecordVal(BifType::Record::KRB::Type_Value);
 					type_val->Assign(0, val_mgr->Count(element->data_type()));
-					type_val->Assign(1, bytestring_to_val(element->pa_data_element()->unknown()->content()));
+					type_val->Assign(1, to_stringval(element->pa_data_element()->unknown()->content()));
 					vv->Assign(vv->Size(), type_val);
 					}
 				break;

--- a/src/analyzer/protocol/krb/krb-types.pac
+++ b/src/analyzer/protocol/krb/krb-types.pac
@@ -8,8 +8,8 @@ VectorVal* proc_cipher_list(const Array* list);
 VectorVal* proc_host_address_list(const BroAnalyzer a, const KRB_Host_Addresses* list);
 RecordVal* proc_host_address(const BroAnalyzer a, const KRB_Host_Address* addr);
 
-VectorVal* proc_tickets(const KRB_Ticket_Sequence* list);
-RecordVal* proc_ticket(const KRB_Ticket* ticket);
+IntrusivePtr<VectorVal> proc_tickets(const KRB_Ticket_Sequence* list);
+IntrusivePtr<RecordVal> proc_ticket(const KRB_Ticket* ticket);
 %}
 
 %code{
@@ -92,9 +92,10 @@ RecordVal* proc_host_address(const BroAnalyzer a, const KRB_Host_Address* addr)
 	return rv;
 }
 
-VectorVal* proc_tickets(const KRB_Ticket_Sequence* list)
-{
-	VectorVal* tickets = new VectorVal(internal_type("KRB::Ticket_Vector")->AsVectorType());
+IntrusivePtr<VectorVal> proc_tickets(const KRB_Ticket_Sequence* list)
+	{
+	auto tickets = make_intrusive<VectorVal>(internal_type("KRB::Ticket_Vector")->AsVectorType());
+
 	for ( uint i = 0; i < list->tickets()->size(); ++i )
 		{
 		KRB_Ticket* element = (*list->tickets())[i];
@@ -102,11 +103,11 @@ VectorVal* proc_tickets(const KRB_Ticket_Sequence* list)
 		}
 
 	return tickets;
-}
+	}
 
-RecordVal* proc_ticket(const KRB_Ticket* ticket)
-{
-	RecordVal* rv = new RecordVal(BifType::Record::KRB::Ticket);
+IntrusivePtr<RecordVal> proc_ticket(const KRB_Ticket* ticket)
+	{
+	auto rv = make_intrusive<RecordVal>(BifType::Record::KRB::Ticket);
 
 	rv->Assign(0, asn1_integer_to_val(ticket->tkt_vno()->data(), TYPE_COUNT));
 	rv->Assign(1, bytestring_to_val(ticket->realm()->data()->content()));
@@ -115,7 +116,7 @@ RecordVal* proc_ticket(const KRB_Ticket* ticket)
 	rv->Assign(4, bytestring_to_val(ticket->enc_part()->data()->ciphertext()->encoding()->content()));
 
 	return rv;
-}
+	}
 %}
 
 type KRB_Principal_Name = record {

--- a/src/analyzer/protocol/login/Login.cc
+++ b/src/analyzer/protocol/login/Login.cc
@@ -423,7 +423,7 @@ void Login_Analyzer::LoginEvent(EventHandlerPtr f, const char* line,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
 		IntrusivePtr{NewRef{}, username},
 		client_name ? IntrusivePtr{NewRef{}, client_name}
-		            : IntrusivePtr{AdoptRef{}, val_mgr->GetEmptyString()},
+		            : val_mgr->EmptyString(),
 		IntrusivePtr{AdoptRef{}, password},
 		make_intrusive<StringVal>(line)
 	);
@@ -593,7 +593,7 @@ Val* Login_Analyzer::PopUserTextVal()
 	if ( s )
 		return new StringVal(new BroString(true, byte_vec(s), strlen(s)));
 	else
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString()->Ref();
 	}
 
 bool Login_Analyzer::MatchesTypeahead(const char* line) const

--- a/src/analyzer/protocol/login/Login.cc
+++ b/src/analyzer/protocol/login/Login.cc
@@ -290,7 +290,7 @@ void Login_Analyzer::AuthenticationDialog(bool orig, char* line)
 	else if ( IsSkipAuthentication(line) )
 		{
 		if ( authentication_skipped )
-			EnqueueConnEvent(authentication_skipped, IntrusivePtr{AdoptRef{}, BuildConnVal()});
+			EnqueueConnEvent(authentication_skipped, ConnVal());
 
 		state = LOGIN_STATE_SKIP;
 		SetSkip(true);
@@ -332,19 +332,19 @@ void Login_Analyzer::SetEnv(bool orig, char* name, char* val)
 
 		else if ( login_terminal && streq(name, "TERM") )
 			EnqueueConnEvent(login_terminal,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				make_intrusive<StringVal>(val)
 			);
 
 		else if ( login_display && streq(name, "DISPLAY") )
 			EnqueueConnEvent(login_display,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				make_intrusive<StringVal>(val)
 			);
 
 		else if ( login_prompt && streq(name, "TTYPROMPT") )
 			EnqueueConnEvent(login_prompt,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				make_intrusive<StringVal>(val)
 			);
 		}
@@ -420,7 +420,7 @@ void Login_Analyzer::LoginEvent(EventHandlerPtr f, const char* line,
 				PopUserTextVal() : new StringVal("<none>");
 
 	EnqueueConnEvent(f,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		IntrusivePtr{NewRef{}, username},
 		client_name ? IntrusivePtr{NewRef{}, client_name}
 		            : val_mgr->EmptyString(),
@@ -443,7 +443,7 @@ void Login_Analyzer::LineEvent(EventHandlerPtr f, const char* line)
 		return;
 
 	EnqueueConnEvent(f,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		make_intrusive<StringVal>(line)
 	);
 	}
@@ -455,7 +455,7 @@ void Login_Analyzer::Confused(const char* msg, const char* line)
 
 	if ( login_confused )
 		EnqueueConnEvent(login_confused,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			make_intrusive<StringVal>(msg),
 			make_intrusive<StringVal>(line)
 		);
@@ -479,7 +479,7 @@ void Login_Analyzer::ConfusionText(const char* line)
 	{
 	if ( login_confused_text )
 		EnqueueConnEvent(login_confused_text,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			make_intrusive<StringVal>(line)
 		);
 	}

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -460,7 +460,7 @@ void NVT_Analyzer::SetTerminal(const u_char* terminal, int len)
 	{
 	if ( login_terminal )
 		EnqueueConnEvent(login_terminal,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			make_intrusive<StringVal>(new BroString(terminal, len, false))
 		);
 	}

--- a/src/analyzer/protocol/login/RSH.cc
+++ b/src/analyzer/protocol/login/RSH.cc
@@ -190,9 +190,9 @@ void Rsh_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		{
 		if ( contents_orig->RshSaveState() == RSH_SERVER_USER_NAME )
 			// First input
-			vl.emplace_back(AdoptRef{}, val_mgr->GetTrue());
+			vl.emplace_back(val_mgr->True());
 		else
-			vl.emplace_back(AdoptRef{}, val_mgr->GetFalse());
+			vl.emplace_back(val_mgr->False());
 
 		EnqueueConnEvent(rsh_request, std::move(vl));
 		}

--- a/src/analyzer/protocol/login/RSH.cc
+++ b/src/analyzer/protocol/login/RSH.cc
@@ -172,7 +172,7 @@ void Rsh_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	vl.reserve(4 + orig);
 	const char* line = (const char*) data;
 	line = skip_whitespace(line);
-	vl.emplace_back(AdoptRef{}, BuildConnVal());
+	vl.emplace_back(ConnVal());
 
 	if ( client_name )
 		vl.emplace_back(NewRef{}, client_name);

--- a/src/analyzer/protocol/login/Rlogin.cc
+++ b/src/analyzer/protocol/login/Rlogin.cc
@@ -245,7 +245,7 @@ void Rlogin_Analyzer::TerminalType(const char* s)
 	{
 	if ( login_terminal )
 		EnqueueConnEvent(login_terminal,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			make_intrusive<StringVal>(s)
 		);
 	}

--- a/src/analyzer/protocol/login/functions.bif
+++ b/src/analyzer/protocol/login/functions.bif
@@ -34,7 +34,7 @@ function get_login_state%(cid: conn_id%): count
 	if ( ! la )
 		return val_mgr->False();
 
-	return val_mgr->GetCount(int(static_cast<analyzer::login::Login_Analyzer*>(la)->LoginState()));
+	return val_mgr->Count(int(static_cast<analyzer::login::Login_Analyzer*>(la)->LoginState()));
 	%}
 
 ## Sets the login state of a connection with a login analyzer.

--- a/src/analyzer/protocol/login/functions.bif
+++ b/src/analyzer/protocol/login/functions.bif
@@ -28,11 +28,11 @@ function get_login_state%(cid: conn_id%): count
 	%{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	analyzer::Analyzer* la = c->FindAnalyzer("Login");
 	if ( ! la )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	return val_mgr->GetCount(int(static_cast<analyzer::login::Login_Analyzer*>(la)->LoginState()));
 	%}
@@ -52,12 +52,12 @@ function set_login_state%(cid: conn_id, new_state: count%): bool
 	%{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	analyzer::Analyzer* la = c->FindAnalyzer("Login");
 	if ( ! la )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	static_cast<analyzer::login::Login_Analyzer*>(la)->SetLoginState(analyzer::login::login_state(new_state));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -1303,14 +1303,12 @@ TableVal* MIME_Message::BuildHeaderTable(MIME_HeaderList& hlist)
 
 	for ( unsigned int i = 0; i < hlist.size(); ++i )
 		{
-		Val* index = val_mgr->GetCount(i+1);	// index starting from 1
+		auto index = val_mgr->Count(i + 1);	// index starting from 1
 
 		MIME_Header* h = hlist[i];
 		RecordVal* header_record = BuildHeaderVal(h);
 
-		t->Assign(index, header_record);
-
-		Unref(index);
+		t->Assign(index.get(), header_record);
 		}
 
 	return t;
@@ -1367,7 +1365,7 @@ void MIME_Mail::Done()
 
 		analyzer->EnqueueConnEvent(mime_content_hash,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(content_hash_length)},
+			val_mgr->Count(content_hash_length),
 			make_intrusive<StringVal>(new BroString(true, digest, 16))
 		);
 		}
@@ -1407,7 +1405,7 @@ void MIME_Mail::EndEntity(MIME_Entity* /* entity */)
 
 		analyzer->EnqueueConnEvent(mime_entity_data,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(s->Len())},
+			val_mgr->Count(s->Len()),
 			make_intrusive<StringVal>(s)
 		);
 
@@ -1474,7 +1472,7 @@ void MIME_Mail::SubmitData(int len, const char* buf)
 
 		analyzer->EnqueueConnEvent(mime_segment_data,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(data_len)},
+			val_mgr->Count(data_len),
 			make_intrusive<StringVal>(data_len, data)
 		);
 		}
@@ -1521,7 +1519,7 @@ void MIME_Mail::SubmitAllData()
 
 		analyzer->EnqueueConnEvent(mime_all_data,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(s->Len())},
+			val_mgr->Count(s->Len()),
 			make_intrusive<StringVal>(s)
 		);
 		}

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -1364,7 +1364,7 @@ void MIME_Mail::Done()
 		md5_hash = nullptr;
 
 		analyzer->EnqueueConnEvent(mime_content_hash,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Count(content_hash_length),
 			make_intrusive<StringVal>(new BroString(true, digest, 16))
 		);
@@ -1391,7 +1391,7 @@ void MIME_Mail::BeginEntity(MIME_Entity* /* entity */)
 	cur_entity_id.clear();
 
 	if ( mime_begin_entity )
-		analyzer->EnqueueConnEvent(mime_begin_entity, IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()});
+		analyzer->EnqueueConnEvent(mime_begin_entity, analyzer->ConnVal());
 
 	buffer_start = data_start = 0;
 	ASSERT(entity_content.size() == 0);
@@ -1404,7 +1404,7 @@ void MIME_Mail::EndEntity(MIME_Entity* /* entity */)
 		BroString* s = concatenate(entity_content);
 
 		analyzer->EnqueueConnEvent(mime_entity_data,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Count(s->Len()),
 			make_intrusive<StringVal>(s)
 		);
@@ -1416,7 +1416,7 @@ void MIME_Mail::EndEntity(MIME_Entity* /* entity */)
 		}
 
 	if ( mime_end_entity )
-		analyzer->EnqueueConnEvent(mime_end_entity, IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()});
+		analyzer->EnqueueConnEvent(mime_end_entity, analyzer->ConnVal());
 
 	file_mgr->EndOfFile(analyzer->GetAnalyzerTag(), analyzer->Conn());
 	cur_entity_id.clear();
@@ -1426,7 +1426,7 @@ void MIME_Mail::SubmitHeader(MIME_Header* h)
 	{
 	if ( mime_one_header )
 		analyzer->EnqueueConnEvent(mime_one_header,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, BuildHeaderVal(h)}
 		);
 	}
@@ -1435,7 +1435,7 @@ void MIME_Mail::SubmitAllHeaders(MIME_HeaderList& hlist)
 	{
 	if ( mime_all_headers )
 		analyzer->EnqueueConnEvent(mime_all_headers,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			IntrusivePtr{AdoptRef{}, BuildHeaderTable(hlist)}
 		);
 	}
@@ -1471,7 +1471,7 @@ void MIME_Mail::SubmitData(int len, const char* buf)
 		int data_len = (buf + len) - data;
 
 		analyzer->EnqueueConnEvent(mime_segment_data,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Count(data_len),
 			make_intrusive<StringVal>(data_len, data)
 		);
@@ -1518,7 +1518,7 @@ void MIME_Mail::SubmitAllData()
 		delete_strings(all_content);
 
 		analyzer->EnqueueConnEvent(mime_all_data,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Count(s->Len()),
 			make_intrusive<StringVal>(s)
 		);
@@ -1546,7 +1546,7 @@ void MIME_Mail::SubmitEvent(int event_type, const char* detail)
 
 	if ( mime_event )
 		analyzer->EnqueueConnEvent(mime_event,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			make_intrusive<StringVal>(category),
 			make_intrusive<StringVal>(detail)
 		);

--- a/src/analyzer/protocol/modbus/modbus-analyzer.pac
+++ b/src/analyzer/protocol/modbus/modbus-analyzer.pac
@@ -29,10 +29,10 @@
 	RecordVal* HeaderToBro(ModbusTCP_TransportHeader *header)
 		{
 		RecordVal* modbus_header = new RecordVal(BifType::Record::ModbusHeaders);
-		modbus_header->Assign(0, val_mgr->GetCount(header->tid()));
-		modbus_header->Assign(1, val_mgr->GetCount(header->pid()));
-		modbus_header->Assign(2, val_mgr->GetCount(header->uid()));
-		modbus_header->Assign(3, val_mgr->GetCount(header->fc()));
+		modbus_header->Assign(0, val_mgr->Count(header->tid()));
+		modbus_header->Assign(1, val_mgr->Count(header->pid()));
+		modbus_header->Assign(2, val_mgr->Count(header->uid()));
+		modbus_header->Assign(3, val_mgr->Count(header->fc()));
 		return modbus_header;
 		}
 
@@ -213,7 +213,7 @@ refine flow ModbusTCP_Flow += {
 			VectorVal* t = new VectorVal(BifType::Vector::ModbusRegisters);
 			for ( unsigned int i=0; i < ${message.registers}->size(); ++i )
 				{
-				Val* r = val_mgr->GetCount(${message.registers[i]});
+				auto r = val_mgr->Count(${message.registers[i]});
 				t->Assign(i, r);
 				}
 
@@ -256,7 +256,7 @@ refine flow ModbusTCP_Flow += {
 			VectorVal* t = new VectorVal(BifType::Vector::ModbusRegisters);
 			for ( unsigned int i=0; i < (${message.registers})->size(); ++i )
 				{
-				Val* r = val_mgr->GetCount(${message.registers[i]});
+				auto r = val_mgr->Count(${message.registers[i]});
 				t->Assign(i, r);
 				}
 
@@ -399,7 +399,7 @@ refine flow ModbusTCP_Flow += {
 			VectorVal * t = new VectorVal(BifType::Vector::ModbusRegisters);
 			for ( unsigned int i = 0; i < (${message.registers}->size()); ++i )
 				{
-				Val* r = val_mgr->GetCount(${message.registers[i]});
+				auto r = val_mgr->Count(${message.registers[i]});
 				t->Assign(i, r);
 				}
 
@@ -435,13 +435,13 @@ refine flow ModbusTCP_Flow += {
 			//VectorVal *t = create_vector_of_count();
 			//for ( unsigned int i = 0; i < (${message.references}->size()); ++i )
 			//	{
-			//	Val* r = val_mgr->GetCount((${message.references[i].ref_type}));
+			//	auto r = val_mgr->Count((${message.references[i].ref_type}));
 			//	t->Assign(i, r);
 			//
-			//	Val* k = val_mgr->GetCount((${message.references[i].file_num}));
+			//	auto k = val_mgr->Count((${message.references[i].file_num}));
 			//	t->Assign(i, k);
 			//
-			//	Val* l = val_mgr->GetCount((${message.references[i].record_num}));
+			//	auto l = val_mgr->Count((${message.references[i].record_num}));
 			//	t->Assign(i, l);
 			//	}
 
@@ -462,7 +462,7 @@ refine flow ModbusTCP_Flow += {
 			//for ( unsigned int i = 0; i < ${message.references}->size(); ++i )
 			//	{
 			//	//TODO: work the reference type in here somewhere
-			//	Val* r = val_mgr->GetCount(${message.references[i].record_data}));
+			//	auto r = val_mgr->Count(${message.references[i].record_data}));
 			//	t->Assign(i, r);
 			//	}
 
@@ -482,18 +482,18 @@ refine flow ModbusTCP_Flow += {
 			//VectorVal* t = create_vector_of_count();
 			//for ( unsigned int i = 0; i < (${message.references}->size()); ++i )
 			//	{
-			//	Val* r = val_mgr->GetCount((${message.references[i].ref_type}));
+			//	auto r = val_mgr->Count((${message.references[i].ref_type}));
 			//	t->Assign(i, r);
 			//
-			//	Val* k = val_mgr->GetCount((${message.references[i].file_num}));
+			//	auto k = val_mgr->Count((${message.references[i].file_num}));
 			//	t->Assign(i, k);
 			//
-			//	Val* n = val_mgr->GetCount((${message.references[i].record_num}));
+			//	auto n = val_mgr->Count((${message.references[i].record_num}));
 			//	t->Assign(i, n);
 			//
 			//	for ( unsigned int j = 0; j < (${message.references[i].register_value}->size()); ++j )
 			//		{
-			//		k = val_mgr->GetCount((${message.references[i].register_value[j]}));
+			//		k = val_mgr->Count((${message.references[i].register_value[j]}));
 			//		t->Assign(i, k);
 			//		}
 			//	}
@@ -515,18 +515,18 @@ refine flow ModbusTCP_Flow += {
 			//VectorVal* t = create_vector_of_count();
 			//for ( unsigned int i = 0; i < (${messages.references}->size()); ++i )
 			//	{
-			//	Val* r = val_mgr->GetCount((${message.references[i].ref_type}));
+			//	auto r = val_mgr->Count((${message.references[i].ref_type}));
 			//	t->Assign(i, r);
 			//
-			//	Val* f = val_mgr->GetCount((${message.references[i].file_num}));
+			//	auto f = val_mgr->Count((${message.references[i].file_num}));
 			//	t->Assign(i, f);
 			//
-			//	Val* rn = val_mgr->GetCount((${message.references[i].record_num}));
+			//	auto rn = val_mgr->Count((${message.references[i].record_num}));
 			//	t->Assign(i, rn);
 			//
 			//	for ( unsigned int j = 0; j<(${message.references[i].register_value}->size()); ++j )
 			//		{
-			//		Val* k = val_mgr->GetCount((${message.references[i].register_value[j]}));
+			//		auto k = val_mgr->Count((${message.references[i].register_value[j]}));
 			//		t->Assign(i, k);
 			//		}
 
@@ -583,7 +583,7 @@ refine flow ModbusTCP_Flow += {
 			VectorVal* t = new VectorVal(BifType::Vector::ModbusRegisters);
 			for ( unsigned int i = 0; i < ${message.write_register_values}->size(); ++i )
 				{
-				Val* r = val_mgr->GetCount(${message.write_register_values[i]});
+				auto r = val_mgr->Count(${message.write_register_values[i]});
 				t->Assign(i, r);
 				}
 
@@ -614,7 +614,7 @@ refine flow ModbusTCP_Flow += {
 			VectorVal* t = new VectorVal(BifType::Vector::ModbusRegisters);
 			for ( unsigned int i = 0; i < ${message.registers}->size(); ++i )
 				{
-				Val* r = val_mgr->GetCount(${message.registers[i]});
+				auto r = val_mgr->Count(${message.registers[i]});
 				t->Assign(i, r);
 				}
 
@@ -657,7 +657,7 @@ refine flow ModbusTCP_Flow += {
 			VectorVal* t = create_vector_of_count();
 			for ( unsigned int i = 0; i < (${message.register_data})->size(); ++i )
 				{
-				Val* r = val_mgr->GetCount(${message.register_data[i]});
+				auto r = val_mgr->Count(${message.register_data[i]});
 				t->Assign(i, r);
 				}
 

--- a/src/analyzer/protocol/modbus/modbus-analyzer.pac
+++ b/src/analyzer/protocol/modbus/modbus-analyzer.pac
@@ -20,7 +20,7 @@
 		for ( uint i = 0; i < quantity; i++ )
 			{
 			char currentCoil = (coils[i/8] >> (i % 8)) % 2;
-			modbus_coils->Assign(i, val_mgr->GetBool(currentCoil));
+			modbus_coils->Assign(i, val_mgr->Bool(currentCoil));
 			}
 
 		return modbus_coils;

--- a/src/analyzer/protocol/mqtt/commands/connack.pac
+++ b/src/analyzer/protocol/mqtt/commands/connack.pac
@@ -15,12 +15,12 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_connack )
 			{
-			auto m = new RecordVal(BifType::Record::MQTT::ConnectAckMsg);
+			auto m = make_intrusive<RecordVal>(BifType::Record::MQTT::ConnectAckMsg);
 			m->Assign(0, val_mgr->Count(${msg.return_code}));
 			m->Assign(1, val_mgr->Bool(${msg.session_present}));
-			BifEvent::generate_mqtt_connack(connection()->bro_analyzer(),
-			                                connection()->bro_analyzer()->Conn(),
-			                                m);
+			BifEvent::enqueue_mqtt_connack(connection()->bro_analyzer(),
+			                               connection()->bro_analyzer()->Conn(),
+			                               std::move(m));
 			}
 
 		return true;

--- a/src/analyzer/protocol/mqtt/commands/connack.pac
+++ b/src/analyzer/protocol/mqtt/commands/connack.pac
@@ -16,7 +16,7 @@ refine flow MQTT_Flow += {
 		if ( mqtt_connack )
 			{
 			auto m = new RecordVal(BifType::Record::MQTT::ConnectAckMsg);
-			m->Assign(0, val_mgr->GetCount(${msg.return_code}));
+			m->Assign(0, val_mgr->Count(${msg.return_code}));
 			m->Assign(1, val_mgr->Bool(${msg.session_present}));
 			BifEvent::generate_mqtt_connack(connection()->bro_analyzer(),
 			                                connection()->bro_analyzer()->Conn(),

--- a/src/analyzer/protocol/mqtt/commands/connack.pac
+++ b/src/analyzer/protocol/mqtt/commands/connack.pac
@@ -17,7 +17,7 @@ refine flow MQTT_Flow += {
 			{
 			auto m = new RecordVal(BifType::Record::MQTT::ConnectAckMsg);
 			m->Assign(0, val_mgr->GetCount(${msg.return_code}));
-			m->Assign(1, val_mgr->GetBool(${msg.session_present}));
+			m->Assign(1, val_mgr->Bool(${msg.session_present}));
 			BifEvent::generate_mqtt_connack(connection()->bro_analyzer(),
 			                                connection()->bro_analyzer()->Conn(),
 			                                m);

--- a/src/analyzer/protocol/mqtt/commands/connect.pac
+++ b/src/analyzer/protocol/mqtt/commands/connect.pac
@@ -44,7 +44,7 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_connect )
 			{
-			auto m = new RecordVal(BifType::Record::MQTT::ConnectMsg);
+			auto m = make_intrusive<RecordVal>(BifType::Record::MQTT::ConnectMsg);
 			m->Assign(0, make_intrusive<StringVal>(${msg.protocol_name.str}.length(),
 			                           reinterpret_cast<const char*>(${msg.protocol_name.str}.begin())));
 			m->Assign(1, val_mgr->Count(${msg.protocol_version}));
@@ -75,9 +75,9 @@ refine flow MQTT_Flow += {
 				                            reinterpret_cast<const char*>(${msg.pass.str}.begin())));
 				}
 
-			BifEvent::generate_mqtt_connect(connection()->bro_analyzer(),
-			                                connection()->bro_analyzer()->Conn(),
-			                                m);
+			BifEvent::enqueue_mqtt_connect(connection()->bro_analyzer(),
+			                               connection()->bro_analyzer()->Conn(),
+			                               std::move(m));
 			}
 
 		// If a connect message was seen, let's say that confirms it.

--- a/src/analyzer/protocol/mqtt/commands/connect.pac
+++ b/src/analyzer/protocol/mqtt/commands/connect.pac
@@ -52,8 +52,8 @@ refine flow MQTT_Flow += {
 			                           reinterpret_cast<const char*>(${msg.client_id.str}.begin())));
 			m->Assign(3, make_intrusive<IntervalVal>(double(${msg.keep_alive}), Seconds));
 
-			m->Assign(4, val_mgr->GetBool(${msg.clean_session}));
-			m->Assign(5, val_mgr->GetBool(${msg.will_retain}));
+			m->Assign(4, val_mgr->Bool(${msg.clean_session}));
+			m->Assign(5, val_mgr->Bool(${msg.will_retain}));
 			m->Assign(6, val_mgr->GetCount(${msg.will_qos}));
 
 			if ( ${msg.will_flag} )

--- a/src/analyzer/protocol/mqtt/commands/connect.pac
+++ b/src/analyzer/protocol/mqtt/commands/connect.pac
@@ -47,14 +47,14 @@ refine flow MQTT_Flow += {
 			auto m = new RecordVal(BifType::Record::MQTT::ConnectMsg);
 			m->Assign(0, make_intrusive<StringVal>(${msg.protocol_name.str}.length(),
 			                           reinterpret_cast<const char*>(${msg.protocol_name.str}.begin())));
-			m->Assign(1, val_mgr->GetCount(${msg.protocol_version}));
+			m->Assign(1, val_mgr->Count(${msg.protocol_version}));
 			m->Assign(2, make_intrusive<StringVal>(${msg.client_id.str}.length(),
 			                           reinterpret_cast<const char*>(${msg.client_id.str}.begin())));
 			m->Assign(3, make_intrusive<IntervalVal>(double(${msg.keep_alive}), Seconds));
 
 			m->Assign(4, val_mgr->Bool(${msg.clean_session}));
 			m->Assign(5, val_mgr->Bool(${msg.will_retain}));
-			m->Assign(6, val_mgr->GetCount(${msg.will_qos}));
+			m->Assign(6, val_mgr->Count(${msg.will_qos}));
 
 			if ( ${msg.will_flag} )
 				{

--- a/src/analyzer/protocol/mqtt/commands/disconnect.pac
+++ b/src/analyzer/protocol/mqtt/commands/disconnect.pac
@@ -11,8 +11,8 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_disconnect )
 			{
-			BifEvent::generate_mqtt_disconnect(connection()->bro_analyzer(),
-			                                   connection()->bro_analyzer()->Conn());
+			BifEvent::enqueue_mqtt_disconnect(connection()->bro_analyzer(),
+			                                  connection()->bro_analyzer()->Conn());
 			}
 
 		return true;

--- a/src/analyzer/protocol/mqtt/commands/pingreq.pac
+++ b/src/analyzer/protocol/mqtt/commands/pingreq.pac
@@ -11,8 +11,8 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_pingreq )
 			{
-			BifEvent::generate_mqtt_pingreq(connection()->bro_analyzer(),
-			                                connection()->bro_analyzer()->Conn());
+			BifEvent::enqueue_mqtt_pingreq(connection()->bro_analyzer(),
+			                               connection()->bro_analyzer()->Conn());
 			}
 
 		return true;

--- a/src/analyzer/protocol/mqtt/commands/pingresp.pac
+++ b/src/analyzer/protocol/mqtt/commands/pingresp.pac
@@ -11,8 +11,8 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_pingresp )
 			{
-			BifEvent::generate_mqtt_pingresp(connection()->bro_analyzer(),
-			                                 connection()->bro_analyzer()->Conn());
+			BifEvent::enqueue_mqtt_pingresp(connection()->bro_analyzer(),
+			                                connection()->bro_analyzer()->Conn());
 			}
 
 		return true;

--- a/src/analyzer/protocol/mqtt/commands/puback.pac
+++ b/src/analyzer/protocol/mqtt/commands/puback.pac
@@ -13,10 +13,10 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_puback )
 			{
-			BifEvent::generate_mqtt_puback(connection()->bro_analyzer(),
-			                               connection()->bro_analyzer()->Conn(),
-			                               is_orig,
-			                               ${msg.msg_id});
+			BifEvent::enqueue_mqtt_puback(connection()->bro_analyzer(),
+			                              connection()->bro_analyzer()->Conn(),
+			                              is_orig,
+			                              ${msg.msg_id});
 			}
 		return true;
 		%}

--- a/src/analyzer/protocol/mqtt/commands/pubcomp.pac
+++ b/src/analyzer/protocol/mqtt/commands/pubcomp.pac
@@ -13,10 +13,10 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_pubcomp )
 			{
-			BifEvent::generate_mqtt_pubcomp(connection()->bro_analyzer(),
-			                                connection()->bro_analyzer()->Conn(),
-			                                is_orig,
-			                                ${msg.msg_id});
+			BifEvent::enqueue_mqtt_pubcomp(connection()->bro_analyzer(),
+			                               connection()->bro_analyzer()->Conn(),
+			                               is_orig,
+			                               ${msg.msg_id});
 			}
 		return true;
 		%}

--- a/src/analyzer/protocol/mqtt/commands/publish.pac
+++ b/src/analyzer/protocol/mqtt/commands/publish.pac
@@ -23,7 +23,7 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_publish )
 			{
-			auto m = new RecordVal(BifType::Record::MQTT::PublishMsg);
+			auto m = make_intrusive<RecordVal>(BifType::Record::MQTT::PublishMsg);
 			m->Assign(0, val_mgr->Bool(${msg.dup}));
 			m->Assign(1, val_mgr->Count(${msg.qos}));
 			m->Assign(2, val_mgr->Bool(${msg.retain}));
@@ -41,11 +41,11 @@ refine flow MQTT_Flow += {
 
 			m->Assign(5, val_mgr->Count(${msg.payload}.length()));
 
-			BifEvent::generate_mqtt_publish(connection()->bro_analyzer(),
-			                                connection()->bro_analyzer()->Conn(),
-			                                ${pdu.is_orig},
-			                                ${msg.qos} == 0 ? 0 : ${msg.msg_id},
-			                                m);
+			BifEvent::enqueue_mqtt_publish(connection()->bro_analyzer(),
+			                               connection()->bro_analyzer()->Conn(),
+			                               ${pdu.is_orig},
+			                               ${msg.qos} == 0 ? 0 : ${msg.msg_id},
+			                               std::move(m));
 			}
 
 		// If a publish message was seen, let's say that confirms it.

--- a/src/analyzer/protocol/mqtt/commands/publish.pac
+++ b/src/analyzer/protocol/mqtt/commands/publish.pac
@@ -25,7 +25,7 @@ refine flow MQTT_Flow += {
 			{
 			auto m = new RecordVal(BifType::Record::MQTT::PublishMsg);
 			m->Assign(0, val_mgr->Bool(${msg.dup}));
-			m->Assign(1, val_mgr->GetCount(${msg.qos}));
+			m->Assign(1, val_mgr->Count(${msg.qos}));
 			m->Assign(2, val_mgr->Bool(${msg.retain}));
 			m->Assign(3, new StringVal(${msg.topic.str}.length(),
 			                           reinterpret_cast<const char*>(${msg.topic.str}.begin())));
@@ -39,7 +39,7 @@ refine flow MQTT_Flow += {
 			m->Assign(4, new StringVal(len,
 			                           reinterpret_cast<const char*>(${msg.payload}.begin())));
 
-			m->Assign(5, val_mgr->GetCount(${msg.payload}.length()));
+			m->Assign(5, val_mgr->Count(${msg.payload}.length()));
 
 			BifEvent::generate_mqtt_publish(connection()->bro_analyzer(),
 			                                connection()->bro_analyzer()->Conn(),

--- a/src/analyzer/protocol/mqtt/commands/publish.pac
+++ b/src/analyzer/protocol/mqtt/commands/publish.pac
@@ -24,9 +24,9 @@ refine flow MQTT_Flow += {
 		if ( mqtt_publish )
 			{
 			auto m = new RecordVal(BifType::Record::MQTT::PublishMsg);
-			m->Assign(0, val_mgr->GetBool(${msg.dup}));
+			m->Assign(0, val_mgr->Bool(${msg.dup}));
 			m->Assign(1, val_mgr->GetCount(${msg.qos}));
-			m->Assign(2, val_mgr->GetBool(${msg.retain}));
+			m->Assign(2, val_mgr->Bool(${msg.retain}));
 			m->Assign(3, new StringVal(${msg.topic.str}.length(),
 			                           reinterpret_cast<const char*>(${msg.topic.str}.begin())));
 

--- a/src/analyzer/protocol/mqtt/commands/pubrec.pac
+++ b/src/analyzer/protocol/mqtt/commands/pubrec.pac
@@ -13,10 +13,10 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_pubrec )
 			{
-			BifEvent::generate_mqtt_pubrec(connection()->bro_analyzer(),
-			                               connection()->bro_analyzer()->Conn(),
-			                               is_orig,
-			                               ${msg.msg_id});
+			BifEvent::enqueue_mqtt_pubrec(connection()->bro_analyzer(),
+			                              connection()->bro_analyzer()->Conn(),
+			                              is_orig,
+			                              ${msg.msg_id});
 			}
 		return true;
 		%}

--- a/src/analyzer/protocol/mqtt/commands/pubrel.pac
+++ b/src/analyzer/protocol/mqtt/commands/pubrel.pac
@@ -13,10 +13,10 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_pubrel )
 			{
-			BifEvent::generate_mqtt_pubrel(connection()->bro_analyzer(),
-			                               connection()->bro_analyzer()->Conn(),
-			                               is_orig,
-			                               ${msg.msg_id});
+			BifEvent::enqueue_mqtt_pubrel(connection()->bro_analyzer(),
+			                              connection()->bro_analyzer()->Conn(),
+			                              is_orig,
+			                              ${msg.msg_id});
 			}
 		return true;
 		%}

--- a/src/analyzer/protocol/mqtt/commands/suback.pac
+++ b/src/analyzer/protocol/mqtt/commands/suback.pac
@@ -14,10 +14,10 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_suback )
 			{
-			BifEvent::generate_mqtt_suback(connection()->bro_analyzer(),
-			                               connection()->bro_analyzer()->Conn(),
-			                               ${msg.msg_id},
-			                               ${msg.granted_QoS});
+			BifEvent::enqueue_mqtt_suback(connection()->bro_analyzer(),
+			                              connection()->bro_analyzer()->Conn(),
+			                              ${msg.msg_id},
+			                              ${msg.granted_QoS});
 			}
 
 		return true;

--- a/src/analyzer/protocol/mqtt/commands/subscribe.pac
+++ b/src/analyzer/protocol/mqtt/commands/subscribe.pac
@@ -19,10 +19,10 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_subscribe )
 			{
-			auto topics = new VectorVal(string_vec);
-			auto qos_levels = new VectorVal(index_vec);
+			auto topics = make_intrusive<VectorVal>(string_vec);
+			auto qos_levels = make_intrusive<VectorVal>(index_vec);
 
-			for (auto topic: *${msg.topics})
+			for ( auto topic: *${msg.topics} )
 				{
 				auto subscribe_topic = new StringVal(${topic.name.str}.length(),
 				                                     reinterpret_cast<const char*>(${topic.name.str}.begin()));
@@ -31,11 +31,11 @@ refine flow MQTT_Flow += {
 				qos_levels->Assign(qos_levels->Size(), qos);
 				}
 
-			BifEvent::generate_mqtt_subscribe(connection()->bro_analyzer(),
-			                                  connection()->bro_analyzer()->Conn(),
-			                                  ${msg.msg_id},
-			                                  topics,
-			                                  qos_levels);
+			BifEvent::enqueue_mqtt_subscribe(connection()->bro_analyzer(),
+			                                 connection()->bro_analyzer()->Conn(),
+			                                 ${msg.msg_id},
+			                                 std::move(topics),
+			                                 std::move(qos_levels));
 			}
 
 		return true;

--- a/src/analyzer/protocol/mqtt/commands/subscribe.pac
+++ b/src/analyzer/protocol/mqtt/commands/subscribe.pac
@@ -26,7 +26,7 @@ refine flow MQTT_Flow += {
 				{
 				auto subscribe_topic = new StringVal(${topic.name.str}.length(),
 				                                     reinterpret_cast<const char*>(${topic.name.str}.begin()));
-				auto qos = val_mgr->GetCount(${topic.requested_QoS});
+				auto qos = val_mgr->Count(${topic.requested_QoS});
 				topics->Assign(topics->Size(), subscribe_topic);
 				qos_levels->Assign(qos_levels->Size(), qos);
 				}

--- a/src/analyzer/protocol/mqtt/commands/unsuback.pac
+++ b/src/analyzer/protocol/mqtt/commands/unsuback.pac
@@ -13,9 +13,9 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_unsuback )
 			{
-			BifEvent::generate_mqtt_unsuback(connection()->bro_analyzer(),
-			                                 connection()->bro_analyzer()->Conn(),
-			                                 ${msg.msg_id});
+			BifEvent::enqueue_mqtt_unsuback(connection()->bro_analyzer(),
+			                                connection()->bro_analyzer()->Conn(),
+			                                ${msg.msg_id});
 			}
 
 		return true;

--- a/src/analyzer/protocol/mqtt/commands/unsubscribe.pac
+++ b/src/analyzer/protocol/mqtt/commands/unsubscribe.pac
@@ -14,19 +14,19 @@ refine flow MQTT_Flow += {
 		%{
 		if ( mqtt_unsubscribe )
 			{
-			auto topics = new VectorVal(string_vec);
+			auto topics = make_intrusive<VectorVal>(string_vec);
 
-			for (auto topic: *${msg.topics})
+			for ( auto topic: *${msg.topics} )
 				{
 				auto unsubscribe_topic = new StringVal(${topic.str}.length(),
 				                                  reinterpret_cast<const char*>(${topic.str}.begin()));
 				topics->Assign(topics->Size(), unsubscribe_topic);
 				}
 
-			BifEvent::generate_mqtt_unsubscribe(connection()->bro_analyzer(),
-			                                    connection()->bro_analyzer()->Conn(),
-			                                    ${msg.msg_id},
-			                                    topics);
+			BifEvent::enqueue_mqtt_unsubscribe(connection()->bro_analyzer(),
+			                                   connection()->bro_analyzer()->Conn(),
+			                                   ${msg.msg_id},
+			                                   std::move(topics));
 			}
 
 		return true;

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -64,18 +64,18 @@ void NCP_Session::DeliverFrame(const binpac::NCP::ncp_frame* frame)
 		if ( frame->is_orig() )
 			analyzer->EnqueueConnEvent(f,
 				IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(frame->frame_type())},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(frame->body_length())},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(req_func)}
+				val_mgr->Count(frame->frame_type()),
+				val_mgr->Count(frame->body_length()),
+				val_mgr->Count(req_func)
 			);
 		else
 			analyzer->EnqueueConnEvent(f,
 				IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(frame->frame_type())},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(frame->body_length())},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(req_frame_type)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(req_func)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(frame->reply()->completion_code())}
+				val_mgr->Count(frame->frame_type()),
+				val_mgr->Count(frame->body_length()),
+				val_mgr->Count(req_frame_type),
+				val_mgr->Count(req_func),
+				val_mgr->Count(frame->reply()->completion_code())
 			);
 		}
 	}

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -63,14 +63,14 @@ void NCP_Session::DeliverFrame(const binpac::NCP::ncp_frame* frame)
 		{
 		if ( frame->is_orig() )
 			analyzer->EnqueueConnEvent(f,
-				IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+				analyzer->ConnVal(),
 				val_mgr->Count(frame->frame_type()),
 				val_mgr->Count(frame->body_length()),
 				val_mgr->Count(req_func)
 			);
 		else
 			analyzer->EnqueueConnEvent(f,
-				IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+				analyzer->ConnVal(),
 				val_mgr->Count(frame->frame_type()),
 				val_mgr->Count(frame->body_length()),
 				val_mgr->Count(req_frame_type),

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -62,8 +62,8 @@ void NetbiosSSN_Interpreter::ParseMessage(unsigned int type, unsigned int flags,
 		analyzer->EnqueueConnEvent(netbios_session_message,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
 			val_mgr->Bool(is_query),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(type)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)}
+			val_mgr->Count(type),
+			val_mgr->Count(len)
 		);
 
 	switch ( type ) {

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -61,7 +61,7 @@ void NetbiosSSN_Interpreter::ParseMessage(unsigned int type, unsigned int flags,
 	if ( netbios_session_message )
 		analyzer->EnqueueConnEvent(netbios_session_message,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_query)},
+			val_mgr->Bool(is_query),
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(type)},
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)}
 		);
@@ -323,7 +323,7 @@ void NetbiosSSN_Interpreter::Event(EventHandlerPtr event, const u_char* data,
 	if ( is_orig >= 0 )
 		analyzer->EnqueueConnEvent(event,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+			val_mgr->Bool(is_orig),
 			make_intrusive<StringVal>(new BroString(data, len, false))
 		);
 	else

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -60,7 +60,7 @@ void NetbiosSSN_Interpreter::ParseMessage(unsigned int type, unsigned int flags,
 	{
 	if ( netbios_session_message )
 		analyzer->EnqueueConnEvent(netbios_session_message,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Bool(is_query),
 			val_mgr->Count(type),
 			val_mgr->Count(len)
@@ -322,13 +322,13 @@ void NetbiosSSN_Interpreter::Event(EventHandlerPtr event, const u_char* data,
 
 	if ( is_orig >= 0 )
 		analyzer->EnqueueConnEvent(event,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Bool(is_orig),
 			make_intrusive<StringVal>(new BroString(data, len, false))
 		);
 	else
 		analyzer->EnqueueConnEvent(event,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			make_intrusive<StringVal>(new BroString(data, len, false))
 		);
 	}

--- a/src/analyzer/protocol/netbios/functions.bif
+++ b/src/analyzer/protocol/netbios/functions.bif
@@ -34,7 +34,7 @@ function decode_netbios_name%(name: string%): string
 			break;
 		}
 
-	return new StringVal(i, result);
+	return make_intrusive<StringVal>(i, result);
 	%}
 
 ## Converts a NetBIOS name type to its corresponding numeric value.

--- a/src/analyzer/protocol/netbios/functions.bif
+++ b/src/analyzer/protocol/netbios/functions.bif
@@ -49,5 +49,5 @@ function decode_netbios_name_type%(name: string%): count
 	%{
 	const u_char* s = name->Bytes();
 	char return_val = ((toupper(s[30]) - 'A') << 4) + (toupper(s[31]) - 'A');
-	return val_mgr->GetCount(return_val);
+	return val_mgr->Count(return_val);
 	%}

--- a/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
+++ b/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
@@ -60,7 +60,7 @@ refine connection NTLM_Conn += {
 					result->Assign(4, utf16_bytestring_to_utf8_val(bro_analyzer()->Conn(), ${val.pairs[i].dns_tree_name.data}));
 					break;
 				case 6:
-					result->Assign(5, val_mgr->GetBool(${val.pairs[i].constrained_auth}));
+					result->Assign(5, val_mgr->Bool(${val.pairs[i].constrained_auth}));
 					break;
 				case 7:
 					result->Assign(6, filetime2brotime(${val.pairs[i].timestamp}));
@@ -79,28 +79,28 @@ refine connection NTLM_Conn += {
 	function build_negotiate_flag_record(val: NTLM_Negotiate_Flags): BroVal
 		%{
 		RecordVal* flags = new RecordVal(BifType::Record::NTLM::NegotiateFlags);
-		flags->Assign(0, val_mgr->GetBool(${val.negotiate_56}));
-		flags->Assign(1, val_mgr->GetBool(${val.negotiate_key_exch}));
-		flags->Assign(2, val_mgr->GetBool(${val.negotiate_128}));
-		flags->Assign(3, val_mgr->GetBool(${val.negotiate_version}));
-		flags->Assign(4, val_mgr->GetBool(${val.negotiate_target_info}));
-		flags->Assign(5, val_mgr->GetBool(${val.request_non_nt_session_key}));
-		flags->Assign(6, val_mgr->GetBool(${val.negotiate_identify}));
-		flags->Assign(7, val_mgr->GetBool(${val.negotiate_extended_sessionsecurity}));
-		flags->Assign(8, val_mgr->GetBool(${val.target_type_server}));
-		flags->Assign(9, val_mgr->GetBool(${val.target_type_domain}));
-		flags->Assign(10, val_mgr->GetBool(${val.negotiate_always_sign}));
-		flags->Assign(11, val_mgr->GetBool(${val.negotiate_oem_workstation_supplied}));
-		flags->Assign(12, val_mgr->GetBool(${val.negotiate_oem_domain_supplied}));
-		flags->Assign(13, val_mgr->GetBool(${val.negotiate_anonymous_connection}));
-		flags->Assign(14, val_mgr->GetBool(${val.negotiate_ntlm}));
-		flags->Assign(15, val_mgr->GetBool(${val.negotiate_lm_key}));
-		flags->Assign(16, val_mgr->GetBool(${val.negotiate_datagram}));
-		flags->Assign(17, val_mgr->GetBool(${val.negotiate_seal}));
-		flags->Assign(18, val_mgr->GetBool(${val.negotiate_sign}));
-		flags->Assign(19, val_mgr->GetBool(${val.request_target}));
-		flags->Assign(20, val_mgr->GetBool(${val.negotiate_oem}));
-		flags->Assign(21, val_mgr->GetBool(${val.negotiate_unicode}));
+		flags->Assign(0, val_mgr->Bool(${val.negotiate_56}));
+		flags->Assign(1, val_mgr->Bool(${val.negotiate_key_exch}));
+		flags->Assign(2, val_mgr->Bool(${val.negotiate_128}));
+		flags->Assign(3, val_mgr->Bool(${val.negotiate_version}));
+		flags->Assign(4, val_mgr->Bool(${val.negotiate_target_info}));
+		flags->Assign(5, val_mgr->Bool(${val.request_non_nt_session_key}));
+		flags->Assign(6, val_mgr->Bool(${val.negotiate_identify}));
+		flags->Assign(7, val_mgr->Bool(${val.negotiate_extended_sessionsecurity}));
+		flags->Assign(8, val_mgr->Bool(${val.target_type_server}));
+		flags->Assign(9, val_mgr->Bool(${val.target_type_domain}));
+		flags->Assign(10, val_mgr->Bool(${val.negotiate_always_sign}));
+		flags->Assign(11, val_mgr->Bool(${val.negotiate_oem_workstation_supplied}));
+		flags->Assign(12, val_mgr->Bool(${val.negotiate_oem_domain_supplied}));
+		flags->Assign(13, val_mgr->Bool(${val.negotiate_anonymous_connection}));
+		flags->Assign(14, val_mgr->Bool(${val.negotiate_ntlm}));
+		flags->Assign(15, val_mgr->Bool(${val.negotiate_lm_key}));
+		flags->Assign(16, val_mgr->Bool(${val.negotiate_datagram}));
+		flags->Assign(17, val_mgr->Bool(${val.negotiate_seal}));
+		flags->Assign(18, val_mgr->Bool(${val.negotiate_sign}));
+		flags->Assign(19, val_mgr->Bool(${val.request_target}));
+		flags->Assign(20, val_mgr->Bool(${val.negotiate_oem}));
+		flags->Assign(21, val_mgr->Bool(${val.negotiate_unicode}));
 
 		return flags;
 		%}

--- a/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
+++ b/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
@@ -16,10 +16,10 @@ refine connection NTLM_Conn += {
 	function build_version_record(val: NTLM_Version): BroVal
 		%{
 		RecordVal* result = new RecordVal(BifType::Record::NTLM::Version);
-		result->Assign(0, val_mgr->GetCount(${val.major_version}));
-		result->Assign(1, val_mgr->GetCount(${val.minor_version}));
-		result->Assign(2, val_mgr->GetCount(${val.build_number}));
-		result->Assign(3, val_mgr->GetCount(${val.ntlm_revision}));
+		result->Assign(0, val_mgr->Count(${val.major_version}));
+		result->Assign(1, val_mgr->Count(${val.minor_version}));
+		result->Assign(2, val_mgr->Count(${val.build_number}));
+		result->Assign(3, val_mgr->Count(${val.ntlm_revision}));
 
 		return result;
 		%}
@@ -66,7 +66,7 @@ refine connection NTLM_Conn += {
 					result->Assign(6, filetime2brotime(${val.pairs[i].timestamp}));
 					break;
 				case 8:
-					result->Assign(7, val_mgr->GetCount(${val.pairs[i].single_host.machine_id}));
+					result->Assign(7, val_mgr->Count(${val.pairs[i].single_host.machine_id}));
 					break;
 				case 9:
 					result->Assign(8, utf16_bytestring_to_utf8_val(bro_analyzer()->Conn(), ${val.pairs[i].target_name.data}));

--- a/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
+++ b/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
@@ -171,7 +171,7 @@ refine connection NTLM_Conn += {
 			result->Assign(3, utf16_bytestring_to_utf8_val(bro_analyzer()->Conn(), ${val.workstation.string.data}));
 
 		if ( ${val}->has_encrypted_session_key() > 0 )
-			result->Assign(4, bytestring_to_val(${val.encrypted_session_key.string.data}));
+			result->Assign(4, to_stringval(${val.encrypted_session_key.string.data}));
 
 		if ( ${val}->has_version() )
 			result->Assign(5, build_version_record(${val.version}));

--- a/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
+++ b/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
@@ -110,7 +110,7 @@ refine connection NTLM_Conn += {
 		if ( ! ntlm_negotiate )
 			return true;
 
-		RecordVal* result = new RecordVal(BifType::Record::NTLM::Negotiate);
+		auto result = make_intrusive<RecordVal>(BifType::Record::NTLM::Negotiate);
 		result->Assign(0, build_negotiate_flag_record(${val.flags}));
 
 		if ( ${val}->has_domain_name() )
@@ -122,9 +122,9 @@ refine connection NTLM_Conn += {
 		if ( ${val}->has_version() )
 		        result->Assign(3, build_version_record(${val.version}));
 
-		BifEvent::generate_ntlm_negotiate(bro_analyzer(),
-		                                  bro_analyzer()->Conn(),
-		                                  result);
+		BifEvent::enqueue_ntlm_negotiate(bro_analyzer(),
+		                                 bro_analyzer()->Conn(),
+		                                 std::move(result));
 
 		return true;
 		%}
@@ -134,7 +134,7 @@ refine connection NTLM_Conn += {
 		if ( ! ntlm_challenge )
 			return true;
 
-		RecordVal* result = new RecordVal(BifType::Record::NTLM::Challenge);
+		auto result = make_intrusive<RecordVal>(BifType::Record::NTLM::Challenge);
 		result->Assign(0, build_negotiate_flag_record(${val.flags}));
 
 		if ( ${val}->has_target_name() )
@@ -146,9 +146,9 @@ refine connection NTLM_Conn += {
 		if ( ${val}->has_target_info() )
 			result->Assign(3, build_av_record(${val.target_info},  ${val.target_info_fields.length}));
 
-		BifEvent::generate_ntlm_challenge(bro_analyzer(),
-		                                  bro_analyzer()->Conn(),
-		                                  result);
+		BifEvent::enqueue_ntlm_challenge(bro_analyzer(),
+		                                 bro_analyzer()->Conn(),
+		                                 std::move(result));
 
 		return true;
 		%}
@@ -158,7 +158,7 @@ refine connection NTLM_Conn += {
 		if ( ! ntlm_authenticate )
 			return true;
 
-		RecordVal* result = new RecordVal(BifType::Record::NTLM::Authenticate);
+		auto result = make_intrusive<RecordVal>(BifType::Record::NTLM::Authenticate);
 		result->Assign(0, build_negotiate_flag_record(${val.flags}));
 
 		if ( ${val}->has_domain_name() > 0 )
@@ -176,9 +176,9 @@ refine connection NTLM_Conn += {
 		if ( ${val}->has_version() )
 			result->Assign(5, build_version_record(${val.version}));
 
-		BifEvent::generate_ntlm_authenticate(bro_analyzer(),
-		                                     bro_analyzer()->Conn(),
-		                                     result);
+		BifEvent::enqueue_ntlm_authenticate(bro_analyzer(),
+		                                    bro_analyzer()->Conn(),
+		                                    std::move(result));
 		return true;
 		%}
 }

--- a/src/analyzer/protocol/ntp/ntp-analyzer.pac
+++ b/src/analyzer/protocol/ntp/ntp-analyzer.pac
@@ -135,7 +135,7 @@ refine flow NTP_Flow += {
 		if ( ! ntp_message )
 			return false;
 
-		RecordVal* rv = new RecordVal(BifType::Record::NTP::Message);
+		auto rv = make_intrusive<RecordVal>(BifType::Record::NTP::Message);
 		rv->Assign(0, val_mgr->Count(${msg.version}));
 		rv->Assign(1, val_mgr->Count(${msg.mode}));
 
@@ -147,9 +147,9 @@ refine flow NTP_Flow += {
 		else if ( ${msg.mode} == 7 )
 			rv->Assign(4, BuildNTPMode7Msg(${msg.mode7}));
 
-		BifEvent::generate_ntp_message(connection()->bro_analyzer(),
-		                               connection()->bro_analyzer()->Conn(),
-		                               is_orig(), rv);
+		BifEvent::enqueue_ntp_message(connection()->bro_analyzer(),
+		                              connection()->bro_analyzer()->Conn(),
+		                              is_orig(), std::move(rv));
 		return true;
 		%}
 };

--- a/src/analyzer/protocol/ntp/ntp-analyzer.pac
+++ b/src/analyzer/protocol/ntp/ntp-analyzer.pac
@@ -91,9 +91,9 @@ refine flow NTP_Flow += {
 		RecordVal* rv = new RecordVal(BifType::Record::NTP::ControlMessage);
 
 		rv->Assign(0, val_mgr->GetCount(${ncm.OpCode}));
-		rv->Assign(1, val_mgr->GetBool(${ncm.R}));
-		rv->Assign(2, val_mgr->GetBool(${ncm.E}));
-		rv->Assign(3, val_mgr->GetBool(${ncm.M}));
+		rv->Assign(1, val_mgr->Bool(${ncm.R}));
+		rv->Assign(2, val_mgr->Bool(${ncm.E}));
+		rv->Assign(3, val_mgr->Bool(${ncm.M}));
 		rv->Assign(4, val_mgr->GetCount(${ncm.sequence}));
 		rv->Assign(5, val_mgr->GetCount(${ncm.status}));
 		rv->Assign(6, val_mgr->GetCount(${ncm.association_id}));
@@ -116,7 +116,7 @@ refine flow NTP_Flow += {
 		RecordVal* rv = new RecordVal(BifType::Record::NTP::Mode7Message);
 
 		rv->Assign(0, val_mgr->GetCount(${m7.request_code}));
-		rv->Assign(1, val_mgr->GetBool(${m7.auth_bit}));
+		rv->Assign(1, val_mgr->Bool(${m7.auth_bit}));
 		rv->Assign(2, val_mgr->GetCount(${m7.sequence}));
 		rv->Assign(3, val_mgr->GetCount(${m7.implementation}));
 		rv->Assign(4, val_mgr->GetCount(${m7.error_code}));

--- a/src/analyzer/protocol/ntp/ntp-analyzer.pac
+++ b/src/analyzer/protocol/ntp/ntp-analyzer.pac
@@ -46,11 +46,11 @@ refine flow NTP_Flow += {
 		switch ( ${nsm.stratum} ) {
 		case 0:
 			// unknown stratum => kiss code
-			rv->Assign(5, bytestring_to_val(${nsm.reference_id}));
+			rv->Assign(5, to_stringval(${nsm.reference_id}));
 			break;
 		case 1:
 			// reference clock => ref clock string
-			rv->Assign(6, bytestring_to_val(${nsm.reference_id}));
+			rv->Assign(6, to_stringval(${nsm.reference_id}));
 			break;
 		default:
 			{
@@ -68,12 +68,12 @@ refine flow NTP_Flow += {
 		if ( ${nsm.mac_len} == 20 )
 			{
 			rv->Assign(12, val_mgr->Count(${nsm.mac.key_id}));
-			rv->Assign(13, bytestring_to_val(${nsm.mac.digest}));
+			rv->Assign(13, to_stringval(${nsm.mac.digest}));
 			}
 		else if ( ${nsm.mac_len} == 24 )
 			{
 			rv->Assign(12, val_mgr->Count(${nsm.mac_ext.key_id}));
-			rv->Assign(13, bytestring_to_val(${nsm.mac_ext.digest}));
+			rv->Assign(13, to_stringval(${nsm.mac_ext.digest}));
 			}
 
 		if ( ${nsm.has_exts} )
@@ -99,12 +99,12 @@ refine flow NTP_Flow += {
 		rv->Assign(6, val_mgr->Count(${ncm.association_id}));
 
 		if ( ${ncm.c} > 0 )
-			rv->Assign(7, bytestring_to_val(${ncm.data}));
+			rv->Assign(7, to_stringval(${ncm.data}));
 
 		if ( ${ncm.has_control_mac} )
 			{
 			rv->Assign(8, val_mgr->Count(${ncm.mac.key_id}));
-			rv->Assign(9, bytestring_to_val(${ncm.mac.crypto_checksum}));
+			rv->Assign(9, to_stringval(${ncm.mac.crypto_checksum}));
 			}
 
 		return rv;
@@ -122,7 +122,7 @@ refine flow NTP_Flow += {
 		rv->Assign(4, val_mgr->Count(${m7.error_code}));
 
 		if ( ${m7.data_len} > 0 )
-			rv->Assign(5, bytestring_to_val(${m7.data}));
+			rv->Assign(5, to_stringval(${m7.data}));
 
 		return rv;
 		%}

--- a/src/analyzer/protocol/ntp/ntp-analyzer.pac
+++ b/src/analyzer/protocol/ntp/ntp-analyzer.pac
@@ -37,7 +37,7 @@ refine flow NTP_Flow += {
 		%{
 		RecordVal* rv = new RecordVal(BifType::Record::NTP::StandardMessage);
 
-		rv->Assign(0, val_mgr->GetCount(${nsm.stratum}));
+		rv->Assign(0, val_mgr->Count(${nsm.stratum}));
 		rv->Assign(1, make_intrusive<Val>(pow(2, ${nsm.poll}), TYPE_INTERVAL));
 		rv->Assign(2, make_intrusive<Val>(pow(2, ${nsm.precision}), TYPE_INTERVAL));
 		rv->Assign(3, proc_ntp_short(${nsm.root_delay}));
@@ -67,19 +67,19 @@ refine flow NTP_Flow += {
 
 		if ( ${nsm.mac_len} == 20 )
 			{
-			rv->Assign(12, val_mgr->GetCount(${nsm.mac.key_id}));
+			rv->Assign(12, val_mgr->Count(${nsm.mac.key_id}));
 			rv->Assign(13, bytestring_to_val(${nsm.mac.digest}));
 			}
 		else if ( ${nsm.mac_len} == 24 )
 			{
-			rv->Assign(12, val_mgr->GetCount(${nsm.mac_ext.key_id}));
+			rv->Assign(12, val_mgr->Count(${nsm.mac_ext.key_id}));
 			rv->Assign(13, bytestring_to_val(${nsm.mac_ext.digest}));
 			}
 
 		if ( ${nsm.has_exts} )
 			{
 			// TODO: add extension fields
-			rv->Assign(14, val_mgr->GetCount((uint32) ${nsm.exts}->size()));
+			rv->Assign(14, val_mgr->Count((uint32) ${nsm.exts}->size()));
 			}
 
 		return rv;
@@ -90,20 +90,20 @@ refine flow NTP_Flow += {
 		%{
 		RecordVal* rv = new RecordVal(BifType::Record::NTP::ControlMessage);
 
-		rv->Assign(0, val_mgr->GetCount(${ncm.OpCode}));
+		rv->Assign(0, val_mgr->Count(${ncm.OpCode}));
 		rv->Assign(1, val_mgr->Bool(${ncm.R}));
 		rv->Assign(2, val_mgr->Bool(${ncm.E}));
 		rv->Assign(3, val_mgr->Bool(${ncm.M}));
-		rv->Assign(4, val_mgr->GetCount(${ncm.sequence}));
-		rv->Assign(5, val_mgr->GetCount(${ncm.status}));
-		rv->Assign(6, val_mgr->GetCount(${ncm.association_id}));
+		rv->Assign(4, val_mgr->Count(${ncm.sequence}));
+		rv->Assign(5, val_mgr->Count(${ncm.status}));
+		rv->Assign(6, val_mgr->Count(${ncm.association_id}));
 
 		if ( ${ncm.c} > 0 )
 			rv->Assign(7, bytestring_to_val(${ncm.data}));
 
 		if ( ${ncm.has_control_mac} )
 			{
-			rv->Assign(8, val_mgr->GetCount(${ncm.mac.key_id}));
+			rv->Assign(8, val_mgr->Count(${ncm.mac.key_id}));
 			rv->Assign(9, bytestring_to_val(${ncm.mac.crypto_checksum}));
 			}
 
@@ -115,11 +115,11 @@ refine flow NTP_Flow += {
 		%{
 		RecordVal* rv = new RecordVal(BifType::Record::NTP::Mode7Message);
 
-		rv->Assign(0, val_mgr->GetCount(${m7.request_code}));
+		rv->Assign(0, val_mgr->Count(${m7.request_code}));
 		rv->Assign(1, val_mgr->Bool(${m7.auth_bit}));
-		rv->Assign(2, val_mgr->GetCount(${m7.sequence}));
-		rv->Assign(3, val_mgr->GetCount(${m7.implementation}));
-		rv->Assign(4, val_mgr->GetCount(${m7.error_code}));
+		rv->Assign(2, val_mgr->Count(${m7.sequence}));
+		rv->Assign(3, val_mgr->Count(${m7.implementation}));
+		rv->Assign(4, val_mgr->Count(${m7.error_code}));
 
 		if ( ${m7.data_len} > 0 )
 			rv->Assign(5, bytestring_to_val(${m7.data}));
@@ -136,8 +136,8 @@ refine flow NTP_Flow += {
 			return false;
 
 		RecordVal* rv = new RecordVal(BifType::Record::NTP::Message);
-		rv->Assign(0, val_mgr->GetCount(${msg.version}));
-		rv->Assign(1, val_mgr->GetCount(${msg.mode}));
+		rv->Assign(0, val_mgr->Count(${msg.version}));
+		rv->Assign(1, val_mgr->Count(${msg.mode}));
 
 		// The standard record
 		if ( ${msg.mode} >=1 && ${msg.mode} <= 5 )

--- a/src/analyzer/protocol/pia/PIA.cc
+++ b/src/analyzer/protocol/pia/PIA.cc
@@ -159,7 +159,7 @@ void PIA_UDP::ActivateAnalyzer(analyzer::Tag tag, const Rule* rule)
 			EnumVal *tval = tag ? tag.AsEnumVal() : GetAnalyzerTag().AsEnumVal();
 
 			mgr.Enqueue(protocol_late_match,
-			    IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			    ConnVal(),
 			    IntrusivePtr{NewRef{}, tval}
 			);
 			}
@@ -307,7 +307,7 @@ void PIA_TCP::ActivateAnalyzer(analyzer::Tag tag, const Rule* rule)
 			EnumVal *tval = tag ? tag.AsEnumVal() : GetAnalyzerTag().AsEnumVal();
 
 			mgr.Enqueue(protocol_late_match,
-			    IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			    ConnVal(),
 			    IntrusivePtr{NewRef{}, tval}
 			);
 			}

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -826,7 +826,7 @@ void POP3_Analyzer::StartTLS()
 		AddChildAnalyzer(ssl);
 
 	if ( pop3_starttls )
-		EnqueueConnEvent(pop3_starttls, IntrusivePtr{AdoptRef{}, BuildConnVal()});
+		EnqueueConnEvent(pop3_starttls, ConnVal());
 	}
 
 void POP3_Analyzer::AuthSuccessfull()
@@ -919,7 +919,7 @@ void POP3_Analyzer::POP3Event(EventHandlerPtr event, bool is_orig,
 	zeek::Args vl;
 	vl.reserve(2 + (bool)arg1 + (bool)arg2);
 
-	vl.emplace_back(AdoptRef{}, BuildConnVal());
+	vl.emplace_back(ConnVal());
 	vl.emplace_back(val_mgr->Bool(is_orig));
 
 	if ( arg1 )

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -920,7 +920,7 @@ void POP3_Analyzer::POP3Event(EventHandlerPtr event, bool is_orig,
 	vl.reserve(2 + (bool)arg1 + (bool)arg2);
 
 	vl.emplace_back(AdoptRef{}, BuildConnVal());
-	vl.emplace_back(AdoptRef{}, val_mgr->GetBool(is_orig));
+	vl.emplace_back(val_mgr->Bool(is_orig));
 
 	if ( arg1 )
 		vl.emplace_back(make_intrusive<StringVal>(arg1));

--- a/src/analyzer/protocol/radius/radius-analyzer.pac
+++ b/src/analyzer/protocol/radius/radius-analyzer.pac
@@ -7,7 +7,7 @@ refine flow RADIUS_Flow += {
 		if ( ! radius_message )
 			return false;
 
-		RecordVal* result = new RecordVal(BifType::Record::RADIUS::Message);
+		auto result = make_intrusive<RecordVal>(BifType::Record::RADIUS::Message);
 		result->Assign(0, val_mgr->Count(${msg.code}));
 		result->Assign(1, val_mgr->Count(${msg.trans_id}));
 		result->Assign(2, bytestring_to_val(${msg.authenticator}));
@@ -41,7 +41,7 @@ refine flow RADIUS_Flow += {
 			result->Assign(3, attributes);
 		}
 
-		BifEvent::generate_radius_message(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), result);
+		BifEvent::enqueue_radius_message(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), std::move(result));
 		return true;
 		%}
 
@@ -50,8 +50,8 @@ refine flow RADIUS_Flow += {
 		if ( ! radius_attribute )
 			return false;
 
-		BifEvent::generate_radius_attribute(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(),
-		                                    ${attr.code}, bytestring_to_val(${attr.value}));
+		BifEvent::enqueue_radius_attribute(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(),
+		                                    ${attr.code}, to_stringval(${attr.value}));
 		return true;
 		%}
 };

--- a/src/analyzer/protocol/radius/radius-analyzer.pac
+++ b/src/analyzer/protocol/radius/radius-analyzer.pac
@@ -10,7 +10,7 @@ refine flow RADIUS_Flow += {
 		auto result = make_intrusive<RecordVal>(BifType::Record::RADIUS::Message);
 		result->Assign(0, val_mgr->Count(${msg.code}));
 		result->Assign(1, val_mgr->Count(${msg.trans_id}));
-		result->Assign(2, bytestring_to_val(${msg.authenticator}));
+		result->Assign(2, to_stringval(${msg.authenticator}));
 
 		if ( ${msg.attributes}->size() )
 			{
@@ -22,18 +22,18 @@ refine flow RADIUS_Flow += {
 
 				// Do we already have a vector of attributes for this type?
 				auto current = attributes->Lookup(index.get());
-				Val* val = bytestring_to_val(${msg.attributes[i].value});
+				IntrusivePtr<Val> val = to_stringval(${msg.attributes[i].value});
 
 				if ( current )
 					{
 					VectorVal* vcurrent = current->AsVectorVal();
-					vcurrent->Assign(vcurrent->Size(), val);
+					vcurrent->Assign(vcurrent->Size(), std::move(val));
 					}
 
 				else
 					{
 					VectorVal* attribute_list = new VectorVal(BifType::Vector::RADIUS::AttributeList);
-					attribute_list->Assign((unsigned int)0, val);
+					attribute_list->Assign((unsigned int)0, std::move(val));
 					attributes->Assign(index.get(), attribute_list);
 					}
 				}

--- a/src/analyzer/protocol/rdp/RDP.cc
+++ b/src/analyzer/protocol/rdp/RDP.cc
@@ -75,7 +75,7 @@ void RDP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 		else
 			{
 			if ( rdp_native_encrypted_data )
-				BifEvent::generate_rdp_native_encrypted_data(
+				BifEvent::enqueue_rdp_native_encrypted_data(
 				        interp->bro_analyzer(), interp->bro_analyzer()->Conn(),
 				        orig, len);
 			}

--- a/src/analyzer/protocol/rdp/rdp-analyzer.pac
+++ b/src/analyzer/protocol/rdp/rdp-analyzer.pac
@@ -73,24 +73,24 @@ refine flow RDP_Flow += {
 			ec_flags->Assign(8, val_mgr->Bool(${ccore.SUPPORT_HEARTBEAT_PDU}));
 
 			RecordVal* ccd = new RecordVal(BifType::Record::RDP::ClientCoreData);
-			ccd->Assign(0, val_mgr->GetCount(${ccore.version_major}));
-			ccd->Assign(1, val_mgr->GetCount(${ccore.version_minor}));
-			ccd->Assign(2, val_mgr->GetCount(${ccore.desktop_width}));
-			ccd->Assign(3, val_mgr->GetCount(${ccore.desktop_height}));
-			ccd->Assign(4, val_mgr->GetCount(${ccore.color_depth}));
-			ccd->Assign(5, val_mgr->GetCount(${ccore.sas_sequence}));
-			ccd->Assign(6, val_mgr->GetCount(${ccore.keyboard_layout}));
-			ccd->Assign(7, val_mgr->GetCount(${ccore.client_build}));
+			ccd->Assign(0, val_mgr->Count(${ccore.version_major}));
+			ccd->Assign(1, val_mgr->Count(${ccore.version_minor}));
+			ccd->Assign(2, val_mgr->Count(${ccore.desktop_width}));
+			ccd->Assign(3, val_mgr->Count(${ccore.desktop_height}));
+			ccd->Assign(4, val_mgr->Count(${ccore.color_depth}));
+			ccd->Assign(5, val_mgr->Count(${ccore.sas_sequence}));
+			ccd->Assign(6, val_mgr->Count(${ccore.keyboard_layout}));
+			ccd->Assign(7, val_mgr->Count(${ccore.client_build}));
 			ccd->Assign(8, utf16_bytestring_to_utf8_val(connection()->bro_analyzer()->Conn(), ${ccore.client_name}));
-			ccd->Assign(9, val_mgr->GetCount(${ccore.keyboard_type}));
-			ccd->Assign(10, val_mgr->GetCount(${ccore.keyboard_sub}));
-			ccd->Assign(11, val_mgr->GetCount(${ccore.keyboard_function_key}));
+			ccd->Assign(9, val_mgr->Count(${ccore.keyboard_type}));
+			ccd->Assign(10, val_mgr->Count(${ccore.keyboard_sub}));
+			ccd->Assign(11, val_mgr->Count(${ccore.keyboard_function_key}));
 			ccd->Assign(12, utf16_bytestring_to_utf8_val(connection()->bro_analyzer()->Conn(), ${ccore.ime_file_name}));
-			ccd->Assign(13, val_mgr->GetCount(${ccore.post_beta2_color_depth}));
-			ccd->Assign(14, val_mgr->GetCount(${ccore.client_product_id}));
-			ccd->Assign(15, val_mgr->GetCount(${ccore.serial_number}));
-			ccd->Assign(16, val_mgr->GetCount(${ccore.high_color_depth}));
-			ccd->Assign(17, val_mgr->GetCount(${ccore.supported_color_depths}));
+			ccd->Assign(13, val_mgr->Count(${ccore.post_beta2_color_depth}));
+			ccd->Assign(14, val_mgr->Count(${ccore.client_product_id}));
+			ccd->Assign(15, val_mgr->Count(${ccore.serial_number}));
+			ccd->Assign(16, val_mgr->Count(${ccore.high_color_depth}));
+			ccd->Assign(17, val_mgr->Count(${ccore.supported_color_depths}));
 			ccd->Assign(18, ec_flags);
 			ccd->Assign(19, utf16_bytestring_to_utf8_val(connection()->bro_analyzer()->Conn(), ${ccore.dig_product_id}));
 
@@ -108,8 +108,8 @@ refine flow RDP_Flow += {
 			return false;
 
 		RecordVal* csd = new RecordVal(BifType::Record::RDP::ClientSecurityData);
-		csd->Assign(0, val_mgr->GetCount(${csec.encryption_methods}));
-		csd->Assign(1, val_mgr->GetCount(${csec.ext_encryption_methods}));
+		csd->Assign(0, val_mgr->Count(${csec.encryption_methods}));
+		csd->Assign(1, val_mgr->Count(${csec.ext_encryption_methods}));
 
 		BifEvent::generate_rdp_client_security_data(connection()->bro_analyzer(),
 		                                            connection()->bro_analyzer()->Conn(),
@@ -131,7 +131,7 @@ refine flow RDP_Flow += {
 				RecordVal* channel_def = new RecordVal(BifType::Record::RDP::ClientChannelDef);
 
 				channel_def->Assign(0, bytestring_to_val(${cnetwork.channel_def_array[i].name}));
-				channel_def->Assign(1, val_mgr->GetCount(${cnetwork.channel_def_array[i].options}));
+				channel_def->Assign(1, val_mgr->Count(${cnetwork.channel_def_array[i].options}));
 
 				channel_def->Assign(2, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_INITIALIZED}));
 				channel_def->Assign(3, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_ENCRYPT_RDP}));
@@ -162,10 +162,10 @@ refine flow RDP_Flow += {
 			return false;
 
 		RecordVal* ccld = new RecordVal(BifType::Record::RDP::ClientClusterData);
-		ccld->Assign(0, val_mgr->GetCount(${ccluster.flags}));
-		ccld->Assign(1, val_mgr->GetCount(${ccluster.redir_session_id}));
+		ccld->Assign(0, val_mgr->Count(${ccluster.flags}));
+		ccld->Assign(1, val_mgr->Count(${ccluster.redir_session_id}));
 		ccld->Assign(2, val_mgr->Bool(${ccluster.REDIRECTION_SUPPORTED}));
-		ccld->Assign(3, val_mgr->GetCount(${ccluster.SERVER_SESSION_REDIRECTION_VERSION_MASK}));
+		ccld->Assign(3, val_mgr->Count(${ccluster.SERVER_SESSION_REDIRECTION_VERSION_MASK}));
 		ccld->Assign(4, val_mgr->Bool(${ccluster.REDIRECTED_SESSIONID_FIELD_VALID}));
 		ccld->Assign(5, val_mgr->Bool(${ccluster.REDIRECTED_SMARTCARD}));
 

--- a/src/analyzer/protocol/rdp/rdp-analyzer.pac
+++ b/src/analyzer/protocol/rdp/rdp-analyzer.pac
@@ -62,15 +62,15 @@ refine flow RDP_Flow += {
 		if ( rdp_client_core_data )
 			{
 			RecordVal* ec_flags = new RecordVal(BifType::Record::RDP::EarlyCapabilityFlags);
-			ec_flags->Assign(0, val_mgr->GetBool(${ccore.SUPPORT_ERRINFO_PDU}));
-			ec_flags->Assign(1, val_mgr->GetBool(${ccore.WANT_32BPP_SESSION}));
-			ec_flags->Assign(2, val_mgr->GetBool(${ccore.SUPPORT_STATUSINFO_PDU}));
-			ec_flags->Assign(3, val_mgr->GetBool(${ccore.STRONG_ASYMMETRIC_KEYS}));
-			ec_flags->Assign(4, val_mgr->GetBool(${ccore.SUPPORT_MONITOR_LAYOUT_PDU}));
-			ec_flags->Assign(5, val_mgr->GetBool(${ccore.SUPPORT_NETCHAR_AUTODETECT}));
-			ec_flags->Assign(6, val_mgr->GetBool(${ccore.SUPPORT_DYNVC_GFX_PROTOCOL}));
-			ec_flags->Assign(7, val_mgr->GetBool(${ccore.SUPPORT_DYNAMIC_TIME_ZONE}));
-			ec_flags->Assign(8, val_mgr->GetBool(${ccore.SUPPORT_HEARTBEAT_PDU}));
+			ec_flags->Assign(0, val_mgr->Bool(${ccore.SUPPORT_ERRINFO_PDU}));
+			ec_flags->Assign(1, val_mgr->Bool(${ccore.WANT_32BPP_SESSION}));
+			ec_flags->Assign(2, val_mgr->Bool(${ccore.SUPPORT_STATUSINFO_PDU}));
+			ec_flags->Assign(3, val_mgr->Bool(${ccore.STRONG_ASYMMETRIC_KEYS}));
+			ec_flags->Assign(4, val_mgr->Bool(${ccore.SUPPORT_MONITOR_LAYOUT_PDU}));
+			ec_flags->Assign(5, val_mgr->Bool(${ccore.SUPPORT_NETCHAR_AUTODETECT}));
+			ec_flags->Assign(6, val_mgr->Bool(${ccore.SUPPORT_DYNVC_GFX_PROTOCOL}));
+			ec_flags->Assign(7, val_mgr->Bool(${ccore.SUPPORT_DYNAMIC_TIME_ZONE}));
+			ec_flags->Assign(8, val_mgr->Bool(${ccore.SUPPORT_HEARTBEAT_PDU}));
 
 			RecordVal* ccd = new RecordVal(BifType::Record::RDP::ClientCoreData);
 			ccd->Assign(0, val_mgr->GetCount(${ccore.version_major}));
@@ -133,17 +133,17 @@ refine flow RDP_Flow += {
 				channel_def->Assign(0, bytestring_to_val(${cnetwork.channel_def_array[i].name}));
 				channel_def->Assign(1, val_mgr->GetCount(${cnetwork.channel_def_array[i].options}));
 
-				channel_def->Assign(2, val_mgr->GetBool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_INITIALIZED}));
-				channel_def->Assign(3, val_mgr->GetBool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_ENCRYPT_RDP}));
-				channel_def->Assign(4, val_mgr->GetBool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_ENCRYPT_SC}));
-				channel_def->Assign(5, val_mgr->GetBool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_ENCRYPT_CS}));
-				channel_def->Assign(6, val_mgr->GetBool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_PRI_HIGH}));
-				channel_def->Assign(7, val_mgr->GetBool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_PRI_MED}));
-				channel_def->Assign(8, val_mgr->GetBool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_PRI_LOW}));
-				channel_def->Assign(9, val_mgr->GetBool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_COMPRESS_RDP}));
-				channel_def->Assign(10, val_mgr->GetBool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_COMPRESS}));
-				channel_def->Assign(11, val_mgr->GetBool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_SHOW_PROTOCOL}));
-				channel_def->Assign(12, val_mgr->GetBool(${cnetwork.channel_def_array[i].REMOTE_CONTROL_PERSISTENT}));
+				channel_def->Assign(2, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_INITIALIZED}));
+				channel_def->Assign(3, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_ENCRYPT_RDP}));
+				channel_def->Assign(4, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_ENCRYPT_SC}));
+				channel_def->Assign(5, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_ENCRYPT_CS}));
+				channel_def->Assign(6, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_PRI_HIGH}));
+				channel_def->Assign(7, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_PRI_MED}));
+				channel_def->Assign(8, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_PRI_LOW}));
+				channel_def->Assign(9, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_COMPRESS_RDP}));
+				channel_def->Assign(10, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_COMPRESS}));
+				channel_def->Assign(11, val_mgr->Bool(${cnetwork.channel_def_array[i].CHANNEL_OPTION_SHOW_PROTOCOL}));
+				channel_def->Assign(12, val_mgr->Bool(${cnetwork.channel_def_array[i].REMOTE_CONTROL_PERSISTENT}));
 
 				channels->Assign(channels->Size(), channel_def);
 				}
@@ -164,10 +164,10 @@ refine flow RDP_Flow += {
 		RecordVal* ccld = new RecordVal(BifType::Record::RDP::ClientClusterData);
 		ccld->Assign(0, val_mgr->GetCount(${ccluster.flags}));
 		ccld->Assign(1, val_mgr->GetCount(${ccluster.redir_session_id}));
-		ccld->Assign(2, val_mgr->GetBool(${ccluster.REDIRECTION_SUPPORTED}));
+		ccld->Assign(2, val_mgr->Bool(${ccluster.REDIRECTION_SUPPORTED}));
 		ccld->Assign(3, val_mgr->GetCount(${ccluster.SERVER_SESSION_REDIRECTION_VERSION_MASK}));
-		ccld->Assign(4, val_mgr->GetBool(${ccluster.REDIRECTED_SESSIONID_FIELD_VALID}));
-		ccld->Assign(5, val_mgr->GetBool(${ccluster.REDIRECTED_SMARTCARD}));
+		ccld->Assign(4, val_mgr->Bool(${ccluster.REDIRECTED_SESSIONID_FIELD_VALID}));
+		ccld->Assign(5, val_mgr->Bool(${ccluster.REDIRECTED_SMARTCARD}));
 
 		BifEvent::generate_rdp_client_cluster_data(connection()->bro_analyzer(),
 		                                           connection()->bro_analyzer()->Conn(),

--- a/src/analyzer/protocol/rdp/rdp-protocol.pac
+++ b/src/analyzer/protocol/rdp/rdp-protocol.pac
@@ -383,9 +383,9 @@ refine connection RDP_Conn += {
 
 		if ( rdp_begin_encryption )
 			{
-			BifEvent::generate_rdp_begin_encryption(bro_analyzer(),
-			                                        bro_analyzer()->Conn(),
-			                                        ${method});
+			BifEvent::enqueue_rdp_begin_encryption(bro_analyzer(),
+			                                       bro_analyzer()->Conn(),
+			                                       ${method});
 			}
 
 		return is_encrypted_;

--- a/src/analyzer/protocol/rdp/rdpeudp-analyzer.pac
+++ b/src/analyzer/protocol/rdp/rdpeudp-analyzer.pac
@@ -45,7 +45,7 @@ refine connection RDPEUDP_Conn += {
 			orig_lossy_ = true;
 
 		if ( rdpeudp_syn )
-			BifEvent::generate_rdpeudp_syn(bro_analyzer(), bro_analyzer()->Conn());
+			BifEvent::enqueue_rdpeudp_syn(bro_analyzer(), bro_analyzer()->Conn());
 
 		state_ = NEED_SYNACK;
 		return true;
@@ -60,7 +60,7 @@ refine connection RDPEUDP_Conn += {
 			return false;
 
 		if ( rdpeudp_synack )
-			BifEvent::generate_rdpeudp_synack(bro_analyzer(), bro_analyzer()->Conn());
+			BifEvent::enqueue_rdpeudp_synack(bro_analyzer(), bro_analyzer()->Conn());
 
 		bro_analyzer()->ProtocolConfirmation();
 		state_ = NEED_ACK;
@@ -79,15 +79,15 @@ refine connection RDPEUDP_Conn += {
 			state_ = ESTABLISHED;
 
 			if ( rdpeudp_established )
-				BifEvent::generate_rdpeudp_established(bro_analyzer(), bro_analyzer()->Conn(), 1);
+				BifEvent::enqueue_rdpeudp_established(bro_analyzer(), bro_analyzer()->Conn(), 1);
 			}
 
 		if ( state_ == ESTABLISHED && rdpeudp_data )
-			BifEvent::generate_rdpeudp_data(bro_analyzer(),
+			BifEvent::enqueue_rdpeudp_data(bro_analyzer(),
 							bro_analyzer()->Conn(),
 							is_orig,
 							1,
-							bytestring_to_val(data)
+							to_stringval(data)
 			);
 
 		return true;
@@ -102,17 +102,17 @@ refine connection RDPEUDP_Conn += {
 		if ( state_ == NEED_ACK )
 			{
 			if ( rdpeudp_established )
-				BifEvent::generate_rdpeudp_established(bro_analyzer(), bro_analyzer()->Conn(), 2);
+				BifEvent::enqueue_rdpeudp_established(bro_analyzer(), bro_analyzer()->Conn(), 2);
 
 			state_ = ESTABLISHED;
 			}
 
 		if ( state_ == ESTABLISHED && rdpeudp_data )
-			BifEvent::generate_rdpeudp_data(bro_analyzer(),
+			BifEvent::enqueue_rdpeudp_data(bro_analyzer(),
 							bro_analyzer()->Conn(),
 							is_orig,
 							2,
-							bytestring_to_val(data)
+							to_stringval(data)
 			);
 
 		return true;

--- a/src/analyzer/protocol/rfb/rfb-analyzer.pac
+++ b/src/analyzer/protocol/rfb/rfb-analyzer.pac
@@ -1,39 +1,46 @@
 refine flow RFB_Flow += {
 	function proc_rfb_version(client: bool, major: bytestring, minor: bytestring) : bool
 		%{
-		if (client)
+		if ( client )
 			{
 			if ( rfb_client_version )
-				BifEvent::generate_rfb_client_version(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), bytestring_to_val(major), bytestring_to_val(minor));
+				BifEvent::enqueue_rfb_client_version(connection()->bro_analyzer(),
+				                                     connection()->bro_analyzer()->Conn(),
+				                                     to_stringval(major),
+				                                     to_stringval(minor));
 
 			connection()->bro_analyzer()->ProtocolConfirmation();
 			}
-			else
+		else
 			{
 			if ( rfb_server_version )
-				BifEvent::generate_rfb_server_version(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), bytestring_to_val(major), bytestring_to_val(minor));
+				BifEvent::enqueue_rfb_server_version(connection()->bro_analyzer(),
+				                                     connection()->bro_analyzer()->Conn(),
+				                                     to_stringval(major),
+				                                     to_stringval(minor));
 			}
+
 		return true;
 		%}
 
 	function proc_rfb_share_flag(shared: bool) : bool
 		%{
 		if ( rfb_share_flag )
-			BifEvent::generate_rfb_share_flag(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), shared);
+			BifEvent::enqueue_rfb_share_flag(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), shared);
 		return true;
 		%}
 
 	function proc_security_types(msg: RFBSecurityType) : bool
 		%{
 		if ( rfb_authentication_type )
-			BifEvent::generate_rfb_authentication_type(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), ${msg.sectype});
+			BifEvent::enqueue_rfb_authentication_type(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), ${msg.sectype});
 		return true;
 		%}
 
 	function proc_security_types37(msg: RFBAuthTypeSelected) : bool
 		%{
 		if ( rfb_authentication_type )
-			BifEvent::generate_rfb_authentication_type(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), ${msg.type});
+			BifEvent::enqueue_rfb_authentication_type(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), ${msg.type});
 		return true;
 		%}
 
@@ -43,9 +50,9 @@ refine flow RFB_Flow += {
 			{
 			auto vec_ptr = ${msg.name};
 			auto name_ptr = &((*vec_ptr)[0]);
-			BifEvent::generate_rfb_server_parameters(
+			BifEvent::enqueue_rfb_server_parameters(
 			    connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(),
-			    new StringVal(${msg.name}->size(), (const char*)name_ptr),
+			    make_intrusive<StringVal>(${msg.name}->size(), (const char*)name_ptr),
 			    ${msg.width},
 			    ${msg.height});
 			}
@@ -55,7 +62,7 @@ refine flow RFB_Flow += {
 	function proc_handle_security_result(result : uint32) : bool
 		%{
 		if ( rfb_auth_result )
-			BifEvent::generate_rfb_auth_result(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), result);
+			BifEvent::enqueue_rfb_auth_result(connection()->bro_analyzer(), connection()->bro_analyzer()->Conn(), result);
 		return true;
 		%}
 };

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -196,7 +196,7 @@ zeek::Args MOUNT_Interp::event_common_vl(RPC_CallInfo *c,
 
 	for (size_t i = 0; i < c->AuxGIDs().size(); ++i)
 		{
-		auxgids->Assign(i, val_mgr->GetCount(c->AuxGIDs()[i]));
+		auxgids->Assign(i, val_mgr->Count(c->AuxGIDs()[i]));
 		}
 
 	auto info = make_intrusive<RecordVal>(BifType::Record::MOUNT3::info_t);
@@ -204,13 +204,13 @@ zeek::Args MOUNT_Interp::event_common_vl(RPC_CallInfo *c,
 	info->Assign(1, BifType::Enum::MOUNT3::status_t->GetVal(mount_status));
 	info->Assign(2, make_intrusive<Val>(c->StartTime(), TYPE_TIME));
 	info->Assign(3, make_intrusive<Val>(c->LastTime() - c->StartTime(), TYPE_INTERVAL));
-	info->Assign(4, val_mgr->GetCount(c->RPCLen()));
+	info->Assign(4, val_mgr->Count(c->RPCLen()));
 	info->Assign(5, make_intrusive<Val>(rep_start_time, TYPE_TIME));
 	info->Assign(6, make_intrusive<Val>(rep_last_time - rep_start_time, TYPE_INTERVAL));
-	info->Assign(7, val_mgr->GetCount(reply_len));
-	info->Assign(8, val_mgr->GetCount(c->Uid()));
-	info->Assign(9, val_mgr->GetCount(c->Gid()));
-	info->Assign(10, val_mgr->GetCount(c->Stamp()));
+	info->Assign(7, val_mgr->Count(reply_len));
+	info->Assign(8, val_mgr->Count(c->Uid()));
+	info->Assign(9, val_mgr->Count(c->Gid()));
+	info->Assign(10, val_mgr->Count(c->Stamp()));
 	info->Assign(11, make_intrusive<StringVal>(c->MachineName()));
 	info->Assign(12, std::move(auxgids));
 

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -191,7 +191,7 @@ zeek::Args MOUNT_Interp::event_common_vl(RPC_CallInfo *c,
 	// These are the first parameters for each mount_* event ...
 	zeek::Args vl;
 	vl.reserve(2 + extra_elements);
-	vl.emplace_back(AdoptRef{}, analyzer->BuildConnVal());
+	vl.emplace_back(analyzer->ConnVal());
 	auto auxgids = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 
 	for (size_t i = 0; i < c->AuxGIDs().size(); ++i)

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -331,20 +331,20 @@ zeek::Args NFS_Interp::event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_
 	auto auxgids = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 
 	for ( size_t i = 0; i < c->AuxGIDs().size(); ++i )
-		auxgids->Assign(i, val_mgr->GetCount(c->AuxGIDs()[i]));
+		auxgids->Assign(i, val_mgr->Count(c->AuxGIDs()[i]));
 
 	auto info = make_intrusive<RecordVal>(BifType::Record::NFS3::info_t);
 	info->Assign(0, BifType::Enum::rpc_status->GetVal(rpc_status));
 	info->Assign(1, BifType::Enum::NFS3::status_t->GetVal(nfs_status));
 	info->Assign(2, make_intrusive<Val>(c->StartTime(), TYPE_TIME));
 	info->Assign(3, make_intrusive<Val>(c->LastTime()-c->StartTime(), TYPE_INTERVAL));
-	info->Assign(4, val_mgr->GetCount(c->RPCLen()));
+	info->Assign(4, val_mgr->Count(c->RPCLen()));
 	info->Assign(5, make_intrusive<Val>(rep_start_time, TYPE_TIME));
 	info->Assign(6, make_intrusive<Val>(rep_last_time-rep_start_time, TYPE_INTERVAL));
-	info->Assign(7, val_mgr->GetCount(reply_len));
-	info->Assign(8, val_mgr->GetCount(c->Uid()));
-	info->Assign(9, val_mgr->GetCount(c->Gid()));
-	info->Assign(10, val_mgr->GetCount(c->Stamp()));
+	info->Assign(7, val_mgr->Count(reply_len));
+	info->Assign(8, val_mgr->Count(c->Uid()));
+	info->Assign(9, val_mgr->Count(c->Gid()));
+	info->Assign(10, val_mgr->Count(c->Stamp()));
 	info->Assign(11, make_intrusive<StringVal>(c->MachineName()));
 	info->Assign(12, std::move(auxgids));
 
@@ -577,7 +577,7 @@ RecordVal* NFS_Interp::nfs3_read_reply(const u_char*& buf, int& n, BifEnum::NFS3
 
 		rep->Assign(0, nfs3_post_op_attr(buf, n));
 		bytes_read = extract_XDR_uint32(buf, n);
-		rep->Assign(1, val_mgr->GetCount(bytes_read));
+		rep->Assign(1, val_mgr->Count(bytes_read));
 		rep->Assign(2, ExtractBool(buf, n));
 		rep->Assign(3, nfs3_file_data(buf, n, offset, bytes_read));
 		}
@@ -660,9 +660,9 @@ RecordVal *NFS_Interp::nfs3_writeargs(const u_char*& buf, int& n)
 
 	writeargs->Assign(0, nfs3_fh(buf, n));
 	offset = extract_XDR_uint64(buf, n);
-	writeargs->Assign(1, val_mgr->GetCount(offset));  // offset
+	writeargs->Assign(1, val_mgr->Count(offset));  // offset
 	bytes = extract_XDR_uint32(buf, n);
-	writeargs->Assign(2, val_mgr->GetCount(bytes));   // size
+	writeargs->Assign(2, val_mgr->Count(bytes));   // size
 
 	writeargs->Assign(3, nfs3_stable_how(buf, n));
 	writeargs->Assign(4, nfs3_file_data(buf, n, offset, bytes));
@@ -806,12 +806,12 @@ RecordVal* NFS_Interp::nfs3_readdir_reply(bool isplus, const u_char*& buf,
 
 Val* NFS_Interp::ExtractUint32(const u_char*& buf, int& n)
 	{
-	return val_mgr->GetCount(extract_XDR_uint32(buf, n));
+	return val_mgr->Count(extract_XDR_uint32(buf, n)).release();
 	}
 
 Val* NFS_Interp::ExtractUint64(const u_char*& buf, int& n)
 	{
-	return val_mgr->GetCount(extract_XDR_uint64(buf, n));
+	return val_mgr->Count(extract_XDR_uint64(buf, n)).release();
 	}
 
 Val* NFS_Interp::ExtractTime(const u_char*& buf, int& n)

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -327,7 +327,7 @@ zeek::Args NFS_Interp::event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_
 	// These are the first parameters for each nfs_* event ...
 	zeek::Args vl;
 	vl.reserve(2 + extra_elements);
-	vl.emplace_back(IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()});
+	vl.emplace_back(analyzer->ConnVal());
 	auto auxgids = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 
 	for ( size_t i = 0; i < c->AuxGIDs().size(); ++i )

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -747,7 +747,7 @@ RecordVal* NFS_Interp::nfs3_readdirargs(bool isplus, const u_char*& buf, int&n)
 	{
 	RecordVal *args = new RecordVal(BifType::Record::NFS3::readdirargs_t);
 
-	args->Assign(0, val_mgr->GetBool(isplus));
+	args->Assign(0, val_mgr->Bool(isplus));
 	args->Assign(1, nfs3_fh(buf, n));
 	args->Assign(2, ExtractUint64(buf,n));	// cookie
 	args->Assign(3, ExtractUint64(buf,n));	// cookieverf
@@ -764,7 +764,7 @@ RecordVal* NFS_Interp::nfs3_readdir_reply(bool isplus, const u_char*& buf,
 	{
 	RecordVal *rep = new RecordVal(BifType::Record::NFS3::readdir_reply_t);
 
-	rep->Assign(0, val_mgr->GetBool(isplus));
+	rep->Assign(0, val_mgr->Bool(isplus));
 
 	if ( status == BifEnum::NFS3::NFS3ERR_OK )
 		{
@@ -826,7 +826,7 @@ Val* NFS_Interp::ExtractInterval(const u_char*& buf, int& n)
 
 Val* NFS_Interp::ExtractBool(const u_char*& buf, int& n)
 	{
-	return val_mgr->GetBool(extract_XDR_uint32(buf, n));
+	return val_mgr->Bool(extract_XDR_uint32(buf, n))->Ref();
 	}
 
 

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -94,7 +94,7 @@ bool PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status statu
 			if ( ! buf )
 				return false;
 
-			reply = val_mgr->GetBool(status);
+			reply = val_mgr->Bool(status)->Ref();
 			event = pm_request_set;
 			}
 		else
@@ -109,7 +109,7 @@ bool PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status statu
 			if ( ! buf )
 				return false;
 
-			reply = val_mgr->GetBool(status);
+			reply = val_mgr->Bool(status)->Ref();
 			event = pm_request_unset;
 			}
 		else
@@ -222,7 +222,7 @@ Val* PortmapperInterp::ExtractPortRequest(const u_char*& buf, int& len)
 	pr->Assign(1, val_mgr->GetCount(extract_XDR_uint32(buf, len)));
 
 	bool is_tcp = extract_XDR_uint32(buf, len) == IPPROTO_TCP;
-	pr->Assign(2, val_mgr->GetBool(is_tcp));
+	pr->Assign(2, val_mgr->Bool(is_tcp));
 	(void) extract_XDR_uint32(buf, len);	// consume the bogus port
 
 	if ( ! buf )

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -150,9 +150,8 @@ bool PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status statu
 				if ( ! m )
 					break;
 
-				Val* index = val_mgr->GetCount(++nmap);
-				mappings->Assign(index, m);
-				Unref(index);
+				auto index = val_mgr->Count(++nmap);
+				mappings->Assign(index.get(), m);
 				}
 
 			if ( ! buf )
@@ -197,8 +196,8 @@ Val* PortmapperInterp::ExtractMapping(const u_char*& buf, int& len)
 	{
 	RecordVal* mapping = new RecordVal(pm_mapping);
 
-	mapping->Assign(0, val_mgr->GetCount(extract_XDR_uint32(buf, len)));
-	mapping->Assign(1, val_mgr->GetCount(extract_XDR_uint32(buf, len)));
+	mapping->Assign(0, val_mgr->Count(extract_XDR_uint32(buf, len)));
+	mapping->Assign(1, val_mgr->Count(extract_XDR_uint32(buf, len)));
 
 	bool is_tcp = extract_XDR_uint32(buf, len) == IPPROTO_TCP;
 	uint32_t port = extract_XDR_uint32(buf, len);
@@ -218,8 +217,8 @@ Val* PortmapperInterp::ExtractPortRequest(const u_char*& buf, int& len)
 	{
 	RecordVal* pr = new RecordVal(pm_port_request);
 
-	pr->Assign(0, val_mgr->GetCount(extract_XDR_uint32(buf, len)));
-	pr->Assign(1, val_mgr->GetCount(extract_XDR_uint32(buf, len)));
+	pr->Assign(0, val_mgr->Count(extract_XDR_uint32(buf, len)));
+	pr->Assign(1, val_mgr->Count(extract_XDR_uint32(buf, len)));
 
 	bool is_tcp = extract_XDR_uint32(buf, len) == IPPROTO_TCP;
 	pr->Assign(2, val_mgr->Bool(is_tcp));
@@ -238,13 +237,13 @@ Val* PortmapperInterp::ExtractCallItRequest(const u_char*& buf, int& len)
 	{
 	RecordVal* c = new RecordVal(pm_callit_request);
 
-	c->Assign(0, val_mgr->GetCount(extract_XDR_uint32(buf, len)));
-	c->Assign(1, val_mgr->GetCount(extract_XDR_uint32(buf, len)));
-	c->Assign(2, val_mgr->GetCount(extract_XDR_uint32(buf, len)));
+	c->Assign(0, val_mgr->Count(extract_XDR_uint32(buf, len)));
+	c->Assign(1, val_mgr->Count(extract_XDR_uint32(buf, len)));
+	c->Assign(2, val_mgr->Count(extract_XDR_uint32(buf, len)));
 
 	int arg_n;
 	(void) extract_XDR_opaque(buf, len, arg_n);
-	c->Assign(3, val_mgr->GetCount(arg_n));
+	c->Assign(3, val_mgr->Count(arg_n));
 
 	if ( ! buf )
 		{
@@ -263,7 +262,7 @@ uint32_t PortmapperInterp::CheckPort(uint32_t port)
 			{
 			analyzer->EnqueueConnEvent(pm_bad_port,
 				IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(port)}
+				val_mgr->Count(port)
 			);
 			}
 

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -126,9 +126,8 @@ bool PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status statu
 
 			RecordVal* rv = c->RequestVal()->AsRecordVal();
 			Val* is_tcp = rv->Lookup(2);
-			reply = val_mgr->GetPort(CheckPort(port),
-					is_tcp->IsOne() ?
-						TRANSPORT_TCP : TRANSPORT_UDP);
+			reply = val_mgr->Port(CheckPort(port), is_tcp->IsOne() ?
+			                      TRANSPORT_TCP : TRANSPORT_UDP)->Ref();
 			event = pm_request_getport;
 			}
 		else
@@ -177,7 +176,7 @@ bool PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status statu
 			if ( ! opaque_reply )
 				return false;
 
-			reply = val_mgr->GetPort(CheckPort(port), TRANSPORT_UDP);
+			reply = val_mgr->Port(CheckPort(port), TRANSPORT_UDP)->Ref();
 			event = pm_request_callit;
 			}
 		else
@@ -201,8 +200,7 @@ Val* PortmapperInterp::ExtractMapping(const u_char*& buf, int& len)
 
 	bool is_tcp = extract_XDR_uint32(buf, len) == IPPROTO_TCP;
 	uint32_t port = extract_XDR_uint32(buf, len);
-	mapping->Assign(2, val_mgr->GetPort(CheckPort(port),
-			is_tcp ? TRANSPORT_TCP : TRANSPORT_UDP));
+	mapping->Assign(2, val_mgr->Port(CheckPort(port), is_tcp ? TRANSPORT_TCP : TRANSPORT_UDP));
 
 	if ( ! buf )
 		{

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -259,7 +259,7 @@ uint32_t PortmapperInterp::CheckPort(uint32_t port)
 		if ( pm_bad_port )
 			{
 			analyzer->EnqueueConnEvent(pm_bad_port,
-				IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+				analyzer->ConnVal(),
 				val_mgr->Count(port)
 			);
 			}
@@ -281,7 +281,7 @@ void PortmapperInterp::Event(EventHandlerPtr f, Val* request, BifEnum::rpc_statu
 
 	zeek::Args vl;
 
-	vl.emplace_back(AdoptRef{}, analyzer->BuildConnVal());
+	vl.emplace_back(analyzer->ConnVal());
 
 	if ( status == BifEnum::RPC_SUCCESS )
 		{

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -340,13 +340,13 @@ void RPC_Interpreter::Event_RPC_Dialogue(RPC_CallInfo* c, BifEnum::rpc_status st
 	if ( rpc_dialogue )
 		analyzer->EnqueueConnEvent(rpc_dialogue,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(c->Program())},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(c->Version())},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(c->Proc())},
+			val_mgr->Count(c->Program()),
+			val_mgr->Count(c->Version()),
+			val_mgr->Count(c->Proc()),
 			BifType::Enum::rpc_status->GetVal(status),
 			make_intrusive<Val>(c->StartTime(), TYPE_TIME),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(c->CallLen())},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(reply_len)}
+			val_mgr->Count(c->CallLen()),
+			val_mgr->Count(reply_len)
 		);
 	}
 
@@ -355,11 +355,11 @@ void RPC_Interpreter::Event_RPC_Call(RPC_CallInfo* c)
 	if ( rpc_call )
 		analyzer->EnqueueConnEvent(rpc_call,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(c->XID())},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(c->Program())},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(c->Version())},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(c->Proc())},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(c->CallLen())}
+			val_mgr->Count(c->XID()),
+			val_mgr->Count(c->Program()),
+			val_mgr->Count(c->Version()),
+			val_mgr->Count(c->Proc()),
+			val_mgr->Count(c->CallLen())
 		);
 	}
 
@@ -368,9 +368,9 @@ void RPC_Interpreter::Event_RPC_Reply(uint32_t xid, BifEnum::rpc_status status, 
 	if ( rpc_reply )
 		analyzer->EnqueueConnEvent(rpc_reply,
 			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(xid)},
+			val_mgr->Count(xid),
 			BifType::Enum::rpc_status->GetVal(status),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(reply_len)}
+			val_mgr->Count(reply_len)
 		);
 	}
 

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -339,7 +339,7 @@ void RPC_Interpreter::Event_RPC_Dialogue(RPC_CallInfo* c, BifEnum::rpc_status st
 	{
 	if ( rpc_dialogue )
 		analyzer->EnqueueConnEvent(rpc_dialogue,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Count(c->Program()),
 			val_mgr->Count(c->Version()),
 			val_mgr->Count(c->Proc()),
@@ -354,7 +354,7 @@ void RPC_Interpreter::Event_RPC_Call(RPC_CallInfo* c)
 	{
 	if ( rpc_call )
 		analyzer->EnqueueConnEvent(rpc_call,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Count(c->XID()),
 			val_mgr->Count(c->Program()),
 			val_mgr->Count(c->Version()),
@@ -367,7 +367,7 @@ void RPC_Interpreter::Event_RPC_Reply(uint32_t xid, BifEnum::rpc_status status, 
 	{
 	if ( rpc_reply )
 		analyzer->EnqueueConnEvent(rpc_reply,
-			IntrusivePtr{AdoptRef{}, analyzer->BuildConnVal()},
+			analyzer->ConnVal(),
 			val_mgr->Count(xid),
 			BifType::Enum::rpc_status->GetVal(status),
 			val_mgr->Count(reply_len)

--- a/src/analyzer/protocol/sip/sip-analyzer.pac
+++ b/src/analyzer/protocol/sip/sip-analyzer.pac
@@ -69,9 +69,8 @@ refine flow SIP_Flow += {
 
 		for ( unsigned int i = 0; i < headers.size(); ++i )
 			{ // index starting from 1
-			Val* index = val_mgr->GetCount(i + 1);
-			t->Assign(index, headers[i]);
-			Unref(index);
+			auto index = val_mgr->Count(i + 1);
+			t->Assign(index.get(), headers[i]);
 			}
 
 		return t;

--- a/src/analyzer/protocol/sip/sip-analyzer.pac
+++ b/src/analyzer/protocol/sip/sip-analyzer.pac
@@ -116,7 +116,7 @@ refine flow SIP_Flow += {
 			}
 
 		header_record->Assign(0, name_val);
-		header_record->Assign(1, bytestring_to_val(value));
+		header_record->Assign(1, to_stringval(value));
 
 		return header_record;
 		%}

--- a/src/analyzer/protocol/sip/sip-analyzer.pac
+++ b/src/analyzer/protocol/sip/sip-analyzer.pac
@@ -100,17 +100,17 @@ refine flow SIP_Flow += {
 	function build_sip_header_val(name: const_bytestring, value: const_bytestring): BroVal
 		%{
 		RecordVal* header_record = new RecordVal(mime_header_rec);
+		IntrusivePtr<StringVal> name_val;
 
-		StringVal* name_val = 0;
 		if ( name.length() > 0 )
 			{
 			// Make it all uppercase.
-			name_val = new StringVal(name.length(), (const char*) name.begin());
+			name_val = make_intrusive<StringVal>(name.length(), (const char*) name.begin());
 			name_val->ToUpper();
 			}
 		else
 			{
-			name_val = val_mgr->GetEmptyString();
+			name_val = val_mgr->EmptyString();
 			}
 
 		header_record->Assign(0, name_val);

--- a/src/analyzer/protocol/smb/smb1-com-check-directory.pac
+++ b/src/analyzer/protocol/smb/smb1-com-check-directory.pac
@@ -3,17 +3,19 @@ refine connection SMB_Conn += {
 	function proc_smb1_check_directory_request(header: SMB_Header, val: SMB1_check_directory_request): bool
 		%{
 		if ( smb1_check_directory_request )
-			BifEvent::generate_smb1_check_directory_request(bro_analyzer(), bro_analyzer()->Conn(),
-									BuildHeaderVal(header),
-									smb_string2stringval(${val.directory_name}));
+			BifEvent::enqueue_smb1_check_directory_request(bro_analyzer(),
+			                                               bro_analyzer()->Conn(),
+			                                               SMBHeaderVal(header),
+			                                               {AdoptRef{}, smb_string2stringval(${val.directory_name})});
 		return true;
 		%}
 
 	function proc_smb1_check_directory_response(header: SMB_Header, val: SMB1_check_directory_response): bool
 		%{
 		if ( smb1_check_directory_response )
-			BifEvent::generate_smb1_check_directory_response(bro_analyzer(), bro_analyzer()->Conn(),
-									 BuildHeaderVal(header));
+			BifEvent::enqueue_smb1_check_directory_response(bro_analyzer(),
+			                                                bro_analyzer()->Conn(),
+			                                                SMBHeaderVal(header));
 		return true;
 		%}
 

--- a/src/analyzer/protocol/smb/smb1-com-close.pac
+++ b/src/analyzer/protocol/smb/smb1-com-close.pac
@@ -3,9 +3,9 @@ refine connection SMB_Conn += {
 	function proc_smb1_close_request(h: SMB_Header, val: SMB1_close_request): bool
 		%{
 		if ( smb1_close_request )
-			BifEvent::generate_smb1_close_request(bro_analyzer(),
+			BifEvent::enqueue_smb1_close_request(bro_analyzer(),
 			                                     bro_analyzer()->Conn(),
-			                                     BuildHeaderVal(h),
+			                                     SMBHeaderVal(h),
 			                                     ${val.file_id});
 
 		file_mgr->EndOfFile(bro_analyzer()->GetAnalyzerTag(),

--- a/src/analyzer/protocol/smb/smb1-com-create-directory.pac
+++ b/src/analyzer/protocol/smb/smb1-com-create-directory.pac
@@ -3,16 +3,17 @@ refine connection SMB_Conn += {
 	function proc_smb1_create_directory_request(header: SMB_Header, val: SMB1_create_directory_request): bool
 		%{
 		if ( smb1_create_directory_request )
-			BifEvent::generate_smb1_create_directory_request(bro_analyzer(), bro_analyzer()->Conn(),
-			                                                 BuildHeaderVal(header),
-			                                                 smb_string2stringval(${val.directory_name}));
+			BifEvent::enqueue_smb1_create_directory_request(bro_analyzer(), bro_analyzer()->Conn(),
+			                                                SMBHeaderVal(header),
+			                                                {AdoptRef{}, smb_string2stringval(${val.directory_name})});
 		return true;
 		%}
 	function proc_smb1_create_directory_response(header: SMB_Header, val: SMB1_create_directory_response): bool
 		%{
 		if ( smb1_create_directory_response )
-			BifEvent::generate_smb1_create_directory_response(bro_analyzer(), bro_analyzer()->Conn(),
-			                                                  BuildHeaderVal(header));
+			BifEvent::enqueue_smb1_create_directory_response(bro_analyzer(),
+			                                                 bro_analyzer()->Conn(),
+			                                                 SMBHeaderVal(header));
 		return true;
 		%}
 

--- a/src/analyzer/protocol/smb/smb1-com-echo.pac
+++ b/src/analyzer/protocol/smb/smb1-com-echo.pac
@@ -3,16 +3,16 @@ refine connection SMB_Conn += {
 	function proc_smb1_echo_request(header: SMB_Header, val: SMB1_echo_request): bool
 		%{
 		if ( smb1_echo_request )
-			BifEvent::generate_smb1_echo_request(bro_analyzer(), bro_analyzer()->Conn(),
-			                                     ${val.echo_count}, bytestring_to_val(${val.data}));
+			BifEvent::enqueue_smb1_echo_request(bro_analyzer(), bro_analyzer()->Conn(),
+			                                    ${val.echo_count}, to_stringval(${val.data}));
 		return true;
 		%}
 
 	function proc_smb1_echo_response(header: SMB_Header, val: SMB1_echo_response): bool
 		%{
 		if ( smb1_echo_response )
-			BifEvent::generate_smb1_echo_response(bro_analyzer(), bro_analyzer()->Conn(),
-			                                      ${val.seq_num}, bytestring_to_val(${val.data}));
+			BifEvent::enqueue_smb1_echo_response(bro_analyzer(), bro_analyzer()->Conn(),
+			                                     ${val.seq_num}, to_stringval(${val.data}));
 		return true;
 		%}
 

--- a/src/analyzer/protocol/smb/smb1-com-logoff-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-logoff-andx.pac
@@ -3,7 +3,7 @@ refine connection SMB_Conn += {
 	function proc_smb1_logoff_andx(header: SMB_Header, val: SMB1_logoff_andx): bool
 		%{
 		if ( smb1_logoff_andx )
-			BifEvent::generate_smb1_logoff_andx(bro_analyzer(), bro_analyzer()->Conn(), ${val.is_orig});
+			BifEvent::enqueue_smb1_logoff_andx(bro_analyzer(), bro_analyzer()->Conn(), ${val.is_orig});
 
 		return true;
 		%}

--- a/src/analyzer/protocol/smb/smb1-com-negotiate.pac
+++ b/src/analyzer/protocol/smb/smb1-com-negotiate.pac
@@ -46,7 +46,7 @@ refine connection SMB_Conn += {
 				{
 				case 0x01:
 					core = new RecordVal(BifType::Record::SMB1::NegotiateResponseCore);
-					core->Assign(0, val_mgr->GetCount(${val.dialect_index}));
+					core->Assign(0, val_mgr->Count(${val.dialect_index}));
 
 					response->Assign(0, core);
 					break;
@@ -61,15 +61,15 @@ refine connection SMB_Conn += {
 					raw->Assign(1, val_mgr->Bool(${val.lanman.raw_write_supported}));
 
 					lanman = new RecordVal(BifType::Record::SMB1::NegotiateResponseLANMAN);
-					lanman->Assign(0, val_mgr->GetCount(${val.word_count}));
-					lanman->Assign(1, val_mgr->GetCount(${val.dialect_index}));
+					lanman->Assign(0, val_mgr->Count(${val.word_count}));
+					lanman->Assign(1, val_mgr->Count(${val.dialect_index}));
 					lanman->Assign(2, security);
-					lanman->Assign(3, val_mgr->GetCount(${val.lanman.max_buffer_size}));
-					lanman->Assign(4, val_mgr->GetCount(${val.lanman.max_mpx_count}));
+					lanman->Assign(3, val_mgr->Count(${val.lanman.max_buffer_size}));
+					lanman->Assign(4, val_mgr->Count(${val.lanman.max_mpx_count}));
 
-					lanman->Assign(5, val_mgr->GetCount(${val.lanman.max_number_vcs}));
+					lanman->Assign(5, val_mgr->Count(${val.lanman.max_number_vcs}));
 					lanman->Assign(6, raw);
-					lanman->Assign(7, val_mgr->GetCount(${val.lanman.session_key}));
+					lanman->Assign(7, val_mgr->Count(${val.lanman.session_key}));
 					lanman->Assign(8, time_from_lanman(${val.lanman.server_time}, ${val.lanman.server_date}, ${val.lanman.server_tz}));
 					lanman->Assign(9, bytestring_to_val(${val.lanman.encryption_key}));
 
@@ -109,15 +109,15 @@ refine connection SMB_Conn += {
 					capabilities->Assign(17, val_mgr->Bool(${val.ntlm.capabilities_extended_security}));
 
 					ntlm = new RecordVal(BifType::Record::SMB1::NegotiateResponseNTLM);
-					ntlm->Assign(0, val_mgr->GetCount(${val.word_count}));
-					ntlm->Assign(1, val_mgr->GetCount(${val.dialect_index}));
+					ntlm->Assign(0, val_mgr->Count(${val.word_count}));
+					ntlm->Assign(1, val_mgr->Count(${val.dialect_index}));
 					ntlm->Assign(2, security);
-					ntlm->Assign(3, val_mgr->GetCount(${val.ntlm.max_buffer_size}));
-					ntlm->Assign(4, val_mgr->GetCount(${val.ntlm.max_mpx_count}));
+					ntlm->Assign(3, val_mgr->Count(${val.ntlm.max_buffer_size}));
+					ntlm->Assign(4, val_mgr->Count(${val.ntlm.max_mpx_count}));
 
-					ntlm->Assign(5, val_mgr->GetCount(${val.ntlm.max_number_vcs}));
-					ntlm->Assign(6, val_mgr->GetCount(${val.ntlm.max_raw_size}));
-					ntlm->Assign(7, val_mgr->GetCount(${val.ntlm.session_key}));
+					ntlm->Assign(5, val_mgr->Count(${val.ntlm.max_number_vcs}));
+					ntlm->Assign(6, val_mgr->Count(${val.ntlm.max_raw_size}));
+					ntlm->Assign(7, val_mgr->Count(${val.ntlm.session_key}));
 					ntlm->Assign(8, capabilities);
 					ntlm->Assign(9, filetime2brotime(${val.ntlm.server_time}));
 

--- a/src/analyzer/protocol/smb/smb1-com-negotiate.pac
+++ b/src/analyzer/protocol/smb/smb1-com-negotiate.pac
@@ -53,12 +53,12 @@ refine connection SMB_Conn += {
 
 				case 0x0d:
 					security = new RecordVal(BifType::Record::SMB1::NegotiateResponseSecurity);
-					security->Assign(0, val_mgr->GetBool(${val.lanman.security_user_level}));
-					security->Assign(1, val_mgr->GetBool(${val.lanman.security_challenge_response}));
+					security->Assign(0, val_mgr->Bool(${val.lanman.security_user_level}));
+					security->Assign(1, val_mgr->Bool(${val.lanman.security_challenge_response}));
 
 					raw = new RecordVal(BifType::Record::SMB1::NegotiateRawMode);
-					raw->Assign(0, val_mgr->GetBool(${val.lanman.raw_read_supported}));
-					raw->Assign(1, val_mgr->GetBool(${val.lanman.raw_write_supported}));
+					raw->Assign(0, val_mgr->Bool(${val.lanman.raw_read_supported}));
+					raw->Assign(1, val_mgr->Bool(${val.lanman.raw_write_supported}));
 
 					lanman = new RecordVal(BifType::Record::SMB1::NegotiateResponseLANMAN);
 					lanman->Assign(0, val_mgr->GetCount(${val.word_count}));
@@ -80,33 +80,33 @@ refine connection SMB_Conn += {
 
 				case 0x11:
 					security = new RecordVal(BifType::Record::SMB1::NegotiateResponseSecurity);
-					security->Assign(0, val_mgr->GetBool(${val.ntlm.security_user_level}));
-					security->Assign(1, val_mgr->GetBool(${val.ntlm.security_challenge_response}));
-					security->Assign(2, val_mgr->GetBool(${val.ntlm.security_signatures_enabled}));
-					security->Assign(3, val_mgr->GetBool(${val.ntlm.security_signatures_required}));
+					security->Assign(0, val_mgr->Bool(${val.ntlm.security_user_level}));
+					security->Assign(1, val_mgr->Bool(${val.ntlm.security_challenge_response}));
+					security->Assign(2, val_mgr->Bool(${val.ntlm.security_signatures_enabled}));
+					security->Assign(3, val_mgr->Bool(${val.ntlm.security_signatures_required}));
 
 					capabilities = new RecordVal(BifType::Record::SMB1::NegotiateCapabilities);
-					capabilities->Assign(0, val_mgr->GetBool(${val.ntlm.capabilities_raw_mode}));
-					capabilities->Assign(1, val_mgr->GetBool(${val.ntlm.capabilities_mpx_mode}));
-					capabilities->Assign(2, val_mgr->GetBool(${val.ntlm.capabilities_unicode}));
-					capabilities->Assign(3, val_mgr->GetBool(${val.ntlm.capabilities_large_files}));
-					capabilities->Assign(4, val_mgr->GetBool(${val.ntlm.capabilities_nt_smbs}));
+					capabilities->Assign(0, val_mgr->Bool(${val.ntlm.capabilities_raw_mode}));
+					capabilities->Assign(1, val_mgr->Bool(${val.ntlm.capabilities_mpx_mode}));
+					capabilities->Assign(2, val_mgr->Bool(${val.ntlm.capabilities_unicode}));
+					capabilities->Assign(3, val_mgr->Bool(${val.ntlm.capabilities_large_files}));
+					capabilities->Assign(4, val_mgr->Bool(${val.ntlm.capabilities_nt_smbs}));
 
-					capabilities->Assign(5, val_mgr->GetBool(${val.ntlm.capabilities_rpc_remote_apis}));
-					capabilities->Assign(6, val_mgr->GetBool(${val.ntlm.capabilities_status32}));
-					capabilities->Assign(7, val_mgr->GetBool(${val.ntlm.capabilities_level_2_oplocks}));
-					capabilities->Assign(8, val_mgr->GetBool(${val.ntlm.capabilities_lock_and_read}));
-					capabilities->Assign(9, val_mgr->GetBool(${val.ntlm.capabilities_nt_find}));
+					capabilities->Assign(5, val_mgr->Bool(${val.ntlm.capabilities_rpc_remote_apis}));
+					capabilities->Assign(6, val_mgr->Bool(${val.ntlm.capabilities_status32}));
+					capabilities->Assign(7, val_mgr->Bool(${val.ntlm.capabilities_level_2_oplocks}));
+					capabilities->Assign(8, val_mgr->Bool(${val.ntlm.capabilities_lock_and_read}));
+					capabilities->Assign(9, val_mgr->Bool(${val.ntlm.capabilities_nt_find}));
 
-					capabilities->Assign(10, val_mgr->GetBool(${val.ntlm.capabilities_dfs}));
-					capabilities->Assign(11, val_mgr->GetBool(${val.ntlm.capabilities_infolevel_passthru}));
-					capabilities->Assign(12, val_mgr->GetBool(${val.ntlm.capabilities_large_readx}));
-					capabilities->Assign(13, val_mgr->GetBool(${val.ntlm.capabilities_large_writex}));
-					capabilities->Assign(14, val_mgr->GetBool(${val.ntlm.capabilities_unix}));
+					capabilities->Assign(10, val_mgr->Bool(${val.ntlm.capabilities_dfs}));
+					capabilities->Assign(11, val_mgr->Bool(${val.ntlm.capabilities_infolevel_passthru}));
+					capabilities->Assign(12, val_mgr->Bool(${val.ntlm.capabilities_large_readx}));
+					capabilities->Assign(13, val_mgr->Bool(${val.ntlm.capabilities_large_writex}));
+					capabilities->Assign(14, val_mgr->Bool(${val.ntlm.capabilities_unix}));
 
-					capabilities->Assign(15, val_mgr->GetBool(${val.ntlm.capabilities_bulk_transfer}));
-					capabilities->Assign(16, val_mgr->GetBool(${val.ntlm.capabilities_compressed_data}));
-					capabilities->Assign(17, val_mgr->GetBool(${val.ntlm.capabilities_extended_security}));
+					capabilities->Assign(15, val_mgr->Bool(${val.ntlm.capabilities_bulk_transfer}));
+					capabilities->Assign(16, val_mgr->Bool(${val.ntlm.capabilities_compressed_data}));
+					capabilities->Assign(17, val_mgr->Bool(${val.ntlm.capabilities_extended_security}));
 
 					ntlm = new RecordVal(BifType::Record::SMB1::NegotiateResponseNTLM);
 					ntlm->Assign(0, val_mgr->GetCount(${val.word_count}));

--- a/src/analyzer/protocol/smb/smb1-com-negotiate.pac
+++ b/src/analyzer/protocol/smb/smb1-com-negotiate.pac
@@ -73,7 +73,7 @@ refine connection SMB_Conn += {
 					lanman->Assign(6, raw);
 					lanman->Assign(7, val_mgr->Count(${val.lanman.session_key}));
 					lanman->Assign(8, time_from_lanman(${val.lanman.server_time}, ${val.lanman.server_date}, ${val.lanman.server_tz}));
-					lanman->Assign(9, bytestring_to_val(${val.lanman.encryption_key}));
+					lanman->Assign(9, to_stringval(${val.lanman.encryption_key}));
 
 					lanman->Assign(10, smb_string2stringval(${val.lanman.primary_domain}));
 
@@ -125,12 +125,12 @@ refine connection SMB_Conn += {
 
 					if ( ${val.ntlm.capabilities_extended_security} == false )
 						{
-						ntlm->Assign(10, bytestring_to_val(${val.ntlm.encryption_key}));
+						ntlm->Assign(10, to_stringval(${val.ntlm.encryption_key}));
 						ntlm->Assign(11, smb_string2stringval(${val.ntlm.domain_name}));
 						}
 					else
 						{
-						ntlm->Assign(12, bytestring_to_val(${val.ntlm.server_guid}));
+						ntlm->Assign(12, to_stringval(${val.ntlm.server_guid}));
 						}
 
 					response->Assign(2, ntlm);

--- a/src/analyzer/protocol/smb/smb1-com-nt-cancel.pac
+++ b/src/analyzer/protocol/smb/smb1-com-nt-cancel.pac
@@ -3,7 +3,9 @@ refine connection SMB_Conn += {
 	function proc_smb1_nt_cancel_request(header: SMB_Header, val: SMB1_nt_cancel_request): bool
 		%{
 		if ( smb1_nt_cancel_request )
-			BifEvent::generate_smb1_nt_cancel_request(bro_analyzer(), bro_analyzer()->Conn(), BuildHeaderVal(header));
+			BifEvent::enqueue_smb1_nt_cancel_request(bro_analyzer(),
+			                                         bro_analyzer()->Conn(),
+			                                         SMBHeaderVal(header));
 		return true;
 		%}
 

--- a/src/analyzer/protocol/smb/smb1-com-nt-create-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-nt-create-andx.pac
@@ -1,27 +1,24 @@
 refine connection SMB_Conn += {
 	function proc_smb1_nt_create_andx_request(header: SMB_Header, val: SMB1_nt_create_andx_request): bool
 		%{
-		StringVal *filename = smb_string2stringval(${val.filename});
+		auto filename = IntrusivePtr<StringVal>{AdoptRef{}, smb_string2stringval(${val.filename})};
+
 		if ( ! ${header.is_pipe} &&
 		     BifConst::SMB::pipe_filenames->AsTable()->Lookup(filename->CheckString()) )
 			{
 			set_tree_is_pipe(${header.tid});
 
 			if ( smb_pipe_connect_heuristic )
-				BifEvent::generate_smb_pipe_connect_heuristic(bro_analyzer(),
-				                                              bro_analyzer()->Conn());
+				BifEvent::enqueue_smb_pipe_connect_heuristic(bro_analyzer(),
+				                                             bro_analyzer()->Conn());
 			}
 
 		if ( smb1_nt_create_andx_request )
 			{
-			BifEvent::generate_smb1_nt_create_andx_request(bro_analyzer(),
+			BifEvent::enqueue_smb1_nt_create_andx_request(bro_analyzer(),
 			                                              bro_analyzer()->Conn(),
-			                                              BuildHeaderVal(header),
-			                                              filename);
-			}
-		else
-			{
-			delete filename;
+			                                              SMBHeaderVal(header),
+			                                              std::move(filename));
 			}
 
 		return true;
@@ -31,15 +28,15 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb1_nt_create_andx_response )
 			{
-			BifEvent::generate_smb1_nt_create_andx_response(bro_analyzer(),
+			BifEvent::enqueue_smb1_nt_create_andx_response(bro_analyzer(),
 			                                               bro_analyzer()->Conn(),
-			                                               BuildHeaderVal(header),
+			                                               SMBHeaderVal(header),
 			                                               ${val.file_id},
 			                                               ${val.end_of_file},
-			                                               SMB_BuildMACTimes(${val.last_write_time},
+			                                               {AdoptRef{}, SMB_BuildMACTimes(${val.last_write_time},
 			                                                                 ${val.last_access_time},
 			                                                                 ${val.create_time},
-			                                                                 ${val.last_change_time}));
+			                                                                 ${val.last_change_time})});
 			}
 
 		return true;

--- a/src/analyzer/protocol/smb/smb1-com-query-information.pac
+++ b/src/analyzer/protocol/smb/smb1-com-query-information.pac
@@ -3,10 +3,10 @@ refine connection SMB_Conn += {
 	function proc_smb1_query_information_request(header: SMB_Header, val: SMB1_query_information_request): bool
 		%{
 		if ( smb1_query_information_request )
-			BifEvent::generate_smb1_query_information_request(bro_analyzer(),
+			BifEvent::enqueue_smb1_query_information_request(bro_analyzer(),
 			                                                 bro_analyzer()->Conn(),
-			                                                 BuildHeaderVal(header),
-			                                                 smb_string2stringval(${val.filename}));
+			                                                 SMBHeaderVal(header),
+			                                                 {AdoptRef{}, smb_string2stringval(${val.filename})});
 		return true;
 		%}
 

--- a/src/analyzer/protocol/smb/smb1-com-read-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-read-andx.pac
@@ -9,9 +9,9 @@ refine connection SMB_Conn += {
 	function proc_smb1_read_andx_request(h: SMB_Header, val: SMB1_read_andx_request): bool
 		%{
 		if ( smb1_read_andx_request )
-			BifEvent::generate_smb1_read_andx_request(bro_analyzer(),
+			BifEvent::enqueue_smb1_read_andx_request(bro_analyzer(),
 			                                         bro_analyzer()->Conn(),
-			                                         BuildHeaderVal(h),
+			                                         SMBHeaderVal(h),
 			                                         ${val.file_id},
 			                                         ${val.read_offset},
 			                                         ${val.max_count});
@@ -23,9 +23,9 @@ refine connection SMB_Conn += {
 	function proc_smb1_read_andx_response(h: SMB_Header, val: SMB1_read_andx_response): bool
 		%{
 		if ( smb1_read_andx_response )
-			BifEvent::generate_smb1_read_andx_response(bro_analyzer(),
+			BifEvent::enqueue_smb1_read_andx_response(bro_analyzer(),
 			                                          bro_analyzer()->Conn(),
-			                                          BuildHeaderVal(h),
+			                                          SMBHeaderVal(h),
 			                                          ${val.data_len});
 
 		if ( ! ${h.is_pipe} && ${val.data_len} > 0 )

--- a/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
@@ -15,13 +15,13 @@ refine connection SMB_Conn += {
 			RecordVal* request = new RecordVal(BifType::Record::SMB1::SessionSetupAndXRequest);
 			RecordVal* capabilities;
 
-			request->Assign(0, val_mgr->GetCount(${val.word_count}));
+			request->Assign(0, val_mgr->Count(${val.word_count}));
 			switch ( ${val.word_count} ) {
 				case 10:	// pre NT LM 0.12
-					request->Assign(1, val_mgr->GetCount(${val.lanman.max_buffer_size}));
-					request->Assign(2, val_mgr->GetCount(${val.lanman.max_mpx_count}));
-					request->Assign(3, val_mgr->GetCount(${val.lanman.vc_number}));
-					request->Assign(4, val_mgr->GetCount(${val.lanman.session_key}));
+					request->Assign(1, val_mgr->Count(${val.lanman.max_buffer_size}));
+					request->Assign(2, val_mgr->Count(${val.lanman.max_mpx_count}));
+					request->Assign(3, val_mgr->Count(${val.lanman.vc_number}));
+					request->Assign(4, val_mgr->Count(${val.lanman.session_key}));
 
 					request->Assign(5, smb_string2stringval(${val.lanman.native_os}));
 					request->Assign(6, smb_string2stringval(${val.lanman.native_lanman}));
@@ -39,10 +39,10 @@ refine connection SMB_Conn += {
 				 	capabilities->Assign(4, val_mgr->Bool(${val.ntlm_extended_security.capabilities.level_2_oplocks}));
 				 	capabilities->Assign(5, val_mgr->Bool(${val.ntlm_extended_security.capabilities.nt_find}));
 
-					request->Assign(1, val_mgr->GetCount(${val.ntlm_extended_security.max_buffer_size}));
-					request->Assign(2, val_mgr->GetCount(${val.ntlm_extended_security.max_mpx_count}));
-					request->Assign(3, val_mgr->GetCount(${val.ntlm_extended_security.vc_number}));
-					request->Assign(4, val_mgr->GetCount(${val.ntlm_extended_security.session_key}));
+					request->Assign(1, val_mgr->Count(${val.ntlm_extended_security.max_buffer_size}));
+					request->Assign(2, val_mgr->Count(${val.ntlm_extended_security.max_mpx_count}));
+					request->Assign(3, val_mgr->Count(${val.ntlm_extended_security.vc_number}));
+					request->Assign(4, val_mgr->Count(${val.ntlm_extended_security.session_key}));
 
 					request->Assign(5, smb_string2stringval(${val.ntlm_extended_security.native_os}));
 					request->Assign(6, smb_string2stringval(${val.ntlm_extended_security.native_lanman}));
@@ -59,10 +59,10 @@ refine connection SMB_Conn += {
 				 	capabilities->Assign(4, val_mgr->Bool(${val.ntlm_nonextended_security.capabilities.level_2_oplocks}));
 				 	capabilities->Assign(5, val_mgr->Bool(${val.ntlm_nonextended_security.capabilities.nt_find}));
 
-					request->Assign(1, val_mgr->GetCount(${val.ntlm_nonextended_security.max_buffer_size}));
-					request->Assign(2, val_mgr->GetCount(${val.ntlm_nonextended_security.max_mpx_count}));
-					request->Assign(3, val_mgr->GetCount(${val.ntlm_nonextended_security.vc_number}));
-					request->Assign(4, val_mgr->GetCount(${val.ntlm_nonextended_security.session_key}));
+					request->Assign(1, val_mgr->Count(${val.ntlm_nonextended_security.max_buffer_size}));
+					request->Assign(2, val_mgr->Count(${val.ntlm_nonextended_security.max_mpx_count}));
+					request->Assign(3, val_mgr->Count(${val.ntlm_nonextended_security.vc_number}));
+					request->Assign(4, val_mgr->Count(${val.ntlm_nonextended_security.session_key}));
 
 					request->Assign(5, smb_string2stringval(${val.ntlm_nonextended_security.native_os}));
 					request->Assign(6, smb_string2stringval(${val.ntlm_nonextended_security.native_lanman}));
@@ -86,7 +86,7 @@ refine connection SMB_Conn += {
 			{
 			RecordVal* response = new RecordVal(BifType::Record::SMB1::SessionSetupAndXResponse);
 
-			response->Assign(0, val_mgr->GetCount(${val.word_count}));
+			response->Assign(0, val_mgr->Count(${val.word_count}));
 			switch ( ${val.word_count} )
 				{
 				case 3: // pre NT LM 0.12

--- a/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
@@ -91,9 +91,9 @@ refine connection SMB_Conn += {
 				{
 				case 3: // pre NT LM 0.12
 					response->Assign(1, val_mgr->Bool(${val.lanman.is_guest}));
-					response->Assign(2, ${val.lanman.byte_count} == 0 ? val_mgr->GetEmptyString() : smb_string2stringval(${val.lanman.native_os[0]}));
-					response->Assign(3, ${val.lanman.byte_count} == 0 ? val_mgr->GetEmptyString() : smb_string2stringval(${val.lanman.native_lanman[0]}));
-					response->Assign(4, ${val.lanman.byte_count} == 0 ? val_mgr->GetEmptyString() : smb_string2stringval(${val.lanman.primary_domain[0]}));
+					response->Assign(2, ${val.lanman.byte_count} == 0 ? val_mgr->EmptyString()->Ref()->AsStringVal() : smb_string2stringval(${val.lanman.native_os[0]}));
+					response->Assign(3, ${val.lanman.byte_count} == 0 ? val_mgr->EmptyString()->Ref()->AsStringVal() : smb_string2stringval(${val.lanman.native_lanman[0]}));
+					response->Assign(4, ${val.lanman.byte_count} == 0 ? val_mgr->EmptyString()->Ref()->AsStringVal() : smb_string2stringval(${val.lanman.primary_domain[0]}));
 					break;
 				case 4: // NT LM 0.12
 					response->Assign(1, val_mgr->Bool(${val.ntlm.is_guest}));

--- a/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
@@ -32,12 +32,12 @@ refine connection SMB_Conn += {
 					break;
 				case 12:	// NT LM 0.12 with extended security
 					capabilities = new RecordVal(BifType::Record::SMB1::SessionSetupAndXCapabilities);
-				 	capabilities->Assign(0, val_mgr->GetBool(${val.ntlm_extended_security.capabilities.unicode}));
-				 	capabilities->Assign(1, val_mgr->GetBool(${val.ntlm_extended_security.capabilities.large_files}));
-				 	capabilities->Assign(2, val_mgr->GetBool(${val.ntlm_extended_security.capabilities.nt_smbs}));
-				 	capabilities->Assign(3, val_mgr->GetBool(${val.ntlm_extended_security.capabilities.status32}));
-				 	capabilities->Assign(4, val_mgr->GetBool(${val.ntlm_extended_security.capabilities.level_2_oplocks}));
-				 	capabilities->Assign(5, val_mgr->GetBool(${val.ntlm_extended_security.capabilities.nt_find}));
+				 	capabilities->Assign(0, val_mgr->Bool(${val.ntlm_extended_security.capabilities.unicode}));
+				 	capabilities->Assign(1, val_mgr->Bool(${val.ntlm_extended_security.capabilities.large_files}));
+				 	capabilities->Assign(2, val_mgr->Bool(${val.ntlm_extended_security.capabilities.nt_smbs}));
+				 	capabilities->Assign(3, val_mgr->Bool(${val.ntlm_extended_security.capabilities.status32}));
+				 	capabilities->Assign(4, val_mgr->Bool(${val.ntlm_extended_security.capabilities.level_2_oplocks}));
+				 	capabilities->Assign(5, val_mgr->Bool(${val.ntlm_extended_security.capabilities.nt_find}));
 
 					request->Assign(1, val_mgr->GetCount(${val.ntlm_extended_security.max_buffer_size}));
 					request->Assign(2, val_mgr->GetCount(${val.ntlm_extended_security.max_mpx_count}));
@@ -52,12 +52,12 @@ refine connection SMB_Conn += {
 
 				case 13: // NT LM 0.12 without extended security
 					capabilities = new RecordVal(BifType::Record::SMB1::SessionSetupAndXCapabilities);
-				 	capabilities->Assign(0, val_mgr->GetBool(${val.ntlm_nonextended_security.capabilities.unicode}));
-				 	capabilities->Assign(1, val_mgr->GetBool(${val.ntlm_nonextended_security.capabilities.large_files}));
-				 	capabilities->Assign(2, val_mgr->GetBool(${val.ntlm_nonextended_security.capabilities.nt_smbs}));
-				 	capabilities->Assign(3, val_mgr->GetBool(${val.ntlm_nonextended_security.capabilities.status32}));
-				 	capabilities->Assign(4, val_mgr->GetBool(${val.ntlm_nonextended_security.capabilities.level_2_oplocks}));
-				 	capabilities->Assign(5, val_mgr->GetBool(${val.ntlm_nonextended_security.capabilities.nt_find}));
+				 	capabilities->Assign(0, val_mgr->Bool(${val.ntlm_nonextended_security.capabilities.unicode}));
+				 	capabilities->Assign(1, val_mgr->Bool(${val.ntlm_nonextended_security.capabilities.large_files}));
+				 	capabilities->Assign(2, val_mgr->Bool(${val.ntlm_nonextended_security.capabilities.nt_smbs}));
+				 	capabilities->Assign(3, val_mgr->Bool(${val.ntlm_nonextended_security.capabilities.status32}));
+				 	capabilities->Assign(4, val_mgr->Bool(${val.ntlm_nonextended_security.capabilities.level_2_oplocks}));
+				 	capabilities->Assign(5, val_mgr->Bool(${val.ntlm_nonextended_security.capabilities.nt_find}));
 
 					request->Assign(1, val_mgr->GetCount(${val.ntlm_nonextended_security.max_buffer_size}));
 					request->Assign(2, val_mgr->GetCount(${val.ntlm_nonextended_security.max_mpx_count}));
@@ -90,13 +90,13 @@ refine connection SMB_Conn += {
 			switch ( ${val.word_count} )
 				{
 				case 3: // pre NT LM 0.12
-					response->Assign(1, val_mgr->GetBool(${val.lanman.is_guest}));
+					response->Assign(1, val_mgr->Bool(${val.lanman.is_guest}));
 					response->Assign(2, ${val.lanman.byte_count} == 0 ? val_mgr->GetEmptyString() : smb_string2stringval(${val.lanman.native_os[0]}));
 					response->Assign(3, ${val.lanman.byte_count} == 0 ? val_mgr->GetEmptyString() : smb_string2stringval(${val.lanman.native_lanman[0]}));
 					response->Assign(4, ${val.lanman.byte_count} == 0 ? val_mgr->GetEmptyString() : smb_string2stringval(${val.lanman.primary_domain[0]}));
 					break;
 				case 4: // NT LM 0.12
-					response->Assign(1, val_mgr->GetBool(${val.ntlm.is_guest}));
+					response->Assign(1, val_mgr->Bool(${val.ntlm.is_guest}));
 					response->Assign(2, smb_string2stringval(${val.ntlm.native_os}));
 					response->Assign(3, smb_string2stringval(${val.ntlm.native_lanman}));
 					//response->Assign(4, smb_string2stringval(${val.ntlm.primary_domain}));

--- a/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
@@ -26,7 +26,7 @@ refine connection SMB_Conn += {
 					request->Assign(5, smb_string2stringval(${val.lanman.native_os}));
 					request->Assign(6, smb_string2stringval(${val.lanman.native_lanman}));
 					request->Assign(7, smb_string2stringval(${val.lanman.account_name}));
-					request->Assign(8, bytestring_to_val(${val.lanman.account_password}));
+					request->Assign(8, to_stringval(${val.lanman.account_password}));
 					request->Assign(9, smb_string2stringval(${val.lanman.primary_domain}));
 
 					break;
@@ -69,8 +69,8 @@ refine connection SMB_Conn += {
 					request->Assign(7, smb_string2stringval(${val.ntlm_nonextended_security.account_name}));
 					request->Assign(9, smb_string2stringval(${val.ntlm_nonextended_security.primary_domain}));
 
-					request->Assign(10, bytestring_to_val(${val.ntlm_nonextended_security.case_insensitive_password}));
-					request->Assign(11, bytestring_to_val(${val.ntlm_nonextended_security.case_sensitive_password}));
+					request->Assign(10, to_stringval(${val.ntlm_nonextended_security.case_insensitive_password}));
+					request->Assign(11, to_stringval(${val.ntlm_nonextended_security.case_sensitive_password}));
 					request->Assign(13, capabilities);
 					break;
 				}
@@ -103,7 +103,7 @@ refine connection SMB_Conn += {
 					response->Assign(2, smb_string2stringval(${val.ntlm.native_os}));
 					response->Assign(3, smb_string2stringval(${val.ntlm.native_lanman}));
 					//response->Assign(4, smb_string2stringval(${val.ntlm.primary_domain}));
-					//response->Assign(5, bytestring_to_val(${val.ntlm.security_blob}));
+					//response->Assign(5, to_stringval(${val.ntlm.security_blob}));
 					break;
 				default: // Error!
 					break;

--- a/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-session-setup-andx.pac
@@ -12,7 +12,7 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb1_session_setup_andx_request )
 			{
-			RecordVal* request = new RecordVal(BifType::Record::SMB1::SessionSetupAndXRequest);
+			auto request = make_intrusive<RecordVal>(BifType::Record::SMB1::SessionSetupAndXRequest);
 			RecordVal* capabilities;
 
 			request->Assign(0, val_mgr->Count(${val.word_count}));
@@ -75,7 +75,10 @@ refine connection SMB_Conn += {
 					break;
 				}
 
-			BifEvent::generate_smb1_session_setup_andx_request(bro_analyzer(), bro_analyzer()->Conn(), BuildHeaderVal(header), request);
+			BifEvent::enqueue_smb1_session_setup_andx_request(bro_analyzer(),
+			                                                  bro_analyzer()->Conn(),
+			                                                  SMBHeaderVal(header),
+			                                                  std::move(request));
 			}
 		return true;
 		%}
@@ -84,9 +87,9 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb1_session_setup_andx_response )
 			{
-			RecordVal* response = new RecordVal(BifType::Record::SMB1::SessionSetupAndXResponse);
-
+			auto response = make_intrusive<RecordVal>(BifType::Record::SMB1::SessionSetupAndXResponse);
 			response->Assign(0, val_mgr->Count(${val.word_count}));
+
 			switch ( ${val.word_count} )
 				{
 				case 3: // pre NT LM 0.12
@@ -106,10 +109,10 @@ refine connection SMB_Conn += {
 					break;
 				}
 
-			BifEvent::generate_smb1_session_setup_andx_response(bro_analyzer(),
-			                                                    bro_analyzer()->Conn(),
-			                                                    BuildHeaderVal(header),
-			                                                    response);
+			BifEvent::enqueue_smb1_session_setup_andx_response(bro_analyzer(),
+			                                                   bro_analyzer()->Conn(),
+			                                                   SMBHeaderVal(header),
+			                                                   std::move(response));
 			}
 
 		return true;

--- a/src/analyzer/protocol/smb/smb1-com-transaction-secondary.pac
+++ b/src/analyzer/protocol/smb/smb1-com-transaction-secondary.pac
@@ -6,14 +6,14 @@ refine connection SMB_Conn += {
 		return false;
 
 	RecordVal* args = new RecordVal(BifType::Record::SMB1::Trans_Sec_Args);
-	args->Assign(0, val_mgr->GetCount(${val.total_param_count}));
-	args->Assign(1, val_mgr->GetCount(${val.total_data_count}));
-	args->Assign(2, val_mgr->GetCount(${val.param_count}));
-	args->Assign(3, val_mgr->GetCount(${val.param_offset}));
-	args->Assign(4, val_mgr->GetCount(${val.param_displacement}));
-	args->Assign(5, val_mgr->GetCount(${val.data_count}));
-	args->Assign(6, val_mgr->GetCount(${val.data_offset}));
-	args->Assign(7, val_mgr->GetCount(${val.data_displacement}));
+	args->Assign(0, val_mgr->Count(${val.total_param_count}));
+	args->Assign(1, val_mgr->Count(${val.total_data_count}));
+	args->Assign(2, val_mgr->Count(${val.param_count}));
+	args->Assign(3, val_mgr->Count(${val.param_offset}));
+	args->Assign(4, val_mgr->Count(${val.param_displacement}));
+	args->Assign(5, val_mgr->Count(${val.data_count}));
+	args->Assign(6, val_mgr->Count(${val.data_offset}));
+	args->Assign(7, val_mgr->Count(${val.data_displacement}));
 
 	StringVal* parameters = new StringVal(${val.parameters}.length(),
 	                                      (const char*)${val.parameters}.data());

--- a/src/analyzer/protocol/smb/smb1-com-transaction-secondary.pac
+++ b/src/analyzer/protocol/smb/smb1-com-transaction-secondary.pac
@@ -17,7 +17,7 @@ refine connection SMB_Conn += {
 
 	StringVal* parameters = new StringVal(${val.parameters}.length(),
 	                                      (const char*)${val.parameters}.data());
-	StringVal* payload_str = nullptr;
+	IntrusivePtr<StringVal> payload_str;
 	SMB1_transaction_data* payload = nullptr;
 
 	if ( ${val.data_count} > 0 )
@@ -29,20 +29,20 @@ refine connection SMB_Conn += {
 		{
 		switch ( payload->trans_type() ) {
 		case SMB_PIPE:
-			payload_str = new StringVal(${val.data_count}, (const char*)${val.data.pipe_data}.data());
+			payload_str = make_intrusive<StringVal>(${val.data_count}, (const char*)${val.data.pipe_data}.data());
 			break;
 		case SMB_UNKNOWN:
-			payload_str = new StringVal(${val.data_count}, (const char*)${val.data.unknown}.data());
+			payload_str = make_intrusive<StringVal>(${val.data_count}, (const char*)${val.data.unknown}.data());
 			break;
 		default:
-			payload_str = new StringVal(${val.data_count}, (const char*)${val.data.data}.data());
+			payload_str = make_intrusive<StringVal>(${val.data_count}, (const char*)${val.data.data}.data());
 			break;
 		}
 		}
 
 	if ( ! payload_str )
 		{
-		payload_str = val_mgr->GetEmptyString();
+		payload_str = val_mgr->EmptyString();
 		}
 
 	BifEvent::generate_smb1_transaction_secondary_request(bro_analyzer(),
@@ -50,7 +50,7 @@ refine connection SMB_Conn += {
 	                                                      BuildHeaderVal(header),
 	                                                      args,
 	                                                      parameters,
-	                                                      payload_str);
+	                                                      payload_str.release());
 
 	return true;
 	%}

--- a/src/analyzer/protocol/smb/smb1-com-transaction-secondary.pac
+++ b/src/analyzer/protocol/smb/smb1-com-transaction-secondary.pac
@@ -5,7 +5,7 @@ refine connection SMB_Conn += {
 	if ( ! smb1_transaction_secondary_request )
 		return false;
 
-	RecordVal* args = new RecordVal(BifType::Record::SMB1::Trans_Sec_Args);
+	auto args = make_intrusive<RecordVal>(BifType::Record::SMB1::Trans_Sec_Args);
 	args->Assign(0, val_mgr->Count(${val.total_param_count}));
 	args->Assign(1, val_mgr->Count(${val.total_data_count}));
 	args->Assign(2, val_mgr->Count(${val.param_count}));
@@ -15,8 +15,8 @@ refine connection SMB_Conn += {
 	args->Assign(6, val_mgr->Count(${val.data_offset}));
 	args->Assign(7, val_mgr->Count(${val.data_displacement}));
 
-	StringVal* parameters = new StringVal(${val.parameters}.length(),
-	                                      (const char*)${val.parameters}.data());
+	auto parameters = make_intrusive<StringVal>(${val.parameters}.length(),
+	                                            (const char*)${val.parameters}.data());
 	IntrusivePtr<StringVal> payload_str;
 	SMB1_transaction_data* payload = nullptr;
 
@@ -45,12 +45,12 @@ refine connection SMB_Conn += {
 		payload_str = val_mgr->EmptyString();
 		}
 
-	BifEvent::generate_smb1_transaction_secondary_request(bro_analyzer(),
-	                                                      bro_analyzer()->Conn(),
-	                                                      BuildHeaderVal(header),
-	                                                      args,
-	                                                      parameters,
-	                                                      payload_str.release());
+	BifEvent::enqueue_smb1_transaction_secondary_request(bro_analyzer(),
+	                                                     bro_analyzer()->Conn(),
+	                                                     SMBHeaderVal(header),
+	                                                     std::move(args),
+	                                                     std::move(parameters),
+	                                                     std::move(payload_str));
 
 	return true;
 	%}

--- a/src/analyzer/protocol/smb/smb1-com-transaction.pac
+++ b/src/analyzer/protocol/smb/smb1-com-transaction.pac
@@ -53,8 +53,8 @@ refine connection SMB_Conn += {
 		if ( ! smb1_transaction_request )
 			return false;
 
-		StringVal* parameters = new StringVal(${val.parameters}.length(),
-		                                      (const char*)${val.parameters}.data());
+		auto parameters = make_intrusive<StringVal>(${val.parameters}.length(),
+		                                            (const char*)${val.parameters}.data());
 		IntrusivePtr<StringVal> payload_str;
 
 		if ( ${val.data_count} > 0 )
@@ -62,13 +62,13 @@ refine connection SMB_Conn += {
 		else
 			payload_str = val_mgr->EmptyString();
 
-		BifEvent::generate_smb1_transaction_request(bro_analyzer(),
-		                                            bro_analyzer()->Conn(),
-		                                            BuildHeaderVal(header),
-		                                            smb_string2stringval(${val.name}),
-		                                            ${val.sub_cmd},
-		                                            parameters,
-		                                            payload_str.release());
+		BifEvent::enqueue_smb1_transaction_request(bro_analyzer(),
+		                                           bro_analyzer()->Conn(),
+		                                           SMBHeaderVal(header),
+		                                           {AdoptRef{}, smb_string2stringval(${val.name})},
+		                                           ${val.sub_cmd},
+		                                           std::move(parameters),
+		                                           std::move(payload_str));
 
 		return true;
 		%}
@@ -78,8 +78,8 @@ refine connection SMB_Conn += {
 		if ( ! smb1_transaction_response )
 			return false;
 
-		StringVal* parameters = new StringVal(${val.parameters}.length(),
-		                                      (const char*)${val.parameters}.data());
+		auto parameters = make_intrusive<StringVal>(${val.parameters}.length(),
+		                                            (const char*)${val.parameters}.data());
 		IntrusivePtr<StringVal> payload_str;
 
 		if ( ${val.data_count} > 0 )
@@ -87,11 +87,11 @@ refine connection SMB_Conn += {
 		else
 			payload_str = val_mgr->EmptyString();
 
-		BifEvent::generate_smb1_transaction_response(bro_analyzer(),
-		                                             bro_analyzer()->Conn(),
-		                                             BuildHeaderVal(header),
-		                                             parameters,
-		                                             payload_str.release());
+		BifEvent::enqueue_smb1_transaction_response(bro_analyzer(),
+		                                            bro_analyzer()->Conn(),
+		                                            SMBHeaderVal(header),
+		                                            std::move(parameters),
+		                                            std::move(payload_str));
 		return true;
 		%}
 };

--- a/src/analyzer/protocol/smb/smb1-com-transaction.pac
+++ b/src/analyzer/protocol/smb/smb1-com-transaction.pac
@@ -9,11 +9,11 @@ enum Trans_subcommands {
 		{
 		switch ( payload->trans_type() ) {
 		case SMB_PIPE:
-			return {AdoptRef{}, bytestring_to_val(payload->pipe_data())};
+			return to_stringval(payload->pipe_data());
 		case SMB_UNKNOWN:
-			return {AdoptRef{}, bytestring_to_val(payload->unknown())};
+			return to_stringval(payload->unknown());
 		default:
-			return {AdoptRef{}, bytestring_to_val(payload->data())};
+			return to_stringval(payload->data());
 		}
 
 		assert(false);

--- a/src/analyzer/protocol/smb/smb1-com-transaction2-secondary.pac
+++ b/src/analyzer/protocol/smb/smb1-com-transaction2-secondary.pac
@@ -6,15 +6,15 @@ refine connection SMB_Conn += {
 		return false;
 
 	RecordVal* args = new RecordVal(BifType::Record::SMB1::Trans2_Sec_Args);
-	args->Assign(0, val_mgr->GetCount(${val.total_param_count}));
-	args->Assign(1, val_mgr->GetCount(${val.total_data_count}));
-	args->Assign(2, val_mgr->GetCount(${val.param_count}));
-	args->Assign(3, val_mgr->GetCount(${val.param_offset}));
-	args->Assign(4, val_mgr->GetCount(${val.param_displacement}));
-	args->Assign(5, val_mgr->GetCount(${val.data_count}));
-	args->Assign(6, val_mgr->GetCount(${val.data_offset}));
-	args->Assign(7, val_mgr->GetCount(${val.data_displacement}));
-	args->Assign(8, val_mgr->GetCount(${val.FID}));
+	args->Assign(0, val_mgr->Count(${val.total_param_count}));
+	args->Assign(1, val_mgr->Count(${val.total_data_count}));
+	args->Assign(2, val_mgr->Count(${val.param_count}));
+	args->Assign(3, val_mgr->Count(${val.param_offset}));
+	args->Assign(4, val_mgr->Count(${val.param_displacement}));
+	args->Assign(5, val_mgr->Count(${val.data_count}));
+	args->Assign(6, val_mgr->Count(${val.data_offset}));
+	args->Assign(7, val_mgr->Count(${val.data_displacement}));
+	args->Assign(8, val_mgr->Count(${val.FID}));
 
 	StringVal* parameters = new StringVal(${val.parameters}.length(), (const char*)${val.parameters}.data());
 	StringVal* payload = new StringVal(${val.data}.length(), (const char*)${val.data}.data());

--- a/src/analyzer/protocol/smb/smb1-com-transaction2-secondary.pac
+++ b/src/analyzer/protocol/smb/smb1-com-transaction2-secondary.pac
@@ -5,7 +5,7 @@ refine connection SMB_Conn += {
 	if ( ! smb1_transaction2_secondary_request )
 		return false;
 
-	RecordVal* args = new RecordVal(BifType::Record::SMB1::Trans2_Sec_Args);
+	auto args = make_intrusive<RecordVal>(BifType::Record::SMB1::Trans2_Sec_Args);
 	args->Assign(0, val_mgr->Count(${val.total_param_count}));
 	args->Assign(1, val_mgr->Count(${val.total_data_count}));
 	args->Assign(2, val_mgr->Count(${val.param_count}));
@@ -16,15 +16,15 @@ refine connection SMB_Conn += {
 	args->Assign(7, val_mgr->Count(${val.data_displacement}));
 	args->Assign(8, val_mgr->Count(${val.FID}));
 
-	StringVal* parameters = new StringVal(${val.parameters}.length(), (const char*)${val.parameters}.data());
-	StringVal* payload = new StringVal(${val.data}.length(), (const char*)${val.data}.data());
+	auto parameters = make_intrusive<StringVal>(${val.parameters}.length(), (const char*)${val.parameters}.data());
+	auto payload = make_intrusive<StringVal>(${val.data}.length(), (const char*)${val.data}.data());
 
-	BifEvent::generate_smb1_transaction2_secondary_request(bro_analyzer(),
-	                                                       bro_analyzer()->Conn(),
-	                                                       BuildHeaderVal(header),
-	                                                       args,
-	                                                       parameters,
-	                                                       payload);
+	BifEvent::enqueue_smb1_transaction2_secondary_request(bro_analyzer(),
+	                                                      bro_analyzer()->Conn(),
+	                                                      SMBHeaderVal(header),
+	                                                      std::move(args),
+	                                                      std::move(parameters),
+	                                                      std::move(payload));
 
 	return true;
 	%}

--- a/src/analyzer/protocol/smb/smb1-com-transaction2.pac
+++ b/src/analyzer/protocol/smb/smb1-com-transaction2.pac
@@ -25,18 +25,18 @@ refine connection SMB_Conn += {
 		if ( smb1_transaction2_request )
 			{
 			RecordVal* args = new RecordVal(BifType::Record::SMB1::Trans2_Args);
-			args->Assign(0, val_mgr->GetCount(${val.total_param_count}));
-			args->Assign(1, val_mgr->GetCount(${val.total_data_count}));
-			args->Assign(2, val_mgr->GetCount(${val.max_param_count}));
-			args->Assign(3, val_mgr->GetCount(${val.max_data_count}));
-			args->Assign(4, val_mgr->GetCount(${val.max_setup_count}));
-			args->Assign(5, val_mgr->GetCount(${val.flags}));
-			args->Assign(6, val_mgr->GetCount(${val.timeout}));
-			args->Assign(7, val_mgr->GetCount(${val.param_count}));
-			args->Assign(8, val_mgr->GetCount(${val.param_offset}));
-			args->Assign(9, val_mgr->GetCount(${val.data_count}));
-			args->Assign(10, val_mgr->GetCount(${val.data_offset}));
-			args->Assign(11, val_mgr->GetCount(${val.setup_count}));
+			args->Assign(0, val_mgr->Count(${val.total_param_count}));
+			args->Assign(1, val_mgr->Count(${val.total_data_count}));
+			args->Assign(2, val_mgr->Count(${val.max_param_count}));
+			args->Assign(3, val_mgr->Count(${val.max_data_count}));
+			args->Assign(4, val_mgr->Count(${val.max_setup_count}));
+			args->Assign(5, val_mgr->Count(${val.flags}));
+			args->Assign(6, val_mgr->Count(${val.timeout}));
+			args->Assign(7, val_mgr->Count(${val.param_count}));
+			args->Assign(8, val_mgr->Count(${val.param_offset}));
+			args->Assign(9, val_mgr->Count(${val.data_count}));
+			args->Assign(10, val_mgr->Count(${val.data_offset}));
+			args->Assign(11, val_mgr->Count(${val.setup_count}));
 
 			BifEvent::generate_smb1_transaction2_request(bro_analyzer(), bro_analyzer()->Conn(), BuildHeaderVal(header), args, ${val.sub_cmd});
 			}
@@ -128,11 +128,11 @@ refine connection SMB_Conn += {
 		if ( smb1_trans2_find_first2_request )
 			{
 			RecordVal* result = new RecordVal(BifType::Record::SMB1::Find_First2_Request_Args);
-			result->Assign(0, val_mgr->GetCount(${val.search_attrs}));
-			result->Assign(1, val_mgr->GetCount(${val.search_count}));
-			result->Assign(2, val_mgr->GetCount(${val.flags}));
-			result->Assign(3, val_mgr->GetCount(${val.info_level}));
-			result->Assign(4, val_mgr->GetCount(${val.search_storage_type}));
+			result->Assign(0, val_mgr->Count(${val.search_attrs}));
+			result->Assign(1, val_mgr->Count(${val.search_count}));
+			result->Assign(2, val_mgr->Count(${val.flags}));
+			result->Assign(3, val_mgr->Count(${val.info_level}));
+			result->Assign(4, val_mgr->Count(${val.search_storage_type}));
 			result->Assign(5, smb_string2stringval(${val.file_name}));
 			BifEvent::generate_smb1_trans2_find_first2_request(bro_analyzer(), bro_analyzer()->Conn(), \
 															   BuildHeaderVal(header), result);

--- a/src/analyzer/protocol/smb/smb1-com-transaction2.pac
+++ b/src/analyzer/protocol/smb/smb1-com-transaction2.pac
@@ -24,7 +24,7 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb1_transaction2_request )
 			{
-			RecordVal* args = new RecordVal(BifType::Record::SMB1::Trans2_Args);
+			auto args = make_intrusive<RecordVal>(BifType::Record::SMB1::Trans2_Args);
 			args->Assign(0, val_mgr->Count(${val.total_param_count}));
 			args->Assign(1, val_mgr->Count(${val.total_data_count}));
 			args->Assign(2, val_mgr->Count(${val.max_param_count}));
@@ -38,7 +38,11 @@ refine connection SMB_Conn += {
 			args->Assign(10, val_mgr->Count(${val.data_offset}));
 			args->Assign(11, val_mgr->Count(${val.setup_count}));
 
-			BifEvent::generate_smb1_transaction2_request(bro_analyzer(), bro_analyzer()->Conn(), BuildHeaderVal(header), args, ${val.sub_cmd});
+			BifEvent::enqueue_smb1_transaction2_request(bro_analyzer(),
+			                                            bro_analyzer()->Conn(),
+			                                            SMBHeaderVal(header),
+			                                            std::move(args),
+			                                            ${val.sub_cmd});
 			}
 
 		return true;
@@ -47,7 +51,7 @@ refine connection SMB_Conn += {
 	function proc_smb1_transaction2_response(header: SMB_Header, val: SMB1_transaction2_response): bool
 		%{
 		//if ( smb1_transaction2_response )
-		//	BifEvent::generate_smb1_transaction2_response(bro_analyzer(), bro_analyzer()->Conn(), BuildHeaderVal(header), ${val.sub_cmd});
+		//	BifEvent::enqueue_smb1_transaction2_response(bro_analyzer(), bro_analyzer()->Conn(), SMBHeaderVal(header), ${val.sub_cmd});
 		return true;
 		%}
 
@@ -127,15 +131,17 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb1_trans2_find_first2_request )
 			{
-			RecordVal* result = new RecordVal(BifType::Record::SMB1::Find_First2_Request_Args);
+			auto result = make_intrusive<RecordVal>(BifType::Record::SMB1::Find_First2_Request_Args);
 			result->Assign(0, val_mgr->Count(${val.search_attrs}));
 			result->Assign(1, val_mgr->Count(${val.search_count}));
 			result->Assign(2, val_mgr->Count(${val.flags}));
 			result->Assign(3, val_mgr->Count(${val.info_level}));
 			result->Assign(4, val_mgr->Count(${val.search_storage_type}));
 			result->Assign(5, smb_string2stringval(${val.file_name}));
-			BifEvent::generate_smb1_trans2_find_first2_request(bro_analyzer(), bro_analyzer()->Conn(), \
-															   BuildHeaderVal(header), result);
+			BifEvent::enqueue_smb1_trans2_find_first2_request(bro_analyzer(),
+			                                                  bro_analyzer()->Conn(),
+															  SMBHeaderVal(header),
+															  std::move(result));
 
 			}
 		return true;
@@ -211,9 +217,10 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb1_trans2_query_path_info_request )
 			{
-			BifEvent::generate_smb1_trans2_query_path_info_request(bro_analyzer(), bro_analyzer()->Conn(), \
-																   BuildHeaderVal(header), \
-																   smb_string2stringval(${val.file_name}));
+			BifEvent::enqueue_smb1_trans2_query_path_info_request(bro_analyzer(),
+			                                                      bro_analyzer()->Conn(),
+																  SMBHeaderVal(header),
+																  {AdoptRef{}, smb_string2stringval(${val.file_name})});
 
 			}
 		return true;
@@ -315,9 +322,10 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb1_trans2_get_dfs_referral_request )
 			{
-			BifEvent::generate_smb1_trans2_get_dfs_referral_request(bro_analyzer(), bro_analyzer()->Conn(), \
-																	BuildHeaderVal(header), \
-																	smb_string2stringval(${val.file_name}));
+			BifEvent::enqueue_smb1_trans2_get_dfs_referral_request(bro_analyzer(),
+			                                                       bro_analyzer()->Conn(),
+			                                                       SMBHeaderVal(header),
+			                                                       {AdoptRef{}, smb_string2stringval(${val.file_name})});
 			}
 		return true;
 		%}

--- a/src/analyzer/protocol/smb/smb1-com-tree-connect-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-tree-connect-andx.pac
@@ -23,7 +23,7 @@ refine connection SMB_Conn += {
 			                                                   bro_analyzer()->Conn(),
 			                                                   BuildHeaderVal(header),
 			                                                   service_string,
-			                                                   ${val.byte_count} > ${val.service.a}->size() ? smb_string2stringval(${val.native_file_system[0]}) : val_mgr->GetEmptyString());
+			                                                   ${val.byte_count} > ${val.service.a}->size() ? smb_string2stringval(${val.native_file_system[0]}) : val_mgr->EmptyString()->Ref()->AsStringVal());
 		else
 			Unref(service_string);
 

--- a/src/analyzer/protocol/smb/smb1-com-tree-disconnect.pac
+++ b/src/analyzer/protocol/smb/smb1-com-tree-disconnect.pac
@@ -3,10 +3,10 @@ refine connection SMB_Conn += {
 	function proc_smb1_tree_disconnect(header: SMB_Header, val: SMB1_tree_disconnect): bool
 		%{
 		if ( smb1_tree_disconnect )
-			BifEvent::generate_smb1_tree_disconnect(bro_analyzer(),
-			                                        bro_analyzer()->Conn(),
-			                                        BuildHeaderVal(header),
-			                                        ${val.is_orig});
+			BifEvent::enqueue_smb1_tree_disconnect(bro_analyzer(),
+			                                       bro_analyzer()->Conn(),
+			                                       SMBHeaderVal(header),
+			                                       ${val.is_orig});
 		return true;
 		%}
 

--- a/src/analyzer/protocol/smb/smb1-com-write-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-write-andx.pac
@@ -3,12 +3,12 @@ refine connection SMB_Conn += {
 	function proc_smb1_write_andx_request(h: SMB_Header, val: SMB1_write_andx_request): bool
 		%{
 		if ( smb1_write_andx_request )
-			BifEvent::generate_smb1_write_andx_request(bro_analyzer(),
-			                                           bro_analyzer()->Conn(),
-			                                           BuildHeaderVal(h),
-			                                           ${val.file_id},
-			                                           ${val.write_offset},
-			                                           ${val.data_len});
+			BifEvent::enqueue_smb1_write_andx_request(bro_analyzer(),
+			                                          bro_analyzer()->Conn(),
+			                                          SMBHeaderVal(h),
+			                                          ${val.file_id},
+			                                          ${val.write_offset},
+			                                          ${val.data_len});
 
 		if ( ! ${h.is_pipe} && ${val.data}.length() > 0 )
 			{
@@ -24,9 +24,9 @@ refine connection SMB_Conn += {
 	function proc_smb1_write_andx_response(h: SMB_Header, val: SMB1_write_andx_response): bool
 		%{
 		if ( smb1_write_andx_response )
-			BifEvent::generate_smb1_write_andx_response(bro_analyzer(),
+			BifEvent::enqueue_smb1_write_andx_response(bro_analyzer(),
 			                                           bro_analyzer()->Conn(),
-			                                           BuildHeaderVal(h),
+			                                           SMBHeaderVal(h),
 			                                           ${val.written_bytes});
 
 		return true;

--- a/src/analyzer/protocol/smb/smb1-protocol.pac
+++ b/src/analyzer/protocol/smb/smb1-protocol.pac
@@ -21,14 +21,14 @@ refine connection SMB_Conn += {
 		//	{ // do nothing
 		//	}
 
-		r->Assign(0, val_mgr->GetCount(${hdr.command}));
-		r->Assign(1, val_mgr->GetCount(${hdr.status}));
-		r->Assign(2, val_mgr->GetCount(${hdr.flags}));
-		r->Assign(3, val_mgr->GetCount(${hdr.flags2}));
-		r->Assign(4, val_mgr->GetCount(${hdr.tid}));
-		r->Assign(5, val_mgr->GetCount(${hdr.pid}));
-		r->Assign(6, val_mgr->GetCount(${hdr.uid}));
-		r->Assign(7, val_mgr->GetCount(${hdr.mid}));
+		r->Assign(0, val_mgr->Count(${hdr.command}));
+		r->Assign(1, val_mgr->Count(${hdr.status}));
+		r->Assign(2, val_mgr->Count(${hdr.flags}));
+		r->Assign(3, val_mgr->Count(${hdr.flags2}));
+		r->Assign(4, val_mgr->Count(${hdr.tid}));
+		r->Assign(5, val_mgr->Count(${hdr.pid}));
+		r->Assign(6, val_mgr->Count(${hdr.uid}));
+		r->Assign(7, val_mgr->Count(${hdr.mid}));
 
 		return r;
 		%}

--- a/src/analyzer/protocol/smb/smb2-com-close.pac
+++ b/src/analyzer/protocol/smb/smb2-com-close.pac
@@ -4,10 +4,10 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb2_close_request )
 			{
-			BifEvent::generate_smb2_close_request(bro_analyzer(),
-			                                      bro_analyzer()->Conn(),
-			                                      BuildSMB2HeaderVal(h),
-			                                      BuildSMB2GUID(${val.file_id}));
+			BifEvent::enqueue_smb2_close_request(bro_analyzer(),
+			                                     bro_analyzer()->Conn(),
+			                                     {AdoptRef{}, BuildSMB2HeaderVal(h)},
+			                                     {AdoptRef{}, BuildSMB2GUID(${val.file_id})});
 			}
 
 		file_mgr->EndOfFile(bro_analyzer()->GetAnalyzerTag(),
@@ -20,7 +20,7 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb2_close_response )
 			{
-			RecordVal* resp = new RecordVal(BifType::Record::SMB2::CloseResponse);
+			auto resp = make_intrusive<RecordVal>(BifType::Record::SMB2::CloseResponse);
 
 			resp->Assign(0, val_mgr->Count(${val.alloc_size}));
 			resp->Assign(1, val_mgr->Count(${val.eof}));
@@ -30,10 +30,10 @@ refine connection SMB_Conn += {
 			                                  ${val.change_time}));
 			resp->Assign(3, smb2_file_attrs_to_bro(${val.file_attrs}));
 
-			BifEvent::generate_smb2_close_response(bro_analyzer(),
-			                                       bro_analyzer()->Conn(),
-			                                       BuildSMB2HeaderVal(h),
-			                                       resp);
+			BifEvent::enqueue_smb2_close_response(bro_analyzer(),
+			                                      bro_analyzer()->Conn(),
+			                                      {AdoptRef{}, BuildSMB2HeaderVal(h)},
+			                                      std::move(resp));
 			}
 
 		return true;

--- a/src/analyzer/protocol/smb/smb2-com-close.pac
+++ b/src/analyzer/protocol/smb/smb2-com-close.pac
@@ -22,8 +22,8 @@ refine connection SMB_Conn += {
 			{
 			RecordVal* resp = new RecordVal(BifType::Record::SMB2::CloseResponse);
 
-			resp->Assign(0, val_mgr->GetCount(${val.alloc_size}));
-			resp->Assign(1, val_mgr->GetCount(${val.eof}));
+			resp->Assign(0, val_mgr->Count(${val.alloc_size}));
+			resp->Assign(1, val_mgr->Count(${val.eof}));
 			resp->Assign(2, SMB_BuildMACTimes(${val.last_write_time},
 			                                  ${val.last_access_time},
 			                                  ${val.creation_time},

--- a/src/analyzer/protocol/smb/smb2-com-create.pac
+++ b/src/analyzer/protocol/smb/smb2-com-create.pac
@@ -17,8 +17,8 @@ refine connection SMB_Conn += {
 			{
 			RecordVal* requestinfo = new RecordVal(BifType::Record::SMB2::CreateRequest);
 			requestinfo->Assign(0, filename);
-			requestinfo->Assign(1, val_mgr->GetCount(${val.disposition}));
-			requestinfo->Assign(2, val_mgr->GetCount(${val.create_options}));
+			requestinfo->Assign(1, val_mgr->Count(${val.disposition}));
+			requestinfo->Assign(2, val_mgr->Count(${val.create_options}));
 			BifEvent::generate_smb2_create_request(bro_analyzer(),
 			                                       bro_analyzer()->Conn(),
 			                                       BuildSMB2HeaderVal(h),
@@ -38,13 +38,13 @@ refine connection SMB_Conn += {
 			{
 			RecordVal* responseinfo = new RecordVal(BifType::Record::SMB2::CreateResponse);
 			responseinfo->Assign(0, BuildSMB2GUID(${val.file_id}));
-			responseinfo->Assign(1, val_mgr->GetCount(${val.eof}));
+			responseinfo->Assign(1, val_mgr->Count(${val.eof}));
 			responseinfo->Assign(2, SMB_BuildMACTimes(${val.last_write_time},
 			                                          ${val.last_access_time},
 			                                          ${val.creation_time},
 			                                          ${val.change_time}));
 			responseinfo->Assign(3, smb2_file_attrs_to_bro(${val.file_attrs}));
-			responseinfo->Assign(4, val_mgr->GetCount(${val.create_action}));
+			responseinfo->Assign(4, val_mgr->Count(${val.create_action}));
 			BifEvent::generate_smb2_create_response(bro_analyzer(),
 			                                        bro_analyzer()->Conn(),
 			                                        BuildSMB2HeaderVal(h),

--- a/src/analyzer/protocol/smb/smb2-com-negotiate.pac
+++ b/src/analyzer/protocol/smb/smb2-com-negotiate.pac
@@ -25,7 +25,7 @@ refine connection SMB_Conn += {
 			VectorVal* dialects = new VectorVal(index_vec);
 			for ( unsigned int i = 0; i < ${val.dialects}->size(); ++i )
 				{
-				dialects->Assign(i, val_mgr->GetCount((*${val.dialects})[i]));
+				dialects->Assign(i, val_mgr->Count((*${val.dialects})[i]));
 				}
 			BifEvent::generate_smb2_negotiate_request(bro_analyzer(), bro_analyzer()->Conn(),
 			                                          BuildSMB2HeaderVal(h),
@@ -41,12 +41,12 @@ refine connection SMB_Conn += {
 			{
 			RecordVal* nr = new RecordVal(BifType::Record::SMB2::NegotiateResponse);
 
-			nr->Assign(0, val_mgr->GetCount(${val.dialect_revision}));
-			nr->Assign(1, val_mgr->GetCount(${val.security_mode}));
+			nr->Assign(0, val_mgr->Count(${val.dialect_revision}));
+			nr->Assign(1, val_mgr->Count(${val.security_mode}));
 			nr->Assign(2, BuildSMB2GUID(${val.server_guid}));
 			nr->Assign(3, filetime2brotime(${val.system_time}));
 			nr->Assign(4, filetime2brotime(${val.server_start_time}));
-			nr->Assign(5, val_mgr->GetCount(${val.negotiate_context_count}));
+			nr->Assign(5, val_mgr->Count(${val.negotiate_context_count}));
 
 			VectorVal* cv = new VectorVal(BifType::Vector::SMB2::NegotiateContextValues);
 

--- a/src/analyzer/protocol/smb/smb2-com-negotiate.pac
+++ b/src/analyzer/protocol/smb/smb2-com-negotiate.pac
@@ -22,14 +22,14 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb2_negotiate_request )
 			{
-			VectorVal* dialects = new VectorVal(index_vec);
+			auto dialects = make_intrusive<VectorVal>(index_vec);
+
 			for ( unsigned int i = 0; i < ${val.dialects}->size(); ++i )
-				{
 				dialects->Assign(i, val_mgr->Count((*${val.dialects})[i]));
-				}
-			BifEvent::generate_smb2_negotiate_request(bro_analyzer(), bro_analyzer()->Conn(),
-			                                          BuildSMB2HeaderVal(h),
-			                                          dialects);
+
+			BifEvent::enqueue_smb2_negotiate_request(bro_analyzer(), bro_analyzer()->Conn(),
+			                                         {AdoptRef{}, BuildSMB2HeaderVal(h)},
+			                                         std::move(dialects));
 			}
 
 		return true;
@@ -39,7 +39,7 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb2_negotiate_response )
 			{
-			RecordVal* nr = new RecordVal(BifType::Record::SMB2::NegotiateResponse);
+			auto nr = make_intrusive<RecordVal>(BifType::Record::SMB2::NegotiateResponse);
 
 			nr->Assign(0, val_mgr->Count(${val.dialect_revision}));
 			nr->Assign(1, val_mgr->Count(${val.security_mode}));
@@ -60,9 +60,9 @@ refine connection SMB_Conn += {
 
 			nr->Assign(6, cv);
 
-			BifEvent::generate_smb2_negotiate_response(bro_analyzer(), bro_analyzer()->Conn(),
-			                                           BuildSMB2HeaderVal(h),
-			                                           nr);
+			BifEvent::enqueue_smb2_negotiate_response(bro_analyzer(), bro_analyzer()->Conn(),
+			                                          {AdoptRef{}, BuildSMB2HeaderVal(h)},
+													  std::move(nr));
 			}
 
 		return true;

--- a/src/analyzer/protocol/smb/smb2-com-read.pac
+++ b/src/analyzer/protocol/smb/smb2-com-read.pac
@@ -26,12 +26,12 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb2_read_request )
 			{
-			BifEvent::generate_smb2_read_request(bro_analyzer(),
-			                                     bro_analyzer()->Conn(),
-			                                     BuildSMB2HeaderVal(h),
-			                                     BuildSMB2GUID(${val.file_id}),
-			                                     ${val.offset},
-			                                     ${val.read_len});
+			BifEvent::enqueue_smb2_read_request(bro_analyzer(),
+			                                    bro_analyzer()->Conn(),
+			                                    {AdoptRef{}, BuildSMB2HeaderVal(h)},
+			                                    {AdoptRef{}, BuildSMB2GUID(${val.file_id})},
+			                                    ${val.offset},
+			                                    ${val.read_len});
 			}
 
 		smb2_read_offsets[${h.message_id}] = ${val.offset};

--- a/src/analyzer/protocol/smb/smb2-com-session-setup.pac
+++ b/src/analyzer/protocol/smb/smb2-com-session-setup.pac
@@ -5,7 +5,7 @@ refine connection SMB_Conn += {
 		if ( smb2_session_setup_request )
 			{
 			RecordVal* req = new RecordVal(BifType::Record::SMB2::SessionSetupRequest);
-			req->Assign(0, val_mgr->GetCount(${val.security_mode}));
+			req->Assign(0, val_mgr->Count(${val.security_mode}));
 
 			BifEvent::generate_smb2_session_setup_request(bro_analyzer(),
 			                                              bro_analyzer()->Conn(),

--- a/src/analyzer/protocol/smb/smb2-com-session-setup.pac
+++ b/src/analyzer/protocol/smb/smb2-com-session-setup.pac
@@ -4,13 +4,13 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb2_session_setup_request )
 			{
-			RecordVal* req = new RecordVal(BifType::Record::SMB2::SessionSetupRequest);
+			auto req = make_intrusive<RecordVal>(BifType::Record::SMB2::SessionSetupRequest);
 			req->Assign(0, val_mgr->Count(${val.security_mode}));
 
-			BifEvent::generate_smb2_session_setup_request(bro_analyzer(),
-			                                              bro_analyzer()->Conn(),
-			                                              BuildSMB2HeaderVal(h),
-			                                              req);
+			BifEvent::enqueue_smb2_session_setup_request(bro_analyzer(),
+			                                             bro_analyzer()->Conn(),
+			                                             {AdoptRef{}, BuildSMB2HeaderVal(h)},
+														 std::move(req));
 			}
 
 		return true;
@@ -20,18 +20,18 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb2_session_setup_response )
 			{
-			RecordVal* flags = new RecordVal(BifType::Record::SMB2::SessionSetupFlags);
+			auto flags = make_intrusive<RecordVal>(BifType::Record::SMB2::SessionSetupFlags);
 			flags->Assign(0, val_mgr->Bool(${val.flag_guest}));
 			flags->Assign(1, val_mgr->Bool(${val.flag_anonymous}));
 			flags->Assign(2, val_mgr->Bool(${val.flag_encrypt}));
 
-			RecordVal* resp = new RecordVal(BifType::Record::SMB2::SessionSetupResponse);
-			resp->Assign(0, flags);
+			auto resp = make_intrusive<RecordVal>(BifType::Record::SMB2::SessionSetupResponse);
+			resp->Assign(0, std::move(flags));
 
-			BifEvent::generate_smb2_session_setup_response(bro_analyzer(),
-			                                               bro_analyzer()->Conn(),
-			                                               BuildSMB2HeaderVal(h),
-			                                               resp);
+			BifEvent::enqueue_smb2_session_setup_response(bro_analyzer(),
+			                                              bro_analyzer()->Conn(),
+			                                              {AdoptRef{}, BuildSMB2HeaderVal(h)},
+			                                              std::move(resp));
 			}
 
 		return true;

--- a/src/analyzer/protocol/smb/smb2-com-session-setup.pac
+++ b/src/analyzer/protocol/smb/smb2-com-session-setup.pac
@@ -21,9 +21,9 @@ refine connection SMB_Conn += {
 		if ( smb2_session_setup_response )
 			{
 			RecordVal* flags = new RecordVal(BifType::Record::SMB2::SessionSetupFlags);
-			flags->Assign(0, val_mgr->GetBool(${val.flag_guest}));
-			flags->Assign(1, val_mgr->GetBool(${val.flag_anonymous}));
-			flags->Assign(2, val_mgr->GetBool(${val.flag_encrypt}));
+			flags->Assign(0, val_mgr->Bool(${val.flag_guest}));
+			flags->Assign(1, val_mgr->Bool(${val.flag_anonymous}));
+			flags->Assign(2, val_mgr->Bool(${val.flag_encrypt}));
 
 			RecordVal* resp = new RecordVal(BifType::Record::SMB2::SessionSetupResponse);
 			resp->Assign(0, flags);

--- a/src/analyzer/protocol/smb/smb2-com-set-info.pac
+++ b/src/analyzer/protocol/smb/smb2-com-set-info.pac
@@ -193,9 +193,9 @@ refine connection SMB_Conn += {
 		if ( smb2_file_fscontrol )
 			{
 			RecordVal* r = new RecordVal(BifType::Record::SMB2::Fscontrol);
-			r->Assign(0, val_mgr->GetInt(${val.free_space_start_filtering}));
-			r->Assign(1, val_mgr->GetInt(${val.free_space_start_threshold}));
-			r->Assign(2, val_mgr->GetInt(${val.free_space_stop_filtering}));
+			r->Assign(0, val_mgr->Int(${val.free_space_start_filtering}));
+			r->Assign(1, val_mgr->Int(${val.free_space_start_threshold}));
+			r->Assign(2, val_mgr->Int(${val.free_space_stop_filtering}));
 			r->Assign(3, val_mgr->GetCount(${val.default_quota_threshold}));
 			r->Assign(4, val_mgr->GetCount(${val.default_quota_limit}));
 			r->Assign(5, val_mgr->GetCount(${val.file_system_control_flags}));

--- a/src/analyzer/protocol/smb/smb2-com-set-info.pac
+++ b/src/analyzer/protocol/smb/smb2-com-set-info.pac
@@ -196,9 +196,9 @@ refine connection SMB_Conn += {
 			r->Assign(0, val_mgr->Int(${val.free_space_start_filtering}));
 			r->Assign(1, val_mgr->Int(${val.free_space_start_threshold}));
 			r->Assign(2, val_mgr->Int(${val.free_space_stop_filtering}));
-			r->Assign(3, val_mgr->GetCount(${val.default_quota_threshold}));
-			r->Assign(4, val_mgr->GetCount(${val.default_quota_limit}));
-			r->Assign(5, val_mgr->GetCount(${val.file_system_control_flags}));
+			r->Assign(3, val_mgr->Count(${val.default_quota_threshold}));
+			r->Assign(4, val_mgr->Count(${val.default_quota_limit}));
+			r->Assign(5, val_mgr->Count(${val.file_system_control_flags}));
 
 			BifEvent::generate_smb2_file_fscontrol(bro_analyzer(),
 			                                       bro_analyzer()->Conn(),

--- a/src/analyzer/protocol/smb/smb2-com-set-info.pac
+++ b/src/analyzer/protocol/smb/smb2-com-set-info.pac
@@ -28,15 +28,15 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file(val: SMB2_file_basic_info): bool
 		%{
 		if ( smb2_file_sattr )
-			BifEvent::generate_smb2_file_sattr(bro_analyzer(),
-			                                      bro_analyzer()->Conn(),
-			                                      BuildSMB2HeaderVal(${val.sir.header}),
-			                                      BuildSMB2GUID(${val.sir.file_id}),
-			                                      SMB_BuildMACTimes(${val.last_write_time},
-			                                                        ${val.last_access_time},
-			                                                        ${val.creation_time},
-			                                                        ${val.change_time}),
-			                                      smb2_file_attrs_to_bro(${val.file_attrs}));
+			BifEvent::enqueue_smb2_file_sattr(bro_analyzer(),
+			                                  bro_analyzer()->Conn(),
+			                                  {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                  {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                  {AdoptRef{}, SMB_BuildMACTimes(${val.last_write_time},
+			                                                       ${val.last_access_time},
+			                                                       ${val.creation_time},
+			                                                       ${val.change_time})},
+			                                  {AdoptRef{}, smb2_file_attrs_to_bro(${val.file_attrs})});
 
 		return true;
 		%}
@@ -44,11 +44,11 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_rename(val: SMB2_file_rename_info): bool
 		%{
 		if ( smb2_file_rename )
-			BifEvent::generate_smb2_file_rename(bro_analyzer(),
-			                                    bro_analyzer()->Conn(),
-			                                    BuildSMB2HeaderVal(${val.sir.header}),
-			                                    BuildSMB2GUID(${val.sir.file_id}),
-			                                    smb2_string2stringval(${val.filename}));
+			BifEvent::enqueue_smb2_file_rename(bro_analyzer(),
+			                                   bro_analyzer()->Conn(),
+			                                   {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                   {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                   {AdoptRef{}, smb2_string2stringval(${val.filename})});
 
 		return true;
 		%}
@@ -56,11 +56,11 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_delete(val: SMB2_file_disposition_info): bool
 		%{
 		if ( smb2_file_delete )
-			BifEvent::generate_smb2_file_delete(bro_analyzer(),
-			                                    bro_analyzer()->Conn(),
-			                                    BuildSMB2HeaderVal(${val.sir.header}),
-			                                    BuildSMB2GUID(${val.sir.file_id}),
-			                                    (${val.delete_pending} > 0));
+			BifEvent::enqueue_smb2_file_delete(bro_analyzer(),
+			                                   bro_analyzer()->Conn(),
+			                                   {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                   {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                   (${val.delete_pending} > 0));
 
 		return true;
 		%}
@@ -68,11 +68,11 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_allocation(val: SMB2_file_allocation_info): bool
 		%{
 		if ( smb2_file_allocation )
-			BifEvent::generate_smb2_file_allocation(bro_analyzer(),
-			                                        bro_analyzer()->Conn(),
-			                                        BuildSMB2HeaderVal(${val.sir.header}),
-			                                        BuildSMB2GUID(${val.sir.file_id}),
-			                                        (${val.allocation_size}));
+			BifEvent::enqueue_smb2_file_allocation(bro_analyzer(),
+			                                       bro_analyzer()->Conn(),
+			                                       {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                       {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                       (${val.allocation_size}));
 
 		return true;
 		%}
@@ -80,35 +80,35 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_endoffile(val: SMB2_file_endoffile_info): bool
 		%{
 		if ( smb2_file_endoffile )
-			BifEvent::generate_smb2_file_endoffile(bro_analyzer(),
-			                                       bro_analyzer()->Conn(),
-			                                       BuildSMB2HeaderVal(${val.sir.header}),
-			                                       BuildSMB2GUID(${val.sir.file_id}),
-			                                       ${val.endoffile});
+			BifEvent::enqueue_smb2_file_endoffile(bro_analyzer(),
+			                                      bro_analyzer()->Conn(),
+			                                      {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                      {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                      ${val.endoffile});
 
 		return true;
 		%}
 
 	function proc_smb2_set_info_request_file_fullea(val: SMB2_file_fullea_info): bool
 		%{
-		if ( smb2_file_fullea ) 
+		if ( smb2_file_fullea )
 			{
-			VectorVal* eas = new VectorVal(BifType::Vector::SMB2::FileEAs);
+			auto eas = make_intrusive<VectorVal>(BifType::Vector::SMB2::FileEAs);
 
 			for ( auto i = 0u; i < ${val.ea_vector}->size(); ++i )
 				{
-				RecordVal* r = new RecordVal(BifType::Record::SMB2::FileEA);
+				auto r = make_intrusive<RecordVal>(BifType::Record::SMB2::FileEA);
 				r->Assign(0, smb2_string2stringval(${val.ea_vector[i].ea_name}));
 				r->Assign(1, smb2_string2stringval(${val.ea_vector[i].ea_value}));
 
-				eas->Assign(i, r);
+				eas->Assign(i, std::move(r));
 				}
 
-			BifEvent::generate_smb2_file_fullea(bro_analyzer(),
-			                                    bro_analyzer()->Conn(),
-			                                    BuildSMB2HeaderVal(${val.sir.header}),
-			                                    BuildSMB2GUID(${val.sir.file_id}),
-			                                    eas);
+			BifEvent::enqueue_smb2_file_fullea(bro_analyzer(),
+			                                   bro_analyzer()->Conn(),
+			                                   {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                   {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+											   std::move(eas));
 			}
 
 		return true;
@@ -117,12 +117,12 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_link(val: SMB2_file_link_info): bool
 		%{
 		if ( smb2_file_link )
-			BifEvent::generate_smb2_file_link(bro_analyzer(),
-			                                  bro_analyzer()->Conn(),
-			                                  BuildSMB2HeaderVal(${val.sir.header}),
-			                                  BuildSMB2GUID(${val.sir.file_id}),
-			                                  ${val.root_directory},
-			                                  smb2_string2stringval(${val.file_name}));
+			BifEvent::enqueue_smb2_file_link(bro_analyzer(),
+			                                 bro_analyzer()->Conn(),
+			                                 {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                 {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                 ${val.root_directory},
+			                                 {AdoptRef{}, smb2_string2stringval(${val.file_name})});
 
 		return true;
 		%}
@@ -130,11 +130,11 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_mode(val: SMB2_file_mode_info): bool
 		%{
 		if ( smb2_file_mode )
-			BifEvent::generate_smb2_file_mode(bro_analyzer(),
-			                                    bro_analyzer()->Conn(),
-			                                    BuildSMB2HeaderVal(${val.sir.header}),
-			                                    BuildSMB2GUID(${val.sir.file_id}),
-			                                    ${val.mode});
+			BifEvent::enqueue_smb2_file_mode(bro_analyzer(),
+			                                 bro_analyzer()->Conn(),
+			                                 {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                 {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                 ${val.mode});
 
 		return true;
 		%}
@@ -142,11 +142,11 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_pipe(val: SMB2_file_pipe_info): bool
 		%{
 		if ( smb2_file_pipe )
-			BifEvent::generate_smb2_file_pipe(bro_analyzer(),
-			                                    bro_analyzer()->Conn(),
-			                                    BuildSMB2HeaderVal(${val.sir.header}),
-			                                    BuildSMB2GUID(${val.sir.file_id}),
-			                                    ${val.read_mode},
+			BifEvent::enqueue_smb2_file_pipe(bro_analyzer(),
+			                                 bro_analyzer()->Conn(),
+			                                 {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                 {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                 ${val.read_mode},
 			                                    ${val.completion_mode});
 
 		return true;
@@ -155,11 +155,11 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_position(val: SMB2_file_position_info): bool
 		%{
 		if ( smb2_file_position )
-			BifEvent::generate_smb2_file_position(bro_analyzer(),
-			                                      bro_analyzer()->Conn(),
-			                                      BuildSMB2HeaderVal(${val.sir.header}),
-			                                      BuildSMB2GUID(${val.sir.file_id}),
-			                                      ${val.current_byte_offset});
+			BifEvent::enqueue_smb2_file_position(bro_analyzer(),
+			                                     bro_analyzer()->Conn(),
+			                                     {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                     {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                     ${val.current_byte_offset});
 
 		return true;
 		%}
@@ -167,11 +167,11 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_shortname(val: SMB2_file_shortname_info): bool
 		%{
 		if ( smb2_file_shortname )
-			BifEvent::generate_smb2_file_shortname(bro_analyzer(),
-			                                       bro_analyzer()->Conn(),
-			                                       BuildSMB2HeaderVal(${val.sir.header}),
-			                                       BuildSMB2GUID(${val.sir.file_id}),
-			                                       smb2_string2stringval(${val.filename}));
+			BifEvent::enqueue_smb2_file_shortname(bro_analyzer(),
+			                                      bro_analyzer()->Conn(),
+			                                      {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                      {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                      {AdoptRef{}, smb2_string2stringval(${val.filename})});
 
 		return true;
 		%}
@@ -179,11 +179,11 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_validdatalength(val: SMB2_file_validdatalength_info): bool
 		%{
 		if ( smb2_file_validdatalength )
-			BifEvent::generate_smb2_file_validdatalength(bro_analyzer(),
-			                                             bro_analyzer()->Conn(),
-			                                             BuildSMB2HeaderVal(${val.sir.header}),
-			                                             BuildSMB2GUID(${val.sir.file_id}),
-			                                             ${val.validdatalength});
+			BifEvent::enqueue_smb2_file_validdatalength(bro_analyzer(),
+			                                            bro_analyzer()->Conn(),
+			                                            {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                            {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                            ${val.validdatalength});
 
 		return true;
 		%}
@@ -192,7 +192,7 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb2_file_fscontrol )
 			{
-			RecordVal* r = new RecordVal(BifType::Record::SMB2::Fscontrol);
+			auto r = make_intrusive<RecordVal>(BifType::Record::SMB2::Fscontrol);
 			r->Assign(0, val_mgr->Int(${val.free_space_start_filtering}));
 			r->Assign(1, val_mgr->Int(${val.free_space_start_threshold}));
 			r->Assign(2, val_mgr->Int(${val.free_space_stop_filtering}));
@@ -200,11 +200,11 @@ refine connection SMB_Conn += {
 			r->Assign(4, val_mgr->Count(${val.default_quota_limit}));
 			r->Assign(5, val_mgr->Count(${val.file_system_control_flags}));
 
-			BifEvent::generate_smb2_file_fscontrol(bro_analyzer(),
-			                                       bro_analyzer()->Conn(),
-			                                       BuildSMB2HeaderVal(${val.sir.header}),
-			                                       BuildSMB2GUID(${val.sir.file_id}),
-			                                       r);
+			BifEvent::enqueue_smb2_file_fscontrol(bro_analyzer(),
+			                                      bro_analyzer()->Conn(),
+			                                      {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                      {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+												  std::move(r));
 			}
 
 		return true;
@@ -213,12 +213,12 @@ refine connection SMB_Conn += {
 	function proc_smb2_set_info_request_file_fsobjectid(val: SMB2_file_fsobjectid_info): bool
 		%{
 		if ( smb2_file_fsobjectid )
-			BifEvent::generate_smb2_file_fsobjectid(bro_analyzer(),
-			                                        bro_analyzer()->Conn(),
-			                                        BuildSMB2HeaderVal(${val.sir.header}),
-			                                        BuildSMB2GUID(${val.sir.file_id}),
-			                                        BuildSMB2GUID(${val.object_id}),
-			                                        smb2_string2stringval(${val.extended_info}));
+			BifEvent::enqueue_smb2_file_fsobjectid(bro_analyzer(),
+			                                       bro_analyzer()->Conn(),
+			                                       {AdoptRef{}, BuildSMB2HeaderVal(${val.sir.header})},
+			                                       {AdoptRef{}, BuildSMB2GUID(${val.sir.file_id})},
+			                                       {AdoptRef{}, BuildSMB2GUID(${val.object_id})},
+			                                       {AdoptRef{}, smb2_string2stringval(${val.extended_info})});
 
 		return true;
 		%}

--- a/src/analyzer/protocol/smb/smb2-com-transform-header.pac
+++ b/src/analyzer/protocol/smb/smb2-com-transform-header.pac
@@ -6,9 +6,9 @@ refine connection SMB_Conn += {
 
 		r->Assign(0, bytestring_to_val(${hdr.signature}));
 		r->Assign(1, bytestring_to_val(${hdr.nonce}));
-		r->Assign(2, val_mgr->GetCount(${hdr.orig_msg_size}));
-		r->Assign(3, val_mgr->GetCount(${hdr.flags}));
-		r->Assign(4, val_mgr->GetCount(${hdr.session_id}));
+		r->Assign(2, val_mgr->Count(${hdr.orig_msg_size}));
+		r->Assign(3, val_mgr->Count(${hdr.flags}));
+		r->Assign(4, val_mgr->Count(${hdr.session_id}));
 
 		return r;
 		%}

--- a/src/analyzer/protocol/smb/smb2-com-transform-header.pac
+++ b/src/analyzer/protocol/smb/smb2-com-transform-header.pac
@@ -16,9 +16,9 @@ refine connection SMB_Conn += {
 	function proc_smb2_transform_header(hdr: SMB2_transform_header) : bool
 		%{
 		if ( smb2_transform_header )
-			BifEvent::generate_smb2_transform_header(bro_analyzer(),
-			                                         bro_analyzer()->Conn(),
-			                                         BuildSMB2TransformHeaderVal(hdr));
+			BifEvent::enqueue_smb2_transform_header(bro_analyzer(),
+			                                        bro_analyzer()->Conn(),
+			                                        {AdoptRef{}, BuildSMB2TransformHeaderVal(hdr)});
 
 		return true;
 		%}

--- a/src/analyzer/protocol/smb/smb2-com-transform-header.pac
+++ b/src/analyzer/protocol/smb/smb2-com-transform-header.pac
@@ -4,8 +4,8 @@ refine connection SMB_Conn += {
 		%{
 		RecordVal* r = new RecordVal(BifType::Record::SMB2::Transform_header);
 
-		r->Assign(0, bytestring_to_val(${hdr.signature}));
-		r->Assign(1, bytestring_to_val(${hdr.nonce}));
+		r->Assign(0, to_stringval(${hdr.signature}));
+		r->Assign(1, to_stringval(${hdr.nonce}));
 		r->Assign(2, val_mgr->Count(${hdr.orig_msg_size}));
 		r->Assign(3, val_mgr->Count(${hdr.flags}));
 		r->Assign(4, val_mgr->Count(${hdr.session_id}));

--- a/src/analyzer/protocol/smb/smb2-com-tree-connect.pac
+++ b/src/analyzer/protocol/smb/smb2-com-tree-connect.pac
@@ -19,7 +19,7 @@ refine connection SMB_Conn += {
 		if ( smb2_tree_connect_response )
 			{
 			RecordVal* resp = new RecordVal(BifType::Record::SMB2::TreeConnectResponse);
-			resp->Assign(0, val_mgr->GetCount(${val.share_type}));
+			resp->Assign(0, val_mgr->Count(${val.share_type}));
 
 			BifEvent::generate_smb2_tree_connect_response(bro_analyzer(),
 			                                              bro_analyzer()->Conn(),

--- a/src/analyzer/protocol/smb/smb2-com-tree-connect.pac
+++ b/src/analyzer/protocol/smb/smb2-com-tree-connect.pac
@@ -3,10 +3,10 @@ refine connection SMB_Conn += {
 	function proc_smb2_tree_connect_request(header: SMB2_Header, val: SMB2_tree_connect_request): bool
 		%{
 		if ( smb2_tree_connect_request )
-			BifEvent::generate_smb2_tree_connect_request(bro_analyzer(),
-			                                             bro_analyzer()->Conn(),
-			                                             BuildSMB2HeaderVal(header),
-			                                             smb2_string2stringval(${val.path}));
+			BifEvent::enqueue_smb2_tree_connect_request(bro_analyzer(),
+			                                            bro_analyzer()->Conn(),
+			                                            {AdoptRef{}, BuildSMB2HeaderVal(header)},
+			                                            {AdoptRef{}, smb2_string2stringval(${val.path})});
 
 		return true;
 		%}
@@ -18,13 +18,13 @@ refine connection SMB_Conn += {
 
 		if ( smb2_tree_connect_response )
 			{
-			RecordVal* resp = new RecordVal(BifType::Record::SMB2::TreeConnectResponse);
+			auto resp = make_intrusive<RecordVal>(BifType::Record::SMB2::TreeConnectResponse);
 			resp->Assign(0, val_mgr->Count(${val.share_type}));
 
-			BifEvent::generate_smb2_tree_connect_response(bro_analyzer(),
-			                                              bro_analyzer()->Conn(),
-			                                              BuildSMB2HeaderVal(header),
-			                                              resp);
+			BifEvent::enqueue_smb2_tree_connect_response(bro_analyzer(),
+			                                             bro_analyzer()->Conn(),
+			                                             {AdoptRef{}, BuildSMB2HeaderVal(header)},
+														 std::move(resp));
 			}
 
 		return true;

--- a/src/analyzer/protocol/smb/smb2-com-tree-disconnect.pac
+++ b/src/analyzer/protocol/smb/smb2-com-tree-disconnect.pac
@@ -7,9 +7,9 @@ refine connection SMB_Conn += {
 
 		if ( smb2_tree_disconnect_request )
 			{
-			BifEvent::generate_smb2_tree_disconnect_request(bro_analyzer(),
-			                                                bro_analyzer()->Conn(),
-			                                                BuildSMB2HeaderVal(header));
+			BifEvent::enqueue_smb2_tree_disconnect_request(bro_analyzer(),
+			                                               bro_analyzer()->Conn(),
+			                                               {AdoptRef{}, BuildSMB2HeaderVal(header)});
 			}
 
 		return true;
@@ -19,9 +19,9 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb2_tree_disconnect_response )
 			{
-			BifEvent::generate_smb2_tree_disconnect_response(bro_analyzer(),
-			                                                 bro_analyzer()->Conn(),
-			                                                 BuildSMB2HeaderVal(header));
+			BifEvent::enqueue_smb2_tree_disconnect_response(bro_analyzer(),
+			                                                bro_analyzer()->Conn(),
+			                                                {AdoptRef{}, BuildSMB2HeaderVal(header)});
 			}
 
 		return true;

--- a/src/analyzer/protocol/smb/smb2-com-write.pac
+++ b/src/analyzer/protocol/smb/smb2-com-write.pac
@@ -4,12 +4,12 @@ refine connection SMB_Conn += {
 		%{
 		if ( smb2_write_request )
 			{
-			BifEvent::generate_smb2_write_request(bro_analyzer(),
-			                                      bro_analyzer()->Conn(),
-			                                      BuildSMB2HeaderVal(h),
-			                                      BuildSMB2GUID(${val.file_id}),
-			                                      ${val.offset},
-			                                      ${val.data_len});
+			BifEvent::enqueue_smb2_write_request(bro_analyzer(),
+			                                     bro_analyzer()->Conn(),
+			                                     {AdoptRef{}, BuildSMB2HeaderVal(h)},
+			                                     {AdoptRef{}, BuildSMB2GUID(${val.file_id})},
+			                                     ${val.offset},
+			                                     ${val.data_len});
 			}
 
 		if ( ! ${h.is_pipe} && ${val.data}.length() > 0 )
@@ -27,10 +27,10 @@ refine connection SMB_Conn += {
 
 		if ( smb2_write_response )
 			{
-			BifEvent::generate_smb2_write_response(bro_analyzer(),
+			BifEvent::enqueue_smb2_write_response(bro_analyzer(),
 			                                      bro_analyzer()->Conn(),
-			                                      BuildSMB2HeaderVal(h),
-							      ${val.write_count});
+			                                      {AdoptRef{}, BuildSMB2HeaderVal(h)},
+			                                      ${val.write_count});
 			}
 
 		return true;

--- a/src/analyzer/protocol/smb/smb2-protocol.pac
+++ b/src/analyzer/protocol/smb/smb2-protocol.pac
@@ -215,9 +215,9 @@ refine connection SMB_Conn += {
 
 		if ( smb2_message )
 			{
-			BifEvent::generate_smb2_message(bro_analyzer(), bro_analyzer()->Conn(),
-			                                BuildSMB2HeaderVal(h),
-			                                is_orig);
+			BifEvent::enqueue_smb2_message(bro_analyzer(), bro_analyzer()->Conn(),
+			                               {AdoptRef{}, BuildSMB2HeaderVal(h)},
+			                               is_orig);
 			}
 		return true;
 		%}

--- a/src/analyzer/protocol/smb/smb2-protocol.pac
+++ b/src/analyzer/protocol/smb/smb2-protocol.pac
@@ -238,21 +238,21 @@ function smb2_file_attrs_to_bro(val: SMB2_file_attributes): BroVal
 	%{
 	RecordVal* r = new RecordVal(BifType::Record::SMB2::FileAttrs);
 
-	r->Assign(0, val_mgr->GetBool(${val.read_only}));
-	r->Assign(1, val_mgr->GetBool(${val.hidden}));
-	r->Assign(2, val_mgr->GetBool(${val.system}));
-	r->Assign(3, val_mgr->GetBool(${val.directory}));
-	r->Assign(4, val_mgr->GetBool(${val.archive}));
-	r->Assign(5, val_mgr->GetBool(${val.normal}));
-	r->Assign(6, val_mgr->GetBool(${val.temporary}));
-	r->Assign(7, val_mgr->GetBool(${val.sparse_file}));
-	r->Assign(8, val_mgr->GetBool(${val.reparse_point}));
-	r->Assign(9, val_mgr->GetBool(${val.compressed}));
-	r->Assign(10, val_mgr->GetBool(${val.offline}));
-	r->Assign(11, val_mgr->GetBool(${val.not_content_indexed}));
-	r->Assign(12, val_mgr->GetBool(${val.encrypted}));
-	r->Assign(13, val_mgr->GetBool(${val.integrity_stream}));
-	r->Assign(14, val_mgr->GetBool(${val.no_scrub_data}));
+	r->Assign(0, val_mgr->Bool(${val.read_only}));
+	r->Assign(1, val_mgr->Bool(${val.hidden}));
+	r->Assign(2, val_mgr->Bool(${val.system}));
+	r->Assign(3, val_mgr->Bool(${val.directory}));
+	r->Assign(4, val_mgr->Bool(${val.archive}));
+	r->Assign(5, val_mgr->Bool(${val.normal}));
+	r->Assign(6, val_mgr->Bool(${val.temporary}));
+	r->Assign(7, val_mgr->Bool(${val.sparse_file}));
+	r->Assign(8, val_mgr->Bool(${val.reparse_point}));
+	r->Assign(9, val_mgr->Bool(${val.compressed}));
+	r->Assign(10, val_mgr->Bool(${val.offline}));
+	r->Assign(11, val_mgr->Bool(${val.not_content_indexed}));
+	r->Assign(12, val_mgr->Bool(${val.encrypted}));
+	r->Assign(13, val_mgr->Bool(${val.integrity_stream}));
+	r->Assign(14, val_mgr->Bool(${val.no_scrub_data}));
 
 	return r;
 	%}

--- a/src/analyzer/protocol/smb/smb2-protocol.pac
+++ b/src/analyzer/protocol/smb/smb2-protocol.pac
@@ -104,20 +104,20 @@ refine connection SMB_Conn += {
 		%{
 		RecordVal* r = new RecordVal(BifType::Record::SMB2::NegotiateContextValue);
 
-		r->Assign(0, val_mgr->GetCount(${ncv.context_type}));
-		r->Assign(1, val_mgr->GetCount(${ncv.data_length}));
+		r->Assign(0, val_mgr->Count(${ncv.context_type}));
+		r->Assign(1, val_mgr->Count(${ncv.data_length}));
 
 		switch ( ${ncv.context_type} ) {
 			case SMB2_PREAUTH_INTEGRITY_CAPABILITIES:
 				{
 				RecordVal* rpreauth = new RecordVal(BifType::Record::SMB2::PreAuthIntegrityCapabilities);
-				rpreauth->Assign(0, val_mgr->GetCount(${ncv.preauth_integrity_capabilities.hash_alg_count}));
-				rpreauth->Assign(1, val_mgr->GetCount(${ncv.preauth_integrity_capabilities.salt_length}));
+				rpreauth->Assign(0, val_mgr->Count(${ncv.preauth_integrity_capabilities.hash_alg_count}));
+				rpreauth->Assign(1, val_mgr->Count(${ncv.preauth_integrity_capabilities.salt_length}));
 
 				VectorVal* ha = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 				for ( int i = 0; i < (${ncv.preauth_integrity_capabilities.hash_alg_count}); ++i )
-						ha->Assign(i, val_mgr->GetCount(${ncv.preauth_integrity_capabilities.hash_alg[i]}));
+						ha->Assign(i, val_mgr->Count(${ncv.preauth_integrity_capabilities.hash_alg[i]}));
 
 				rpreauth->Assign(2, ha);
 				rpreauth->Assign(3, bytestring_to_val(${ncv.preauth_integrity_capabilities.salt}));
@@ -128,12 +128,12 @@ refine connection SMB_Conn += {
 			case SMB2_ENCRYPTION_CAPABILITIES:
 				{
 				RecordVal* rencr = new RecordVal(BifType::Record::SMB2::EncryptionCapabilities);
-				rencr->Assign(0, val_mgr->GetCount(${ncv.encryption_capabilities.cipher_count}));
+				rencr->Assign(0, val_mgr->Count(${ncv.encryption_capabilities.cipher_count}));
 
 				VectorVal* c = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 				for ( int i = 0; i < (${ncv.encryption_capabilities.cipher_count}); ++i )
-						c->Assign(i, val_mgr->GetCount(${ncv.encryption_capabilities.ciphers[i]}));
+						c->Assign(i, val_mgr->Count(${ncv.encryption_capabilities.ciphers[i]}));
 
 				rencr->Assign(1, c);
 				r->Assign(3, rencr);
@@ -143,12 +143,12 @@ refine connection SMB_Conn += {
 			case SMB2_COMPRESSION_CAPABILITIES:
 				{
 				RecordVal* rcomp = new RecordVal(BifType::Record::SMB2::CompressionCapabilities);
-				rcomp->Assign(0, val_mgr->GetCount(${ncv.compression_capabilities.alg_count}));
+				rcomp->Assign(0, val_mgr->Count(${ncv.compression_capabilities.alg_count}));
 
 				VectorVal* c = new VectorVal(internal_type("index_vec")->AsVectorType());
 
 				for ( int i = 0; i < (${ncv.compression_capabilities.alg_count}); ++i )
-						c->Assign(i, val_mgr->GetCount(${ncv.compression_capabilities.algs[i]}));
+						c->Assign(i, val_mgr->Count(${ncv.compression_capabilities.algs[i]}));
 
 				rcomp->Assign(1, c);
 				r->Assign(4, rcomp);
@@ -172,15 +172,15 @@ refine connection SMB_Conn += {
 		%{
 		RecordVal* r = new RecordVal(BifType::Record::SMB2::Header);
 
-		r->Assign(0, val_mgr->GetCount(${hdr.credit_charge}));
-		r->Assign(1, val_mgr->GetCount(${hdr.status}));
-		r->Assign(2, val_mgr->GetCount(${hdr.command}));
-		r->Assign(3, val_mgr->GetCount(${hdr.credits}));
-		r->Assign(4, val_mgr->GetCount(${hdr.flags}));
-		r->Assign(5, val_mgr->GetCount(${hdr.message_id}));
-		r->Assign(6, val_mgr->GetCount(${hdr.process_id}));
-		r->Assign(7, val_mgr->GetCount(${hdr.tree_id}));
-		r->Assign(8, val_mgr->GetCount(${hdr.session_id}));
+		r->Assign(0, val_mgr->Count(${hdr.credit_charge}));
+		r->Assign(1, val_mgr->Count(${hdr.status}));
+		r->Assign(2, val_mgr->Count(${hdr.command}));
+		r->Assign(3, val_mgr->Count(${hdr.credits}));
+		r->Assign(4, val_mgr->Count(${hdr.flags}));
+		r->Assign(5, val_mgr->Count(${hdr.message_id}));
+		r->Assign(6, val_mgr->Count(${hdr.process_id}));
+		r->Assign(7, val_mgr->Count(${hdr.tree_id}));
+		r->Assign(8, val_mgr->Count(${hdr.session_id}));
 		r->Assign(9, bytestring_to_val(${hdr.signature}));
 
 		return r;
@@ -190,8 +190,8 @@ refine connection SMB_Conn += {
 		%{
 		RecordVal* r = new RecordVal(BifType::Record::SMB2::GUID);
 
-		r->Assign(0, val_mgr->GetCount(${file_id.persistent}));
-		r->Assign(1, val_mgr->GetCount(${file_id._volatile}));
+		r->Assign(0, val_mgr->Count(${file_id.persistent}));
+		r->Assign(1, val_mgr->Count(${file_id._volatile}));
 
 		return r;
 		%}

--- a/src/analyzer/protocol/smb/smb2-protocol.pac
+++ b/src/analyzer/protocol/smb/smb2-protocol.pac
@@ -120,7 +120,7 @@ refine connection SMB_Conn += {
 						ha->Assign(i, val_mgr->Count(${ncv.preauth_integrity_capabilities.hash_alg[i]}));
 
 				rpreauth->Assign(2, ha);
-				rpreauth->Assign(3, bytestring_to_val(${ncv.preauth_integrity_capabilities.salt}));
+				rpreauth->Assign(3, to_stringval(${ncv.preauth_integrity_capabilities.salt}));
 				r->Assign(2, rpreauth);
 				}
 				break;
@@ -157,7 +157,7 @@ refine connection SMB_Conn += {
 
 			case SMB2_NETNAME_NEGOTIATE_CONTEXT_ID:
 				{
-				r->Assign(5, bytestring_to_val(${ncv.netname_negotiate_context_id.net_name}));
+				r->Assign(5, to_stringval(${ncv.netname_negotiate_context_id.net_name}));
 				}
 				break;
 
@@ -181,7 +181,7 @@ refine connection SMB_Conn += {
 		r->Assign(6, val_mgr->Count(${hdr.process_id}));
 		r->Assign(7, val_mgr->Count(${hdr.tree_id}));
 		r->Assign(8, val_mgr->Count(${hdr.session_id}));
-		r->Assign(9, bytestring_to_val(${hdr.signature}));
+		r->Assign(9, to_stringval(${hdr.signature}));
 
 		return r;
 		%}

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -221,7 +221,7 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 				{
 				EnqueueConnEvent(smtp_data,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(data_len, line)
 				);
 				}
@@ -351,11 +351,11 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 
 				EnqueueConnEvent(smtp_reply,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig)},
+					val_mgr->Bool(orig),
 					IntrusivePtr{AdoptRef{}, val_mgr->GetCount(reply_code)},
 					make_intrusive<StringVal>(cmd),
 					make_intrusive<StringVal>(end_of_line - line, line),
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool((pending_reply > 0))}
+					val_mgr->Bool((pending_reply > 0))
 				);
 				}
 			}
@@ -860,7 +860,7 @@ void SMTP_Analyzer::RequestEvent(int cmd_len, const char* cmd,
 
 		EnqueueConnEvent(smtp_request,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(orig_is_sender)},
+			val_mgr->Bool(orig_is_sender),
 			std::move(cmd_arg),
 			make_intrusive<StringVal>(arg_len, arg)
 		);
@@ -881,7 +881,7 @@ void SMTP_Analyzer::Unexpected(bool is_sender, const char* msg,
 
 		EnqueueConnEvent(smtp_unexpected,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+			val_mgr->Bool(is_orig),
 			make_intrusive<StringVal>(msg),
 			make_intrusive<StringVal>(detail_len, detail)
 		);

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -352,7 +352,7 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 				EnqueueConnEvent(smtp_reply,
 					IntrusivePtr{AdoptRef{}, BuildConnVal()},
 					val_mgr->Bool(orig),
-					IntrusivePtr{AdoptRef{}, val_mgr->GetCount(reply_code)},
+					val_mgr->Count(reply_code),
 					make_intrusive<StringVal>(cmd),
 					make_intrusive<StringVal>(end_of_line - line, line),
 					val_mgr->Bool((pending_reply > 0))

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -220,7 +220,7 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 			if ( smtp_data && ! skip_data )
 				{
 				EnqueueConnEvent(smtp_data,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(data_len, line)
 				);
@@ -350,7 +350,7 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 				}
 
 				EnqueueConnEvent(smtp_reply,
-					IntrusivePtr{AdoptRef{}, BuildConnVal()},
+					ConnVal(),
 					val_mgr->Bool(orig),
 					val_mgr->Count(reply_code),
 					make_intrusive<StringVal>(cmd),
@@ -410,7 +410,7 @@ void SMTP_Analyzer::StartTLS()
 		AddChildAnalyzer(ssl);
 
 	if ( smtp_starttls )
-		EnqueueConnEvent(smtp_starttls, IntrusivePtr{AdoptRef{}, BuildConnVal()});
+		EnqueueConnEvent(smtp_starttls, ConnVal());
 	}
 
 
@@ -859,7 +859,7 @@ void SMTP_Analyzer::RequestEvent(int cmd_len, const char* cmd,
 		cmd_arg->ToUpper();
 
 		EnqueueConnEvent(smtp_request,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(orig_is_sender),
 			std::move(cmd_arg),
 			make_intrusive<StringVal>(arg_len, arg)
@@ -880,7 +880,7 @@ void SMTP_Analyzer::Unexpected(bool is_sender, const char* msg,
 			is_orig = ! is_orig;
 
 		EnqueueConnEvent(smtp_unexpected,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(is_orig),
 			make_intrusive<StringVal>(msg),
 			make_intrusive<StringVal>(detail_len, detail)

--- a/src/analyzer/protocol/smtp/functions.bif
+++ b/src/analyzer/protocol/smtp/functions.bif
@@ -13,5 +13,5 @@ function skip_smtp_data%(c: connection%): any
 	analyzer::Analyzer* sa = c->FindAnalyzer("SMTP");
 	if ( sa )
 		static_cast<analyzer::smtp::SMTP_Analyzer*>(sa)->SkipData();
-	return 0;
+	return nullptr;
 	%}

--- a/src/analyzer/protocol/snmp/snmp-analyzer.pac
+++ b/src/analyzer/protocol/snmp/snmp-analyzer.pac
@@ -134,9 +134,9 @@ RecordVal* build_hdrV3(const Header* header)
 	v3->Assign(1, asn1_integer_to_val(global_data->max_size(),
 	                                        TYPE_COUNT));
 	v3->Assign(2, val_mgr->GetCount(flags_byte));
-	v3->Assign(3, val_mgr->GetBool(flags_byte & 0x01));
-	v3->Assign(4, val_mgr->GetBool(flags_byte & 0x02));
-	v3->Assign(5, val_mgr->GetBool(flags_byte & 0x04));
+	v3->Assign(3, val_mgr->Bool(flags_byte & 0x01));
+	v3->Assign(4, val_mgr->Bool(flags_byte & 0x02));
+	v3->Assign(5, val_mgr->Bool(flags_byte & 0x04));
 	v3->Assign(6, asn1_integer_to_val(global_data->security_model(),
 	                                        TYPE_COUNT));
 	v3->Assign(7, asn1_octet_string_to_val(v3hdr->security_parameters()));

--- a/src/analyzer/protocol/snmp/snmp-analyzer.pac
+++ b/src/analyzer/protocol/snmp/snmp-analyzer.pac
@@ -47,7 +47,7 @@ Val* asn1_obj_to_val(const ASN1Encoding* obj)
 	RecordVal* rval = new RecordVal(BifType::Record::SNMP::ObjectValue);
 	uint8 tag = obj->meta()->tag();
 
-	rval->Assign(0, val_mgr->GetCount(tag));
+	rval->Assign(0, val_mgr->Count(tag));
 
 	switch ( tag ) {
 	case VARBIND_UNSPECIFIED_TAG:
@@ -93,7 +93,7 @@ Val* time_ticks_to_val(const TimeTicks* tt)
 RecordVal* build_hdr(const Header* header)
 	{
 	RecordVal* rv = new RecordVal(BifType::Record::SNMP::Header);
-	rv->Assign(0, val_mgr->GetCount(header->version()));
+	rv->Assign(0, val_mgr->Count(header->version()));
 
 	switch ( header->version() ) {
 	case SNMPV1_TAG:
@@ -133,7 +133,7 @@ RecordVal* build_hdrV3(const Header* header)
 	v3->Assign(0, asn1_integer_to_val(global_data->id(), TYPE_COUNT));
 	v3->Assign(1, asn1_integer_to_val(global_data->max_size(),
 	                                        TYPE_COUNT));
-	v3->Assign(2, val_mgr->GetCount(flags_byte));
+	v3->Assign(2, val_mgr->Count(flags_byte));
 	v3->Assign(3, val_mgr->Bool(flags_byte & 0x01));
 	v3->Assign(4, val_mgr->Bool(flags_byte & 0x02));
 	v3->Assign(5, val_mgr->Bool(flags_byte & 0x04));

--- a/src/analyzer/protocol/socks/socks-analyzer.pac
+++ b/src/analyzer/protocol/socks/socks-analyzer.pac
@@ -111,7 +111,7 @@ refine connection SOCKS_Conn += {
 			                                 ${request.command},
 			                                 sa,
 			                                 val_mgr->GetPort(${request.port}, TRANSPORT_TCP),
-			                                 val_mgr->GetEmptyString());
+			                                 val_mgr->EmptyString()->Ref()->AsStringVal());
 		else
 			Unref(sa);
 

--- a/src/analyzer/protocol/socks/socks-analyzer.pac
+++ b/src/analyzer/protocol/socks/socks-analyzer.pac
@@ -35,7 +35,7 @@ refine connection SOCKS_Conn += {
 			                                 4,
 			                                 ${request.command},
 			                                 sa,
-			                                 val_mgr->GetPort(${request.port}, TRANSPORT_TCP),
+			                                 val_mgr->Port(${request.port}, TRANSPORT_TCP)->Ref()->AsPortVal(),
 			                                 array_to_string(${request.user}));
 			}
 
@@ -56,7 +56,7 @@ refine connection SOCKS_Conn += {
 			                               4,
 			                               ${reply.status},
 			                               sa,
-			                               val_mgr->GetPort(${reply.port}, TRANSPORT_TCP));
+			                               val_mgr->Port(${reply.port}, TRANSPORT_TCP)->Ref()->AsPortVal());
 			}
 
 		bro_analyzer()->ProtocolConfirmation();
@@ -110,7 +110,7 @@ refine connection SOCKS_Conn += {
 			                                 5,
 			                                 ${request.command},
 			                                 sa,
-			                                 val_mgr->GetPort(${request.port}, TRANSPORT_TCP),
+			                                 val_mgr->Port(${request.port}, TRANSPORT_TCP)->Ref()->AsPortVal(),
 			                                 val_mgr->EmptyString()->Ref()->AsStringVal());
 		else
 			Unref(sa);
@@ -152,7 +152,7 @@ refine connection SOCKS_Conn += {
 			                               5,
 			                               ${reply.reply},
 			                               sa,
-			                               val_mgr->GetPort(${reply.port}, TRANSPORT_TCP));
+			                               val_mgr->Port(${reply.port}, TRANSPORT_TCP)->Ref()->AsPortVal());
 		else
 			Unref(sa);
 

--- a/src/analyzer/protocol/ssh/SSH.cc
+++ b/src/analyzer/protocol/ssh/SSH.cc
@@ -91,9 +91,9 @@ void SSH_Analyzer::Undelivered(uint64_t seq, int len, bool orig)
 void SSH_Analyzer::ProcessEncryptedSegment(int len, bool orig)
 	{
 	if ( ssh_encrypted_packet )
-		BifEvent::generate_ssh_encrypted_packet(interp->bro_analyzer(),
-		                                        interp->bro_analyzer()->Conn(),
-		                                        orig, len);
+		BifEvent::enqueue_ssh_encrypted_packet(interp->bro_analyzer(),
+		                                       interp->bro_analyzer()->Conn(),
+		                                       orig, len);
 
 	if ( ! auth_decision_made )
 		ProcessEncrypted(len, orig);
@@ -132,9 +132,9 @@ void SSH_Analyzer::ProcessEncrypted(int len, bool orig)
 			{
 			auth_decision_made = true;
 			if ( ssh_auth_attempted )
-				BifEvent::generate_ssh_auth_attempted(interp->bro_analyzer(), interp->bro_analyzer()->Conn(), true);
+				BifEvent::enqueue_ssh_auth_attempted(interp->bro_analyzer(), interp->bro_analyzer()->Conn(), true);
 			if ( ssh_auth_successful )
-				BifEvent::generate_ssh_auth_successful(interp->bro_analyzer(), interp->bro_analyzer()->Conn(), true);
+				BifEvent::enqueue_ssh_auth_successful(interp->bro_analyzer(), interp->bro_analyzer()->Conn(), true);
 			return;
 			}
 
@@ -159,7 +159,7 @@ void SSH_Analyzer::ProcessEncrypted(int len, bool orig)
 		if ( len == userauth_failure_size )
 			{
 			if ( ssh_auth_attempted )
-				BifEvent::generate_ssh_auth_attempted(interp->bro_analyzer(), interp->bro_analyzer()->Conn(), false);
+				BifEvent::enqueue_ssh_auth_attempted(interp->bro_analyzer(), interp->bro_analyzer()->Conn(), false);
 			return;
 			}
 
@@ -168,9 +168,9 @@ void SSH_Analyzer::ProcessEncrypted(int len, bool orig)
 			{
 			auth_decision_made = true;
 			if ( ssh_auth_attempted )
-				BifEvent::generate_ssh_auth_attempted(interp->bro_analyzer(), interp->bro_analyzer()->Conn(), true);
+				BifEvent::enqueue_ssh_auth_attempted(interp->bro_analyzer(), interp->bro_analyzer()->Conn(), true);
 			if ( ssh_auth_successful )
-				BifEvent::generate_ssh_auth_successful(interp->bro_analyzer(), interp->bro_analyzer()->Conn(), false);
+				BifEvent::enqueue_ssh_auth_successful(interp->bro_analyzer(), interp->bro_analyzer()->Conn(), false);
 			return;
 			}
 		}

--- a/src/analyzer/protocol/ssh/ssh-analyzer.pac
+++ b/src/analyzer/protocol/ssh/ssh-analyzer.pac
@@ -101,7 +101,7 @@ refine flow SSH_Flow += {
 			}
 
 
-		result->Assign(6, val_mgr->GetBool(!${msg.is_orig}));
+		result->Assign(6, val_mgr->Bool(!${msg.is_orig}));
 
 		BifEvent::generate_ssh_capabilities(connection()->bro_analyzer(),
 			connection()->bro_analyzer()->Conn(), bytestring_to_val(${msg.cookie}),

--- a/src/analyzer/protocol/ssh/ssh-analyzer.pac
+++ b/src/analyzer/protocol/ssh/ssh-analyzer.pac
@@ -52,15 +52,15 @@ refine flow SSH_Flow += {
 		%{
 		if ( ssh_client_version && ${msg.is_orig } )
 			{
-			BifEvent::generate_ssh_client_version(connection()->bro_analyzer(), 
-				connection()->bro_analyzer()->Conn(), 
-				bytestring_to_val(${msg.version}));
+			BifEvent::enqueue_ssh_client_version(connection()->bro_analyzer(),
+				connection()->bro_analyzer()->Conn(),
+				to_stringval(${msg.version}));
 			}
 		else if ( ssh_server_version )
 			{
-			BifEvent::generate_ssh_server_version(connection()->bro_analyzer(), 
-				connection()->bro_analyzer()->Conn(), 
-				bytestring_to_val(${msg.version}));
+			BifEvent::enqueue_ssh_server_version(connection()->bro_analyzer(),
+				connection()->bro_analyzer()->Conn(),
+				to_stringval(${msg.version}));
 			}
 		return true;
 		%}
@@ -70,7 +70,7 @@ refine flow SSH_Flow += {
 		if ( ! ssh_capabilities )
 			return false;
 
-		RecordVal* result = new RecordVal(BifType::Record::SSH::Capabilities);
+		auto result = make_intrusive<RecordVal>(BifType::Record::SSH::Capabilities);
 		result->Assign(0, name_list_to_vector(${msg.kex_algorithms.val}));
 		result->Assign(1, name_list_to_vector(${msg.server_host_key_algorithms.val}));
 
@@ -103,8 +103,8 @@ refine flow SSH_Flow += {
 
 		result->Assign(6, val_mgr->Bool(!${msg.is_orig}));
 
-		BifEvent::generate_ssh_capabilities(connection()->bro_analyzer(),
-			connection()->bro_analyzer()->Conn(), bytestring_to_val(${msg.cookie}),
+		BifEvent::enqueue_ssh_capabilities(connection()->bro_analyzer(),
+			connection()->bro_analyzer()->Conn(), to_stringval(${msg.cookie}),
 			result);
 
 		return true;
@@ -115,9 +115,9 @@ refine flow SSH_Flow += {
 		%{
 		if ( ssh2_dh_server_params )
 			{
-			BifEvent::generate_ssh2_dh_server_params(connection()->bro_analyzer(),
+			BifEvent::enqueue_ssh2_dh_server_params(connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
-				bytestring_to_val(${msg.p.val}), bytestring_to_val(${msg.g.val}));
+				to_stringval(${msg.p.val}), to_stringval(${msg.g.val}));
 			}
 		return true;
 		%}
@@ -126,9 +126,9 @@ refine flow SSH_Flow += {
 		%{
 		if ( ssh2_ecc_key )
 			{
-			BifEvent::generate_ssh2_ecc_key(connection()->bro_analyzer(),
+			BifEvent::enqueue_ssh2_ecc_key(connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
-				is_orig, bytestring_to_val(q));
+				is_orig, to_stringval(q));
 			}
 		return true;
 		%}
@@ -137,10 +137,10 @@ refine flow SSH_Flow += {
 		%{
 		if ( ssh2_gss_error )
 			{
-			BifEvent::generate_ssh2_gss_error(connection()->bro_analyzer(),
+			BifEvent::enqueue_ssh2_gss_error(connection()->bro_analyzer(),
 				connection()->bro_analyzer()->Conn(),
 				${msg.major_status}, ${msg.minor_status},
-				bytestring_to_val(${msg.message.val}));
+				to_stringval(${msg.message.val}));
 			}
 		return true;
 		%}
@@ -149,9 +149,9 @@ refine flow SSH_Flow += {
 		%{
 		if ( ssh2_server_host_key )
 			{
-			BifEvent::generate_ssh2_server_host_key(connection()->bro_analyzer(), 
-				connection()->bro_analyzer()->Conn(), 
-				bytestring_to_val(${key}));
+			BifEvent::enqueue_ssh2_server_host_key(connection()->bro_analyzer(),
+				connection()->bro_analyzer()->Conn(),
+				to_stringval(${key}));
 			}
 		return true;
 		%}
@@ -160,10 +160,10 @@ refine flow SSH_Flow += {
 		%{
 		if ( ssh1_server_host_key )
 			{
-			BifEvent::generate_ssh1_server_host_key(connection()->bro_analyzer(), 
-				connection()->bro_analyzer()->Conn(), 
-				bytestring_to_val(${p}),
-				bytestring_to_val(${e}));
+			BifEvent::enqueue_ssh1_server_host_key(connection()->bro_analyzer(),
+				connection()->bro_analyzer()->Conn(),
+				to_stringval(${p}),
+				to_stringval(${e}));
 			}
 		return true;
 		%}

--- a/src/analyzer/protocol/ssl/functions.bif
+++ b/src/analyzer/protocol/ssl/functions.bif
@@ -14,5 +14,5 @@ function set_ssl_established%(c: connection%): any
 	analyzer::Analyzer* sa = c->FindAnalyzer("SSL");
 	if ( sa )
 		static_cast<analyzer::ssl::SSL_Analyzer*>(sa)->StartEncryption();
-	return 0;
+	return nullptr;
 	%}

--- a/src/analyzer/protocol/ssl/proc-client-hello.pac
+++ b/src/analyzer/protocol/ssl/proc-client-hello.pac
@@ -25,7 +25,7 @@
 			VectorVal* cipher_vec = new VectorVal(internal_type("index_vec")->AsVectorType());
 			for ( unsigned int i = 0; i < cipher_suites->size(); ++i )
 				{
-				Val* ciph = val_mgr->GetCount((*cipher_suites)[i]);
+				auto ciph = val_mgr->Count((*cipher_suites)[i]);
 				cipher_vec->Assign(i, ciph);
 				}
 
@@ -34,7 +34,7 @@
 				{
 				for ( unsigned int i = 0; i < compression_methods->size(); ++i )
 					{
-					Val* comp = val_mgr->GetCount((*compression_methods)[i]);
+					auto comp = val_mgr->Count((*compression_methods)[i]);
 					comp_vec->Assign(i, comp);
 					}
 				}

--- a/src/analyzer/protocol/ssl/proc-server-hello.pac
+++ b/src/analyzer/protocol/ssl/proc-server-hello.pac
@@ -25,11 +25,12 @@
 			if ( v2 == 0 && server_random.length() >= 4 )
 				ts = ntohl(*((uint32*)server_random.data()));
 
-			BifEvent::generate_ssl_server_hello(bro_analyzer(),
+			BifEvent::enqueue_ssl_server_hello(bro_analyzer(),
 							bro_analyzer()->Conn(),
-							version, record_version(), ts, new StringVal(server_random.length(),
-							(const char*) server_random.data()),
-							to_string_val(session_id),
+							version, record_version(), ts,
+							make_intrusive<StringVal>(server_random.length(),
+							                          (const char*) server_random.data()),
+							{AdoptRef{}, to_string_val(session_id)},
 							ciphers->size()==0 ? 0 : ciphers->at(0), comp_method);
 
 			delete ciphers;

--- a/src/analyzer/protocol/ssl/ssl-analyzer.pac
+++ b/src/analyzer/protocol/ssl/ssl-analyzer.pac
@@ -18,7 +18,7 @@ refine connection SSL_Conn += {
 	function proc_v2_client_master_key(rec: SSLRecord, cipher_kind: int) : bool
 		%{
 		if ( ssl_established )
-			BifEvent::generate_ssl_established(bro_analyzer(), bro_analyzer()->Conn());
+			BifEvent::enqueue_ssl_established(bro_analyzer(), bro_analyzer()->Conn());
 
 		return true;
 		%}

--- a/src/analyzer/protocol/ssl/ssl-dtls-analyzer.pac
+++ b/src/analyzer/protocol/ssl/ssl-dtls-analyzer.pac
@@ -32,7 +32,7 @@ refine connection SSL_Conn += {
 	function proc_alert(rec: SSLRecord, level : int, desc : int) : bool
 		%{
 		if ( ssl_alert )
-			BifEvent::generate_ssl_alert(bro_analyzer(), bro_analyzer()->Conn(),
+			BifEvent::enqueue_ssl_alert(bro_analyzer(), bro_analyzer()->Conn(),
 							${rec.is_orig}, level, desc);
 		return true;
 		%}
@@ -52,11 +52,11 @@ refine connection SSL_Conn += {
 			{
 			established_ = true;
 			if ( ssl_established )
-				BifEvent::generate_ssl_established(bro_analyzer(), bro_analyzer()->Conn());
+				BifEvent::enqueue_ssl_established(bro_analyzer(), bro_analyzer()->Conn());
 			}
 
 		if ( ssl_encrypted_data )
-			BifEvent::generate_ssl_encrypted_data(bro_analyzer(),
+			BifEvent::enqueue_ssl_encrypted_data(bro_analyzer(),
 				bro_analyzer()->Conn(), ${rec.is_orig}, ${rec.raw_tls_version}, ${rec.content_type}, ${rec.length});
 
 		return true;
@@ -65,7 +65,7 @@ refine connection SSL_Conn += {
 	function proc_plaintext_record(rec : SSLRecord) : bool
 		%{
 		if ( ssl_plaintext_data )
-			BifEvent::generate_ssl_plaintext_data(bro_analyzer(),
+			BifEvent::enqueue_ssl_plaintext_data(bro_analyzer(),
 				bro_analyzer()->Conn(), ${rec.is_orig}, ${rec.raw_tls_version}, ${rec.content_type}, ${rec.length});
 
 		return true;
@@ -74,9 +74,9 @@ refine connection SSL_Conn += {
 	function proc_heartbeat(rec : SSLRecord, type: uint8, payload_length: uint16, data: bytestring) : bool
 		%{
 		if ( ssl_heartbeat )
-			BifEvent::generate_ssl_heartbeat(bro_analyzer(),
+			BifEvent::enqueue_ssl_heartbeat(bro_analyzer(),
 				bro_analyzer()->Conn(), ${rec.is_orig}, ${rec.length}, type, payload_length,
-				new StringVal(data.length(), (const char*) data.data()));
+				make_intrusive<StringVal>(data.length(), (const char*) data.data()));
 		return true;
 		%}
 
@@ -96,7 +96,7 @@ refine connection SSL_Conn += {
 	function proc_ccs(rec: SSLRecord) : bool
 		%{
 		if ( ssl_change_cipher_spec )
-			BifEvent::generate_ssl_change_cipher_spec(bro_analyzer(),
+			BifEvent::enqueue_ssl_change_cipher_spec(bro_analyzer(),
 				bro_analyzer()->Conn(), ${rec.is_orig});
 
 		return true;

--- a/src/analyzer/protocol/ssl/tls-handshake-analyzer.pac
+++ b/src/analyzer/protocol/ssl/tls-handshake-analyzer.pac
@@ -34,10 +34,10 @@ refine connection Handshake_Conn += {
 		%{
 		if ( ssl_session_ticket_handshake )
 			{
-			BifEvent::generate_ssl_session_ticket_handshake(bro_analyzer(),
+			BifEvent::enqueue_ssl_session_ticket_handshake(bro_analyzer(),
 							bro_analyzer()->Conn(),
 							${rec.ticket_lifetime_hint},
-							new StringVal(${rec.data}.length(), (const char*) ${rec.data}.data()));
+							make_intrusive<StringVal>(${rec.data}.length(), (const char*) ${rec.data}.data()));
 			}
 		return true;
 		%}
@@ -64,9 +64,9 @@ refine connection Handshake_Conn += {
 		const unsigned char* data = sourcedata.begin() + 4;
 
 		if ( ssl_extension )
-			BifEvent::generate_ssl_extension(bro_analyzer(),
+			BifEvent::enqueue_ssl_extension(bro_analyzer(),
 						bro_analyzer()->Conn(), ${rec.is_orig}, type,
-						new StringVal(length, reinterpret_cast<const char*>(data)));
+						make_intrusive<StringVal>(length, reinterpret_cast<const char*>(data)));
 		return true;
 		%}
 
@@ -75,7 +75,7 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_ec_point_formats )
 			return true;
 
-		VectorVal* points = new VectorVal(internal_type("index_vec")->AsVectorType());
+		auto points = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 
 		if ( point_format_list )
 			{
@@ -83,8 +83,8 @@ refine connection Handshake_Conn += {
 				points->Assign(i, val_mgr->Count((*point_format_list)[i]));
 			}
 
-		BifEvent::generate_ssl_extension_ec_point_formats(bro_analyzer(), bro_analyzer()->Conn(),
-		   ${rec.is_orig}, points);
+		BifEvent::enqueue_ssl_extension_ec_point_formats(bro_analyzer(), bro_analyzer()->Conn(),
+		   ${rec.is_orig}, std::move(points));
 
 		return true;
 		%}
@@ -94,7 +94,7 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_elliptic_curves )
 			return true;
 
-		VectorVal* curves = new VectorVal(internal_type("index_vec")->AsVectorType());
+		auto curves = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 
 		if ( list )
 			{
@@ -102,8 +102,8 @@ refine connection Handshake_Conn += {
 				curves->Assign(i, val_mgr->Count((*list)[i]));
 			}
 
-		BifEvent::generate_ssl_extension_elliptic_curves(bro_analyzer(), bro_analyzer()->Conn(),
-		   ${rec.is_orig}, curves);
+		BifEvent::enqueue_ssl_extension_elliptic_curves(bro_analyzer(), bro_analyzer()->Conn(),
+		   ${rec.is_orig}, std::move(curves));
 
 		return true;
 		%}
@@ -113,7 +113,7 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_key_share )
 			return true;
 
-		VectorVal* nglist = new VectorVal(internal_type("index_vec")->AsVectorType());
+		auto nglist = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 
 		if ( keyshare )
 			{
@@ -121,7 +121,7 @@ refine connection Handshake_Conn += {
 				nglist->Assign(i, val_mgr->Count((*keyshare)[i]->namedgroup()));
 			}
 
-		BifEvent::generate_ssl_extension_key_share(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, nglist);
+		BifEvent::enqueue_ssl_extension_key_share(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, std::move(nglist));
 
 		return true;
 		%}
@@ -131,10 +131,10 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_key_share )
 			return true;
 
-		VectorVal* nglist = new VectorVal(internal_type("index_vec")->AsVectorType());
+		auto nglist = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 
 		nglist->Assign(0u, val_mgr->Count(keyshare->namedgroup()));
-		BifEvent::generate_ssl_extension_key_share(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, nglist);
+		BifEvent::enqueue_ssl_extension_key_share(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, std::move(nglist));
 		return true;
 		%}
 
@@ -143,10 +143,10 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_key_share )
 			return true;
 
-		VectorVal* nglist = new VectorVal(internal_type("index_vec")->AsVectorType());
+		auto nglist = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 
 		nglist->Assign(0u, val_mgr->Count(namedgroup));
-		BifEvent::generate_ssl_extension_key_share(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, nglist);
+		BifEvent::enqueue_ssl_extension_key_share(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, std::move(nglist));
 		return true;
 		%}
 
@@ -155,7 +155,7 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_signature_algorithm )
 			return true;
 
-		VectorVal* slist = new VectorVal(internal_type("signature_and_hashalgorithm_vec")->AsVectorType());
+		auto slist = make_intrusive<VectorVal>(internal_type("signature_and_hashalgorithm_vec")->AsVectorType());
 
 		if ( supported_signature_algorithms )
 			{
@@ -168,7 +168,7 @@ refine connection Handshake_Conn += {
 				}
 			}
 
-		BifEvent::generate_ssl_extension_signature_algorithm(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, slist);
+		BifEvent::enqueue_ssl_extension_signature_algorithm(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, std::move(slist));
 
 		return true;
 		%}
@@ -178,7 +178,7 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_application_layer_protocol_negotiation )
 			return true;
 
-		VectorVal* plist = new VectorVal(internal_type("string_vec")->AsVectorType());
+		auto plist = make_intrusive<VectorVal>(internal_type("string_vec")->AsVectorType());
 
 		if ( protocols )
 			{
@@ -186,15 +186,15 @@ refine connection Handshake_Conn += {
 				plist->Assign(i, make_intrusive<StringVal>((*protocols)[i]->name().length(), (const char*) (*protocols)[i]->name().data()));
 			}
 
-		BifEvent::generate_ssl_extension_application_layer_protocol_negotiation(bro_analyzer(), bro_analyzer()->Conn(),
-											${rec.is_orig}, plist);
+		BifEvent::enqueue_ssl_extension_application_layer_protocol_negotiation(bro_analyzer(), bro_analyzer()->Conn(),
+											${rec.is_orig}, std::move(plist));
 
 		return true;
 		%}
 
 	function proc_server_name(rec: HandshakeRecord, list: ServerName[]) : bool
 		%{
-		VectorVal* servers = new VectorVal(internal_type("string_vec")->AsVectorType());
+		auto servers = make_intrusive<VectorVal>(internal_type("string_vec")->AsVectorType());
 
 		if ( list )
 			{
@@ -215,10 +215,8 @@ refine connection Handshake_Conn += {
 			}
 
 		if ( ssl_extension_server_name )
-			BifEvent::generate_ssl_extension_server_name(bro_analyzer(), bro_analyzer()->Conn(),
-		   	   ${rec.is_orig}, servers);
-		else
-			Unref(servers);
+			BifEvent::enqueue_ssl_extension_server_name(bro_analyzer(), bro_analyzer()->Conn(),
+		   	   ${rec.is_orig}, std::move(servers));
 
 		return true;
 		%}
@@ -228,7 +226,7 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_supported_versions )
 			return true;
 
-		VectorVal* versions = new VectorVal(internal_type("index_vec")->AsVectorType());
+		auto versions = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 
 		if ( versions_list )
 			{
@@ -236,8 +234,8 @@ refine connection Handshake_Conn += {
 				versions->Assign(i, val_mgr->Count((*versions_list)[i]));
 			}
 
-		BifEvent::generate_ssl_extension_supported_versions(bro_analyzer(), bro_analyzer()->Conn(),
-			${rec.is_orig}, versions);
+		BifEvent::enqueue_ssl_extension_supported_versions(bro_analyzer(), bro_analyzer()->Conn(),
+			${rec.is_orig}, std::move(versions));
 
 		return true;
 		%}
@@ -247,11 +245,11 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_supported_versions )
 			return true;
 
-		VectorVal* versions = new VectorVal(internal_type("index_vec")->AsVectorType());
+		auto versions = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 		versions->Assign(0u, val_mgr->Count(version));
 
-		BifEvent::generate_ssl_extension_supported_versions(bro_analyzer(), bro_analyzer()->Conn(),
-			${rec.is_orig}, versions);
+		BifEvent::enqueue_ssl_extension_supported_versions(bro_analyzer(), bro_analyzer()->Conn(),
+			${rec.is_orig}, std::move(versions));
 
 		return true;
 		%}
@@ -261,7 +259,7 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_psk_key_exchange_modes )
 			return true;
 
-		VectorVal* modes = new VectorVal(internal_type("index_vec")->AsVectorType());
+		auto modes = make_intrusive<VectorVal>(internal_type("index_vec")->AsVectorType());
 
 		if ( mode_list )
 			{
@@ -269,8 +267,8 @@ refine connection Handshake_Conn += {
 				modes->Assign(i, val_mgr->Count((*mode_list)[i]));
 			}
 
-		BifEvent::generate_ssl_extension_psk_key_exchange_modes(bro_analyzer(), bro_analyzer()->Conn(),
-			${rec.is_orig}, modes);
+		BifEvent::enqueue_ssl_extension_psk_key_exchange_modes(bro_analyzer(), bro_analyzer()->Conn(),
+			${rec.is_orig}, std::move(modes));
 
 		return true;
 		%}
@@ -316,10 +314,10 @@ refine connection Handshake_Conn += {
 			                 bro_analyzer()->Conn(), false, file_id, "application/ocsp-response");
 
 			if ( ssl_stapled_ocsp )
-				BifEvent::generate_ssl_stapled_ocsp(bro_analyzer(),
+				BifEvent::enqueue_ssl_stapled_ocsp(bro_analyzer(),
 				        bro_analyzer()->Conn(),
 				        ${rec.is_orig},
-				        new StringVal(response.length(), (const char*) response.data()));
+				        make_intrusive<StringVal>(response.length(), (const char*) response.data()));
 
 			file_mgr->EndOfFile(file_id);
 			}
@@ -337,12 +335,15 @@ refine connection Handshake_Conn += {
 			return true;
 
 		if ( ssl_ecdh_server_params )
-			BifEvent::generate_ssl_ecdh_server_params(bro_analyzer(),
-				bro_analyzer()->Conn(), ${kex.params.curve}, new StringVal(${kex.params.point}.length(), (const char*)${kex.params.point}.data()));
+			BifEvent::enqueue_ssl_ecdh_server_params(bro_analyzer(),
+			                                         bro_analyzer()->Conn(),
+			                                         ${kex.params.curve},
+			                                         make_intrusive<StringVal>(${kex.params.point}.length(), (const char*)${kex.params.point}.data()));
 
 		if ( ssl_server_signature )
 			{
-			RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
+			auto ha = make_intrusive<RecordVal>(BifType::Record::SSL::SignatureAndHashAlgorithm);
+
 			if ( ${kex.signed_params.uses_signature_and_hashalgorithm} )
 				{
 				ha->Assign(0, val_mgr->Count(${kex.signed_params.algorithm.HashAlgorithm}));
@@ -355,8 +356,10 @@ refine connection Handshake_Conn += {
 				ha->Assign(1, val_mgr->Count(256));
 				}
 
-			BifEvent::generate_ssl_server_signature(bro_analyzer(),
-				bro_analyzer()->Conn(), ha, new StringVal(${kex.signed_params.signature}.length(), (const char*)(${kex.signed_params.signature}).data()));
+			BifEvent::enqueue_ssl_server_signature(bro_analyzer(),
+			                                       bro_analyzer()->Conn(),
+			                                       std::move(ha),
+			                                       make_intrusive<StringVal>(${kex.signed_params.signature}.length(), (const char*)(${kex.signed_params.signature}).data()));
 			}
 
 		return true;
@@ -368,8 +371,10 @@ refine connection Handshake_Conn += {
 			return true;
 
 		if ( ssl_ecdh_server_params )
-			BifEvent::generate_ssl_ecdh_server_params(bro_analyzer(),
-				bro_analyzer()->Conn(), ${kex.params.curve}, new StringVal(${kex.params.point}.length(), (const char*)${kex.params.point}.data()));
+			BifEvent::enqueue_ssl_ecdh_server_params(bro_analyzer(),
+			                                         bro_analyzer()->Conn(),
+			                                         ${kex.params.curve},
+			                                         make_intrusive<StringVal>(${kex.params.point}.length(), (const char*)${kex.params.point}.data()));
 
 		return true;
 		%}
@@ -377,7 +382,9 @@ refine connection Handshake_Conn += {
 	function proc_rsa_client_key_exchange(rec: HandshakeRecord, rsa_pms: bytestring) : bool
 		%{
 		if ( ssl_rsa_client_pms )
-			BifEvent::generate_ssl_rsa_client_pms(bro_analyzer(), bro_analyzer()->Conn(), new StringVal(rsa_pms.length(), (const char*)rsa_pms.data()));
+			BifEvent::enqueue_ssl_rsa_client_pms(bro_analyzer(),
+			                                     bro_analyzer()->Conn(),
+			                                     make_intrusive<StringVal>(rsa_pms.length(), (const char*)rsa_pms.data()));
 
 		return true;
 		%}
@@ -385,7 +392,9 @@ refine connection Handshake_Conn += {
 	function proc_dh_client_key_exchange(rec: HandshakeRecord, Yc: bytestring) : bool
 		%{
 		if ( ssl_dh_client_params )
-			BifEvent::generate_ssl_dh_client_params(bro_analyzer(), bro_analyzer()->Conn(), new StringVal(Yc.length(), (const char*)Yc.data()));
+			BifEvent::enqueue_ssl_dh_client_params(bro_analyzer(),
+			                                       bro_analyzer()->Conn(),
+			                                       make_intrusive<StringVal>(Yc.length(), (const char*)Yc.data()));
 
 		return true;
 		%}
@@ -393,7 +402,9 @@ refine connection Handshake_Conn += {
 	function proc_ecdh_client_key_exchange(rec: HandshakeRecord, point: bytestring) : bool
 		%{
 		if ( ssl_ecdh_client_params )
-			BifEvent::generate_ssl_ecdh_client_params(bro_analyzer(), bro_analyzer()->Conn(), new StringVal(point.length(), (const char*)point.data()));
+			BifEvent::enqueue_ssl_ecdh_client_params(bro_analyzer(),
+			                                         bro_analyzer()->Conn(),
+			                                         make_intrusive<StringVal>(point.length(), (const char*)point.data()));
 
 		return true;
 		%}
@@ -403,17 +414,17 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_signed_certificate_timestamp )
 			return true;
 
-		RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
+		auto ha = make_intrusive<RecordVal>(BifType::Record::SSL::SignatureAndHashAlgorithm);
 		ha->Assign(0, val_mgr->Count(digitally_signed_algorithms->HashAlgorithm()));
 		ha->Assign(1, val_mgr->Count(digitally_signed_algorithms->SignatureAlgorithm()));
 
-		BifEvent::generate_ssl_extension_signed_certificate_timestamp(bro_analyzer(),
+		BifEvent::enqueue_ssl_extension_signed_certificate_timestamp(bro_analyzer(),
 			bro_analyzer()->Conn(), ${rec.is_orig},
 			version,
-			new StringVal(logid.length(), reinterpret_cast<const char*>(logid.begin())),
+			make_intrusive<StringVal>(logid.length(), reinterpret_cast<const char*>(logid.begin())),
 			timestamp,
-			ha,
-			new StringVal(digitally_signed_signature.length(), reinterpret_cast<const char*>(digitally_signed_signature.begin()))
+			std::move(ha),
+			make_intrusive<StringVal>(digitally_signed_signature.length(), reinterpret_cast<const char*>(digitally_signed_signature.begin()))
 		);
 
 		return true;
@@ -422,16 +433,17 @@ refine connection Handshake_Conn += {
 	function proc_dhe_server_key_exchange(rec: HandshakeRecord, p: bytestring, g: bytestring, Ys: bytestring, signed_params: ServerKeyExchangeSignature) : bool
 		%{
 		if ( ssl_ecdh_server_params )
-			BifEvent::generate_ssl_dh_server_params(bro_analyzer(),
+			BifEvent::enqueue_ssl_dh_server_params(bro_analyzer(),
 			  bro_analyzer()->Conn(),
-			  new StringVal(p.length(), (const char*) p.data()),
-			  new StringVal(g.length(), (const char*) g.data()),
-			  new StringVal(Ys.length(), (const char*) Ys.data())
+			  make_intrusive<StringVal>(p.length(), (const char*) p.data()),
+			  make_intrusive<StringVal>(g.length(), (const char*) g.data()),
+			  make_intrusive<StringVal>(Ys.length(), (const char*) Ys.data())
 			  );
 
 		if ( ssl_server_signature )
 			{
-			RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
+			auto ha = make_intrusive<RecordVal>(BifType::Record::SSL::SignatureAndHashAlgorithm);
+
 			if ( ${signed_params.uses_signature_and_hashalgorithm} )
 				{
 				ha->Assign(0, val_mgr->Count(${signed_params.algorithm.HashAlgorithm}));
@@ -444,9 +456,9 @@ refine connection Handshake_Conn += {
 				ha->Assign(1, val_mgr->Count(256));
 				}
 
-			BifEvent::generate_ssl_server_signature(bro_analyzer(),
-			  bro_analyzer()->Conn(), ha,
-			  new StringVal(${signed_params.signature}.length(), (const char*)(${signed_params.signature}).data())
+			BifEvent::enqueue_ssl_server_signature(bro_analyzer(),
+			  bro_analyzer()->Conn(), std::move(ha),
+			  make_intrusive<StringVal>(${signed_params.signature}.length(), (const char*)(${signed_params.signature}).data())
 			  );
 			}
 
@@ -456,11 +468,11 @@ refine connection Handshake_Conn += {
 	function proc_dh_anon_server_key_exchange(rec: HandshakeRecord, p: bytestring, g: bytestring, Ys: bytestring) : bool
 		%{
 		if ( ssl_dh_server_params )
-			BifEvent::generate_ssl_dh_server_params(bro_analyzer(),
+			BifEvent::enqueue_ssl_dh_server_params(bro_analyzer(),
 			  bro_analyzer()->Conn(),
-			  new StringVal(p.length(), (const char*) p.data()),
-			  new StringVal(g.length(), (const char*) g.data()),
-			  new StringVal(Ys.length(), (const char*) Ys.data())
+			  make_intrusive<StringVal>(p.length(), (const char*) p.data()),
+			  make_intrusive<StringVal>(g.length(), (const char*) g.data()),
+			  make_intrusive<StringVal>(Ys.length(), (const char*) Ys.data())
 			  );
 
 		return true;
@@ -469,7 +481,7 @@ refine connection Handshake_Conn += {
 	function proc_handshake(is_orig: bool, msg_type: uint8, length: uint24) : bool
 		%{
 		if ( ssl_handshake_message )
-			BifEvent::generate_ssl_handshake_message(bro_analyzer(),
+			BifEvent::enqueue_ssl_handshake_message(bro_analyzer(),
 				bro_analyzer()->Conn(), is_orig, msg_type, to_int()(length));
 
 		return true;
@@ -480,7 +492,7 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_pre_shared_key_server_hello )
 			return true;
 
-		VectorVal* slist = new VectorVal(internal_type("psk_identity_vec")->AsVectorType());
+		auto slist = make_intrusive<VectorVal>(internal_type("psk_identity_vec")->AsVectorType());
 
 		if ( identities && identities->identities() )
 			{
@@ -493,15 +505,16 @@ refine connection Handshake_Conn += {
 				}
 			}
 
-		VectorVal* blist = new VectorVal(internal_type("string_vec")->AsVectorType());
+		auto blist = make_intrusive<VectorVal>(internal_type("string_vec")->AsVectorType());
+
 		if ( binders && binders->binders() )
 			{
 			for ( auto&& binder : *(binders->binders()) )
 				blist->Assign(blist->Size(), make_intrusive<StringVal>(binder->binder().length(), (const char*) binder->binder().data()));
 			}
 
-		BifEvent::generate_ssl_extension_pre_shared_key_client_hello(bro_analyzer(), bro_analyzer()->Conn(),
-			${rec.is_orig}, slist, blist);
+		BifEvent::enqueue_ssl_extension_pre_shared_key_client_hello(bro_analyzer(), bro_analyzer()->Conn(),
+			${rec.is_orig}, std::move(slist), std::move(blist));
 
 		return true;
 		%}
@@ -511,7 +524,7 @@ refine connection Handshake_Conn += {
 		if ( ! ssl_extension_pre_shared_key_client_hello )
 			return true;
 
-		BifEvent::generate_ssl_extension_pre_shared_key_server_hello(bro_analyzer(),
+		BifEvent::enqueue_ssl_extension_pre_shared_key_server_hello(bro_analyzer(),
 			bro_analyzer()->Conn(), ${rec.is_orig}, selected_identity);
 
 		return true;

--- a/src/analyzer/protocol/ssl/tls-handshake-analyzer.pac
+++ b/src/analyzer/protocol/ssl/tls-handshake-analyzer.pac
@@ -80,7 +80,7 @@ refine connection Handshake_Conn += {
 		if ( point_format_list )
 			{
 			for ( unsigned int i = 0; i < point_format_list->size(); ++i )
-				points->Assign(i, val_mgr->GetCount((*point_format_list)[i]));
+				points->Assign(i, val_mgr->Count((*point_format_list)[i]));
 			}
 
 		BifEvent::generate_ssl_extension_ec_point_formats(bro_analyzer(), bro_analyzer()->Conn(),
@@ -99,7 +99,7 @@ refine connection Handshake_Conn += {
 		if ( list )
 			{
 			for ( unsigned int i = 0; i < list->size(); ++i )
-				curves->Assign(i, val_mgr->GetCount((*list)[i]));
+				curves->Assign(i, val_mgr->Count((*list)[i]));
 			}
 
 		BifEvent::generate_ssl_extension_elliptic_curves(bro_analyzer(), bro_analyzer()->Conn(),
@@ -118,7 +118,7 @@ refine connection Handshake_Conn += {
 		if ( keyshare )
 			{
 			for ( unsigned int i = 0; i < keyshare->size(); ++i )
-				nglist->Assign(i, val_mgr->GetCount((*keyshare)[i]->namedgroup()));
+				nglist->Assign(i, val_mgr->Count((*keyshare)[i]->namedgroup()));
 			}
 
 		BifEvent::generate_ssl_extension_key_share(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, nglist);
@@ -133,7 +133,7 @@ refine connection Handshake_Conn += {
 
 		VectorVal* nglist = new VectorVal(internal_type("index_vec")->AsVectorType());
 
-		nglist->Assign(0u, val_mgr->GetCount(keyshare->namedgroup()));
+		nglist->Assign(0u, val_mgr->Count(keyshare->namedgroup()));
 		BifEvent::generate_ssl_extension_key_share(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, nglist);
 		return true;
 		%}
@@ -145,7 +145,7 @@ refine connection Handshake_Conn += {
 
 		VectorVal* nglist = new VectorVal(internal_type("index_vec")->AsVectorType());
 
-		nglist->Assign(0u, val_mgr->GetCount(namedgroup));
+		nglist->Assign(0u, val_mgr->Count(namedgroup));
 		BifEvent::generate_ssl_extension_key_share(bro_analyzer(), bro_analyzer()->Conn(), ${rec.is_orig}, nglist);
 		return true;
 		%}
@@ -162,8 +162,8 @@ refine connection Handshake_Conn += {
 			for ( unsigned int i = 0; i < supported_signature_algorithms->size(); ++i )
 				{
 				RecordVal* el = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
-				el->Assign(0, val_mgr->GetCount((*supported_signature_algorithms)[i]->HashAlgorithm()));
-				el->Assign(1, val_mgr->GetCount((*supported_signature_algorithms)[i]->SignatureAlgorithm()));
+				el->Assign(0, val_mgr->Count((*supported_signature_algorithms)[i]->HashAlgorithm()));
+				el->Assign(1, val_mgr->Count((*supported_signature_algorithms)[i]->SignatureAlgorithm()));
 				slist->Assign(i, el);
 				}
 			}
@@ -233,7 +233,7 @@ refine connection Handshake_Conn += {
 		if ( versions_list )
 			{
 			for ( unsigned int i = 0; i < versions_list->size(); ++i )
-				versions->Assign(i, val_mgr->GetCount((*versions_list)[i]));
+				versions->Assign(i, val_mgr->Count((*versions_list)[i]));
 			}
 
 		BifEvent::generate_ssl_extension_supported_versions(bro_analyzer(), bro_analyzer()->Conn(),
@@ -248,7 +248,7 @@ refine connection Handshake_Conn += {
 			return true;
 
 		VectorVal* versions = new VectorVal(internal_type("index_vec")->AsVectorType());
-		versions->Assign(0u, val_mgr->GetCount(version));
+		versions->Assign(0u, val_mgr->Count(version));
 
 		BifEvent::generate_ssl_extension_supported_versions(bro_analyzer(), bro_analyzer()->Conn(),
 			${rec.is_orig}, versions);
@@ -266,7 +266,7 @@ refine connection Handshake_Conn += {
 		if ( mode_list )
 			{
 			for ( unsigned int i = 0; i < mode_list->size(); ++i )
-				modes->Assign(i, val_mgr->GetCount((*mode_list)[i]));
+				modes->Assign(i, val_mgr->Count((*mode_list)[i]));
 			}
 
 		BifEvent::generate_ssl_extension_psk_key_exchange_modes(bro_analyzer(), bro_analyzer()->Conn(),
@@ -345,14 +345,14 @@ refine connection Handshake_Conn += {
 			RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
 			if ( ${kex.signed_params.uses_signature_and_hashalgorithm} )
 				{
-				ha->Assign(0, val_mgr->GetCount(${kex.signed_params.algorithm.HashAlgorithm}));
-				ha->Assign(1, val_mgr->GetCount(${kex.signed_params.algorithm.SignatureAlgorithm}));
+				ha->Assign(0, val_mgr->Count(${kex.signed_params.algorithm.HashAlgorithm}));
+				ha->Assign(1, val_mgr->Count(${kex.signed_params.algorithm.SignatureAlgorithm}));
 				}
 			else
 				{
 				// set to impossible value
-				ha->Assign(0, val_mgr->GetCount(256));
-				ha->Assign(1, val_mgr->GetCount(256));
+				ha->Assign(0, val_mgr->Count(256));
+				ha->Assign(1, val_mgr->Count(256));
 				}
 
 			BifEvent::generate_ssl_server_signature(bro_analyzer(),
@@ -404,8 +404,8 @@ refine connection Handshake_Conn += {
 			return true;
 
 		RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
-		ha->Assign(0, val_mgr->GetCount(digitally_signed_algorithms->HashAlgorithm()));
-		ha->Assign(1, val_mgr->GetCount(digitally_signed_algorithms->SignatureAlgorithm()));
+		ha->Assign(0, val_mgr->Count(digitally_signed_algorithms->HashAlgorithm()));
+		ha->Assign(1, val_mgr->Count(digitally_signed_algorithms->SignatureAlgorithm()));
 
 		BifEvent::generate_ssl_extension_signed_certificate_timestamp(bro_analyzer(),
 			bro_analyzer()->Conn(), ${rec.is_orig},
@@ -434,14 +434,14 @@ refine connection Handshake_Conn += {
 			RecordVal* ha = new RecordVal(BifType::Record::SSL::SignatureAndHashAlgorithm);
 			if ( ${signed_params.uses_signature_and_hashalgorithm} )
 				{
-				ha->Assign(0, val_mgr->GetCount(${signed_params.algorithm.HashAlgorithm}));
-				ha->Assign(1, val_mgr->GetCount(${signed_params.algorithm.SignatureAlgorithm}));
+				ha->Assign(0, val_mgr->Count(${signed_params.algorithm.HashAlgorithm}));
+				ha->Assign(1, val_mgr->Count(${signed_params.algorithm.SignatureAlgorithm}));
 				}
 				else
 				{
 				// set to impossible value
-				ha->Assign(0, val_mgr->GetCount(256));
-				ha->Assign(1, val_mgr->GetCount(256));
+				ha->Assign(0, val_mgr->Count(256));
+				ha->Assign(1, val_mgr->Count(256));
 				}
 
 			BifEvent::generate_ssl_server_signature(bro_analyzer(),
@@ -488,7 +488,7 @@ refine connection Handshake_Conn += {
 				{
 				RecordVal* el = new RecordVal(BifType::Record::SSL::PSKIdentity);
 				el->Assign(0, make_intrusive<StringVal>(identity->identity().length(), (const char*) identity->identity().data()));
-				el->Assign(1, val_mgr->GetCount(identity->obfuscated_ticket_age()));
+				el->Assign(1, val_mgr->Count(identity->obfuscated_ticket_age()));
 				slist->Assign(slist->Size(), el);
 				}
 			}

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -135,10 +135,9 @@ void SteppingStoneEndpoint::Event(EventHandlerPtr f, int id1, int id2)
 		return;
 
 	if ( id2 >= 0 )
-		endp->TCP()->EnqueueConnEvent(f, IntrusivePtr{AdoptRef{}, val_mgr->GetInt(id1)},
-		                                 IntrusivePtr{AdoptRef{}, val_mgr->GetInt(id2)});
+		endp->TCP()->EnqueueConnEvent(f, val_mgr->Int(id1), val_mgr->Int(id2));
 	else
-		endp->TCP()->EnqueueConnEvent(f, IntrusivePtr{AdoptRef{}, val_mgr->GetInt(id1)});
+		endp->TCP()->EnqueueConnEvent(f, val_mgr->Int(id1));
 	}
 
 void SteppingStoneEndpoint::CreateEndpEvent(bool is_orig)
@@ -148,7 +147,7 @@ void SteppingStoneEndpoint::CreateEndpEvent(bool is_orig)
 
 	endp->TCP()->EnqueueConnEvent(stp_create_endp,
 		IntrusivePtr{AdoptRef{}, endp->TCP()->BuildConnVal()},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetInt(stp_id)},
+		val_mgr->Int(stp_id),
 		val_mgr->Bool(is_orig)
 	);
 	}

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -146,7 +146,7 @@ void SteppingStoneEndpoint::CreateEndpEvent(bool is_orig)
 		return;
 
 	endp->TCP()->EnqueueConnEvent(stp_create_endp,
-		IntrusivePtr{AdoptRef{}, endp->TCP()->BuildConnVal()},
+		endp->TCP()->ConnVal(),
 		val_mgr->Int(stp_id),
 		val_mgr->Bool(is_orig)
 	);

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -149,7 +149,7 @@ void SteppingStoneEndpoint::CreateEndpEvent(bool is_orig)
 	endp->TCP()->EnqueueConnEvent(stp_create_endp,
 		IntrusivePtr{AdoptRef{}, endp->TCP()->BuildConnVal()},
 		IntrusivePtr{AdoptRef{}, val_mgr->GetInt(stp_id)},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)}
+		val_mgr->Bool(is_orig)
 	);
 	}
 

--- a/src/analyzer/protocol/syslog/syslog-analyzer.pac
+++ b/src/analyzer/protocol/syslog/syslog-analyzer.pac
@@ -15,20 +15,20 @@ flow Syslog_Flow
 			return true;
 
 		if ( ${m.has_pri} )
-			BifEvent::generate_syslog_message(
+			BifEvent::enqueue_syslog_message(
 			    connection()->bro_analyzer(),
 			    connection()->bro_analyzer()->Conn(),
 			    ${m.PRI.facility},
 			    ${m.PRI.severity},
-			    new StringVal(${m.msg}.length(), (const char*)${m.msg}.begin())
+			    make_intrusive<StringVal>(${m.msg}.length(), (const char*)${m.msg}.begin())
 			    );
 		else
-			BifEvent::generate_syslog_message(
+			BifEvent::enqueue_syslog_message(
 			    connection()->bro_analyzer(),
 			    connection()->bro_analyzer()->Conn(),
 			    999,
 			    999,
-			    new StringVal(${m.msg}.length(), (const char*)${m.msg}.begin())
+			    make_intrusive<StringVal>(${m.msg}.length(), (const char*)${m.msg}.begin())
 			    );
 
 		return true;

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -109,14 +109,14 @@ static RecordVal* build_syn_packet_val(bool is_orig, const IP_Hdr* ip,
 
 	RecordVal* v = new RecordVal(SYN_packet);
 
-	v->Assign(0, val_mgr->GetBool(is_orig));
-	v->Assign(1, val_mgr->GetBool(int(ip->DF())));
+	v->Assign(0, val_mgr->Bool(is_orig));
+	v->Assign(1, val_mgr->Bool(int(ip->DF())));
 	v->Assign(2, val_mgr->GetCount((ip->TTL())));
 	v->Assign(3, val_mgr->GetCount((ip->TotalLen())));
 	v->Assign(4, val_mgr->GetCount(ntohs(tcp->th_win)));
 	v->Assign(5, val_mgr->GetInt(winscale));
 	v->Assign(6, val_mgr->GetCount(MSS));
-	v->Assign(7, val_mgr->GetBool(SACK));
+	v->Assign(7, val_mgr->Bool(SACK));
 
 	return v;
 	}
@@ -787,7 +787,7 @@ void TCP_Analyzer::GeneratePacketEvent(
 	{
 	EnqueueConnEvent(tcp_packet,
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+		val_mgr->Bool(is_orig),
 		make_intrusive<StringVal>(flags.AsString()),
 		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(rel_seq)},
 		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(flags.ACK() ? rel_ack : 0)},
@@ -1347,7 +1347,7 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 			auto length = kind < 2 ? 1 : o[1];
 			EnqueueConnEvent(tcp_option,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+				val_mgr->Bool(is_orig),
 				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(kind)},
 				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(length)}
 				);
@@ -1460,7 +1460,7 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 
 		EnqueueConnEvent(tcp_options,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+			val_mgr->Bool(is_orig),
 			std::move(option_list)
 			);
 		}
@@ -1782,7 +1782,7 @@ void TCP_Analyzer::EndpointEOF(TCP_Reassembler* endp)
 	if ( connection_EOF )
 		EnqueueConnEvent(connection_EOF,
 			IntrusivePtr{AdoptRef{}, BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(endp->IsOrig())}
+			val_mgr->Bool(endp->IsOrig())
 		);
 
 	const analyzer_list& children(GetChildren());
@@ -2062,7 +2062,7 @@ bool TCPStats_Endpoint::DataSent(double /* t */, uint64_t seq, int len, int capl
 		if ( tcp_rexmit )
 			endp->TCP()->EnqueueConnEvent(tcp_rexmit,
 				IntrusivePtr{AdoptRef{}, endp->TCP()->BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(endp->IsOrig())},
+				val_mgr->Bool(endp->IsOrig()),
 				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(seq)},
 				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)},
 				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(data_in_flight)},

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -114,7 +114,7 @@ static RecordVal* build_syn_packet_val(bool is_orig, const IP_Hdr* ip,
 	v->Assign(2, val_mgr->GetCount((ip->TTL())));
 	v->Assign(3, val_mgr->GetCount((ip->TotalLen())));
 	v->Assign(4, val_mgr->GetCount(ntohs(tcp->th_win)));
-	v->Assign(5, val_mgr->GetInt(winscale));
+	v->Assign(5, val_mgr->Int(winscale));
 	v->Assign(6, val_mgr->GetCount(MSS));
 	v->Assign(7, val_mgr->Bool(SACK));
 

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -786,7 +786,7 @@ void TCP_Analyzer::GeneratePacketEvent(
 					bool is_orig, TCP_Flags flags)
 	{
 	EnqueueConnEvent(tcp_packet,
-		IntrusivePtr{AdoptRef{}, BuildConnVal()},
+		ConnVal(),
 		val_mgr->Bool(is_orig),
 		make_intrusive<StringVal>(flags.AsString()),
 		val_mgr->Count(rel_seq),
@@ -1102,7 +1102,7 @@ void TCP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 
 		if ( connection_SYN_packet )
 			EnqueueConnEvent(connection_SYN_packet,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				IntrusivePtr{NewRef{}, SYN_vals}
 			);
 
@@ -1346,7 +1346,7 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 			auto kind = o[0];
 			auto length = kind < 2 ? 1 : o[1];
 			EnqueueConnEvent(tcp_option,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(is_orig),
 				val_mgr->Count(kind),
 				val_mgr->Count(length)
@@ -1459,7 +1459,7 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 			}
 
 		EnqueueConnEvent(tcp_options,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(is_orig),
 			std::move(option_list)
 			);
@@ -1781,7 +1781,7 @@ void TCP_Analyzer::EndpointEOF(TCP_Reassembler* endp)
 	{
 	if ( connection_EOF )
 		EnqueueConnEvent(connection_EOF,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			val_mgr->Bool(endp->IsOrig())
 		);
 
@@ -2061,7 +2061,7 @@ bool TCPStats_Endpoint::DataSent(double /* t */, uint64_t seq, int len, int capl
 
 		if ( tcp_rexmit )
 			endp->TCP()->EnqueueConnEvent(tcp_rexmit,
-				IntrusivePtr{AdoptRef{}, endp->TCP()->BuildConnVal()},
+				endp->TCP()->ConnVal(),
 				val_mgr->Bool(endp->IsOrig()),
 				val_mgr->Count(seq),
 				val_mgr->Count(len),
@@ -2116,7 +2116,7 @@ void TCPStats_Analyzer::Done()
 
 	if ( conn_stats )
 		EnqueueConnEvent(conn_stats,
-			IntrusivePtr{AdoptRef{}, BuildConnVal()},
+			ConnVal(),
 			IntrusivePtr{AdoptRef{}, orig_stats->BuildStats()},
 			IntrusivePtr{AdoptRef{}, resp_stats->BuildStats()}
 		);

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -111,11 +111,11 @@ static RecordVal* build_syn_packet_val(bool is_orig, const IP_Hdr* ip,
 
 	v->Assign(0, val_mgr->Bool(is_orig));
 	v->Assign(1, val_mgr->Bool(int(ip->DF())));
-	v->Assign(2, val_mgr->GetCount((ip->TTL())));
-	v->Assign(3, val_mgr->GetCount((ip->TotalLen())));
-	v->Assign(4, val_mgr->GetCount(ntohs(tcp->th_win)));
+	v->Assign(2, val_mgr->Count((ip->TTL())));
+	v->Assign(3, val_mgr->Count((ip->TotalLen())));
+	v->Assign(4, val_mgr->Count(ntohs(tcp->th_win)));
 	v->Assign(5, val_mgr->Int(winscale));
-	v->Assign(6, val_mgr->GetCount(MSS));
+	v->Assign(6, val_mgr->Count(MSS));
 	v->Assign(7, val_mgr->Bool(SACK));
 
 	return v;
@@ -789,9 +789,9 @@ void TCP_Analyzer::GeneratePacketEvent(
 		IntrusivePtr{AdoptRef{}, BuildConnVal()},
 		val_mgr->Bool(is_orig),
 		make_intrusive<StringVal>(flags.AsString()),
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(rel_seq)},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(flags.ACK() ? rel_ack : 0)},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)},
+		val_mgr->Count(rel_seq),
+		val_mgr->Count(flags.ACK() ? rel_ack : 0),
+		val_mgr->Count(len),
 		// We need the min() here because Ethernet padding can lead to
 		// caplen > len.
 		make_intrusive<StringVal>(std::min(caplen, len), (const char*) data)
@@ -1289,10 +1289,10 @@ void TCP_Analyzer::UpdateConnVal(RecordVal *conn_val)
 	RecordVal *orig_endp_val = conn_val->Lookup("orig")->AsRecordVal();
 	RecordVal *resp_endp_val = conn_val->Lookup("resp")->AsRecordVal();
 
-	orig_endp_val->Assign(0, val_mgr->GetCount(orig->Size()));
-	orig_endp_val->Assign(1, val_mgr->GetCount(int(orig->state)));
-	resp_endp_val->Assign(0, val_mgr->GetCount(resp->Size()));
-	resp_endp_val->Assign(1, val_mgr->GetCount(int(resp->state)));
+	orig_endp_val->Assign(0, val_mgr->Count(orig->Size()));
+	orig_endp_val->Assign(1, val_mgr->Count(int(orig->state)));
+	resp_endp_val->Assign(0, val_mgr->Count(resp->Size()));
+	resp_endp_val->Assign(1, val_mgr->Count(int(resp->state)));
 
 	// Call children's UpdateConnVal
 	Analyzer::UpdateConnVal(conn_val);
@@ -1348,8 +1348,8 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 			EnqueueConnEvent(tcp_option,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
 				val_mgr->Bool(is_orig),
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(kind)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(length)}
+				val_mgr->Count(kind),
+				val_mgr->Count(length)
 				);
 			}
 
@@ -1373,8 +1373,8 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 			auto length = kind < 2 ? 1 : o[1];
 			auto option_record = new RecordVal(BifType::Record::TCP::Option);
 			option_list->Assign(option_list->Size(), option_record);
-			option_record->Assign(0, val_mgr->GetCount(kind));
-			option_record->Assign(1, val_mgr->GetCount(length));
+			option_record->Assign(0, val_mgr->Count(kind));
+			option_record->Assign(1, val_mgr->Count(length));
 
 			switch ( kind ) {
 			case 2:
@@ -1382,7 +1382,7 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 				if ( length == 4 )
 					{
 					auto mss = ntohs(*reinterpret_cast<const uint16_t*>(o + 2));
-					option_record->Assign(3, val_mgr->GetCount(mss));
+					option_record->Assign(3, val_mgr->Count(mss));
 					}
 				else
 					{
@@ -1396,7 +1396,7 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 				if ( length == 3 )
 					{
 					auto scale = o[2];
-					option_record->Assign(4, val_mgr->GetCount(scale));
+					option_record->Assign(4, val_mgr->Count(scale));
 					}
 				else
 					{
@@ -1425,7 +1425,7 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 					auto sack = new VectorVal(vt);
 
 					for ( auto i = 0; i < num_pointers; ++i )
-						sack->Assign(sack->Size(), val_mgr->GetCount(ntohl(p[i])));
+						sack->Assign(sack->Size(), val_mgr->Count(ntohl(p[i])));
 
 					option_record->Assign(5, sack);
 					}
@@ -1442,8 +1442,8 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 					{
 					auto send = ntohl(*reinterpret_cast<const uint32_t*>(o + 2));
 					auto echo = ntohl(*reinterpret_cast<const uint32_t*>(o + 6));
-					option_record->Assign(6, val_mgr->GetCount(send));
-					option_record->Assign(7, val_mgr->GetCount(echo));
+					option_record->Assign(6, val_mgr->Count(send));
+					option_record->Assign(7, val_mgr->Count(echo));
 					}
 				else
 					{
@@ -2063,10 +2063,10 @@ bool TCPStats_Endpoint::DataSent(double /* t */, uint64_t seq, int len, int capl
 			endp->TCP()->EnqueueConnEvent(tcp_rexmit,
 				IntrusivePtr{AdoptRef{}, endp->TCP()->BuildConnVal()},
 				val_mgr->Bool(endp->IsOrig()),
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(seq)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(data_in_flight)},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(endp->peer->window)}
+				val_mgr->Count(seq),
+				val_mgr->Count(len),
+				val_mgr->Count(data_in_flight),
+				val_mgr->Count(endp->peer->window)
 			);
 		}
 	else
@@ -2079,13 +2079,13 @@ RecordVal* TCPStats_Endpoint::BuildStats()
 	{
 	RecordVal* stats = new RecordVal(endpoint_stats);
 
-	stats->Assign(0, val_mgr->GetCount(num_pkts));
-	stats->Assign(1, val_mgr->GetCount(num_rxmit));
-	stats->Assign(2, val_mgr->GetCount(num_rxmit_bytes));
-	stats->Assign(3, val_mgr->GetCount(num_in_order));
-	stats->Assign(4, val_mgr->GetCount(num_OO));
-	stats->Assign(5, val_mgr->GetCount(num_repl));
-	stats->Assign(6, val_mgr->GetCount(endian_type));
+	stats->Assign(0, val_mgr->Count(num_pkts));
+	stats->Assign(1, val_mgr->Count(num_rxmit));
+	stats->Assign(2, val_mgr->Count(num_rxmit_bytes));
+	stats->Assign(3, val_mgr->Count(num_in_order));
+	stats->Assign(4, val_mgr->Count(num_OO));
+	stats->Assign(5, val_mgr->Count(num_repl));
+	stats->Assign(6, val_mgr->Count(endian_type));
 
 	return stats;
 	}

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.cc
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.cc
@@ -238,7 +238,7 @@ bool TCP_Endpoint::DataSent(double t, uint64_t seq, int len, int caplen,
 
 			if ( contents_file_write_failure )
 				tcp_analyzer->EnqueueConnEvent(contents_file_write_failure,
-					IntrusivePtr{AdoptRef{}, Conn()->BuildConnVal()},
+					Conn()->ConnVal(),
 					val_mgr->Bool(IsOrig()),
 					make_intrusive<StringVal>(buf)
 				);

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.cc
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.cc
@@ -239,7 +239,7 @@ bool TCP_Endpoint::DataSent(double t, uint64_t seq, int len, int caplen,
 			if ( contents_file_write_failure )
 				tcp_analyzer->EnqueueConnEvent(contents_file_write_failure,
 					IntrusivePtr{AdoptRef{}, Conn()->BuildConnVal()},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(IsOrig())},
+					val_mgr->Bool(IsOrig()),
 					make_intrusive<StringVal>(buf)
 				);
 			}

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -154,8 +154,8 @@ void TCP_Reassembler::Gap(uint64_t seq, uint64_t len)
 		dst_analyzer->EnqueueConnEvent(content_gap,
 			IntrusivePtr{AdoptRef{}, dst_analyzer->BuildConnVal()},
 			val_mgr->Bool(IsOrig()),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(seq)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)}
+			val_mgr->Count(seq),
+			val_mgr->Count(len)
 		);
 
 	if ( type == Direct )
@@ -615,7 +615,7 @@ void TCP_Reassembler::DeliverBlock(uint64_t seq, int len, const u_char* data)
 		tcp_analyzer->EnqueueConnEvent(tcp_contents,
 			IntrusivePtr{AdoptRef{}, tcp_analyzer->BuildConnVal()},
 			val_mgr->Bool(IsOrig()),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(seq)},
+			val_mgr->Count(seq),
 			make_intrusive<StringVal>(len, (const char*) data)
 		);
 

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -153,7 +153,7 @@ void TCP_Reassembler::Gap(uint64_t seq, uint64_t len)
 	if ( report_gap(endp, endp->peer) )
 		dst_analyzer->EnqueueConnEvent(content_gap,
 			IntrusivePtr{AdoptRef{}, dst_analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(IsOrig())},
+			val_mgr->Bool(IsOrig()),
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(seq)},
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)}
 		);
@@ -363,7 +363,7 @@ void TCP_Reassembler::RecordBlock(const DataBlock& b, BroFile* f)
 	if ( contents_file_write_failure )
 		tcp_analyzer->EnqueueConnEvent(contents_file_write_failure,
 			IntrusivePtr{AdoptRef{}, Endpoint()->Conn()->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(IsOrig())},
+			val_mgr->Bool(IsOrig()),
 			make_intrusive<StringVal>("TCP reassembler content write failure")
 		);
 	}
@@ -378,7 +378,7 @@ void TCP_Reassembler::RecordGap(uint64_t start_seq, uint64_t upper_seq, BroFile*
 	if ( contents_file_write_failure )
 		tcp_analyzer->EnqueueConnEvent(contents_file_write_failure,
 			IntrusivePtr{AdoptRef{}, Endpoint()->Conn()->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(IsOrig())},
+			val_mgr->Bool(IsOrig()),
 			make_intrusive<StringVal>("TCP reassembler gap write failure")
 		);
 	}
@@ -614,7 +614,7 @@ void TCP_Reassembler::DeliverBlock(uint64_t seq, int len, const u_char* data)
 	if ( deliver_tcp_contents )
 		tcp_analyzer->EnqueueConnEvent(tcp_contents,
 			IntrusivePtr{AdoptRef{}, tcp_analyzer->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(IsOrig())},
+			val_mgr->Bool(IsOrig()),
 			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(seq)},
 			make_intrusive<StringVal>(len, (const char*) data)
 		);

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -150,7 +150,7 @@ void TCP_Reassembler::Gap(uint64_t seq, uint64_t len)
 
 	if ( report_gap(endp, endp->peer) )
 		dst_analyzer->EnqueueConnEvent(content_gap,
-			IntrusivePtr{AdoptRef{}, dst_analyzer->BuildConnVal()},
+			dst_analyzer->ConnVal(),
 			val_mgr->Bool(IsOrig()),
 			val_mgr->Count(seq),
 			val_mgr->Count(len)
@@ -360,7 +360,7 @@ void TCP_Reassembler::RecordBlock(const DataBlock& b, BroFile* f)
 
 	if ( contents_file_write_failure )
 		tcp_analyzer->EnqueueConnEvent(contents_file_write_failure,
-			IntrusivePtr{AdoptRef{}, Endpoint()->Conn()->BuildConnVal()},
+			Endpoint()->Conn()->ConnVal(),
 			val_mgr->Bool(IsOrig()),
 			make_intrusive<StringVal>("TCP reassembler content write failure")
 		);
@@ -375,7 +375,7 @@ void TCP_Reassembler::RecordGap(uint64_t start_seq, uint64_t upper_seq, BroFile*
 
 	if ( contents_file_write_failure )
 		tcp_analyzer->EnqueueConnEvent(contents_file_write_failure,
-			IntrusivePtr{AdoptRef{}, Endpoint()->Conn()->BuildConnVal()},
+			Endpoint()->Conn()->ConnVal(),
 			val_mgr->Bool(IsOrig()),
 			make_intrusive<StringVal>("TCP reassembler gap write failure")
 		);
@@ -455,7 +455,7 @@ void TCP_Reassembler::Overlap(const u_char* b1, const u_char* b2, uint64_t n)
 		BroString* b2_s = new BroString((const u_char*) b2, n, false);
 
 		tcp_analyzer->EnqueueConnEvent(rexmit_inconsistency,
-			IntrusivePtr{AdoptRef{}, tcp_analyzer->BuildConnVal()},
+			tcp_analyzer->ConnVal(),
 			make_intrusive<StringVal>(b1_s),
 			make_intrusive<StringVal>(b2_s),
 			make_intrusive<StringVal>(flags.AsString())
@@ -611,7 +611,7 @@ void TCP_Reassembler::DeliverBlock(uint64_t seq, int len, const u_char* data)
 
 	if ( deliver_tcp_contents )
 		tcp_analyzer->EnqueueConnEvent(tcp_contents,
-			IntrusivePtr{AdoptRef{}, tcp_analyzer->BuildConnVal()},
+			tcp_analyzer->ConnVal(),
 			val_mgr->Bool(IsOrig()),
 			val_mgr->Count(seq),
 			make_intrusive<StringVal>(len, (const char*) data)

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -42,19 +42,17 @@ TCP_Reassembler::TCP_Reassembler(analyzer::Analyzer* arg_dst_analyzer,
 
 	if ( ::tcp_contents )
 		{
-		auto dst_port_val = val_mgr->GetPort(ntohs(tcp_analyzer->Conn()->RespPort()),
-					TRANSPORT_TCP);
+		const auto& dst_port_val = val_mgr->Port(ntohs(tcp_analyzer->Conn()->RespPort()),
+		                                         TRANSPORT_TCP);
 		TableVal* ports = IsOrig() ?
 			tcp_content_delivery_ports_orig :
 			tcp_content_delivery_ports_resp;
-		auto result = ports->Lookup(dst_port_val);
+		auto result = ports->Lookup(dst_port_val.get());
 
 		if ( (IsOrig() && tcp_content_deliver_all_orig) ||
 		     (! IsOrig() && tcp_content_deliver_all_resp) ||
 		     (result && result->AsBool()) )
 			deliver_tcp_contents = true;
-
-		Unref(dst_port_val);
 		}
 	}
 

--- a/src/analyzer/protocol/tcp/functions.bif
+++ b/src/analyzer/protocol/tcp/functions.bif
@@ -99,10 +99,10 @@ function set_contents_file%(cid: conn_id, direction: count, f: file%): bool
 	%{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	c->GetRootAnalyzer()->SetContentsFile(direction, f);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Returns the file handle of the contents file of a connection.

--- a/src/analyzer/protocol/tcp/functions.bif
+++ b/src/analyzer/protocol/tcp/functions.bif
@@ -20,18 +20,18 @@ function get_orig_seq%(cid: conn_id%): count
 	%{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return val_mgr->GetCount(0);
+		return val_mgr->Count(0);
 
 	if ( c->ConnTransport() != TRANSPORT_TCP )
-		return val_mgr->GetCount(0);
+		return val_mgr->Count(0);
 
 	analyzer::Analyzer* tc = c->FindAnalyzer("TCP");
 	if ( tc )
-		return val_mgr->GetCount(static_cast<analyzer::tcp::TCP_Analyzer*>(tc)->OrigSeq());
+		return val_mgr->Count(static_cast<analyzer::tcp::TCP_Analyzer*>(tc)->OrigSeq());
 	else
 		{
 		reporter->Error("connection does not have TCP analyzer");
-		return val_mgr->GetCount(0);
+		return val_mgr->Count(0);
 		}
 	%}
 
@@ -49,18 +49,18 @@ function get_resp_seq%(cid: conn_id%): count
 	%{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return val_mgr->GetCount(0);
+		return val_mgr->Count(0);
 
 	if ( c->ConnTransport() != TRANSPORT_TCP )
-		return val_mgr->GetCount(0);
+		return val_mgr->Count(0);
 
 	analyzer::Analyzer* tc = c->FindAnalyzer("TCP");
 	if ( tc )
-		return val_mgr->GetCount(static_cast<analyzer::tcp::TCP_Analyzer*>(tc)->RespSeq());
+		return val_mgr->Count(static_cast<analyzer::tcp::TCP_Analyzer*>(tc)->RespSeq());
 	else
 		{
 		reporter->Error("connection does not have TCP analyzer");
-		return val_mgr->GetCount(0);
+		return val_mgr->Count(0);
 		}
 	%}
 

--- a/src/analyzer/protocol/tcp/functions.bif
+++ b/src/analyzer/protocol/tcp/functions.bif
@@ -126,7 +126,7 @@ function get_contents_file%(cid: conn_id, direction: count%): file
 	if ( f )
 		{
 		Ref(f);
-		return new Val(f);
+		return make_intrusive<Val>(f);
 		}
 
 	// Return some sort of error value.
@@ -135,5 +135,5 @@ function get_contents_file%(cid: conn_id, direction: count%): file
 	else
 		builtin_error("no contents file for given direction");
 
-	return new Val(new BroFile(stderr, "-", "w"));
+	return make_intrusive<Val>(new BroFile(stderr, "-", "w"));
 	%}

--- a/src/analyzer/protocol/teredo/Teredo.cc
+++ b/src/analyzer/protocol/teredo/Teredo.cc
@@ -132,7 +132,7 @@ RecordVal* TeredoEncapsulation::BuildVal(const IP_Hdr* inner) const
 		RecordVal* teredo_origin = new RecordVal(teredo_origin_type);
 		uint16_t port = ntohs(*((uint16_t*)(origin_indication + 2))) ^ 0xFFFF;
 		uint32_t addr = ntohl(*((uint32_t*)(origin_indication + 4))) ^ 0xFFFFFFFF;
-		teredo_origin->Assign(0, val_mgr->GetPort(port, TRANSPORT_UDP));
+		teredo_origin->Assign(0, val_mgr->Port(port, TRANSPORT_UDP));
 		teredo_origin->Assign(1, make_intrusive<AddrVal>(htonl(addr)));
 		teredo_hdr->Assign(1, teredo_origin);
 		}

--- a/src/analyzer/protocol/teredo/Teredo.cc
+++ b/src/analyzer/protocol/teredo/Teredo.cc
@@ -122,8 +122,8 @@ RecordVal* TeredoEncapsulation::BuildVal(const IP_Hdr* inner) const
 		    new BroString(auth + 4, id_len, true)));
 		teredo_auth->Assign(1, make_intrusive<StringVal>(
 		    new BroString(auth + 4 + id_len, au_len, true)));
-		teredo_auth->Assign(2, val_mgr->GetCount(nonce));
-		teredo_auth->Assign(3, val_mgr->GetCount(conf));
+		teredo_auth->Assign(2, val_mgr->Count(nonce));
+		teredo_auth->Assign(3, val_mgr->Count(conf));
 		teredo_hdr->Assign(0, teredo_auth);
 		}
 

--- a/src/analyzer/protocol/teredo/Teredo.h
+++ b/src/analyzer/protocol/teredo/Teredo.h
@@ -74,7 +74,7 @@ public:
 	const u_char* Authentication() const
 		{ return auth; }
 
-	RecordVal* BuildVal(const IP_Hdr* inner) const;
+	IntrusivePtr<RecordVal> BuildVal(const IP_Hdr* inner) const;
 
 protected:
 	bool DoParse(const u_char* data, int& len, bool found_orig, bool found_au);

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -135,8 +135,8 @@ void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 	if ( udp_contents )
 		{
 		bool do_udp_contents = false;
-		auto sport_val = IntrusivePtr{AdoptRef{}, val_mgr->GetPort(ntohs(up->uh_sport), TRANSPORT_UDP)};
-		auto dport_val = IntrusivePtr{AdoptRef{}, val_mgr->GetPort(ntohs(up->uh_dport), TRANSPORT_UDP)};
+		const auto& sport_val = val_mgr->Port(ntohs(up->uh_sport), TRANSPORT_UDP);
+		const auto& dport_val = val_mgr->Port(ntohs(up->uh_dport), TRANSPORT_UDP);
 
 		if ( udp_content_ports->Lookup(dport_val.get()) ||
 		     udp_content_ports->Lookup(sport_val.get()) )
@@ -145,7 +145,7 @@ void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 			{
 			uint16_t p = udp_content_delivery_ports_use_resp ? Conn()->RespPort()
 			                                                 : up->uh_dport;
-			auto port_val = IntrusivePtr{AdoptRef{}, val_mgr->GetPort(ntohs(p), TRANSPORT_UDP)};
+			const auto& port_val = val_mgr->Port(ntohs(p), TRANSPORT_UDP);
 
 			if ( is_orig )
 				{

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -166,7 +166,7 @@ void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 		if ( do_udp_contents )
 			EnqueueConnEvent(udp_contents,
 				IntrusivePtr{AdoptRef{}, BuildConnVal()},
-				IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+				val_mgr->Bool(is_orig),
 				make_intrusive<StringVal>(len, (const char*) data)
 			);
 		}

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -165,7 +165,7 @@ void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 
 		if ( do_udp_contents )
 			EnqueueConnEvent(udp_contents,
-				IntrusivePtr{AdoptRef{}, BuildConnVal()},
+				ConnVal(),
 				val_mgr->Bool(is_orig),
 				make_intrusive<StringVal>(len, (const char*) data)
 			);

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -228,14 +228,14 @@ void UDP_Analyzer::UpdateEndpointVal(RecordVal* endp, bool is_orig)
 	bro_int_t size = is_orig ? request_len : reply_len;
 	if ( size < 0 )
 		{
-		endp->Assign(0, val_mgr->GetCount(0));
-		endp->Assign(1, val_mgr->GetCount(int(UDP_INACTIVE)));
+		endp->Assign(0, val_mgr->Count(0));
+		endp->Assign(1, val_mgr->Count(int(UDP_INACTIVE)));
 		}
 
 	else
 		{
-		endp->Assign(0, val_mgr->GetCount(size));
-		endp->Assign(1, val_mgr->GetCount(int(UDP_ACTIVE)));
+		endp->Assign(0, val_mgr->Count(size));
+		endp->Assign(1, val_mgr->Count(int(UDP_ACTIVE)));
 		}
 	}
 

--- a/src/analyzer/protocol/vxlan/VXLAN.cc
+++ b/src/analyzer/protocol/vxlan/VXLAN.cc
@@ -102,7 +102,7 @@ void VXLAN_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 
 	if ( vxlan_packet )
 		Conn()->Event(vxlan_packet, nullptr, inner->BuildPktHdrVal(),
-		              val_mgr->GetCount(vni));
+		              val_mgr->Count(vni).release());
 
 	EncapsulatingConn ec(Conn(), BifEnum::Tunnel::VXLAN);
 	sessions->DoNextInnerPacket(network_time, &pkt, inner, estack, ec);

--- a/src/analyzer/protocol/vxlan/VXLAN.cc
+++ b/src/analyzer/protocol/vxlan/VXLAN.cc
@@ -101,8 +101,9 @@ void VXLAN_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 	ProtocolConfirmation();
 
 	if ( vxlan_packet )
-		Conn()->Event(vxlan_packet, nullptr, inner->BuildPktHdrVal(),
-		              val_mgr->Count(vni).release());
+		Conn()->EnqueueEvent(vxlan_packet, nullptr, ConnVal(),
+		                     IntrusivePtr{AdoptRef{}, inner->BuildPktHdrVal()},
+		                     val_mgr->Count(vni));
 
 	EncapsulatingConn ec(Conn(), BifEnum::Tunnel::VXLAN);
 	sessions->DoNextInnerPacket(network_time, &pkt, inner, estack, ec);

--- a/src/analyzer/protocol/xmpp/xmpp-analyzer.pac
+++ b/src/analyzer/protocol/xmpp/xmpp-analyzer.pac
@@ -33,7 +33,7 @@ refine connection XMPP_Conn += {
 			{
 			bro_analyzer()->StartTLS();
 			if ( xmpp_starttls )
-				BifEvent::generate_xmpp_starttls(bro_analyzer(), bro_analyzer()->Conn());
+				BifEvent::enqueue_xmpp_starttls(bro_analyzer(), bro_analyzer()->Conn());
 			}
 		else if ( !is_orig && token == "proceed" )
 			reporter->Weird(bro_analyzer()->Conn(), "XMPP: proceed without starttls");

--- a/src/binpac_bro-lib.pac
+++ b/src/binpac_bro-lib.pac
@@ -21,7 +21,7 @@ function utf16_bytestring_to_utf8_val(conn: Connection, utf16: bytestring): Stri
 		{
 		reporter->Info("utf16 too long in utf16_bytestring_to_utf8_val");
 		// If the conversion didn't go well, return the original data.
-		return bytestring_to_val(utf16);
+		return to_stringval(utf16).release();
 		}
 
 	resultstring.resize(utf8size, '\0');
@@ -49,7 +49,7 @@ function utf16_bytestring_to_utf8_val(conn: Connection, utf16: bytestring): Stri
 		{
 		reporter->Weird(conn, "utf16_conversion_failed", "utf16 conversion failed in utf16_bytestring_to_utf8_val");
 		// If the conversion didn't go well, return the original data.
-		return bytestring_to_val(utf16);
+		return to_stringval(utf16).release();
 		}
 
 	*targetstart = 0;

--- a/src/binpac_bro.h
+++ b/src/binpac_bro.h
@@ -8,6 +8,7 @@ namespace analyzer { class Analyzer; }
 
 #include "util.h"
 #include "Val.h"
+#include "IntrusivePtr.h"
 #include "event.bif.func_h"
 #include "analyzer/Analyzer.h"
 #include "file_analysis/Analyzer.h"
@@ -31,5 +32,10 @@ inline StringVal* bytestring_to_val(const_bytestring const &str)
 	{
 	return new StringVal(str.length(), (const char*) str.begin());
 	}
+
+inline IntrusivePtr<StringVal> to_stringval(const_bytestring const& str)
+    {
+	return make_intrusive<StringVal>(str.length(), (const char*) str.begin());
+    }
 
 } // namespace binpac

--- a/src/binpac_bro.h
+++ b/src/binpac_bro.h
@@ -28,6 +28,7 @@ inline StringVal* string_to_val(string const &str)
 	return new StringVal(str.c_str());
 	}
 
+[[deprecated("Remove in v4.1.  Use binpac::to_stringval() instead.")]]
 inline StringVal* bytestring_to_val(const_bytestring const &str)
 	{
 	return new StringVal(str.length(), (const char*) str.begin());

--- a/src/binpac_bro.h
+++ b/src/binpac_bro.h
@@ -23,6 +23,7 @@ typedef Val* BroVal;
 typedef PortVal* BroPortVal;
 typedef StringVal* BroStringVal;
 
+[[deprecated("Remove in v4.1.  Use StringVal constructor directly.")]]
 inline StringVal* string_to_val(string const &str)
 	{
 	return new StringVal(str.c_str());

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -90,7 +90,7 @@ struct val_converter {
 	result_type operator()(bool a)
 		{
 		if ( type->Tag() == TYPE_BOOL )
-			return val_mgr->GetBool(a);
+			return val_mgr->Bool(a)->Ref();
 		return nullptr;
 		}
 

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -790,7 +790,7 @@ static bool data_type_check(const broker::data& d, BroType* t)
 IntrusivePtr<Val> bro_broker::data_to_val(broker::data d, BroType* type)
 	{
 	if ( type->Tag() == TYPE_ANY )
-		return {AdoptRef{}, bro_broker::make_data_val(move(d))};
+		return bro_broker::make_data_val(move(d));
 
 	return {AdoptRef{}, caf::visit(val_converter{type}, std::move(d))};
 	}
@@ -1018,9 +1018,9 @@ broker::expected<broker::data> bro_broker::val_to_data(const Val* v)
 	return broker::ec::invalid_data;
 	}
 
-RecordVal* bro_broker::make_data_val(Val* v)
+IntrusivePtr<RecordVal> bro_broker::make_data_val(Val* v)
 	{
-	auto rval = new RecordVal(BifType::Record::Broker::Data);
+	auto rval = make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 	auto data = val_to_data(v);
 
 	if  ( data )
@@ -1031,84 +1031,84 @@ RecordVal* bro_broker::make_data_val(Val* v)
 	return rval;
 	}
 
-RecordVal* bro_broker::make_data_val(broker::data d)
+IntrusivePtr<RecordVal> bro_broker::make_data_val(broker::data d)
 	{
-	auto rval = new RecordVal(BifType::Record::Broker::Data);
+	auto rval = make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 	rval->Assign(0, make_intrusive<DataVal>(move(d)));
 	return rval;
 	}
 
 struct data_type_getter {
-	using result_type = EnumVal*;
+	using result_type = IntrusivePtr<EnumVal>;
 
 	result_type operator()(broker::none)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::NONE).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::NONE);
 		}
 
 	result_type operator()(bool)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::BOOL).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::BOOL);
 		}
 
 	result_type operator()(uint64_t)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::COUNT).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::COUNT);
 		}
 
 	result_type operator()(int64_t)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::INT).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::INT);
 		}
 
 	result_type operator()(double)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::DOUBLE).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::DOUBLE);
 		}
 
 	result_type operator()(const std::string&)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::STRING).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::STRING);
 		}
 
 	result_type operator()(const broker::address&)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::ADDR).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::ADDR);
 		}
 
 	result_type operator()(const broker::subnet&)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::SUBNET).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::SUBNET);
 		}
 
 	result_type operator()(const broker::port&)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::PORT).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::PORT);
 		}
 
 	result_type operator()(const broker::timestamp&)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::TIME).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::TIME);
 		}
 
 	result_type operator()(const broker::timespan&)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::INTERVAL).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::INTERVAL);
 		}
 
 	result_type operator()(const broker::enum_value&)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::ENUM).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::ENUM);
 		}
 
 	result_type operator()(const broker::set&)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::SET).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::SET);
 		}
 
 	result_type operator()(const broker::table&)
 		{
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::TABLE).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::TABLE);
 		}
 
 	result_type operator()(const broker::vector&)
@@ -1116,11 +1116,11 @@ struct data_type_getter {
 		// Note that Broker uses vectors to store record data, so there's
 		// no actual way to tell if this data was originally associated
 		// with a Bro record.
-		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::VECTOR).release();
+		return BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::VECTOR);
 		}
 };
 
-EnumVal* bro_broker::get_data_type(RecordVal* v, Frame* frame)
+IntrusivePtr<EnumVal> bro_broker::get_data_type(RecordVal* v, Frame* frame)
 	{
 	return caf::visit(data_type_getter{}, opaque_field_to_data(v, frame));
 	}

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -97,9 +97,9 @@ struct val_converter {
 	result_type operator()(uint64_t a)
 		{
 		if ( type->Tag() == TYPE_COUNT )
-			return val_mgr->GetCount(a);
+			return val_mgr->Count(a).release();
 		if ( type->Tag() == TYPE_COUNTER )
-			return val_mgr->GetCount(a);
+			return val_mgr->Count(a).release();
 		return nullptr;
 		}
 

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -106,7 +106,7 @@ struct val_converter {
 	result_type operator()(int64_t a)
 		{
 		if ( type->Tag() == TYPE_INT )
-			return val_mgr->GetInt(a);
+			return val_mgr->Int(a).release();
 		return nullptr;
 		}
 

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -161,7 +161,7 @@ struct val_converter {
 	result_type operator()(broker::port& a)
 		{
 		if ( type->Tag() == TYPE_PORT )
-			return val_mgr->GetPort(a.number(), bro_broker::to_bro_port_proto(a.type()));
+			return val_mgr->Port(a.number(), bro_broker::to_bro_port_proto(a.type()))->Ref();
 
 		return nullptr;
 		}

--- a/src/broker/Data.h
+++ b/src/broker/Data.h
@@ -29,14 +29,14 @@ TransportProto to_bro_port_proto(broker::port::protocol tp);
  * @return a Broker::Data value, where the optional field is set if the conversion
  * was possible, else it is unset.
  */
-RecordVal* make_data_val(Val* v);
+IntrusivePtr<RecordVal> make_data_val(Val* v);
 
 /**
  * Create a Broker::Data value from a Broker data value.
  * @param d the Broker value to wrap in an opaque type.
  * @return a Broker::Data value that wraps the Broker value.
  */
-RecordVal* make_data_val(broker::data d);
+IntrusivePtr<RecordVal> make_data_val(broker::data d);
 
 /**
  * Get the type of Broker data that Broker::Data wraps.
@@ -44,7 +44,7 @@ RecordVal* make_data_val(broker::data d);
  * @param frame used to get location info upon error.
  * @return a Broker::DataType value.
  */
-EnumVal* get_data_type(RecordVal* v, Frame* frame);
+IntrusivePtr<EnumVal> get_data_type(RecordVal* v, Frame* frame);
 
 /**
  * Convert a Bro value to a Broker data value.

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -1250,14 +1250,14 @@ void Manager::ProcessStatus(broker::status stat)
 		if ( ctx->network )
 			{
 			network_info->Assign(0, make_intrusive<StringVal>(ctx->network->address.data()));
-			network_info->Assign(1, val_mgr->GetPort(ctx->network->port, TRANSPORT_TCP));
+			network_info->Assign(1, val_mgr->Port(ctx->network->port, TRANSPORT_TCP));
 			}
 		else
 			{
 			// TODO: are there any status messages where the ctx->network
 			// is not set and actually could be?
 			network_info->Assign(0, make_intrusive<StringVal>("<unknown>"));
-			network_info->Assign(1, val_mgr->GetPort(0, TRANSPORT_TCP));
+			network_info->Assign(1, val_mgr->Port(0, TRANSPORT_TCP));
 			}
 
 		endpoint_info->Assign(1, std::move(network_info));

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -745,26 +745,22 @@ RecordVal* Manager::MakeEvent(val_list* args, Frame* frame)
 			return rval;
 			}
 
-		RecordVal* data_val;
+		IntrusivePtr<RecordVal> data_val;
 
 		if ( same_type(got_type, bro_broker::DataVal::ScriptDataType()) )
-			{
-			data_val = (*args)[i]->AsRecordVal();
-			Ref(data_val);
-			}
+			data_val = {NewRef{}, (*args)[i]->AsRecordVal()};
 		else
 			data_val = make_data_val((*args)[i]);
 
 		if ( ! data_val->Lookup(0) )
 			{
-			Unref(data_val);
 			rval->Assign(0, nullptr);
 			Error("failed to convert param #%d of type %s to broker data",
 				  i, type_name(got_type->Tag()));
 			return rval;
 			}
 
-		arg_vec->Assign(i - 1, data_val);
+		arg_vec->Assign(i - 1, std::move(data_val));
 		}
 
 	return rval;

--- a/src/broker/Store.h
+++ b/src/broker/Store.h
@@ -24,9 +24,9 @@ EnumVal* query_status(bool success);
  * @return a Broker::QueryResult value that has a Broker::QueryStatus indicating
  * a failure.
  */
-inline RecordVal* query_result()
+inline IntrusivePtr<RecordVal> query_result()
 	{
-	auto rval = new RecordVal(BifType::Record::Broker::QueryResult);
+	auto rval = make_intrusive<RecordVal>(BifType::Record::Broker::QueryResult);
 	rval->Assign(0, query_status(false));
 	rval->Assign(1, make_intrusive<RecordVal>(BifType::Record::Broker::Data));
 	return rval;
@@ -37,11 +37,11 @@ inline RecordVal* query_result()
  * @return a Broker::QueryResult value that has a Broker::QueryStatus indicating
  * a success.
  */
-inline RecordVal* query_result(RecordVal* data)
+inline IntrusivePtr<RecordVal> query_result(IntrusivePtr<RecordVal> data)
 	{
-	auto rval = new RecordVal(BifType::Record::Broker::QueryResult);
+	auto rval = make_intrusive<RecordVal>(BifType::Record::Broker::QueryResult);
 	rval->Assign(0, query_status(true));
-	rval->Assign(1, data);
+	rval->Assign(1, std::move(data));
 	return rval;
 	}
 
@@ -62,19 +62,17 @@ public:
 		Unref(trigger);
 		}
 
-	void Result(RecordVal* result)
+	void Result(const IntrusivePtr<RecordVal>& result)
 		{
-		trigger->Cache(call, result);
+		trigger->Cache(call, result.get());
 		trigger->Release();
-		Unref(result);
 		}
 
 	void Abort()
 		{
 		auto result = query_result();
-		trigger->Cache(call, result);
+		trigger->Cache(call, result.get());
 		trigger->Release();
-		Unref(result);
 		}
 
 	bool Disabled() const

--- a/src/broker/comm.bif
+++ b/src/broker/comm.bif
@@ -135,5 +135,5 @@ function Broker::__peers%(%): PeerInfos
 function Broker::__node_id%(%): string
 	%{
 	bro_broker::Manager::ScriptScopeGuard ssg;
-	return new StringVal(broker_mgr->NodeID());
+	return make_intrusive<StringVal>(broker_mgr->NodeID());
 	%}

--- a/src/broker/comm.bif
+++ b/src/broker/comm.bif
@@ -56,11 +56,11 @@ function Broker::__listen%(a: string, p: port%): port
 	if ( ! p->IsTCP() )
 		{
 		builtin_error("listen port must use tcp");
-		return val_mgr->GetPort(0, TRANSPORT_UNKNOWN);
+		return val_mgr->Port(0, TRANSPORT_UNKNOWN);
 		}
 
 	auto rval = broker_mgr->Listen(a->Len() ? a->CheckString() : "", p->Port());
-	return val_mgr->GetPort(rval, TRANSPORT_TCP);
+	return val_mgr->Port(rval, TRANSPORT_TCP);
 	%}
 
 function Broker::__peer%(a: string, p: port, retry: interval%): bool
@@ -110,12 +110,12 @@ function Broker::__peers%(%): PeerInfos
 		if ( n )
 			{
 			network_info->Assign(0, make_intrusive<AddrVal>(IPAddr(n->address)));
-			network_info->Assign(1, val_mgr->GetPort(n->port, TRANSPORT_TCP));
+			network_info->Assign(1, val_mgr->Port(n->port, TRANSPORT_TCP));
 			}
 		else
 			{
 			network_info->Assign(0, make_intrusive<AddrVal>("0.0.0.0"));
-			network_info->Assign(1, val_mgr->GetPort(0, TRANSPORT_TCP));
+			network_info->Assign(1, val_mgr->Port(0, TRANSPORT_TCP));
 			}
 
 		endpoint_info->Assign(0, make_intrusive<StringVal>(to_string(p.peer.node)));

--- a/src/broker/comm.bif
+++ b/src/broker/comm.bif
@@ -70,11 +70,11 @@ function Broker::__peer%(a: string, p: port, retry: interval%): bool
 	if ( ! p->IsTCP() )
 		{
 		builtin_error("remote connection port must use tcp");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	broker_mgr->Peer(a->CheckString(), p->Port(), retry);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__unpeer%(a: string, p: port%): bool
@@ -84,11 +84,11 @@ function Broker::__unpeer%(a: string, p: port%): bool
 	if ( ! p->IsTCP() )
 		{
 		builtin_error("remote connection port must use tcp");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	broker_mgr->Unpeer(a->CheckString(), p->Port());
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__peers%(%): PeerInfos

--- a/src/broker/data.bif
+++ b/src/broker/data.bif
@@ -52,7 +52,7 @@ function Broker::__opaque_clone_through_serialization%(d: any%): any
         	return val_mgr->False();
 		}
 	
-	return OpaqueVal::Unserialize(std::move(*x)).release();
+	return OpaqueVal::Unserialize(std::move(*x));
 	%}
 
 function Broker::__set_create%(%): Broker::Data
@@ -123,7 +123,7 @@ function Broker::__set_remove%(s: Broker::Data, key: any%): bool
 
 function Broker::__set_iterator%(s: Broker::Data%): opaque of Broker::SetIterator
 	%{
-	return new bro_broker::SetIterator(s->AsRecordVal(), TYPE_TABLE, frame);
+	return make_intrusive<bro_broker::SetIterator>(s->AsRecordVal(), TYPE_TABLE, frame);
 	%}
 
 function Broker::__set_iterator_last%(it: opaque of Broker::SetIterator%): bool
@@ -204,7 +204,7 @@ function Broker::__table_insert%(t: Broker::Data, key: any, val: any%): Broker::
 	if ( ! k )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 		}
 
 	auto v = bro_broker::val_to_data(val);
@@ -212,7 +212,7 @@ function Broker::__table_insert%(t: Broker::Data, key: any, val: any%): Broker::
 	if ( ! v )
 		{
 		builtin_error("invalid Broker data conversion for value argument");
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 		}
 
 	try
@@ -225,7 +225,7 @@ function Broker::__table_insert%(t: Broker::Data, key: any, val: any%): Broker::
 	catch (const std::out_of_range&)
 		{
 		table[std::move(*k)] = std::move(*v);
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 		}
 	%}
 
@@ -239,13 +239,13 @@ function Broker::__table_remove%(t: Broker::Data, key: any%): Broker::Data
 	if ( ! k )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 		}
 
 	auto it = table.find(*k);
 
 	if ( it == table.end() )
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 	else
 		{
 		auto rval = bro_broker::make_data_val(move(it->second));
@@ -264,20 +264,20 @@ function Broker::__table_lookup%(t: Broker::Data, key: any%): Broker::Data
 	if ( ! k )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 		}
 
 	auto it = table.find(*k);
 
 	if ( it == table.end() )
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 	else
 		return bro_broker::make_data_val(it->second);
 	%}
 
 function Broker::__table_iterator%(t: Broker::Data%): opaque of Broker::TableIterator
 	%{
-	return new bro_broker::TableIterator(t->AsRecordVal(), TYPE_TABLE, frame);
+	return make_intrusive<bro_broker::TableIterator>(t->AsRecordVal(), TYPE_TABLE, frame);
 	%}
 
 function Broker::__table_iterator_last%(it: opaque of Broker::TableIterator%): bool
@@ -367,7 +367,7 @@ function Broker::__vector_replace%(v: Broker::Data, idx: count, d: any%): Broker
 		}
 
 	if ( idx >= vec.size() )
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 
 	auto rval = bro_broker::make_data_val(move(vec[idx]));
 	vec[idx] = std::move(*item);
@@ -380,7 +380,7 @@ function Broker::__vector_remove%(v: Broker::Data, idx: count%): Broker::Data
 	                                                          TYPE_VECTOR, frame);
 
 	if ( idx >= vec.size() )
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 
 	auto rval = bro_broker::make_data_val(move(vec[idx]));
 	vec.erase(vec.begin() + idx);
@@ -393,14 +393,14 @@ function Broker::__vector_lookup%(v: Broker::Data, idx: count%): Broker::Data
 	                                                          TYPE_VECTOR, frame);
 
 	if ( idx >= vec.size() )
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 
 	return bro_broker::make_data_val(vec[idx]);
 	%}
 
 function Broker::__vector_iterator%(v: Broker::Data%): opaque of Broker::VectorIterator
 	%{
-	return new bro_broker::VectorIterator(v->AsRecordVal(), TYPE_VECTOR, frame);
+	return make_intrusive<bro_broker::VectorIterator>(v->AsRecordVal(), TYPE_VECTOR, frame);
 	%}
 
 function Broker::__vector_iterator_last%(it: opaque of Broker::VectorIterator%): bool
@@ -472,14 +472,14 @@ function Broker::__record_lookup%(r: Broker::Data, idx: count%): Broker::Data
 	                                                        TYPE_RECORD, frame);
 
 	if ( idx >= v.size() || caf::get_if<broker::none>(&v[idx]) )
-		return new RecordVal(BifType::Record::Broker::Data);
+		return make_intrusive<RecordVal>(BifType::Record::Broker::Data);
 
 	return bro_broker::make_data_val(v[idx]);
 	%}
 
 function Broker::__record_iterator%(r: Broker::Data%): opaque of Broker::RecordIterator
 	%{
-	return new bro_broker::RecordIterator(r->AsRecordVal(), TYPE_RECORD, frame);
+	return make_intrusive<bro_broker::RecordIterator>(r->AsRecordVal(), TYPE_RECORD, frame);
 	%}
 
 function Broker::__record_iterator_last%(it: opaque of Broker::RecordIterator%): bool

--- a/src/broker/data.bif
+++ b/src/broker/data.bif
@@ -72,7 +72,7 @@ function Broker::__set_size%(s: Broker::Data%): count
 	%{
 	auto& v = bro_broker::require_data_type<broker::set>(s->AsRecordVal(),
 	                                                     TYPE_TABLE, frame);
-	return val_mgr->GetCount(static_cast<uint64_t>(v.size()));
+	return val_mgr->Count(static_cast<uint64_t>(v.size()));
 	%}
 
 function Broker::__set_contains%(s: Broker::Data, key: any%): bool
@@ -175,7 +175,7 @@ function Broker::__table_size%(t: Broker::Data%): count
 	%{
 	auto& v = bro_broker::require_data_type<broker::table>(t->AsRecordVal(),
 	                                                       TYPE_TABLE, frame);
-	return val_mgr->GetCount(static_cast<uint64_t>(v.size()));
+	return val_mgr->Count(static_cast<uint64_t>(v.size()));
 	%}
 
 function Broker::__table_contains%(t: Broker::Data, key: any%): bool
@@ -334,7 +334,7 @@ function Broker::__vector_size%(v: Broker::Data%): count
 	%{
 	auto& vec = bro_broker::require_data_type<broker::vector>(v->AsRecordVal(),
 	                                                          TYPE_VECTOR, frame);
-	return val_mgr->GetCount(static_cast<uint64_t>(vec.size()));
+	return val_mgr->Count(static_cast<uint64_t>(vec.size()));
 	%}
 
 function Broker::__vector_insert%(v: Broker::Data, idx:count, d: any%): bool
@@ -444,7 +444,7 @@ function Broker::__record_size%(r: Broker::Data%): count
 	%{
 	auto& v = bro_broker::require_data_type<broker::vector>(r->AsRecordVal(),
 	                                                        TYPE_RECORD, frame);
-	return val_mgr->GetCount(static_cast<uint64_t>(v.size()));
+	return val_mgr->Count(static_cast<uint64_t>(v.size()));
 	%}
 
 function Broker::__record_assign%(r: Broker::Data, idx: count, d: any%): bool

--- a/src/broker/data.bif
+++ b/src/broker/data.bif
@@ -87,7 +87,7 @@ function Broker::__set_contains%(s: Broker::Data, key: any%): bool
 		return val_mgr->False();
 		}
 
-	return val_mgr->GetBool(v.find(*k) != v.end());
+	return val_mgr->Bool(v.find(*k) != v.end());
 	%}
 
 function Broker::__set_insert%(s: Broker::Data, key: any%): bool
@@ -103,7 +103,7 @@ function Broker::__set_insert%(s: Broker::Data, key: any%): bool
 		return val_mgr->False();
 		}
 
-	return val_mgr->GetBool(v.insert(std::move(*k)).second);
+	return val_mgr->Bool(v.insert(std::move(*k)).second);
 	%}
 
 function Broker::__set_remove%(s: Broker::Data, key: any%): bool
@@ -118,7 +118,7 @@ function Broker::__set_remove%(s: Broker::Data, key: any%): bool
 		return val_mgr->False();
 		}
 
-	return val_mgr->GetBool(v.erase(*k) > 0);
+	return val_mgr->Bool(v.erase(*k) > 0);
 	%}
 
 function Broker::__set_iterator%(s: Broker::Data%): opaque of Broker::SetIterator
@@ -129,7 +129,7 @@ function Broker::__set_iterator%(s: Broker::Data%): opaque of Broker::SetIterato
 function Broker::__set_iterator_last%(it: opaque of Broker::SetIterator%): bool
 	%{
 	auto set_it = static_cast<bro_broker::SetIterator*>(it);
-	return val_mgr->GetBool(set_it->it == set_it->dat.end());
+	return val_mgr->Bool(set_it->it == set_it->dat.end());
 	%}
 
 function Broker::__set_iterator_next%(it: opaque of Broker::SetIterator%): bool
@@ -140,7 +140,7 @@ function Broker::__set_iterator_next%(it: opaque of Broker::SetIterator%): bool
 		return val_mgr->False();
 
 	++set_it->it;
-	return val_mgr->GetBool(set_it->it != set_it->dat.end());
+	return val_mgr->Bool(set_it->it != set_it->dat.end());
 	%}
 
 function Broker::__set_iterator_value%(it: opaque of Broker::SetIterator%): Broker::Data
@@ -191,7 +191,7 @@ function Broker::__table_contains%(t: Broker::Data, key: any%): bool
 		return val_mgr->False();
 		}
 
-	return val_mgr->GetBool(v.find(*k) != v.end());
+	return val_mgr->Bool(v.find(*k) != v.end());
 	%}
 
 function Broker::__table_insert%(t: Broker::Data, key: any, val: any%): Broker::Data
@@ -283,7 +283,7 @@ function Broker::__table_iterator%(t: Broker::Data%): opaque of Broker::TableIte
 function Broker::__table_iterator_last%(it: opaque of Broker::TableIterator%): bool
 	%{
 	auto ti = static_cast<bro_broker::TableIterator*>(it);
-	return val_mgr->GetBool(ti->it == ti->dat.end());
+	return val_mgr->Bool(ti->it == ti->dat.end());
 	%}
 
 function Broker::__table_iterator_next%(it: opaque of Broker::TableIterator%): bool
@@ -294,7 +294,7 @@ function Broker::__table_iterator_next%(it: opaque of Broker::TableIterator%): b
 		return val_mgr->False();
 
 	++ti->it;
-	return val_mgr->GetBool(ti->it != ti->dat.end());
+	return val_mgr->Bool(ti->it != ti->dat.end());
 	%}
 
 function Broker::__table_iterator_value%(it: opaque of Broker::TableIterator%): Broker::TableItem
@@ -406,7 +406,7 @@ function Broker::__vector_iterator%(v: Broker::Data%): opaque of Broker::VectorI
 function Broker::__vector_iterator_last%(it: opaque of Broker::VectorIterator%): bool
 	%{
 	auto vi = static_cast<bro_broker::VectorIterator*>(it);
-	return val_mgr->GetBool(vi->it == vi->dat.end());
+	return val_mgr->Bool(vi->it == vi->dat.end());
 	%}
 
 function Broker::__vector_iterator_next%(it: opaque of Broker::VectorIterator%): bool
@@ -417,7 +417,7 @@ function Broker::__vector_iterator_next%(it: opaque of Broker::VectorIterator%):
 		return val_mgr->False();
 
 	++vi->it;
-	return val_mgr->GetBool(vi->it != vi->dat.end());
+	return val_mgr->Bool(vi->it != vi->dat.end());
 	%}
 
 function Broker::__vector_iterator_value%(it: opaque of Broker::VectorIterator%): Broker::Data
@@ -485,7 +485,7 @@ function Broker::__record_iterator%(r: Broker::Data%): opaque of Broker::RecordI
 function Broker::__record_iterator_last%(it: opaque of Broker::RecordIterator%): bool
 	%{
 	auto ri = static_cast<bro_broker::RecordIterator*>(it);
-	return val_mgr->GetBool(ri->it == ri->dat.end());
+	return val_mgr->Bool(ri->it == ri->dat.end());
 	%}
 
 function Broker::__record_iterator_next%(it: opaque of Broker::RecordIterator%): bool
@@ -496,7 +496,7 @@ function Broker::__record_iterator_next%(it: opaque of Broker::RecordIterator%):
 		return val_mgr->False();
 
 	++ri->it;
-	return val_mgr->GetBool(ri->it != ri->dat.end());
+	return val_mgr->Bool(ri->it != ri->dat.end());
 	%}
 
 function Broker::__record_iterator_value%(it: opaque of Broker::RecordIterator%): Broker::Data

--- a/src/broker/data.bif
+++ b/src/broker/data.bif
@@ -49,7 +49,7 @@ function Broker::__opaque_clone_through_serialization%(d: any%): any
 	if ( ! x )
 		{
 		builtin_error("cannot serialize object to clone");
-        	return val_mgr->GetFalse();
+        	return val_mgr->False();
 		}
 	
 	return OpaqueVal::Unserialize(std::move(*x)).release();
@@ -65,7 +65,7 @@ function Broker::__set_clear%(s: Broker::Data%): bool
 	auto& v = bro_broker::require_data_type<broker::set>(s->AsRecordVal(),
 	                                                     TYPE_TABLE, frame);
 	v.clear();
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__set_size%(s: Broker::Data%): count
@@ -84,7 +84,7 @@ function Broker::__set_contains%(s: Broker::Data, key: any%): bool
 	if ( ! k )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	return val_mgr->GetBool(v.find(*k) != v.end());
@@ -100,7 +100,7 @@ function Broker::__set_insert%(s: Broker::Data, key: any%): bool
 	if ( ! k )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	return val_mgr->GetBool(v.insert(std::move(*k)).second);
@@ -115,7 +115,7 @@ function Broker::__set_remove%(s: Broker::Data, key: any%): bool
 	if ( ! k )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	return val_mgr->GetBool(v.erase(*k) > 0);
@@ -137,7 +137,7 @@ function Broker::__set_iterator_next%(it: opaque of Broker::SetIterator%): bool
 	auto set_it = static_cast<bro_broker::SetIterator*>(it);
 
 	if ( set_it->it == set_it->dat.end() )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	++set_it->it;
 	return val_mgr->GetBool(set_it->it != set_it->dat.end());
@@ -168,7 +168,7 @@ function Broker::__table_clear%(t: Broker::Data%): bool
 	auto& v = bro_broker::require_data_type<broker::table>(t->AsRecordVal(),
 	                                                       TYPE_TABLE, frame);
 	v.clear();
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__table_size%(t: Broker::Data%): count
@@ -188,7 +188,7 @@ function Broker::__table_contains%(t: Broker::Data, key: any%): bool
 	if ( ! k )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	return val_mgr->GetBool(v.find(*k) != v.end());
@@ -291,7 +291,7 @@ function Broker::__table_iterator_next%(it: opaque of Broker::TableIterator%): b
 	auto ti = static_cast<bro_broker::TableIterator*>(it);
 
 	if ( ti->it == ti->dat.end() )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	++ti->it;
 	return val_mgr->GetBool(ti->it != ti->dat.end());
@@ -327,7 +327,7 @@ function Broker::__vector_clear%(v: Broker::Data%): bool
 	auto& vec = bro_broker::require_data_type<broker::vector>(v->AsRecordVal(),
 	                                                          TYPE_VECTOR, frame);
 	vec.clear();
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__vector_size%(v: Broker::Data%): count
@@ -346,12 +346,12 @@ function Broker::__vector_insert%(v: Broker::Data, idx:count, d: any%): bool
 	if ( ! item )
 		{
 		builtin_error("invalid Broker data conversion for item argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	idx = min(idx, static_cast<uint64_t>(vec.size()));
 	vec.insert(vec.begin() + idx, std::move(*item));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__vector_replace%(v: Broker::Data, idx: count, d: any%): Broker::Data
@@ -363,7 +363,7 @@ function Broker::__vector_replace%(v: Broker::Data, idx: count, d: any%): Broker
 	if ( ! item )
 		{
 		builtin_error("invalid Broker data conversion for item argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( idx >= vec.size() )
@@ -414,7 +414,7 @@ function Broker::__vector_iterator_next%(it: opaque of Broker::VectorIterator%):
 	auto vi = static_cast<bro_broker::VectorIterator*>(it);
 
 	if ( vi->it == vi->dat.end() )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	++vi->it;
 	return val_mgr->GetBool(vi->it != vi->dat.end());
@@ -452,18 +452,18 @@ function Broker::__record_assign%(r: Broker::Data, idx: count, d: any%): bool
 	auto& v = bro_broker::require_data_type<broker::vector>(r->AsRecordVal(),
 	                                                       TYPE_RECORD, frame);
 	if ( idx >= v.size() )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	auto item = bro_broker::val_to_data(d);
 
 	if ( ! item )
 		{
 		builtin_error("invalid Broker data conversion for item argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	v[idx] = std::move(*item);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__record_lookup%(r: Broker::Data, idx: count%): Broker::Data
@@ -493,7 +493,7 @@ function Broker::__record_iterator_next%(it: opaque of Broker::RecordIterator%):
 	auto ri = static_cast<bro_broker::RecordIterator*>(it);
 
 	if ( ri->it == ri->dat.end() )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	++ri->it;
 	return val_mgr->GetBool(ri->it != ri->dat.end());

--- a/src/broker/messaging.bif
+++ b/src/broker/messaging.bif
@@ -111,7 +111,7 @@ function Broker::publish%(topic: string, ...%): bool
 		args.push_back((*bif_args)[i].get());
 
 	auto rval = publish_event_args(args, topic->AsString(), frame);
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 function Broker::__flush_logs%(%): count
@@ -125,42 +125,42 @@ function Broker::__publish_id%(topic: string, id: string%): bool
 	bro_broker::Manager::ScriptScopeGuard ssg;
 	auto rval = broker_mgr->PublishIdentifier(topic->CheckString(),
 	                                          id->CheckString());
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 function Broker::__auto_publish%(topic: string, ev: any%): bool
 	%{
 	bro_broker::Manager::ScriptScopeGuard ssg;
 	auto rval = broker_mgr->AutoPublishEvent(topic->CheckString(), ev);
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 function Broker::__auto_unpublish%(topic: string, ev: any%): bool
 	%{
 	bro_broker::Manager::ScriptScopeGuard ssg;
 	auto rval = broker_mgr->AutoUnpublishEvent(topic->CheckString(), ev);
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 function Broker::__subscribe%(topic_prefix: string%): bool
 	%{
 	bro_broker::Manager::ScriptScopeGuard ssg;
 	auto rval = broker_mgr->Subscribe(topic_prefix->CheckString());
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 function Broker::__forward%(topic_prefix: string%): bool
 	%{
 	bro_broker::Manager::ScriptScopeGuard ssg;
 	auto rval = broker_mgr->Forward(topic_prefix->CheckString());
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 function Broker::__unsubscribe%(topic_prefix: string%): bool
 	%{
 	bro_broker::Manager::ScriptScopeGuard ssg;
 	auto rval = broker_mgr->Unsubscribe(topic_prefix->CheckString());
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 module Cluster;
@@ -201,7 +201,7 @@ function Cluster::publish_rr%(pool: Pool, key: string, ...%): bool
 		args.push_back((*bif_args)[i].get());
 
 	auto rval = publish_event_args(args, topic->AsString(), frame);
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 
@@ -238,5 +238,5 @@ function Cluster::publish_hrw%(pool: Pool, key: any, ...%): bool
 		args.push_back((*bif_args)[i].get());
 
 	auto rval = publish_event_args(args, topic->AsString(), frame);
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}

--- a/src/broker/messaging.bif
+++ b/src/broker/messaging.bif
@@ -117,7 +117,7 @@ function Broker::publish%(topic: string, ...%): bool
 function Broker::__flush_logs%(%): count
 	%{
 	auto rval = broker_mgr->FlushLogBuffers();
-	return val_mgr->GetCount(static_cast<uint64_t>(rval));
+	return val_mgr->Count(static_cast<uint64_t>(rval));
 	%}
 
 function Broker::__publish_id%(topic: string, id: string%): bool

--- a/src/broker/messaging.bif
+++ b/src/broker/messaging.bif
@@ -192,7 +192,7 @@ function Cluster::publish_rr%(pool: Pool, key: string, ...%): bool
 	auto topic = topic_func->Call(vl);
 
 	if ( ! topic->AsString()->Len() )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	const auto& bif_args = @ARGS@;
 	val_list args(bif_args->size() - 2);
@@ -229,7 +229,7 @@ function Cluster::publish_hrw%(pool: Pool, key: any, ...%): bool
 	auto topic = topic_func->Call(vl);
 
 	if ( ! topic->AsString()->Len() )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	const auto& bif_args = @ARGS@;
 	val_list args(bif_args->size() - 2);

--- a/src/broker/store.bif
+++ b/src/broker/store.bif
@@ -98,7 +98,7 @@ function Broker::__is_closed%(h: opaque of Broker::Store%): bool
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
-	return val_mgr->GetBool(broker_mgr->LookupStore(handle->store.name()));
+	return val_mgr->Bool(broker_mgr->LookupStore(handle->store.name()));
 	%}
 
 function Broker::__close%(h: opaque of Broker::Store%): bool
@@ -112,7 +112,7 @@ function Broker::__close%(h: opaque of Broker::Store%): bool
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
-	return val_mgr->GetBool(broker_mgr->CloseStore(handle->store.name()));
+	return val_mgr->Bool(broker_mgr->CloseStore(handle->store.name()));
 	%}
 
 function Broker::__store_name%(h: opaque of Broker::Store%): string

--- a/src/broker/store.bif
+++ b/src/broker/store.bif
@@ -94,7 +94,7 @@ function Broker::__is_closed%(h: opaque of Broker::Store%): bool
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -108,7 +108,7 @@ function Broker::__close%(h: opaque of Broker::Store%): bool
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -133,7 +133,7 @@ function Broker::__exists%(h: opaque of Broker::Store,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -178,7 +178,7 @@ function Broker::__get%(h: opaque of Broker::Store,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -223,7 +223,7 @@ function Broker::__put_unique%(h: opaque of Broker::Store,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -277,7 +277,7 @@ function Broker::__get_index_from_value%(h: opaque of Broker::Store,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -330,7 +330,7 @@ function Broker::__keys%(h: opaque of Broker::Store%): Broker::QueryResult
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -368,7 +368,7 @@ function Broker::__put%(h: opaque of Broker::Store,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -378,17 +378,17 @@ function Broker::__put%(h: opaque of Broker::Store,
 	if ( ! key )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! val )
 		{
 		builtin_error("invalid Broker data conversion for value argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	handle->store.put(std::move(*key), std::move(*val), prepare_expiry(e));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__erase%(h: opaque of Broker::Store, k: any%): bool
@@ -396,7 +396,7 @@ function Broker::__erase%(h: opaque of Broker::Store, k: any%): bool
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -405,11 +405,11 @@ function Broker::__erase%(h: opaque of Broker::Store, k: any%): bool
 	if ( ! key )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	handle->store.erase(std::move(*key));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__increment%(h: opaque of Broker::Store, k: any, a: any,
@@ -418,7 +418,7 @@ function Broker::__increment%(h: opaque of Broker::Store, k: any, a: any,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -428,18 +428,18 @@ function Broker::__increment%(h: opaque of Broker::Store, k: any, a: any,
 	if ( ! key )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! amount )
 		{
 		builtin_error("invalid Broker data conversion for amount argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	handle->store.increment(std::move(*key), std::move(*amount),
 	                        prepare_expiry(e));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__decrement%(h: opaque of Broker::Store, k: any, a: any,
@@ -448,7 +448,7 @@ function Broker::__decrement%(h: opaque of Broker::Store, k: any, a: any,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -458,17 +458,17 @@ function Broker::__decrement%(h: opaque of Broker::Store, k: any, a: any,
 	if ( ! key )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! amount )
 		{
 		builtin_error("invalid Broker data conversion for amount argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	handle->store.decrement(std::move(*key), std::move(*amount), prepare_expiry(e));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__append%(h: opaque of Broker::Store, k: any, s: any,
@@ -477,7 +477,7 @@ function Broker::__append%(h: opaque of Broker::Store, k: any, s: any,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -487,17 +487,17 @@ function Broker::__append%(h: opaque of Broker::Store, k: any, s: any,
 	if ( ! key )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! str )
 		{
 		builtin_error("invalid Broker data conversion for str argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	handle->store.append(std::move(*key), std::move(*str), prepare_expiry(e));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__insert_into_set%(h: opaque of Broker::Store, k: any, i: any,
@@ -506,7 +506,7 @@ function Broker::__insert_into_set%(h: opaque of Broker::Store, k: any, i: any,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -516,18 +516,18 @@ function Broker::__insert_into_set%(h: opaque of Broker::Store, k: any, i: any,
 	if ( ! key )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! idx )
 		{
 		builtin_error("invalid Broker data conversion for index argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	handle->store.insert_into(std::move(*key), std::move(*idx),
 	                          prepare_expiry(e));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__insert_into_table%(h: opaque of Broker::Store, k: any,
@@ -536,7 +536,7 @@ function Broker::__insert_into_table%(h: opaque of Broker::Store, k: any,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -547,24 +547,24 @@ function Broker::__insert_into_table%(h: opaque of Broker::Store, k: any,
 	if ( ! key )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! idx )
 		{
 		builtin_error("invalid Broker data conversion for index argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! val )
 		{
 		builtin_error("invalid Broker data conversion for value argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	handle->store.insert_into(std::move(*key), std::move(*idx),
 	                          std::move(*val), prepare_expiry(e));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__remove_from%(h: opaque of Broker::Store, k: any, i: any,
@@ -573,7 +573,7 @@ function Broker::__remove_from%(h: opaque of Broker::Store, k: any, i: any,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -583,18 +583,18 @@ function Broker::__remove_from%(h: opaque of Broker::Store, k: any, i: any,
 	if ( ! key )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! idx )
 		{
 		builtin_error("invalid Broker data conversion for index argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	handle->store.remove_from(std::move(*key), std::move(*idx),
 	                          prepare_expiry(e));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__push%(h: opaque of Broker::Store, k: any, v: any,
@@ -603,7 +603,7 @@ function Broker::__push%(h: opaque of Broker::Store, k: any, v: any,
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -613,17 +613,17 @@ function Broker::__push%(h: opaque of Broker::Store, k: any, v: any,
 	if ( ! key )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! val )
 		{
 		builtin_error("invalid Broker data conversion for value argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	handle->store.push(std::move(*key), std::move(*val), prepare_expiry(e));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__pop%(h: opaque of Broker::Store, k: any, e: interval%): bool
@@ -631,7 +631,7 @@ function Broker::__pop%(h: opaque of Broker::Store, k: any, e: interval%): bool
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
@@ -640,11 +640,11 @@ function Broker::__pop%(h: opaque of Broker::Store, k: any, e: interval%): bool
 	if ( ! key )
 		{
 		builtin_error("invalid Broker data conversion for key argument");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	handle->store.pop(std::move(*key), prepare_expiry(e));
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 function Broker::__clear%(h: opaque of Broker::Store%): bool
@@ -652,11 +652,11 @@ function Broker::__clear%(h: opaque of Broker::Store%): bool
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
 
 	handle->store.clear();
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}

--- a/src/broker/store.bif
+++ b/src/broker/store.bif
@@ -124,7 +124,7 @@ function Broker::__store_name%(h: opaque of Broker::Store%): string
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);
-	return new StringVal(handle->store.name());
+	return make_intrusive<StringVal>(handle->store.name());
 	%}
 
 function Broker::__exists%(h: opaque of Broker::Store,
@@ -169,7 +169,7 @@ function Broker::__exists%(h: opaque of Broker::Store,
 	auto req_id = handle->proxy.exists(std::move(*key));
 	broker_mgr->TrackStoreQuery(handle, req_id, cb);
 
-	return 0;
+	return nullptr;
 	%}
 
 function Broker::__get%(h: opaque of Broker::Store,
@@ -214,7 +214,7 @@ function Broker::__get%(h: opaque of Broker::Store,
 	auto req_id = handle->proxy.get(std::move(*key));
 	broker_mgr->TrackStoreQuery(handle, req_id, cb);
 
-	return 0;
+	return nullptr;
 	%}
 
 function Broker::__put_unique%(h: opaque of Broker::Store,
@@ -268,7 +268,7 @@ function Broker::__put_unique%(h: opaque of Broker::Store,
 	                                       prepare_expiry(e));
 	broker_mgr->TrackStoreQuery(handle, req_id, cb);
 
-	return 0;
+	return nullptr;
 	%}
 
 function Broker::__get_index_from_value%(h: opaque of Broker::Store,
@@ -322,7 +322,7 @@ function Broker::__get_index_from_value%(h: opaque of Broker::Store,
 	                                                 std::move(*index));
 	broker_mgr->TrackStoreQuery(handle, req_id, cb);
 
-	return 0;
+	return nullptr;
 	%}
 
 function Broker::__keys%(h: opaque of Broker::Store%): Broker::QueryResult
@@ -359,7 +359,7 @@ function Broker::__keys%(h: opaque of Broker::Store%): Broker::QueryResult
 	auto req_id = handle->proxy.keys();
 	broker_mgr->TrackStoreQuery(handle, req_id, cb);
 
-	return 0;
+	return nullptr;
 	%}
 
 function Broker::__put%(h: opaque of Broker::Store,

--- a/src/broker/store.bif
+++ b/src/broker/store.bif
@@ -120,7 +120,7 @@ function Broker::__store_name%(h: opaque of Broker::Store%): string
 	if ( ! h )
 		{
 		builtin_error("invalid Broker store handle");
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	auto handle = static_cast<bro_broker::StoreHandleVal*>(h);

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -34,9 +34,9 @@ static RecordVal* get_conn_id_val(const Connection* conn)
 	{
 	RecordVal* v = new RecordVal(conn_id);
 	v->Assign(0, make_intrusive<AddrVal>(conn->OrigAddr()));
-	v->Assign(1, val_mgr->GetPort(ntohs(conn->OrigPort()), conn->ConnTransport()));
+	v->Assign(1, val_mgr->Port(ntohs(conn->OrigPort()), conn->ConnTransport()));
 	v->Assign(2, make_intrusive<AddrVal>(conn->RespAddr()));
-	v->Assign(3, val_mgr->GetPort(ntohs(conn->RespPort()), conn->ConnTransport()));
+	v->Assign(3, val_mgr->Port(ntohs(conn->RespPort()), conn->ConnTransport()));
 	return v;
 	}
 

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -97,7 +97,7 @@ File::File(const std::string& file_id, const std::string& source_name, Connectio
 
 	if ( conn )
 		{
-		val->Assign(is_orig_idx, val_mgr->GetBool(is_orig));
+		val->Assign(is_orig_idx, val_mgr->Bool(is_orig));
 		UpdateConnectionFields(conn, is_orig);
 		}
 
@@ -157,7 +157,7 @@ void File::RaiseFileOverNewConnection(Connection* conn, bool is_orig)
 		FileEvent(file_over_new_connection, {
 			IntrusivePtr{NewRef{}, val},
 			IntrusivePtr{AdoptRef{}, conn->BuildConnVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)},
+			val_mgr->Bool(is_orig),
 		});
 		}
 	}

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -301,7 +301,7 @@ bool File::SetMime(const std::string& mime_type)
 
 	auto meta = make_intrusive<RecordVal>(fa_metadata_type);
 	meta->Assign(meta_mime_type_idx, make_intrusive<StringVal>(mime_type));
-	meta->Assign(meta_inferred_idx, val_mgr->GetFalse());
+	meta->Assign(meta_inferred_idx, val_mgr->False());
 
 	FileEvent(file_sniff, {IntrusivePtr{NewRef{}, val}, std::move(meta)});
 	return true;

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -226,13 +226,13 @@ bool File::SetExtractionLimit(RecordVal* args, uint64_t bytes)
 void File::IncrementByteCount(uint64_t size, int field_idx)
 	{
 	uint64_t old = LookupFieldDefaultCount(field_idx);
-	val->Assign(field_idx, val_mgr->GetCount(old + size));
+	val->Assign(field_idx, val_mgr->Count(old + size));
 	}
 
 void File::SetTotalBytes(uint64_t size)
 	{
 	DBG_LOG(DBG_FILE_ANALYSIS, "[%s] Total bytes %" PRIu64, id.c_str(), size);
-	val->Assign(total_bytes_idx, val_mgr->GetCount(size));
+	val->Assign(total_bytes_idx, val_mgr->Count(size));
 	}
 
 bool File::IsComplete() const
@@ -455,8 +455,8 @@ void File::DeliverChunk(const u_char* data, uint64_t len, uint64_t offset)
 				{
 				FileEvent(file_reassembly_overflow, {
 					IntrusivePtr{NewRef{}, val},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetCount(current_offset)},
-					IntrusivePtr{AdoptRef{}, val_mgr->GetCount(gap_bytes)}
+					val_mgr->Count(current_offset),
+					val_mgr->Count(gap_bytes)
 				});
 				}
 			}
@@ -600,8 +600,8 @@ void File::Gap(uint64_t offset, uint64_t len)
 		{
 		FileEvent(file_gap, {
 			IntrusivePtr{NewRef{}, val},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(offset)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)}
+			val_mgr->Count(offset),
+			val_mgr->Count(len)
 		});
 		}
 

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -145,7 +145,7 @@ bool File::UpdateConnectionFields(Connection* conn, bool is_orig)
 		return false;
 		}
 
-	conns->AsTableVal()->Assign(idx, conn->BuildConnVal());
+	conns->AsTableVal()->Assign(idx, conn->ConnVal());
 	Unref(idx);
 	return true;
 	}
@@ -156,7 +156,7 @@ void File::RaiseFileOverNewConnection(Connection* conn, bool is_orig)
 		{
 		FileEvent(file_over_new_connection, {
 			IntrusivePtr{NewRef{}, val},
-			IntrusivePtr{AdoptRef{}, conn->BuildConnVal()},
+			conn->ConnVal(),
 			val_mgr->Bool(is_orig),
 		});
 		}

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -448,9 +448,8 @@ bool Manager::IsDisabled(const analyzer::Tag& tag)
 	if ( ! disabled )
 		disabled = internal_const_val("Files::disable")->AsTableVal();
 
-	Val* index = val_mgr->GetCount(bool(tag));
-	auto yield = disabled->Lookup(index);
-	Unref(index);
+	auto index = val_mgr->Count(bool(tag));
+	auto yield = disabled->Lookup(index.get());
 
 	if ( ! yield )
 		return false;

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -437,7 +437,7 @@ string Manager::GetFileID(const analyzer::Tag& tag, Connection* c, bool is_orig)
 	mgr.Enqueue(get_file_handle,
 		IntrusivePtr{NewRef{}, tagval},
 		IntrusivePtr{AdoptRef{}, c->BuildConnVal()},
-		IntrusivePtr{AdoptRef{}, val_mgr->GetBool(is_orig)}
+		val_mgr->Bool(is_orig)
 	);
 	mgr.Drain(); // need file handle immediately so we don't have to buffer data
 	return current_file_id;

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -524,7 +524,7 @@ VectorVal* file_analysis::GenMIMEMatchesVal(const RuleMatcher::MIME_Matches& m)
 		for ( set<string>::const_iterator it2 = it->second.begin();
 		      it2 != it->second.end(); ++it2 )
 			{
-			element->Assign(0, val_mgr->GetInt(it->first));
+			element->Assign(0, val_mgr->Int(it->first));
 			element->Assign(1, make_intrusive<StringVal>(*it2));
 			}
 

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -511,14 +511,14 @@ string Manager::DetectMIME(const u_char* data, uint64_t len) const
 	return *(matches.begin()->second.begin());
 	}
 
-VectorVal* file_analysis::GenMIMEMatchesVal(const RuleMatcher::MIME_Matches& m)
+IntrusivePtr<VectorVal> file_analysis::GenMIMEMatchesVal(const RuleMatcher::MIME_Matches& m)
 	{
-	VectorVal* rval = new VectorVal(mime_matches);
+	auto rval = make_intrusive<VectorVal>(mime_matches);
 
 	for ( RuleMatcher::MIME_Matches::const_iterator it = m.begin();
 	      it != m.end(); ++it )
 		{
-		RecordVal* element = new RecordVal(mime_match);
+		auto element = make_intrusive<RecordVal>(mime_match);
 
 		for ( set<string>::const_iterator it2 = it->second.begin();
 		      it2 != it->second.end(); ++it2 )
@@ -527,7 +527,7 @@ VectorVal* file_analysis::GenMIMEMatchesVal(const RuleMatcher::MIME_Matches& m)
 			element->Assign(1, make_intrusive<StringVal>(*it2));
 			}
 
-		rval->Assign(rval->Size(), element);
+		rval->Assign(rval->Size(), std::move(element));
 		}
 
 	return rval;

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -436,7 +436,7 @@ string Manager::GetFileID(const analyzer::Tag& tag, Connection* c, bool is_orig)
 
 	mgr.Enqueue(get_file_handle,
 		IntrusivePtr{NewRef{}, tagval},
-		IntrusivePtr{AdoptRef{}, c->BuildConnVal()},
+		c->ConnVal(),
 		val_mgr->Bool(is_orig)
 	);
 	mgr.Drain(); // need file handle immediately so we don't have to buffer data

--- a/src/file_analysis/Manager.h
+++ b/src/file_analysis/Manager.h
@@ -423,7 +423,7 @@ private:
  * Returns a script-layer value corresponding to the \c mime_matches type.
  * @param m The MIME match information with which to populate the value.
  */
-VectorVal* GenMIMEMatchesVal(const RuleMatcher::MIME_Matches& m);
+IntrusivePtr<VectorVal> GenMIMEMatchesVal(const RuleMatcher::MIME_Matches& m);
 
 } // namespace file_analysis
 

--- a/src/file_analysis/analyzer/data_event/DataEvent.cc
+++ b/src/file_analysis/analyzer/data_event/DataEvent.cc
@@ -45,7 +45,7 @@ bool DataEvent::DeliverChunk(const u_char* data, uint64_t len, uint64_t offset)
 	mgr.Enqueue(chunk_event,
 		IntrusivePtr{NewRef{}, GetFile()->GetVal()},
 		make_intrusive<StringVal>(new BroString(data, len, false)),
-		IntrusivePtr{AdoptRef{}, val_mgr->GetCount(offset)}
+		val_mgr->Count(offset)
 	);
 
 	return true;

--- a/src/file_analysis/analyzer/extract/Extract.cc
+++ b/src/file_analysis/analyzer/extract/Extract.cc
@@ -94,8 +94,8 @@ bool Extract::DeliverStream(const u_char* data, uint64_t len)
 		f->FileEvent(file_extraction_limit, {
 			IntrusivePtr{NewRef{}, f->GetVal()},
 			IntrusivePtr{NewRef{}, Args()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(limit)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(len)}
+			val_mgr->Count(limit),
+			val_mgr->Count(len)
 		});
 
 		// Limit may have been modified by a BIF, re-check it.

--- a/src/file_analysis/analyzer/extract/functions.bif
+++ b/src/file_analysis/analyzer/extract/functions.bif
@@ -13,7 +13,7 @@ function FileExtract::__set_limit%(file_id: string, args: any, n: count%): bool
 	using BifType::Record::Files::AnalyzerArgs;
 	auto rv = args->AsRecordVal()->CoerceTo(AnalyzerArgs);
 	bool result = file_mgr->SetExtractionLimit(file_id->CheckString(), rv.get(), n);
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 module GLOBAL;

--- a/src/file_analysis/analyzer/pe/pe-analyzer.pac
+++ b/src/file_analysis/analyzer/pe/pe-analyzer.pac
@@ -13,7 +13,7 @@ VectorVal* process_rvas(const RVAS* rva_table)
 	{
 	VectorVal* rvas = new VectorVal(internal_type("index_vec")->AsVectorType());
 	for ( uint16 i=0; i < rva_table->rvas()->size(); ++i )
-		rvas->Assign(i, val_mgr->GetCount((*rva_table->rvas())[i]->size()));
+		rvas->Assign(i, val_mgr->Count((*rva_table->rvas())[i]->size()));
 
 	return rvas;
 	}
@@ -30,9 +30,8 @@ refine flow File += {
 			{
 			if ( ((c >> i) & 0x1) == 1 )
 				{
-				Val *ch = val_mgr->GetCount((1<<i)&mask);
-				char_set->Assign(ch, 0);
-				Unref(ch);
+				auto ch = val_mgr->Count((1<<i)&mask);
+				char_set->Assign(ch.get(), 0);
 				}
 			}
 		return char_set;
@@ -44,22 +43,22 @@ refine flow File += {
 			{
 			auto dh = make_intrusive<RecordVal>(BifType::Record::PE::DOSHeader);
 			dh->Assign(0, make_intrusive<StringVal>(${h.signature}.length(), (const char*) ${h.signature}.data()));
-			dh->Assign(1, val_mgr->GetCount(${h.UsedBytesInTheLastPage}));
-			dh->Assign(2, val_mgr->GetCount(${h.FileSizeInPages}));
-			dh->Assign(3, val_mgr->GetCount(${h.NumberOfRelocationItems}));
-			dh->Assign(4, val_mgr->GetCount(${h.HeaderSizeInParagraphs}));
-			dh->Assign(5, val_mgr->GetCount(${h.MinimumExtraParagraphs}));
-			dh->Assign(6, val_mgr->GetCount(${h.MaximumExtraParagraphs}));
-			dh->Assign(7, val_mgr->GetCount(${h.InitialRelativeSS}));
-			dh->Assign(8, val_mgr->GetCount(${h.InitialSP}));
-			dh->Assign(9, val_mgr->GetCount(${h.Checksum}));
-			dh->Assign(10, val_mgr->GetCount(${h.InitialIP}));
-			dh->Assign(11, val_mgr->GetCount(${h.InitialRelativeCS}));
-			dh->Assign(12, val_mgr->GetCount(${h.AddressOfRelocationTable}));
-			dh->Assign(13, val_mgr->GetCount(${h.OverlayNumber}));
-			dh->Assign(14, val_mgr->GetCount(${h.OEMid}));
-			dh->Assign(15, val_mgr->GetCount(${h.OEMinfo}));
-			dh->Assign(16, val_mgr->GetCount(${h.AddressOfNewExeHeader}));
+			dh->Assign(1, val_mgr->Count(${h.UsedBytesInTheLastPage}));
+			dh->Assign(2, val_mgr->Count(${h.FileSizeInPages}));
+			dh->Assign(3, val_mgr->Count(${h.NumberOfRelocationItems}));
+			dh->Assign(4, val_mgr->Count(${h.HeaderSizeInParagraphs}));
+			dh->Assign(5, val_mgr->Count(${h.MinimumExtraParagraphs}));
+			dh->Assign(6, val_mgr->Count(${h.MaximumExtraParagraphs}));
+			dh->Assign(7, val_mgr->Count(${h.InitialRelativeSS}));
+			dh->Assign(8, val_mgr->Count(${h.InitialSP}));
+			dh->Assign(9, val_mgr->Count(${h.Checksum}));
+			dh->Assign(10, val_mgr->Count(${h.InitialIP}));
+			dh->Assign(11, val_mgr->Count(${h.InitialRelativeCS}));
+			dh->Assign(12, val_mgr->Count(${h.AddressOfRelocationTable}));
+			dh->Assign(13, val_mgr->Count(${h.OverlayNumber}));
+			dh->Assign(14, val_mgr->Count(${h.OEMid}));
+			dh->Assign(15, val_mgr->Count(${h.OEMinfo}));
+			dh->Assign(16, val_mgr->Count(${h.AddressOfNewExeHeader}));
 
 			mgr.Enqueue(pe_dos_header,
 			    IntrusivePtr{NewRef{}, connection()->bro_analyzer()->GetFile()->GetVal()},
@@ -93,11 +92,11 @@ refine flow File += {
 		if ( pe_file_header )
 			{
 			auto fh = make_intrusive<RecordVal>(BifType::Record::PE::FileHeader);
-			fh->Assign(0, val_mgr->GetCount(${h.Machine}));
+			fh->Assign(0, val_mgr->Count(${h.Machine}));
 			fh->Assign(1, make_intrusive<Val>(static_cast<double>(${h.TimeDateStamp}), TYPE_TIME));
-			fh->Assign(2, val_mgr->GetCount(${h.PointerToSymbolTable}));
-			fh->Assign(3, val_mgr->GetCount(${h.NumberOfSymbols}));
-			fh->Assign(4, val_mgr->GetCount(${h.SizeOfOptionalHeader}));
+			fh->Assign(2, val_mgr->Count(${h.PointerToSymbolTable}));
+			fh->Assign(3, val_mgr->Count(${h.NumberOfSymbols}));
+			fh->Assign(4, val_mgr->Count(${h.SizeOfOptionalHeader}));
 			fh->Assign(5, characteristics_to_bro(${h.Characteristics}, 16));
 
 			mgr.Enqueue(pe_file_header,
@@ -122,31 +121,31 @@ refine flow File += {
 			{
 			auto oh = make_intrusive<RecordVal>(BifType::Record::PE::OptionalHeader);
 
-			oh->Assign(0, val_mgr->GetCount(${h.magic}));
-			oh->Assign(1, val_mgr->GetCount(${h.major_linker_version}));
-			oh->Assign(2, val_mgr->GetCount(${h.minor_linker_version}));
-			oh->Assign(3, val_mgr->GetCount(${h.size_of_code}));
-			oh->Assign(4, val_mgr->GetCount(${h.size_of_init_data}));
-			oh->Assign(5, val_mgr->GetCount(${h.size_of_uninit_data}));
-			oh->Assign(6, val_mgr->GetCount(${h.addr_of_entry_point}));
-			oh->Assign(7, val_mgr->GetCount(${h.base_of_code}));
+			oh->Assign(0, val_mgr->Count(${h.magic}));
+			oh->Assign(1, val_mgr->Count(${h.major_linker_version}));
+			oh->Assign(2, val_mgr->Count(${h.minor_linker_version}));
+			oh->Assign(3, val_mgr->Count(${h.size_of_code}));
+			oh->Assign(4, val_mgr->Count(${h.size_of_init_data}));
+			oh->Assign(5, val_mgr->Count(${h.size_of_uninit_data}));
+			oh->Assign(6, val_mgr->Count(${h.addr_of_entry_point}));
+			oh->Assign(7, val_mgr->Count(${h.base_of_code}));
 
 			if ( ${h.pe_format} != PE32_PLUS )
-				oh->Assign(8, val_mgr->GetCount(${h.base_of_data}));
+				oh->Assign(8, val_mgr->Count(${h.base_of_data}));
 
-			oh->Assign(9, val_mgr->GetCount(${h.image_base}));
-			oh->Assign(10, val_mgr->GetCount(${h.section_alignment}));
-			oh->Assign(11, val_mgr->GetCount(${h.file_alignment}));
-			oh->Assign(12, val_mgr->GetCount(${h.os_version_major}));
-			oh->Assign(13, val_mgr->GetCount(${h.os_version_minor}));
-			oh->Assign(14, val_mgr->GetCount(${h.major_image_version}));
-			oh->Assign(15, val_mgr->GetCount(${h.minor_image_version}));
-			oh->Assign(16, val_mgr->GetCount(${h.minor_subsys_version}));
-			oh->Assign(17, val_mgr->GetCount(${h.minor_subsys_version}));
-			oh->Assign(18, val_mgr->GetCount(${h.size_of_image}));
-			oh->Assign(19, val_mgr->GetCount(${h.size_of_headers}));
-			oh->Assign(20, val_mgr->GetCount(${h.checksum}));
-			oh->Assign(21, val_mgr->GetCount(${h.subsystem}));
+			oh->Assign(9, val_mgr->Count(${h.image_base}));
+			oh->Assign(10, val_mgr->Count(${h.section_alignment}));
+			oh->Assign(11, val_mgr->Count(${h.file_alignment}));
+			oh->Assign(12, val_mgr->Count(${h.os_version_major}));
+			oh->Assign(13, val_mgr->Count(${h.os_version_minor}));
+			oh->Assign(14, val_mgr->Count(${h.major_image_version}));
+			oh->Assign(15, val_mgr->Count(${h.minor_image_version}));
+			oh->Assign(16, val_mgr->Count(${h.minor_subsys_version}));
+			oh->Assign(17, val_mgr->Count(${h.minor_subsys_version}));
+			oh->Assign(18, val_mgr->Count(${h.size_of_image}));
+			oh->Assign(19, val_mgr->Count(${h.size_of_headers}));
+			oh->Assign(20, val_mgr->Count(${h.checksum}));
+			oh->Assign(21, val_mgr->Count(${h.subsystem}));
 			oh->Assign(22, characteristics_to_bro(${h.dll_characteristics}, 16));
 
 			oh->Assign(23, process_rvas(${h.rvas}));
@@ -173,14 +172,14 @@ refine flow File += {
 				name_len = first_null - ${h.name}.data();
 			section_header->Assign(0, make_intrusive<StringVal>(name_len, (const char*) ${h.name}.data()));
 
-			section_header->Assign(1, val_mgr->GetCount(${h.virtual_size}));
-			section_header->Assign(2, val_mgr->GetCount(${h.virtual_addr}));
-			section_header->Assign(3, val_mgr->GetCount(${h.size_of_raw_data}));
-			section_header->Assign(4, val_mgr->GetCount(${h.ptr_to_raw_data}));
-			section_header->Assign(5, val_mgr->GetCount(${h.non_used_ptr_to_relocs}));
-			section_header->Assign(6, val_mgr->GetCount(${h.non_used_ptr_to_line_nums}));
-			section_header->Assign(7, val_mgr->GetCount(${h.non_used_num_of_relocs}));
-			section_header->Assign(8, val_mgr->GetCount(${h.non_used_num_of_line_nums}));
+			section_header->Assign(1, val_mgr->Count(${h.virtual_size}));
+			section_header->Assign(2, val_mgr->Count(${h.virtual_addr}));
+			section_header->Assign(3, val_mgr->Count(${h.size_of_raw_data}));
+			section_header->Assign(4, val_mgr->Count(${h.ptr_to_raw_data}));
+			section_header->Assign(5, val_mgr->Count(${h.non_used_ptr_to_relocs}));
+			section_header->Assign(6, val_mgr->Count(${h.non_used_ptr_to_line_nums}));
+			section_header->Assign(7, val_mgr->Count(${h.non_used_num_of_relocs}));
+			section_header->Assign(8, val_mgr->Count(${h.non_used_num_of_line_nums}));
 			section_header->Assign(9, characteristics_to_bro(${h.characteristics}, 32));
 
 			mgr.Enqueue(pe_section_header,

--- a/src/file_analysis/analyzer/unified2/unified2-analyzer.pac
+++ b/src/file_analysis/analyzer/unified2/unified2-analyzer.pac
@@ -129,7 +129,7 @@ refine flow Flow += {
 			packet->Assign(2, val_mgr->Count(${pkt.event_second}));
 			packet->Assign(3, make_intrusive<Val>(ts_to_double(${pkt.packet_ts}), TYPE_TIME));
 			packet->Assign(4, val_mgr->Count(${pkt.link_type}));
-			packet->Assign(5, bytestring_to_val(${pkt.packet_data}));
+			packet->Assign(5, to_stringval(${pkt.packet_data}));
 
 			mgr.Enqueue(::unified2_packet,
 					IntrusivePtr{NewRef{}, connection()->bro_analyzer()->GetFile()->GetVal()},

--- a/src/file_analysis/analyzer/unified2/unified2-analyzer.pac
+++ b/src/file_analysis/analyzer/unified2/unified2-analyzer.pac
@@ -67,19 +67,19 @@ refine flow Flow += {
 		if ( ::unified2_event )
 			{
 			auto ids_event = make_intrusive<RecordVal>(BifType::Record::Unified2::IDSEvent);
-			ids_event->Assign(0, val_mgr->GetCount(${ev.sensor_id}));
-			ids_event->Assign(1, val_mgr->GetCount(${ev.event_id}));
+			ids_event->Assign(0, val_mgr->Count(${ev.sensor_id}));
+			ids_event->Assign(1, val_mgr->Count(${ev.event_id}));
 			ids_event->Assign(2, make_intrusive<Val>(ts_to_double(${ev.ts}), TYPE_TIME));
-			ids_event->Assign(3, val_mgr->GetCount(${ev.signature_id}));
-			ids_event->Assign(4, val_mgr->GetCount(${ev.generator_id}));
-			ids_event->Assign(5, val_mgr->GetCount(${ev.signature_revision}));
-			ids_event->Assign(6, val_mgr->GetCount(${ev.classification_id}));
-			ids_event->Assign(7, val_mgr->GetCount(${ev.priority_id}));
+			ids_event->Assign(3, val_mgr->Count(${ev.signature_id}));
+			ids_event->Assign(4, val_mgr->Count(${ev.generator_id}));
+			ids_event->Assign(5, val_mgr->Count(${ev.signature_revision}));
+			ids_event->Assign(6, val_mgr->Count(${ev.classification_id}));
+			ids_event->Assign(7, val_mgr->Count(${ev.priority_id}));
 			ids_event->Assign(8, unified2_addr_to_bro_addr(${ev.src_ip}));
 			ids_event->Assign(9, unified2_addr_to_bro_addr(${ev.dst_ip}));
 			ids_event->Assign(10, to_port(${ev.src_p}, ${ev.protocol}));
 			ids_event->Assign(11, to_port(${ev.dst_p}, ${ev.protocol}));
-			ids_event->Assign(17, val_mgr->GetCount(${ev.packet_action}));
+			ids_event->Assign(17, val_mgr->Count(${ev.packet_action}));
 
 			mgr.Enqueue(::unified2_event,
 					IntrusivePtr{NewRef{}, connection()->bro_analyzer()->GetFile()->GetVal()},
@@ -93,23 +93,23 @@ refine flow Flow += {
 		if ( ::unified2_event )
 			{
 			auto ids_event = make_intrusive<RecordVal>(BifType::Record::Unified2::IDSEvent);
-			ids_event->Assign(0, val_mgr->GetCount(${ev.sensor_id}));
-			ids_event->Assign(1, val_mgr->GetCount(${ev.event_id}));
+			ids_event->Assign(0, val_mgr->Count(${ev.sensor_id}));
+			ids_event->Assign(1, val_mgr->Count(${ev.event_id}));
 			ids_event->Assign(2, make_intrusive<Val>(ts_to_double(${ev.ts}), TYPE_TIME));
-			ids_event->Assign(3, val_mgr->GetCount(${ev.signature_id}));
-			ids_event->Assign(4, val_mgr->GetCount(${ev.generator_id}));
-			ids_event->Assign(5, val_mgr->GetCount(${ev.signature_revision}));
-			ids_event->Assign(6, val_mgr->GetCount(${ev.classification_id}));
-			ids_event->Assign(7, val_mgr->GetCount(${ev.priority_id}));
+			ids_event->Assign(3, val_mgr->Count(${ev.signature_id}));
+			ids_event->Assign(4, val_mgr->Count(${ev.generator_id}));
+			ids_event->Assign(5, val_mgr->Count(${ev.signature_revision}));
+			ids_event->Assign(6, val_mgr->Count(${ev.classification_id}));
+			ids_event->Assign(7, val_mgr->Count(${ev.priority_id}));
 			ids_event->Assign(8, unified2_addr_to_bro_addr(${ev.src_ip}));
 			ids_event->Assign(9, unified2_addr_to_bro_addr(${ev.dst_ip}));
 			ids_event->Assign(10, to_port(${ev.src_p}, ${ev.protocol}));
 			ids_event->Assign(11, to_port(${ev.dst_p}, ${ev.protocol}));
-			ids_event->Assign(12, val_mgr->GetCount(${ev.impact_flag}));
-			ids_event->Assign(13, val_mgr->GetCount(${ev.impact}));
-			ids_event->Assign(14, val_mgr->GetCount(${ev.blocked}));
-			ids_event->Assign(15, val_mgr->GetCount(${ev.mpls_label}));
-			ids_event->Assign(16, val_mgr->GetCount(${ev.vlan_id}));
+			ids_event->Assign(12, val_mgr->Count(${ev.impact_flag}));
+			ids_event->Assign(13, val_mgr->Count(${ev.impact}));
+			ids_event->Assign(14, val_mgr->Count(${ev.blocked}));
+			ids_event->Assign(15, val_mgr->Count(${ev.mpls_label}));
+			ids_event->Assign(16, val_mgr->Count(${ev.vlan_id}));
 
 			mgr.Enqueue(::unified2_event,
 					IntrusivePtr{NewRef{}, connection()->bro_analyzer()->GetFile()->GetVal()},
@@ -124,11 +124,11 @@ refine flow Flow += {
 		if ( ::unified2_packet )
 			{
 			auto packet = make_intrusive<RecordVal>(BifType::Record::Unified2::Packet);
-			packet->Assign(0, val_mgr->GetCount(${pkt.sensor_id}));
-			packet->Assign(1, val_mgr->GetCount(${pkt.event_id}));
-			packet->Assign(2, val_mgr->GetCount(${pkt.event_second}));
+			packet->Assign(0, val_mgr->Count(${pkt.sensor_id}));
+			packet->Assign(1, val_mgr->Count(${pkt.event_id}));
+			packet->Assign(2, val_mgr->Count(${pkt.event_second}));
 			packet->Assign(3, make_intrusive<Val>(ts_to_double(${pkt.packet_ts}), TYPE_TIME));
-			packet->Assign(4, val_mgr->GetCount(${pkt.link_type}));
+			packet->Assign(4, val_mgr->Count(${pkt.link_type}));
 			packet->Assign(5, bytestring_to_val(${pkt.packet_data}));
 
 			mgr.Enqueue(::unified2_packet,

--- a/src/file_analysis/analyzer/unified2/unified2-analyzer.pac
+++ b/src/file_analysis/analyzer/unified2/unified2-analyzer.pac
@@ -45,7 +45,7 @@ refine flow Flow += {
 			}
 		%}
 
-	function to_port(n: uint16, p: uint8): PortVal
+	function to_port(n: uint16, p: uint8): Val
 		%{
 		TransportProto proto = TRANSPORT_UNKNOWN;
 		switch ( p ) {
@@ -54,7 +54,7 @@ refine flow Flow += {
 		case 17: proto = TRANSPORT_UDP; break;
 		}
 
-		return val_mgr->GetPort(n, proto);
+		return val_mgr->Port(n, proto)->Ref();
 		%}
 
 	#function proc_record(rec: Record) : bool

--- a/src/file_analysis/analyzer/x509/OCSP.cc
+++ b/src/file_analysis/analyzer/x509/OCSP.cc
@@ -89,10 +89,10 @@ static bool ocsp_add_cert_id(const OCSP_CERTID* cert_id, zeek::Args* vl, BIO* bi
 	if ( ! res )
 		{
 		reporter->Weird("OpenSSL failed to get OCSP_CERTID info");
-		vl->emplace_back(AdoptRef{}, val_mgr->GetEmptyString());
-		vl->emplace_back(AdoptRef{}, val_mgr->GetEmptyString());
-		vl->emplace_back(AdoptRef{}, val_mgr->GetEmptyString());
-		vl->emplace_back(AdoptRef{}, val_mgr->GetEmptyString());
+		vl->emplace_back(val_mgr->EmptyString());
+		vl->emplace_back(val_mgr->EmptyString());
+		vl->emplace_back(val_mgr->EmptyString());
+		vl->emplace_back(val_mgr->EmptyString());
 		return false;
 		}
 
@@ -215,8 +215,9 @@ typedef struct ocsp_basic_response_st {
     STACK_OF(X509) *certs;
 } OCSP_BASICRESP;
 */
-static StringVal* parse_basic_resp_sig_alg(OCSP_BASICRESP* basic_resp,
-                                           BIO* bio, char* buf, size_t buf_len)
+static IntrusivePtr<StringVal> parse_basic_resp_sig_alg(OCSP_BASICRESP* basic_resp,
+                                                        BIO* bio, char* buf,
+                                                        size_t buf_len)
 	{
 	int der_basic_resp_len = 0;
 	unsigned char* der_basic_resp_dat = nullptr;
@@ -224,7 +225,7 @@ static StringVal* parse_basic_resp_sig_alg(OCSP_BASICRESP* basic_resp,
 	der_basic_resp_len = i2d_OCSP_BASICRESP(basic_resp, &der_basic_resp_dat);
 
 	if ( der_basic_resp_len <= 0 )
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 
 	const unsigned char* const_der_basic_resp_dat = der_basic_resp_dat;
 
@@ -233,13 +234,13 @@ static StringVal* parse_basic_resp_sig_alg(OCSP_BASICRESP* basic_resp,
 	if ( ! bseq )
 		{
 		OPENSSL_free(der_basic_resp_dat);
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	if ( sk_ASN1_TYPE_num(bseq) < 3 )
 		{
 		OPENSSL_free(der_basic_resp_dat);
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	auto constexpr sig_alg_idx = 1u;
@@ -248,7 +249,7 @@ static StringVal* parse_basic_resp_sig_alg(OCSP_BASICRESP* basic_resp,
 	if ( ASN1_TYPE_get(aseq_type) != V_ASN1_SEQUENCE )
 		{
 		OPENSSL_free(der_basic_resp_dat);
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	auto aseq_str = aseq_type->value.asn1_string;
@@ -260,13 +261,13 @@ static StringVal* parse_basic_resp_sig_alg(OCSP_BASICRESP* basic_resp,
 	if ( ! aseq )
 		{
 		OPENSSL_free(der_basic_resp_dat);
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	if ( sk_ASN1_TYPE_num(aseq) < 1 )
 		{
 		OPENSSL_free(der_basic_resp_dat);
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	auto constexpr alg_obj_idx = 0u;
@@ -275,13 +276,13 @@ static StringVal* parse_basic_resp_sig_alg(OCSP_BASICRESP* basic_resp,
 	if ( ASN1_TYPE_get(alg_obj_type) != V_ASN1_OBJECT )
 		{
 		OPENSSL_free(der_basic_resp_dat);
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	auto alg_obj = alg_obj_type->value.object;
 	i2a_ASN1_OBJECT(bio, alg_obj);
 	auto alg_len = BIO_read(bio, buf, buf_len);
-	auto rval = new StringVal(alg_len, buf);
+	auto rval = make_intrusive<StringVal>(alg_len, buf);
 	BIO_reset(bio);
 
 	OPENSSL_free(der_basic_resp_dat);
@@ -521,7 +522,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPONSE *resp)
 	else
 		{
 		reporter->Weird("OpenSSL failed to get OCSP responder id");
-		vl.emplace_back(AdoptRef{}, val_mgr->GetEmptyString());
+		vl.emplace_back(val_mgr->EmptyString());
 		}
 
 	// producedAt
@@ -625,7 +626,7 @@ void file_analysis::OCSP::ParseResponse(OCSP_RESPONSE *resp)
 	vl.emplace_back(make_intrusive<StringVal>(len, buf));
 	BIO_reset(bio);
 #else
-	vl.emplace_back(AdoptRef{}, parse_basic_resp_sig_alg(basic_resp, bio, buf, sizeof(buf)));
+	vl.emplace_back(parse_basic_resp_sig_alg(basic_resp, bio, buf, sizeof(buf)));
 #endif
 
 	//i2a_ASN1_OBJECT(bio, basic_resp->signature);

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -290,7 +290,7 @@ void file_analysis::X509::ParseBasicConstraints(X509_EXTENSION* ex)
 		if ( x509_ext_basic_constraints )
 			{
 			auto pBasicConstraint = make_intrusive<RecordVal>(BifType::Record::X509::BasicConstraints);
-			pBasicConstraint->Assign(0, val_mgr->GetBool(constr->ca));
+			pBasicConstraint->Assign(0, val_mgr->Bool(constr->ca));
 
 			if ( constr->pathlen )
 				pBasicConstraint->Assign(1, val_mgr->GetCount((int32_t) ASN1_INTEGER_get(constr->pathlen)));
@@ -434,7 +434,7 @@ void file_analysis::X509::ParseSAN(X509_EXTENSION* ext)
 		if ( ips != nullptr )
 			sanExt->Assign(3, ips);
 
-		sanExt->Assign(4, val_mgr->GetBool(otherfields));
+		sanExt->Assign(4, val_mgr->Bool(otherfields));
 
 		mgr.Enqueue(x509_ext_subject_alternative_name,
 		            IntrusivePtr{NewRef{}, GetFile()->GetVal()},

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -121,7 +121,7 @@ RecordVal* file_analysis::X509::ParseCertificate(X509Val* cert_val, File* f)
 	RecordVal* pX509Cert = new RecordVal(BifType::Record::X509::Certificate);
 	BIO *bio = BIO_new(BIO_s_mem());
 
-	pX509Cert->Assign(0, val_mgr->GetCount((uint64_t) X509_get_version(ssl_cert) + 1));
+	pX509Cert->Assign(0, val_mgr->Count((uint64_t) X509_get_version(ssl_cert) + 1));
 	i2a_ASN1_INTEGER(bio, X509_get_serialNumber(ssl_cert));
 	int len = BIO_read(bio, buf, sizeof(buf));
 	pX509Cert->Assign(1, make_intrusive<StringVal>(len, buf));
@@ -229,7 +229,7 @@ RecordVal* file_analysis::X509::ParseCertificate(X509Val* cert_val, File* f)
 
 		unsigned int length = KeyLength(pkey);
 		if ( length > 0 )
-			pX509Cert->Assign(10, val_mgr->GetCount(length));
+			pX509Cert->Assign(10, val_mgr->Count(length));
 
 		EVP_PKEY_free(pkey);
 		}
@@ -293,7 +293,7 @@ void file_analysis::X509::ParseBasicConstraints(X509_EXTENSION* ex)
 			pBasicConstraint->Assign(0, val_mgr->Bool(constr->ca));
 
 			if ( constr->pathlen )
-				pBasicConstraint->Assign(1, val_mgr->GetCount((int32_t) ASN1_INTEGER_get(constr->pathlen)));
+				pBasicConstraint->Assign(1, val_mgr->Count((int32_t) ASN1_INTEGER_get(constr->pathlen)));
 
 			mgr.Enqueue(x509_ext_basic_constraints,
 				IntrusivePtr{NewRef{}, GetFile()->GetVal()},

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -86,7 +86,7 @@ public:
 	 * @param Returns the new record value and passes ownership to
 	 * caller.
 	 */
-	static RecordVal* ParseCertificate(X509Val* cert_val, File* file = nullptr);
+	static IntrusivePtr<RecordVal> ParseCertificate(X509Val* cert_val, File* file = nullptr);
 
 	static file_analysis::Analyzer* Instantiate(RecordVal* args, File* file)
 		{ return new X509(args, file); }

--- a/src/file_analysis/analyzer/x509/X509Common.cc
+++ b/src/file_analysis/analyzer/x509/X509Common.cc
@@ -276,7 +276,7 @@ void file_analysis::X509Common::ParseExtension(X509_EXTENSION* ex, const EventHa
 		pX509Ext->Assign(1, make_intrusive<StringVal>(short_name));
 
 	pX509Ext->Assign(2, make_intrusive<StringVal>(oid));
-	pX509Ext->Assign(3, val_mgr->GetBool(critical));
+	pX509Ext->Assign(3, val_mgr->Bool(critical));
 	pX509Ext->Assign(4, ext_val);
 
 	// send off generic extension event
@@ -289,7 +289,7 @@ void file_analysis::X509Common::ParseExtension(X509_EXTENSION* ex, const EventHa
 	if ( h == ocsp_extension )
 		mgr.Enqueue(h, IntrusivePtr{NewRef{}, GetFile()->GetVal()},
 					std::move(pX509Ext),
-					IntrusivePtr{AdoptRef{}, val_mgr->GetBool(global)});
+					val_mgr->Bool(global));
 	else
 		mgr.Enqueue(h, IntrusivePtr{NewRef{}, GetFile()->GetVal()},
 		            std::move(pX509Ext));

--- a/src/file_analysis/analyzer/x509/X509Common.cc
+++ b/src/file_analysis/analyzer/x509/X509Common.cc
@@ -316,7 +316,7 @@ IntrusivePtr<StringVal> file_analysis::X509Common::GetExtensionFromBIO(BIO* bio,
 	if ( length == 0 )
 		{
 		BIO_free_all(bio);
-		return {AdoptRef{}, val_mgr->GetEmptyString()};
+		return val_mgr->EmptyString();
 		}
 
 	char* buffer = (char*) malloc(length);

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -623,7 +623,7 @@ function sct_verify%(cert: opaque of x509, logid: string, log_key: string, signa
 	if ( precert && issuer_key_hash->Len() != 32)
 		{
 		reporter->Error("Invalid issuer_key_hash length");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	std::string data;
@@ -647,7 +647,7 @@ function sct_verify%(cert: opaque of x509, logid: string, log_key: string, signa
 		if ( pos < 0 )
 			{
 			reporter->Error("NID_ct_precert_scts not found");
-			return val_mgr->GetFalse();
+			return val_mgr->False();
 			}
 #else
 		int num_ext = X509_get_ext_count(x);
@@ -751,7 +751,7 @@ sct_verify_err:
 		EVP_PKEY_free(key);
 
 	reporter->Error("%s", errstr.c_str());
-	return val_mgr->GetFalse();
+	return val_mgr->False();
 	%}
 
 
@@ -902,7 +902,7 @@ function x509_set_certificate_cache%(tbl: string_any_table%) : bool
 	%{
 	file_analysis::X509::SetCertificateCache({NewRef{}, tbl->AsTableVal()});
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## This function sets up the callback that is called when an entry is matched against the table set
@@ -920,5 +920,5 @@ function x509_set_certificate_cache_hit_callback%(f: string_any_file_hook%) : bo
 	%{
 	file_analysis::X509::SetCertificateCacheHitCallback({NewRef{}, f->AsFunc()});
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -11,9 +11,9 @@
 #include <openssl/err.h>
 
 // construct an error record
-RecordVal* x509_result_record(uint64_t num, const char* reason, Val* chainVector = nullptr)
+IntrusivePtr<RecordVal> x509_result_record(uint64_t num, const char* reason, Val* chainVector = nullptr)
 	{
-	RecordVal* rrecord = new RecordVal(BifType::Record::X509::Result);
+	auto rrecord = make_intrusive<RecordVal>(BifType::Record::X509::Result);
 
 	rrecord->Assign(0, val_mgr->Int(num));
 	rrecord->Assign(1, make_intrusive<StringVal>(reason));
@@ -161,7 +161,7 @@ function x509_parse%(cert: opaque of x509%): X509::Certificate
 function x509_from_der%(der: string%): opaque of x509
     %{
     const u_char* data = der->Bytes();
-    return new file_analysis::X509Val(d2i_X509(nullptr, &data, der->Len()));
+    return make_intrusive<file_analysis::X509Val>(d2i_X509(nullptr, &data, der->Len()));
     %}
 
 ## Returns the string form of a certificate.
@@ -194,7 +194,7 @@ function x509_get_certificate_string%(cert: opaque of x509, pem: bool &default=F
 	if ( ! ext_val )
 		ext_val = val_mgr->EmptyString();
 
-	return ext_val.release();
+	return ext_val;
 	%}
 
 ## Verifies an OCSP reply.
@@ -215,7 +215,7 @@ function x509_get_certificate_string%(cert: opaque of x509, pem: bool &default=F
 ##              x509_get_certificate_string x509_verify
 function x509_ocsp_verify%(certs: x509_opaque_vector, ocsp_reply: string, root_certs: table_string_of_string, verify_time: time &default=network_time()%): X509::Result
 	%{
-	RecordVal* rval = 0;
+	IntrusivePtr<RecordVal> rval;
 	X509_STORE* ctx = ::file_analysis::X509::GetRootStore(root_certs->AsTableVal());
 	if ( ! ctx )
 		return x509_result_record(-1, "Problem initializing root store");
@@ -578,7 +578,7 @@ function x509_verify%(certs: x509_opaque_vector, root_certs: table_string_of_str
 
 x509_verify_chainerror:
 
-	RecordVal* rrecord = x509_result_record(X509_STORE_CTX_get_error(csc), X509_verify_cert_error_string(X509_STORE_CTX_get_error(csc)), chainVector);
+	auto rrecord = x509_result_record(X509_STORE_CTX_get_error(csc), X509_verify_cert_error_string(X509_STORE_CTX_get_error(csc)), chainVector);
 
 	X509_STORE_CTX_cleanup(csc);
 	X509_STORE_CTX_free(csc);
@@ -761,7 +761,7 @@ sct_verify_err:
  * 1 -> issuer name
  * 2 -> pubkey
  */
-StringVal* x509_entity_hash(file_analysis::X509Val *cert_handle, unsigned int hash_alg, unsigned int type)
+IntrusivePtr<StringVal> x509_entity_hash(file_analysis::X509Val *cert_handle, unsigned int hash_alg, unsigned int type)
 	{
 	assert(cert_handle);
 
@@ -824,7 +824,7 @@ StringVal* x509_entity_hash(file_analysis::X509Val *cert_handle, unsigned int ha
 
 	assert( len <= sizeof(md) );
 
-	return new StringVal(len, reinterpret_cast<const char*>(md));
+	return make_intrusive<StringVal>(len, reinterpret_cast<const char*>(md));
 	}
 %%}
 

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -192,7 +192,7 @@ function x509_get_certificate_string%(cert: opaque of x509, pem: bool &default=F
 	auto ext_val = file_analysis::X509::GetExtensionFromBIO(bio);
 
 	if ( ! ext_val )
-		ext_val = {AdoptRef{}, val_mgr->GetEmptyString()};
+		ext_val = val_mgr->EmptyString();
 
 	return ext_val.release();
 	%}

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -15,7 +15,7 @@ RecordVal* x509_result_record(uint64_t num, const char* reason, Val* chainVector
 	{
 	RecordVal* rrecord = new RecordVal(BifType::Record::X509::Result);
 
-	rrecord->Assign(0, val_mgr->GetInt(num));
+	rrecord->Assign(0, val_mgr->Int(num));
 	rrecord->Assign(1, make_intrusive<StringVal>(reason));
 	if ( chainVector )
 		rrecord->Assign(2, chainVector);

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -742,7 +742,7 @@ function sct_verify%(cert: opaque of x509, logid: string, log_key: string, signa
 	EVP_MD_CTX_destroy(mdctx);
 	EVP_PKEY_free(key);
 
-	return val_mgr->GetBool(success);
+	return val_mgr->Bool(success);
 
 sct_verify_err:
 	if (mdctx)

--- a/src/file_analysis/analyzer/x509/x509-extension.pac
+++ b/src/file_analysis/analyzer/x509/x509-extension.pac
@@ -40,11 +40,11 @@ refine connection MockConnection += {
 
 		mgr.Enqueue(x509_ocsp_ext_signed_certificate_timestamp,
 			IntrusivePtr{NewRef{}, bro_analyzer()->GetFile()->GetVal()},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(version)},
+			val_mgr->Count(version),
 			make_intrusive<StringVal>(logid.length(), reinterpret_cast<const char*>(logid.begin())),
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(timestamp)},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(digitally_signed_algorithms->HashAlgorithm())},
-			IntrusivePtr{AdoptRef{}, val_mgr->GetCount(digitally_signed_algorithms->SignatureAlgorithm())},
+			val_mgr->Count(timestamp),
+			val_mgr->Count(digitally_signed_algorithms->HashAlgorithm()),
+			val_mgr->Count(digitally_signed_algorithms->SignatureAlgorithm()),
 			make_intrusive<StringVal>(digitally_signed_signature.length(), reinterpret_cast<const char*>(digitally_signed_signature.begin()))
 			);
 

--- a/src/file_analysis/file_analysis.bif
+++ b/src/file_analysis/file_analysis.bif
@@ -68,7 +68,7 @@ function Files::__stop%(file_id: string%): bool
 ## :zeek:see:`Files::analyzer_name`.
 function Files::__analyzer_name%(tag: Files::Tag%) : string
 	%{
-	return new StringVal(file_mgr->GetComponentName(tag));
+	return make_intrusive<StringVal>(file_mgr->GetComponentName(tag));
 	%}
 
 ## :zeek:see:`Files::file_exists`.
@@ -86,11 +86,11 @@ function Files::__lookup_file%(fuid: string%): fa_file
 	auto f = file_mgr->LookupFile(fuid->CheckString());
 	if ( f != nullptr )
 		{
-		return f->GetVal()->Ref();
+		return IntrusivePtr{NewRef{}, f->GetVal()};
 		}
 	
 	reporter->Error("file ID %s not a known file", fuid->CheckString());
-	return 0;
+	return nullptr;
 	%}
 
 module GLOBAL;
@@ -108,7 +108,7 @@ function set_file_handle%(handle: string%): any
 	auto bytes = reinterpret_cast<const char*>(handle->Bytes());
 	auto h = std::string(bytes, handle->Len());
 	file_mgr->SetHandle(h);
-	return 0;
+	return nullptr;
 	%}
 
 const Files::salt: string;

--- a/src/file_analysis/file_analysis.bif
+++ b/src/file_analysis/file_analysis.bif
@@ -14,28 +14,28 @@ type AnalyzerArgs: record;
 function Files::__set_timeout_interval%(file_id: string, t: interval%): bool
 	%{
 	bool result = file_mgr->SetTimeoutInterval(file_id->CheckString(), t);
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 ## :zeek:see:`Files::enable_reassembly`.
 function Files::__enable_reassembly%(file_id: string%): bool
 	%{
 	bool result = file_mgr->EnableReassembly(file_id->CheckString());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 ## :zeek:see:`Files::disable_reassembly`.
 function Files::__disable_reassembly%(file_id: string%): bool
 	%{
 	bool result = file_mgr->DisableReassembly(file_id->CheckString());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 ## :zeek:see:`Files::set_reassembly_buffer_size`.
 function Files::__set_reassembly_buffer%(file_id: string, max: count%): bool
 	%{
 	bool result = file_mgr->SetReassemblyBuffer(file_id->CheckString(), max);
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 ## :zeek:see:`Files::add_analyzer`.
@@ -45,7 +45,7 @@ function Files::__add_analyzer%(file_id: string, tag: Files::Tag, args: any%): b
 	auto rv = args->AsRecordVal()->CoerceTo(AnalyzerArgs);
 	bool result = file_mgr->AddAnalyzer(file_id->CheckString(),
 	                                    file_mgr->GetComponentTag(tag), rv.get());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 ## :zeek:see:`Files::remove_analyzer`.
@@ -55,14 +55,14 @@ function Files::__remove_analyzer%(file_id: string, tag: Files::Tag, args: any%)
 	auto rv = args->AsRecordVal()->CoerceTo(AnalyzerArgs);
 	bool result = file_mgr->RemoveAnalyzer(file_id->CheckString(),
 	                                       file_mgr->GetComponentTag(tag) , rv.get());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 ## :zeek:see:`Files::stop`.
 function Files::__stop%(file_id: string%): bool
 	%{
 	bool result = file_mgr->IgnoreFile(file_id->CheckString());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 ## :zeek:see:`Files::analyzer_name`.

--- a/src/file_analysis/file_analysis.bif
+++ b/src/file_analysis/file_analysis.bif
@@ -75,9 +75,9 @@ function Files::__analyzer_name%(tag: Files::Tag%) : string
 function Files::__file_exists%(fuid: string%): bool
 	%{
 	if ( file_mgr->LookupFile(fuid->CheckString()) != nullptr )
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 	else
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 	%}
 
 ## :zeek:see:`Files::lookup_file`.

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -2262,7 +2262,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, BroType* request_typ
 		return val_mgr->Bool(val->val.int_val)->Ref();
 
 	case TYPE_INT:
-		return val_mgr->GetInt(val->val.int_val);
+		return val_mgr->Int(val->val.int_val).release();
 
 	case TYPE_COUNT:
 	case TYPE_COUNTER:
@@ -2410,7 +2410,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, bool& have_error) co
 		return val_mgr->Bool(val->val.int_val)->Ref();
 
 	case TYPE_INT:
-		return val_mgr->GetInt(val->val.int_val);
+		return val_mgr->Int(val->val.int_val).release();
 
 	case TYPE_COUNT:
 	case TYPE_COUNTER:

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -2259,7 +2259,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, BroType* request_typ
 
 	switch ( val->type ) {
 	case TYPE_BOOL:
-		return val_mgr->GetBool(val->val.int_val);
+		return val_mgr->Bool(val->val.int_val)->Ref();
 
 	case TYPE_INT:
 		return val_mgr->GetInt(val->val.int_val);
@@ -2407,7 +2407,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, bool& have_error) co
 
 	switch ( val->type ) {
 	case TYPE_BOOL:
-		return val_mgr->GetBool(val->val.int_val);
+		return val_mgr->Bool(val->val.int_val)->Ref();
 
 	case TYPE_INT:
 		return val_mgr->GetInt(val->val.int_val);

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -2280,7 +2280,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, BroType* request_typ
 		}
 
 	case TYPE_PORT:
-		return val_mgr->GetPort(val->val.port_val.port, val->val.port_val.proto);
+		return val_mgr->Port(val->val.port_val.port, val->val.port_val.proto)->Ref();
 
 	case TYPE_ADDR:
 		{
@@ -2428,7 +2428,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, bool& have_error) co
 		}
 
 	case TYPE_PORT:
-		return val_mgr->GetPort(val->val.port_val.port, val->val.port_val.proto);
+		return val_mgr->Port(val->val.port_val.port, val->val.port_val.proto)->Ref();
 
 	case TYPE_ADDR:
 		{

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -2266,7 +2266,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, BroType* request_typ
 
 	case TYPE_COUNT:
 	case TYPE_COUNTER:
-		return val_mgr->GetCount(val->val.int_val);
+		return val_mgr->Count(val->val.int_val).release();
 
 	case TYPE_DOUBLE:
 	case TYPE_TIME:
@@ -2414,7 +2414,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, bool& have_error) co
 
 	case TYPE_COUNT:
 	case TYPE_COUNTER:
-		return val_mgr->GetCount(val->val.int_val);
+		return val_mgr->Count(val->val.int_val).release();
 
 	case TYPE_DOUBLE:
 	case TYPE_TIME:

--- a/src/input/input.bif
+++ b/src/input/input.bif
@@ -19,31 +19,31 @@ type AnalysisDescription: record;
 function Input::__create_table_stream%(description: Input::TableDescription%) : bool
 	%{
 	bool res = input_mgr->CreateTableStream(description->AsRecordVal());
-	return val_mgr->GetBool(res);
+	return val_mgr->Bool(res);
 	%}
 
 function Input::__create_event_stream%(description: Input::EventDescription%) : bool
 	%{
 	bool res = input_mgr->CreateEventStream(description->AsRecordVal());
-	return val_mgr->GetBool(res);
+	return val_mgr->Bool(res);
 	%}
 
 function Input::__create_analysis_stream%(description: Input::AnalysisDescription%) : bool
 	%{
 	bool res = input_mgr->CreateAnalysisStream(description->AsRecordVal());
-	return val_mgr->GetBool(res);
+	return val_mgr->Bool(res);
 	%}
 
 function Input::__remove_stream%(id: string%) : bool
 	%{
 	bool res = input_mgr->RemoveStream(id->AsString()->CheckString());
-	return val_mgr->GetBool(res);
+	return val_mgr->Bool(res);
 	%}
 
 function Input::__force_update%(id: string%) : bool
 	%{
 	bool res = input_mgr->ForceUpdate(id->AsString()->CheckString());
-	return val_mgr->GetBool(res);
+	return val_mgr->Bool(res);
 	%}
 
 # Options for the input framework

--- a/src/iosource/Packet.cc
+++ b/src/iosource/Packet.cc
@@ -628,12 +628,12 @@ RecordVal* Packet::BuildPktHdrVal() const
 		l2_hdr->Assign(4, FmtEUI48(data));  	// dst
 
 		if ( vlan )
-			l2_hdr->Assign(5, val_mgr->GetCount(vlan));
+			l2_hdr->Assign(5, val_mgr->Count(vlan));
 
 		if ( inner_vlan )
-			l2_hdr->Assign(6, val_mgr->GetCount(inner_vlan));
+			l2_hdr->Assign(6, val_mgr->Count(inner_vlan));
 
-		l2_hdr->Assign(7, val_mgr->GetCount(eth_type));
+		l2_hdr->Assign(7, val_mgr->Count(eth_type));
 
 		if ( eth_type == ETHERTYPE_ARP || eth_type == ETHERTYPE_REVARP )
 			// We also identify ARP for L3 over ethernet
@@ -642,8 +642,8 @@ RecordVal* Packet::BuildPktHdrVal() const
 	else
 		l2_hdr->Assign(0, BifType::Enum::link_encap->GetVal(BifEnum::LINK_UNKNOWN));
 
-	l2_hdr->Assign(1, val_mgr->GetCount(len));
-	l2_hdr->Assign(2, val_mgr->GetCount(cap_len));
+	l2_hdr->Assign(1, val_mgr->Count(len));
+	l2_hdr->Assign(2, val_mgr->Count(cap_len));
 
 	l2_hdr->Assign(8, BifType::Enum::layer3_proto->GetVal(l3));
 

--- a/src/iosource/pcap/pcap.bif
+++ b/src/iosource/pcap/pcap.bif
@@ -43,7 +43,7 @@ function precompile_pcap_filter%(id: PcapFilterID, s: string%): bool
 	if ( ps && ! ps->PrecompileFilter(id->ForceAsInt(), s->CheckString()) )
 		success = false;
 
-	return val_mgr->GetBool(success);
+	return val_mgr->Bool(success);
 	%}
 
 ## Installs a PCAP filter that has been precompiled with
@@ -72,7 +72,7 @@ function Pcap::install_pcap_filter%(id: PcapFilterID%): bool
 	if ( ps && ! ps->SetFilter(id->ForceAsInt()) )
 		success = false;
 
-	return val_mgr->GetBool(success);
+	return val_mgr->Bool(success);
 	%}
 
 ## Returns a string representation of the last PCAP error.

--- a/src/iosource/pcap/pcap.bif
+++ b/src/iosource/pcap/pcap.bif
@@ -34,7 +34,7 @@ function precompile_pcap_filter%(id: PcapFilterID, s: string%): bool
 		// lookups and limit the ID space so that that doesn't grow too
 		// large.
 		builtin_error(fmt("PCAP filter ids must remain below 100 (is %" PRId64 ")", id->AsInt()));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	bool success = true;

--- a/src/iosource/pcap/pcap.bif
+++ b/src/iosource/pcap/pcap.bif
@@ -96,8 +96,8 @@ function error%(%): string
 		{
 		const char* err = ps->ErrorMsg();
 		if ( *err )
-			return new StringVal(err);
+			return make_intrusive<StringVal>(err);
 		}
 
-	return new StringVal("no error");
+	return make_intrusive<StringVal>("no error");
 	%}

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -289,7 +289,7 @@ bool Manager::CreateStream(EnumVal* id, RecordVal* sval)
 		if ( ! same_type((*args)[0], columns) )
 			{
 			reporter->Error("stream event's argument type does not match column record type");
-			return val_mgr->GetFalse();
+			return false;
 			}
 		}
 

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -1521,7 +1521,7 @@ bool Manager::FinishedRotation(WriterFrontend* writer, const char* new_name, con
 	info->Assign(2, make_intrusive<StringVal>(winfo->writer->Info().path));
 	info->Assign(3, make_intrusive<Val>(open, TYPE_TIME));
 	info->Assign(4, make_intrusive<Val>(close, TYPE_TIME));
-	info->Assign(5, val_mgr->GetBool(terminating));
+	info->Assign(5, val_mgr->Bool(terminating));
 
 	Func* func = winfo->postprocessor;
 	if ( ! func )

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -741,7 +741,7 @@ bool Manager::Write(EnumVal* id, RecordVal* columns_arg)
 			if ( filter->path_val )
 				path_arg = {NewRef{}, filter->path_val};
 			else
-				path_arg = {AdoptRef{}, val_mgr->GetEmptyString()};
+				path_arg = val_mgr->EmptyString();
 
 			IntrusivePtr<Val> rec_arg;
 			BroType* rt = filter->path_func->FType()->Args()->FieldType("rec");

--- a/src/logging/logging.bif
+++ b/src/logging/logging.bif
@@ -19,53 +19,53 @@ enum PrintLogType %{
 function Log::__create_stream%(id: Log::ID, stream: Log::Stream%) : bool
 	%{
 	bool result = log_mgr->CreateStream(id->AsEnumVal(), stream->AsRecordVal());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Log::__remove_stream%(id: Log::ID%) : bool
 	%{
 	bool result = log_mgr->RemoveStream(id->AsEnumVal());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Log::__enable_stream%(id: Log::ID%) : bool
 	%{
 	bool result = log_mgr->EnableStream(id->AsEnumVal());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Log::__disable_stream%(id: Log::ID%) : bool
 	%{
 	bool result = log_mgr->DisableStream(id->AsEnumVal());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Log::__add_filter%(id: Log::ID, filter: Log::Filter%) : bool
 	%{
 	bool result = log_mgr->AddFilter(id->AsEnumVal(), filter->AsRecordVal());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Log::__remove_filter%(id: Log::ID, name: string%) : bool
 	%{
 	bool result = log_mgr->RemoveFilter(id->AsEnumVal(), name);
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Log::__write%(id: Log::ID, columns: any%) : bool
 	%{
 	bool result = log_mgr->Write(id->AsEnumVal(), columns->AsRecordVal());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Log::__set_buf%(id: Log::ID, buffered: bool%): bool
 	%{
 	bool result = log_mgr->SetBuf(id->AsEnumVal(), buffered);
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}
 
 function Log::__flush%(id: Log::ID%): bool
 	%{
 	bool result = log_mgr->Flush(id->AsEnumVal());
-	return val_mgr->GetBool(result);
+	return val_mgr->Bool(result);
 	%}

--- a/src/main.cc
+++ b/src/main.cc
@@ -875,7 +875,7 @@ int main(int argc, char** argv)
 
 			mgr.Enqueue(zeek_script_loaded,
 				make_intrusive<StringVal>(i->name.c_str()),
-				IntrusivePtr{AdoptRef{}, val_mgr->GetCount(i->include_level)}
+				val_mgr->Count(i->include_level)
 			);
 			}
 		}

--- a/src/option.bif
+++ b/src/option.bif
@@ -92,7 +92,7 @@ function Option::set%(ID: string, val: any, location: string &default=""%): bool
 			}
 
 		auto rval = call_option_handlers_and_set_value(ID, i, std::move(val_from_data), location);
-		return val_mgr->GetBool(rval);
+		return val_mgr->Bool(rval);
 		}
 
 	if ( ! same_type(i->Type(), val->Type()) )
@@ -106,7 +106,7 @@ function Option::set%(ID: string, val: any, location: string &default=""%): bool
 			        IntrusivePtr{NewRef{}, i->Type()->AsTableType()},
 			        IntrusivePtr{NewRef{}, i->ID_Val()->AsTableVal()->Attrs()});
 			auto rval = call_option_handlers_and_set_value(ID, i, std::move(tv), location);
-			return val_mgr->GetBool(rval);
+			return val_mgr->Bool(rval);
 			}
 
 		builtin_error(fmt("Incompatible type for set of ID '%s': got '%s', need '%s'",
@@ -115,7 +115,7 @@ function Option::set%(ID: string, val: any, location: string &default=""%): bool
 		}
 
 	auto rval = call_option_handlers_and_set_value(ID, i, {NewRef{}, val}, location);
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 ## Set a change handler for an option. The change handler will be

--- a/src/option.bif
+++ b/src/option.bif
@@ -63,20 +63,20 @@ function Option::set%(ID: string, val: any, location: string &default=""%): bool
 	if ( ! i )
 		{
 		builtin_error(fmt("Could not find ID named '%s'", ID->CheckString()));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! i->HasVal() )
 		{
 		// should be impossible because initialization is enforced
 		builtin_error(fmt("ID '%s' has no value", ID->CheckString()));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! i->IsOption() )
 		{
 		builtin_error(fmt("ID '%s' is not an option", ID->CheckString()));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( same_type(val->Type(), bro_broker::DataVal::ScriptDataType()) )
@@ -88,7 +88,7 @@ function Option::set%(ID: string, val: any, location: string &default=""%): bool
 			{
 			builtin_error(fmt("Incompatible type for set of ID '%s': got broker data '%s', need '%s'",
 				ID->CheckString(), dv->data.get_type_name(), type_name(i->Type()->Tag())));
-			return val_mgr->GetFalse();
+			return val_mgr->False();
 			}
 
 		auto rval = call_option_handlers_and_set_value(ID, i, std::move(val_from_data), location);
@@ -111,7 +111,7 @@ function Option::set%(ID: string, val: any, location: string &default=""%): bool
 
 		builtin_error(fmt("Incompatible type for set of ID '%s': got '%s', need '%s'",
 			ID->CheckString(), type_name(val->Type()->Tag()), type_name(i->Type()->Tag())));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto rval = call_option_handlers_and_set_value(ID, i, {NewRef{}, val}, location);
@@ -148,26 +148,26 @@ function Option::set_change_handler%(ID: string, on_change: any, priority: int &
 	if ( ! i )
 		{
 		builtin_error(fmt("Could not find ID named '%s'", ID->CheckString()));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! i->IsOption() )
 		{
 		builtin_error(fmt("ID '%s' is not an option", ID->CheckString()));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( on_change->Type()->Tag() != TYPE_FUNC )
 		{
 		builtin_error(fmt("Option::on_change needs function argument; got '%s' for ID '%s'",
 			type_name(on_change->Type()->Tag()), ID->CheckString()));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( on_change->Type()->AsFuncType()->Flavor() != FUNC_FLAVOR_FUNCTION )
 		{
 		builtin_error("Option::on_change needs function argument; not hook or event");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	const type_list* args = on_change->Type()->AsFuncType()->ArgTypes()->Types();
@@ -175,38 +175,38 @@ function Option::set_change_handler%(ID: string, on_change: any, priority: int &
 		{
 		builtin_error(fmt("Wrong number of arguments for passed function in Option::on_change for ID '%s'; expected 2 or 3, got %d",
 			ID->CheckString(), args->length()));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( (*args)[0]->Tag() != TYPE_STRING )
 		{
 		builtin_error(fmt("First argument of passed function has to be string in Option::on_change for ID '%s'; got '%s'",
 			ID->CheckString(), type_name((*args)[0]->Tag())));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! same_type((*args)[1], i->Type()) )
 		{
 		builtin_error(fmt("Second argument of passed function has to be %s in Option::on_change for ID '%s'; got '%s'",
 			type_name(i->Type()->Tag()), ID->CheckString(), type_name((*args)[1]->Tag())));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( args->length() == 3 && (*args)[2]->Tag() != TYPE_STRING )
 		{
 		builtin_error(fmt("Third argument of passed function has to be string in Option::on_change for ID '%s'; got '%s'",
 			ID->CheckString(), type_name((*args)[2]->Tag())));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( ! same_type(on_change->Type()->AsFuncType()->YieldType(), i->Type()) )
 		{
 		builtin_error(fmt("Passed function needs to return type '%s' for ID '%s'; got '%s'",
 			type_name(i->Type()->Tag()), ID->CheckString(), type_name(on_change->Type()->AsFuncType()->YieldType()->Tag())));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	auto* func = on_change->AsFunc();
 	i->AddOptionHandler({NewRef{}, func}, -priority);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}

--- a/src/parse.y
+++ b/src/parse.y
@@ -1319,8 +1319,7 @@ index_slice:
 			set_location(@1, @6);
 
 			auto low = $3 ? IntrusivePtr<Expr>{AdoptRef{}, $3} :
-			                make_intrusive<ConstExpr>(
-			                    IntrusivePtr<Val>{AdoptRef{}, val_mgr->GetCount(0)});
+			                make_intrusive<ConstExpr>(val_mgr->Count(0));
 
 			auto high = $5 ? IntrusivePtr<Expr>{AdoptRef{}, $5} :
 			                 make_intrusive<SizeExpr>(

--- a/src/parse.y
+++ b/src/parse.y
@@ -481,7 +481,7 @@ expr:
 			{
 			set_location(@2, @4);
 			$$ = add_and_assign_local({AdoptRef{}, $2}, {AdoptRef{}, $4},
-			                          {AdoptRef{}, val_mgr->GetTrue()}).release();
+			                          val_mgr->True()).release();
 			}
 
 	|	expr '[' expr_list ']'

--- a/src/probabilistic/bloom-filter.bif
+++ b/src/probabilistic/bloom-filter.bif
@@ -180,9 +180,9 @@ function bloomfilter_lookup%(bf: opaque of bloomfilter, x: any%): count
 		reporter->Error("incompatible Bloom filter types");
 
 	else
-		return val_mgr->GetCount(static_cast<uint64_t>(bfv->Count(x)));
+		return val_mgr->Count(static_cast<uint64_t>(bfv->Count(x)));
 
-	return val_mgr->GetCount(0);
+	return val_mgr->Count(0);
 	%}
 
 ## Removes all elements from a Bloom filter. This function resets all bits in

--- a/src/probabilistic/bloom-filter.bif
+++ b/src/probabilistic/bloom-filter.bif
@@ -37,7 +37,7 @@ function bloomfilter_basic_init%(fp: double, capacity: count,
 	if ( fp < 0.0 || fp > 1.0 )
 		{
 		reporter->Error("false-positive rate must take value between 0 and 1");
-		return 0;
+		return nullptr;
 		}
 
 	size_t cells = BasicBloomFilter::M(fp, capacity);
@@ -46,7 +46,7 @@ function bloomfilter_basic_init%(fp: double, capacity: count,
                                  name->Len());
 	const Hasher* h = new DoubleHasher(optimal_k, seed);
 
-	return new BloomFilterVal(new BasicBloomFilter(h, cells));
+	return make_intrusive<BloomFilterVal>(new BasicBloomFilter(h, cells));
 	%}
 
 ## Creates a basic Bloom filter. This function serves as a low-level
@@ -74,19 +74,19 @@ function bloomfilter_basic_init2%(k: count, cells: count,
 	if ( k == 0 )
 		{
 		reporter->Error("number of hash functions must be non-negative");
-		return 0;
+		return nullptr;
 		}
 	if ( cells == 0 )
 		{
 		reporter->Error("number of cells must be non-negative");
-		return 0;
+		return nullptr;
 		}
 
 	Hasher::seed_t seed = Hasher::MakeSeed(name->Len() > 0 ? name->Bytes() : 0,
 				       name->Len());
 	const Hasher* h = new DoubleHasher(k, seed);
 
-	return new BloomFilterVal(new BasicBloomFilter(h, cells));
+	return make_intrusive<BloomFilterVal>(new BasicBloomFilter(h, cells));
 	%}
 
 ## Creates a counting Bloom filter.
@@ -118,7 +118,7 @@ function bloomfilter_counting_init%(k: count, cells: count, max: count,
 	if ( max == 0 )
 		{
 		reporter->Error("max counter value must be greater than 0");
-		return 0;
+		return nullptr;
 		}
 
 	Hasher::seed_t seed = Hasher::MakeSeed(name->Len() > 0 ? name->Bytes() : 0,
@@ -130,7 +130,7 @@ function bloomfilter_counting_init%(k: count, cells: count, max: count,
 	while ( max >>= 1 )
 		++width;
 
-	return new BloomFilterVal(new CountingBloomFilter(h, cells, width));
+	return make_intrusive<BloomFilterVal>(new CountingBloomFilter(h, cells, width));
 	%}
 
 ## Adds an element to a Bloom filter.
@@ -155,7 +155,7 @@ function bloomfilter_add%(bf: opaque of bloomfilter, x: any%): any
 	else
 		bfv->Add(x);
 
-	return 0;
+	return nullptr;
 	%}
 
 ## Retrieves the counter for a given element in a Bloom filter.
@@ -201,7 +201,7 @@ function bloomfilter_clear%(bf: opaque of bloomfilter%): any
 	if ( bfv->Type() ) // Untyped Bloom filters are already empty.
 		bfv->Clear();
 
-	return 0;
+	return nullptr;
 	%}
 
 ## Merges two Bloom filters.
@@ -230,10 +230,10 @@ function bloomfilter_merge%(bf1: opaque of bloomfilter,
 	     ! same_type(bfv1->Type(), bfv2->Type()) )
 		{
 		reporter->Error("incompatible Bloom filter types");
-		return 0;
+		return nullptr;
 		}
 
-	return BloomFilterVal::Merge(bfv1, bfv2).release();
+	return BloomFilterVal::Merge(bfv1, bfv2);
 	%}
 
 ## Returns a string with a representation of a Bloom filter's internal
@@ -245,5 +245,5 @@ function bloomfilter_merge%(bf1: opaque of bloomfilter,
 function bloomfilter_internal_state%(bf: opaque of bloomfilter%): string
 	%{
 	BloomFilterVal* bfv = static_cast<BloomFilterVal*>(bf);
-	return new StringVal(bfv->InternalState());
+	return make_intrusive<StringVal>(bfv->InternalState());
 	%}

--- a/src/probabilistic/cardinality-counter.bif
+++ b/src/probabilistic/cardinality-counter.bif
@@ -45,17 +45,17 @@ function hll_cardinality_add%(handle: opaque of cardinality, elem: any%): bool
 	if ( ! cv->Type() && ! cv->Typify(elem->Type()) )
 		{
 		reporter->Error("failed to set HLL type");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	else if ( ! same_type(cv->Type(), elem->Type()) )
 		{
 		reporter->Error("incompatible HLL data type");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	cv->Add(elem);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Merges a HLL cardinality counter into another.
@@ -82,7 +82,7 @@ function hll_cardinality_merge_into%(handle1: opaque of cardinality, handle2: op
 	     ! same_type(v1->Type(), v2->Type()) )
 		{
 		reporter->Error("incompatible HLL types");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	CardinalityCounter* h1 = v1->Get();
@@ -92,10 +92,10 @@ function hll_cardinality_merge_into%(handle1: opaque of cardinality, handle2: op
 	if ( ! res )
 		{
 		reporter->Error("Cardinality counters with different parameters cannot be merged");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Estimate the current cardinality of an HLL cardinality counter.

--- a/src/probabilistic/cardinality-counter.bif
+++ b/src/probabilistic/cardinality-counter.bif
@@ -113,7 +113,7 @@ function hll_cardinality_estimate%(handle: opaque of cardinality%): double
 
 	double estimate = h->Size();
 
-	return new Val(estimate, TYPE_DOUBLE);
+	return make_intrusive<Val>(estimate, TYPE_DOUBLE);
 	%}
 
 ## Copy a HLL cardinality counter.

--- a/src/probabilistic/top-k.bif
+++ b/src/probabilistic/top-k.bif
@@ -36,7 +36,7 @@ function topk_add%(handle: opaque of topk, value: any%): any
 	probabilistic::TopkVal* h = (probabilistic::TopkVal*) handle;
 	h->Encountered(value);
 
-	return 0;
+	return nullptr;
 	%}
 
 ## Get the first *k* elements of the top-k data structure.
@@ -53,7 +53,7 @@ function topk_get_top%(handle: opaque of topk, k: count%): any_vec
 	%{
 	assert(handle);
 	probabilistic::TopkVal* h = (probabilistic::TopkVal*) handle;
-	return h->GetTopK(k);
+	return IntrusivePtr{AdoptRef{}, h->GetTopK(k)};
 	%}
 
 ## Get an overestimated count of how often a value has been encountered.
@@ -157,7 +157,7 @@ function topk_merge%(handle1: opaque of topk, handle2: opaque of topk%): any
 
 	h1->Merge(h2);
 
-	return 0;
+	return nullptr;
 	%}
 
 ## Merge the second top-k data structure into the first and prunes the final
@@ -183,5 +183,5 @@ function topk_merge_prune%(handle1: opaque of topk, handle2: opaque of topk%): a
 
 	h1->Merge(h2, true);
 
-	return 0;
+	return nullptr;
 	%}

--- a/src/probabilistic/top-k.bif
+++ b/src/probabilistic/top-k.bif
@@ -74,7 +74,7 @@ function topk_count%(handle: opaque of topk, value: any%): count
 	%{
 	assert(handle);
 	probabilistic::TopkVal* h = (probabilistic::TopkVal*) handle;
-	return val_mgr->GetCount(h->GetCount(value));
+	return val_mgr->Count(h->GetCount(value));
 	%}
 
 ## Get the maximal overestimation for count.
@@ -94,7 +94,7 @@ function topk_epsilon%(handle: opaque of topk, value: any%): count
 	%{
 	assert(handle);
 	probabilistic::TopkVal* h = (probabilistic::TopkVal*) handle;
-	return val_mgr->GetCount(h->GetEpsilon(value));
+	return val_mgr->Count(h->GetEpsilon(value));
 	%}
 
 ## Get the number of elements this data structure is supposed to track (given
@@ -113,7 +113,7 @@ function topk_size%(handle: opaque of topk%): count
 	%{
 	assert(handle);
 	probabilistic::TopkVal* h = (probabilistic::TopkVal*) handle;
-	return val_mgr->GetCount(h->GetSize());
+	return val_mgr->Count(h->GetSize());
 	%}
 
 ## Get the sum of all counts of all elements in the data structure.
@@ -133,7 +133,7 @@ function topk_sum%(handle: opaque of topk%): count
 	%{
 	assert(handle);
 	probabilistic::TopkVal* h = (probabilistic::TopkVal*) handle;
-	return val_mgr->GetCount(h->GetSum());
+	return val_mgr->Count(h->GetSum());
 	%}
 
 ## Merge the second top-k data structure into the first.

--- a/src/reporter.bif
+++ b/src/reporter.bif
@@ -153,7 +153,7 @@ function Reporter::file_weird%(name: string, f: fa_file, addl: string &default="
 ## Returns: Current weird sampling whitelist
 function Reporter::get_weird_sampling_whitelist%(%): string_set
 	%{
-	TableVal* set = new TableVal({NewRef{}, string_set});
+	auto set = make_intrusive<TableVal>(IntrusivePtr{NewRef{}, string_set});
 	for ( auto el : reporter->GetWeirdSamplingWhitelist() )
 		{
 		auto idx = make_intrusive<StringVal>(el);
@@ -232,7 +232,7 @@ function Reporter::set_weird_sampling_rate%(weird_sampling_rate: count%) : bool
 ## Returns: weird sampling duration.
 function Reporter::get_weird_sampling_duration%(%) : interval
 	%{
-	return new Val(reporter->GetWeirdSamplingDuration(), TYPE_INTERVAL);
+	return make_intrusive<Val>(reporter->GetWeirdSamplingDuration(), TYPE_INTERVAL);
 	%}
 
 ## Sets the current weird sampling duration. Please note that

--- a/src/reporter.bif
+++ b/src/reporter.bif
@@ -193,7 +193,7 @@ function Reporter::set_weird_sampling_whitelist%(weird_sampling_whitelist: strin
 ## Returns: current weird sampling threshold.
 function Reporter::get_weird_sampling_threshold%(%) : count
 	%{
-	return val_mgr->GetCount(reporter->GetWeirdSamplingThreshold());
+	return val_mgr->Count(reporter->GetWeirdSamplingThreshold());
 	%}
 
 ## Sets the current weird sampling threshold
@@ -213,7 +213,7 @@ function Reporter::set_weird_sampling_threshold%(weird_sampling_threshold: count
 ## Returns: weird sampling rate.
 function Reporter::get_weird_sampling_rate%(%) : count
 	%{
-	return val_mgr->GetCount(reporter->GetWeirdSamplingRate());
+	return val_mgr->Count(reporter->GetWeirdSamplingRate());
 	%}
 
 ## Sets the weird sampling rate.

--- a/src/reporter.bif
+++ b/src/reporter.bif
@@ -25,7 +25,7 @@ function Reporter::info%(msg: string%): bool
 	reporter->PushLocation(frame->GetCall()->GetLocationInfo());
 	reporter->Info("%s", msg->CheckString());
 	reporter->PopLocation();
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Generates a message that warns of a potential problem.
@@ -40,7 +40,7 @@ function Reporter::warning%(msg: string%): bool
 	reporter->PushLocation(frame->GetCall()->GetLocationInfo());
 	reporter->Warning("%s", msg->CheckString());
 	reporter->PopLocation();
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Generates a non-fatal error indicative of a definite problem that should
@@ -56,7 +56,7 @@ function Reporter::error%(msg: string%): bool
 	reporter->PushLocation(frame->GetCall()->GetLocationInfo());
 	reporter->Error("%s", msg->CheckString());
 	reporter->PopLocation();
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Generates a fatal error on stderr and terminates program execution.
@@ -69,7 +69,7 @@ function Reporter::fatal%(msg: string%): bool
 	reporter->PushLocation(frame->GetCall()->GetLocationInfo());
 	reporter->FatalError("%s", msg->CheckString());
 	reporter->PopLocation();
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Generates a fatal error on stderr and terminates program execution
@@ -83,7 +83,7 @@ function Reporter::fatal_error_with_core%(msg: string%): bool
 	reporter->PushLocation(frame->GetCall()->GetLocationInfo());
 	reporter->FatalErrorWithCore("%s", msg->CheckString());
 	reporter->PopLocation();
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Generates a "net" weird.
@@ -94,7 +94,7 @@ function Reporter::fatal_error_with_core%(msg: string%): bool
 function Reporter::net_weird%(name: string%): bool
 	%{
 	reporter->Weird(name->CheckString());
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Generates a "flow" weird.
@@ -109,7 +109,7 @@ function Reporter::net_weird%(name: string%): bool
 function Reporter::flow_weird%(name: string, orig: addr, resp: addr%): bool
 	%{
 	reporter->Weird(orig->AsAddr(), resp->AsAddr(), name->CheckString());
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Generates a "conn" weird.
@@ -124,7 +124,7 @@ function Reporter::flow_weird%(name: string, orig: addr, resp: addr%): bool
 function Reporter::conn_weird%(name: string, c: connection, addl: string &default=""%): bool
 	%{
 	reporter->Weird(c, name->CheckString(), addl->CheckString());
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Generates a "file" weird.
@@ -142,10 +142,10 @@ function Reporter::file_weird%(name: string, f: fa_file, addl: string &default="
 	auto file = file_mgr->LookupFile(fuid->CheckString());
 
 	if ( ! file )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	reporter->Weird(file, name->CheckString(), addl->CheckString());
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Gets the weird sampling whitelist
@@ -185,7 +185,7 @@ function Reporter::set_weird_sampling_whitelist%(weird_sampling_whitelist: strin
 		delete k;
 		}
 	reporter->SetWeirdSamplingWhitelist(whitelist_set);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 %}
 
 ## Gets the current weird sampling threshold
@@ -204,7 +204,7 @@ function Reporter::get_weird_sampling_threshold%(%) : count
 function Reporter::set_weird_sampling_threshold%(weird_sampling_threshold: count%) : bool
 	%{
 	reporter->SetWeirdSamplingThreshold(weird_sampling_threshold);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 
@@ -224,7 +224,7 @@ function Reporter::get_weird_sampling_rate%(%) : count
 function Reporter::set_weird_sampling_rate%(weird_sampling_rate: count%) : bool
 	%{
 	reporter->SetWeirdSamplingRate(weird_sampling_rate);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Gets the current weird sampling duration.
@@ -244,5 +244,5 @@ function Reporter::get_weird_sampling_duration%(%) : interval
 function Reporter::set_weird_sampling_duration%(weird_sampling_duration: interval%) : bool
 	%{
 	reporter->SetWeirdSamplingDuration(weird_sampling_duration);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}

--- a/src/scan.l
+++ b/src/scan.l
@@ -476,7 +476,7 @@ F	RET_CONST(val_mgr->False()->Ref())
 	}
 
 {D}		{
-		RET_CONST(val_mgr->GetCount(static_cast<bro_uint_t>(strtoull(yytext, (char**) NULL, 10))))
+		RET_CONST(val_mgr->Count(static_cast<bro_uint_t>(strtoull(yytext, (char**) NULL, 10))).release())
 		}
 {FLOAT}		RET_CONST(new Val(atof(yytext), TYPE_DOUBLE))
 
@@ -524,7 +524,7 @@ F	RET_CONST(val_mgr->False()->Ref())
 {FLOAT}{OWS}msec(s?)	RET_CONST(new IntervalVal(atof(yytext),Milliseconds))
 {FLOAT}{OWS}usec(s?)	RET_CONST(new IntervalVal(atof(yytext),Microseconds))
 
-"0x"{HEX}+	RET_CONST(val_mgr->GetCount(static_cast<bro_uint_t>(strtoull(yytext, 0, 16))))
+"0x"{HEX}+	RET_CONST(val_mgr->Count(static_cast<bro_uint_t>(strtoull(yytext, 0, 16))).release())
 
 {H}("."{H})+		RET_CONST(dns_mgr->LookupHost(yytext).release())
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -487,7 +487,7 @@ F	RET_CONST(val_mgr->False()->Ref())
 			reporter->Error("bad port number - %s", yytext);
 			p = 0;
 			}
-		RET_CONST(val_mgr->GetPort(p, TRANSPORT_TCP))
+		RET_CONST(val_mgr->Port(p, TRANSPORT_TCP)->Ref())
 		}
 {D}"/udp"	{
 		uint32_t p = atoi(yytext);
@@ -496,7 +496,7 @@ F	RET_CONST(val_mgr->False()->Ref())
 			reporter->Error("bad port number - %s", yytext);
 			p = 0;
 			}
-		RET_CONST(val_mgr->GetPort(p, TRANSPORT_UDP))
+		RET_CONST(val_mgr->Port(p, TRANSPORT_UDP)->Ref())
 		}
 {D}"/icmp"	{
 		uint32_t p = atoi(yytext);
@@ -505,7 +505,7 @@ F	RET_CONST(val_mgr->False()->Ref())
 			reporter->Error("bad port number - %s", yytext);
 			p = 0;
 			}
-		RET_CONST(val_mgr->GetPort(p, TRANSPORT_ICMP))
+		RET_CONST(val_mgr->Port(p, TRANSPORT_ICMP)->Ref())
 		}
 {D}"/unknown"	{
 		uint32_t p = atoi(yytext);
@@ -514,7 +514,7 @@ F	RET_CONST(val_mgr->False()->Ref())
 			reporter->Error("bad port number - %s", yytext);
 			p = 0;
 			}
-		RET_CONST(val_mgr->GetPort(p, TRANSPORT_UNKNOWN))
+		RET_CONST(val_mgr->Port(p, TRANSPORT_UNKNOWN)->Ref())
 		}
 
 {FLOAT}{OWS}day(s?)	RET_CONST(new IntervalVal(atof(yytext),Days))

--- a/src/scan.l
+++ b/src/scan.l
@@ -466,8 +466,8 @@ when	return TOK_WHEN;
 <IGNORE>[^@\n]+	/* eat */
 <IGNORE>.	/* eat */
 
-T	RET_CONST(val_mgr->GetTrue())
-F	RET_CONST(val_mgr->GetFalse())
+T	RET_CONST(val_mgr->True()->Ref())
+F	RET_CONST(val_mgr->False()->Ref())
 
 {ID}	{
 	yylval.str = copy_string(yytext);

--- a/src/stats.bif
+++ b/src/stats.bif
@@ -57,10 +57,10 @@ function get_net_stats%(%): NetStats
 	RecordVal* r = new RecordVal(NetStats);
 	int n = 0;
 
-	r->Assign(n++, val_mgr->GetCount(recv));
-	r->Assign(n++, val_mgr->GetCount(drop));
-	r->Assign(n++, val_mgr->GetCount(link));
-	r->Assign(n++, val_mgr->GetCount(bytes_recv));
+	r->Assign(n++, val_mgr->Count(recv));
+	r->Assign(n++, val_mgr->Count(drop));
+	r->Assign(n++, val_mgr->Count(link));
+	r->Assign(n++, val_mgr->Count(bytes_recv));
 
 	return r;
 	%}
@@ -86,16 +86,16 @@ function get_conn_stats%(%): ConnStats
 	RecordVal* r = new RecordVal(ConnStats);
 	int n = 0;
 
-	r->Assign(n++, val_mgr->GetCount(Connection::TotalConnections()));
-	r->Assign(n++, val_mgr->GetCount(Connection::CurrentConnections()));
-	r->Assign(n++, val_mgr->GetCount(sessions->CurrentConnections()));
+	r->Assign(n++, val_mgr->Count(Connection::TotalConnections()));
+	r->Assign(n++, val_mgr->Count(Connection::CurrentConnections()));
+	r->Assign(n++, val_mgr->Count(sessions->CurrentConnections()));
 
 	SessionStats s;
 	if ( sessions )
 		sessions->GetStats(s);
 
 #define ADD_STAT(x) \
-	r->Assign(n++, val_mgr->GetCount(unsigned(sessions ? x : 0)));
+	r->Assign(n++, val_mgr->Count(unsigned(sessions ? x : 0)));
 
 	ADD_STAT(s.num_packets);
 	ADD_STAT(s.num_fragments);
@@ -110,7 +110,7 @@ function get_conn_stats%(%): ConnStats
 	ADD_STAT(s.max_ICMP_conns);
 	ADD_STAT(s.cumulative_ICMP_conns);
 
-	r->Assign(n++, val_mgr->GetCount(killed_by_inactivity));
+	r->Assign(n++, val_mgr->Count(killed_by_inactivity));
 
 	return r;
 	%}
@@ -147,9 +147,9 @@ function get_proc_stats%(%): ProcStats
 		double(ru.ru_stime.tv_sec) + double(ru.ru_stime.tv_usec) / 1e6;
 
 #ifdef DEBUG
-	r->Assign(n++, val_mgr->GetCount(1));
+	r->Assign(n++, val_mgr->Count(1));
 #else
-	r->Assign(n++, val_mgr->GetCount(0));
+	r->Assign(n++, val_mgr->Count(0));
 #endif
 
 	r->Assign(n++, make_intrusive<Val>(bro_start_time, TYPE_TIME));
@@ -160,14 +160,14 @@ function get_proc_stats%(%): ProcStats
 
 	uint64_t total_mem;
 	get_memory_usage(&total_mem, NULL);
-	r->Assign(n++, val_mgr->GetCount(unsigned(total_mem)));
+	r->Assign(n++, val_mgr->Count(unsigned(total_mem)));
 
-	r->Assign(n++, val_mgr->GetCount(unsigned(ru.ru_minflt)));
-	r->Assign(n++, val_mgr->GetCount(unsigned(ru.ru_majflt)));
-	r->Assign(n++, val_mgr->GetCount(unsigned(ru.ru_nswap)));
-	r->Assign(n++, val_mgr->GetCount(unsigned(ru.ru_inblock)));
-	r->Assign(n++, val_mgr->GetCount(unsigned(ru.ru_oublock)));
-	r->Assign(n++, val_mgr->GetCount(unsigned(ru.ru_nivcsw)));
+	r->Assign(n++, val_mgr->Count(unsigned(ru.ru_minflt)));
+	r->Assign(n++, val_mgr->Count(unsigned(ru.ru_majflt)));
+	r->Assign(n++, val_mgr->Count(unsigned(ru.ru_nswap)));
+	r->Assign(n++, val_mgr->Count(unsigned(ru.ru_inblock)));
+	r->Assign(n++, val_mgr->Count(unsigned(ru.ru_oublock)));
+	r->Assign(n++, val_mgr->Count(unsigned(ru.ru_nivcsw)));
 
 	return r;
 	%}
@@ -193,8 +193,8 @@ function get_event_stats%(%): EventStats
 	RecordVal* r = new RecordVal(EventStats);
 	int n = 0;
 
-	r->Assign(n++, val_mgr->GetCount(num_events_queued));
-	r->Assign(n++, val_mgr->GetCount(num_events_dispatched));
+	r->Assign(n++, val_mgr->Count(num_events_queued));
+	r->Assign(n++, val_mgr->Count(num_events_dispatched));
 
 	return r;
 	%}
@@ -220,10 +220,10 @@ function get_reassembler_stats%(%): ReassemblerStats
 	RecordVal* r = new RecordVal(ReassemblerStats);
 	int n = 0;
 
-	r->Assign(n++, val_mgr->GetCount(Reassembler::MemoryAllocation(REASSEM_FILE)));
-	r->Assign(n++, val_mgr->GetCount(Reassembler::MemoryAllocation(REASSEM_FRAG)));
-	r->Assign(n++, val_mgr->GetCount(Reassembler::MemoryAllocation(REASSEM_TCP)));
-	r->Assign(n++, val_mgr->GetCount(Reassembler::MemoryAllocation(REASSEM_UNKNOWN)));
+	r->Assign(n++, val_mgr->Count(Reassembler::MemoryAllocation(REASSEM_FILE)));
+	r->Assign(n++, val_mgr->Count(Reassembler::MemoryAllocation(REASSEM_FRAG)));
+	r->Assign(n++, val_mgr->Count(Reassembler::MemoryAllocation(REASSEM_TCP)));
+	r->Assign(n++, val_mgr->Count(Reassembler::MemoryAllocation(REASSEM_UNKNOWN)));
 
 	return r;
 	%}
@@ -252,12 +252,12 @@ function get_dns_stats%(%): DNSStats
 	DNS_Mgr::Stats dstats;
 	dns_mgr->GetStats(&dstats);
 
-	r->Assign(n++, val_mgr->GetCount(unsigned(dstats.requests)));
-	r->Assign(n++, val_mgr->GetCount(unsigned(dstats.successful)));
-	r->Assign(n++, val_mgr->GetCount(unsigned(dstats.failed)));
-	r->Assign(n++, val_mgr->GetCount(unsigned(dstats.pending)));
-	r->Assign(n++, val_mgr->GetCount(unsigned(dstats.cached_hosts)));
-	r->Assign(n++, val_mgr->GetCount(unsigned(dstats.cached_addresses)));
+	r->Assign(n++, val_mgr->Count(unsigned(dstats.requests)));
+	r->Assign(n++, val_mgr->Count(unsigned(dstats.successful)));
+	r->Assign(n++, val_mgr->Count(unsigned(dstats.failed)));
+	r->Assign(n++, val_mgr->Count(unsigned(dstats.pending)));
+	r->Assign(n++, val_mgr->Count(unsigned(dstats.cached_hosts)));
+	r->Assign(n++, val_mgr->Count(unsigned(dstats.cached_addresses)));
 
 	return r;
 	%}
@@ -283,9 +283,9 @@ function get_timer_stats%(%): TimerStats
 	RecordVal* r = new RecordVal(TimerStats);
 	int n = 0;
 
-	r->Assign(n++, val_mgr->GetCount(unsigned(timer_mgr->Size())));
-	r->Assign(n++, val_mgr->GetCount(unsigned(timer_mgr->PeakSize())));
-	r->Assign(n++, val_mgr->GetCount(timer_mgr->CumulativeNum()));
+	r->Assign(n++, val_mgr->Count(unsigned(timer_mgr->Size())));
+	r->Assign(n++, val_mgr->Count(unsigned(timer_mgr->PeakSize())));
+	r->Assign(n++, val_mgr->Count(timer_mgr->CumulativeNum()));
 
 	return r;
 	%}
@@ -311,9 +311,9 @@ function get_file_analysis_stats%(%): FileAnalysisStats
 	RecordVal* r = new RecordVal(FileAnalysisStats);
 	int n = 0;
 
-	r->Assign(n++, val_mgr->GetCount(file_mgr->CurrentFiles()));
-	r->Assign(n++, val_mgr->GetCount(file_mgr->MaxFiles()));
-	r->Assign(n++, val_mgr->GetCount(file_mgr->CumulativeFiles()));
+	r->Assign(n++, val_mgr->Count(file_mgr->CurrentFiles()));
+	r->Assign(n++, val_mgr->Count(file_mgr->MaxFiles()));
+	r->Assign(n++, val_mgr->Count(file_mgr->CumulativeFiles()));
 
 	return r;
 	%}
@@ -339,7 +339,7 @@ function get_thread_stats%(%): ThreadStats
 	RecordVal* r = new RecordVal(ThreadStats);
 	int n = 0;
 
-	r->Assign(n++, val_mgr->GetCount(thread_mgr->NumThreads()));
+	r->Assign(n++, val_mgr->Count(thread_mgr->NumThreads()));
 
 	return r;
 	%}
@@ -365,10 +365,10 @@ function get_gap_stats%(%): GapStats
 	RecordVal* r = new RecordVal(GapStats);
 	int n = 0;
 
-	r->Assign(n++, val_mgr->GetCount(tot_ack_events));
-	r->Assign(n++, val_mgr->GetCount(tot_ack_bytes));
-	r->Assign(n++, val_mgr->GetCount(tot_gap_events));
-	r->Assign(n++, val_mgr->GetCount(tot_gap_bytes));
+	r->Assign(n++, val_mgr->Count(tot_ack_events));
+	r->Assign(n++, val_mgr->Count(tot_ack_bytes));
+	r->Assign(n++, val_mgr->Count(tot_gap_events));
+	r->Assign(n++, val_mgr->Count(tot_gap_bytes));
 
 	return r;
 	%}
@@ -402,13 +402,13 @@ function get_matcher_stats%(%): MatcherStats
 	if ( rule_matcher )
 		rule_matcher->GetStats(&s);
 
-	r->Assign(n++, val_mgr->GetCount(s.matchers));
-	r->Assign(n++, val_mgr->GetCount(s.nfa_states));
-	r->Assign(n++, val_mgr->GetCount(s.dfa_states));
-	r->Assign(n++, val_mgr->GetCount(s.computed));
-	r->Assign(n++, val_mgr->GetCount(s.mem));
-	r->Assign(n++, val_mgr->GetCount(s.hits));
-	r->Assign(n++, val_mgr->GetCount(s.misses));
+	r->Assign(n++, val_mgr->Count(s.matchers));
+	r->Assign(n++, val_mgr->Count(s.nfa_states));
+	r->Assign(n++, val_mgr->Count(s.dfa_states));
+	r->Assign(n++, val_mgr->Count(s.computed));
+	r->Assign(n++, val_mgr->Count(s.mem));
+	r->Assign(n++, val_mgr->Count(s.hits));
+	r->Assign(n++, val_mgr->Count(s.misses));
 
 	return r;
 	%}
@@ -436,15 +436,15 @@ function get_broker_stats%(%): BrokerStats
 	int n = 0;
 
 	auto cs = broker_mgr->GetStatistics();
-	r->Assign(n++, val_mgr->GetCount(static_cast<uint64_t>(cs.num_peers)));
-	r->Assign(n++, val_mgr->GetCount(static_cast<uint64_t>(cs.num_stores)));
-	r->Assign(n++, val_mgr->GetCount(static_cast<uint64_t>(cs.num_pending_queries)));
-	r->Assign(n++, val_mgr->GetCount(static_cast<uint64_t>(cs.num_events_incoming)));
-	r->Assign(n++, val_mgr->GetCount(static_cast<uint64_t>(cs.num_events_outgoing)));
-	r->Assign(n++, val_mgr->GetCount(static_cast<uint64_t>(cs.num_logs_incoming)));
-	r->Assign(n++, val_mgr->GetCount(static_cast<uint64_t>(cs.num_logs_outgoing)));
-	r->Assign(n++, val_mgr->GetCount(static_cast<uint64_t>(cs.num_ids_incoming)));
-	r->Assign(n++, val_mgr->GetCount(static_cast<uint64_t>(cs.num_ids_outgoing)));
+	r->Assign(n++, val_mgr->Count(static_cast<uint64_t>(cs.num_peers)));
+	r->Assign(n++, val_mgr->Count(static_cast<uint64_t>(cs.num_stores)));
+	r->Assign(n++, val_mgr->Count(static_cast<uint64_t>(cs.num_pending_queries)));
+	r->Assign(n++, val_mgr->Count(static_cast<uint64_t>(cs.num_events_incoming)));
+	r->Assign(n++, val_mgr->Count(static_cast<uint64_t>(cs.num_events_outgoing)));
+	r->Assign(n++, val_mgr->Count(static_cast<uint64_t>(cs.num_logs_incoming)));
+	r->Assign(n++, val_mgr->Count(static_cast<uint64_t>(cs.num_logs_outgoing)));
+	r->Assign(n++, val_mgr->Count(static_cast<uint64_t>(cs.num_ids_incoming)));
+	r->Assign(n++, val_mgr->Count(static_cast<uint64_t>(cs.num_ids_outgoing)));
 
 	return r;
 	%}
@@ -475,11 +475,11 @@ function get_reporter_stats%(%): ReporterStats
 	for ( auto& kv : reporter->GetWeirdsByType() )
 		{
 		Val* weird = new StringVal(kv.first);
-		weirds_by_type->Assign(weird, val_mgr->GetCount(kv.second));
+		weirds_by_type->Assign(weird, val_mgr->Count(kv.second));
 		Unref(weird);
 		}
 
-	r->Assign(n++, val_mgr->GetCount(reporter->GetWeirdCount()));
+	r->Assign(n++, val_mgr->Count(reporter->GetWeirdCount()));
 	r->Assign(n++, weirds_by_type);
 
 	return r;

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -25,10 +25,10 @@ function levenshtein_distance%(s1: string, s2: string%): count
 	unsigned int m = s2->Len();
 
 	if ( ! n )
-		return val_mgr->GetCount(m);
+		return val_mgr->Count(m);
 
 	if ( ! m )
-		return val_mgr->GetCount(n);
+		return val_mgr->Count(n);
 
 	vector<vector<unsigned int> > d(n + 1, vector<unsigned int>(m + 1));
 
@@ -47,7 +47,7 @@ function levenshtein_distance%(s1: string, s2: string%): count
 				      d[i-1][j-1] + (s1->Bytes()[i-1] == s2->Bytes()[j-1] ? 0 : 1));
 		}
 
-	return val_mgr->GetCount(d[n][m]);
+	return val_mgr->Count(d[n][m]);
 	%}
 
 ## Concatenates all arguments into a single string. The function takes a
@@ -285,9 +285,8 @@ Val* do_split(StringVal* str_val, RE_Matcher* re, int incl_sep, int max_num_sep)
 			n=0;
 			}
 
-		Val* ind = val_mgr->GetCount(++num);
-		a->Assign(ind, make_intrusive<StringVal>(offset, (const char*) s));
-		Unref(ind);
+		auto ind = val_mgr->Count(++num);
+		a->Assign(ind.get(), make_intrusive<StringVal>(offset, (const char*) s));
 
 		// No more separators will be needed if this is the end of string.
 		if ( n <= 0 )
@@ -295,9 +294,8 @@ Val* do_split(StringVal* str_val, RE_Matcher* re, int incl_sep, int max_num_sep)
 
 		if ( incl_sep )
 			{ // including the part that matches the pattern
-			ind = val_mgr->GetCount(++num);
-			a->Assign(ind, make_intrusive<StringVal>(end_of_match, (const char*) s+offset));
-			Unref(ind);
+			ind = val_mgr->Count(++num);
+			a->Assign(ind.get(), make_intrusive<StringVal>(end_of_match, (const char*) s+offset));
 			}
 
 		if ( max_num_sep && num_sep >= max_num_sep )
@@ -459,7 +457,7 @@ function strcmp%(s1: string, s2: string%): int
 ## .. zeek:see:: find_all find_last
 function strstr%(big: string, little: string%): count
 	%{
-	return val_mgr->GetCount(
+	return val_mgr->Count(
 		1 + big->AsString()->FindSubstring(little->AsString()));
 	%}
 

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -444,7 +444,7 @@ function gsub%(str: string, re: pattern, repl: string%): string
 ##          *s1* is greater than, equal to, or less than *s2*.
 function strcmp%(s1: string, s2: string%): int
 	%{
-	return val_mgr->GetInt(Bstr_cmp(s1->AsString(), s2->AsString()));
+	return val_mgr->Int(Bstr_cmp(s1->AsString(), s2->AsString()));
 	%}
 
 ## Locates the first occurrence of one string in another.

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -75,7 +75,7 @@ function string_cat%(...%): string
 		}
 	*b = 0;
 
-	return new StringVal(s);
+	return make_intrusive<StringVal>(s);
 	%}
 
 ## Joins all values in the given vector of strings with a separator placed
@@ -114,7 +114,7 @@ function join_string_vec%(vec: string_vec, sep: string%): string
 	BroString* s = new BroString(1, d.TakeBytes(), d.Len());
 	s->SetUseFreeToDelete(true);
 
-	return new StringVal(s);
+	return make_intrusive<StringVal>(s);
 	%}
 
 ## Returns an edited version of a string that applies a special
@@ -162,7 +162,7 @@ function edit%(arg_s: string, arg_edit_char: string%): string
 
 	new_s[ind] = '\0';
 
-	return new StringVal(new BroString(1, byte_vec(new_s), ind));
+	return make_intrusive<StringVal>(new BroString(1, byte_vec(new_s), ind));
 	%}
 
 ## Get a substring from a string, given a starting position and length.
@@ -185,7 +185,7 @@ function sub_bytes%(s: string, start: count, n: int%): string
 	if ( ! ss )
 		ss = new BroString("");
 
-	return new StringVal(ss);
+	return make_intrusive<StringVal>(ss);
 	%}
 
 %%{
@@ -199,11 +199,12 @@ static int match_prefix(int s_len, const char* s, int t_len, const char* t)
 	return 1;
 	}
 
-VectorVal* do_split_string(StringVal* str_val, RE_Matcher* re, int incl_sep,
-                           int max_num_sep)
+static IntrusivePtr<VectorVal> do_split_string(StringVal* str_val,
+                                               RE_Matcher* re, int incl_sep,
+                                               int max_num_sep)
 	{
 	// string_vec is used early in the version script - do not use the NetVar.
-	VectorVal* rval = new VectorVal(internal_type("string_vec")->AsVectorType());
+	auto rval = make_intrusive<VectorVal>(internal_type("string_vec")->AsVectorType());
 	const u_char* s = str_val->Bytes();
 	int n = str_val->Len();
 	const u_char* end_of_s = s + n;
@@ -476,7 +477,7 @@ function subst_string%(s: string, from: string, to: string%): string
 	%{
 	const int little_len = from->Len();
 	if ( little_len == 0 )
-		return s->Ref();
+		return IntrusivePtr{NewRef{}, s};
 
 	int big_len = s->Len();
 	const u_char* big = s->Bytes();
@@ -511,7 +512,7 @@ function subst_string%(s: string, from: string, to: string%): string
 		vs.push_back(dc);
 		}
 
-	return new StringVal(concatenate(vs));
+	return make_intrusive<StringVal>(concatenate(vs));
 	%}
 
 ## Replaces all uppercase letters in a string with their lowercase counterpart.
@@ -540,7 +541,7 @@ function to_lower%(str: string%): string
 
     *ls++ = '\0';
 
-	return new StringVal(new BroString(1, lower_s, n));
+	return make_intrusive<StringVal>(new BroString(1, lower_s, n));
 	%}
 
 ## Replaces all lowercase letters in a string with their uppercase counterpart.
@@ -569,7 +570,7 @@ function to_upper%(str: string%): string
 
     *us++ = '\0';
 
-	return new StringVal(new BroString(1, upper_s, n));
+	return make_intrusive<StringVal>(new BroString(1, upper_s, n));
 	%}
 
 ## Replaces non-printable characters in a string with escaped sequences. The
@@ -589,7 +590,7 @@ function to_upper%(str: string%): string
 function clean%(str: string%): string
 	%{
 	char* s = str->AsString()->Render();
-	return new StringVal(new BroString(1, byte_vec(s), strlen(s)));
+	return make_intrusive<StringVal>(new BroString(1, byte_vec(s), strlen(s)));
 	%}
 
 ## Replaces non-printable characters in a string with escaped sequences. The
@@ -607,7 +608,7 @@ function clean%(str: string%): string
 function to_string_literal%(str: string%): string
 	%{
 	char* s = str->AsString()->Render(BroString::BRO_STRING_LITERAL);
-	return new StringVal(new BroString(1, byte_vec(s), strlen(s)));
+	return make_intrusive<StringVal>(new BroString(1, byte_vec(s), strlen(s)));
 	%}
 
 ## Determines whether a given string contains only ASCII characters.
@@ -665,7 +666,7 @@ function string_to_ascii_hex%(s: string%): string
 	for ( int i = 0; i < s->Len(); ++i )
 		sprintf(x + i * 2, "%02x", sp[i]);
 
-	return new StringVal(new BroString(1, (u_char*) x, s->Len() * 2));
+	return make_intrusive<StringVal>(new BroString(1, (u_char*) x, s->Len() * 2));
 	%}
 
 ## Uses the Smith-Waterman algorithm to find similar/overlapping substrings.
@@ -744,7 +745,7 @@ function strip%(str: string%): string
 
 	if ( n == 0 )
 		// Empty string.
-		return new StringVal(new BroString(s, n, 1));
+		return make_intrusive<StringVal>(new BroString(s, n, 1));
 
 	const u_char* sp = s;
 
@@ -757,7 +758,7 @@ function strip%(str: string%): string
 	while ( isspace(*sp) && sp <= e )
 		++sp;
 
-	return new StringVal(new BroString(sp, (e - sp + 1), 1));
+	return make_intrusive<StringVal>(new BroString(sp, (e - sp + 1), 1));
 	%}
 
 %%{
@@ -792,7 +793,7 @@ function lstrip%(str: string, chars: string &default=" \t\n\r\v\f"%): string
 
 	// empty input string
 	if ( n == 0 )
-		return new StringVal(new BroString(s, n, 1));
+		return make_intrusive<StringVal>(new BroString(s, n, 1));
 
 	int i;
 	auto bs_chars = chars->AsString();
@@ -801,7 +802,7 @@ function lstrip%(str: string, chars: string &default=" \t\n\r\v\f"%): string
 		if ( ! should_strip(s[i], bs_chars) )
 			break;
 
-	return new StringVal(new BroString(s + i, n - i, 1));
+	return make_intrusive<StringVal>(new BroString(s + i, n - i, 1));
 	%}
 
 ## Removes all combinations of characters in the *chars* argument
@@ -823,7 +824,7 @@ function rstrip%(str: string, chars: string &default=" \t\n\r\v\f"%): string
 
 	// empty input string
 	if ( n == 0 )
-		return new StringVal(new BroString(s, n, 1));
+		return make_intrusive<StringVal>(new BroString(s, n, 1));
 
 	int n_to_remove;
 	auto bs_chars = chars->AsString();
@@ -832,7 +833,7 @@ function rstrip%(str: string, chars: string &default=" \t\n\r\v\f"%): string
 		if ( ! should_strip(s[n - n_to_remove - 1], bs_chars) )
 			break;
 
-	return new StringVal(new BroString(s, n - n_to_remove, 1));
+	return make_intrusive<StringVal>(new BroString(s, n - n_to_remove, 1));
 	%}
 
 ## Generates a string of a given size and fills it with repetitions of a source
@@ -854,7 +855,7 @@ function string_fill%(len: int, source: string%): string
 
 	dst[len - 1] = 0;
 
-	return new StringVal(new BroString(1, byte_vec(dst), len));
+	return make_intrusive<StringVal>(new BroString(1, byte_vec(dst), len));
 	%}
 
 ## Takes a string and escapes characters that would allow execution of
@@ -894,7 +895,7 @@ function safe_shell_quote%(source: string%): string
 
 	dst[j++] = '"';
 	dst[j] = '\0';
-	return new StringVal(new BroString(1, dst, j));
+	return make_intrusive<StringVal>(new BroString(1, dst, j));
 	%}
 
 ## Finds all occurrences of a pattern in a string.
@@ -949,7 +950,7 @@ function find_last%(str: string, re: pattern%) : string
 		{
 		int n = re->MatchPrefix(t, e - t);
 		if ( n >= 0 )
-			return new StringVal(n, (const char*) t);
+			return make_intrusive<StringVal>(n, (const char*) t);
 		}
 
 	return val_mgr->EmptyString();
@@ -1083,5 +1084,5 @@ function reverse%(str: string%) : string
 	%{
 	string s = string((const char*)str->Bytes(), str->Len());
 	reverse(s.begin(), s.end());
-	return new StringVal(s.length(), (const char*)s.c_str());
+	return make_intrusive<StringVal>(s.length(), (const char*)s.c_str());
 	%}

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -952,7 +952,7 @@ function find_last%(str: string, re: pattern%) : string
 			return new StringVal(n, (const char*) t);
 		}
 
-	return val_mgr->GetEmptyString();
+	return val_mgr->EmptyString();
 	%}
 
 ## Returns a hex dump for given input data. The hex dump renders 16 bytes per
@@ -997,13 +997,13 @@ function hexdump%(data_str: string%) : string
 	unsigned data_size = data_str->Len();
 
 	if ( ! data )
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 
 	int num_lines = (data_size / 16) + 1;
 	int len = num_lines * HEX_LINE_WIDTH;
 	u_char* hex_data = new u_char[len + 1];
 	if ( ! hex_data )
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 
 	memset(hex_data, ' ', len);
 

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -627,9 +627,9 @@ function is_ascii%(str: string%): bool
 
 	for ( int i = 0; i < n; ++i )
 		if ( s[i] > 127 )
-			return val_mgr->GetFalse();
+			return val_mgr->False();
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Replaces non-printable characters in a string with escaped sequences. The

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -1311,9 +1311,9 @@ void Supervisor::SupervisedNode::Init(zeek::Options* options) const
 		options->scripts_to_load.emplace_back(s);
 	}
 
-RecordVal* Supervisor::Status(std::string_view node_name)
+IntrusivePtr<RecordVal> Supervisor::Status(std::string_view node_name)
 	{
-	auto rval = new RecordVal(BifType::Record::Supervisor::Status);
+	auto rval = make_intrusive<RecordVal>(BifType::Record::Supervisor::Status);
 	auto tt = BifType::Record::Supervisor::Status->FieldType("nodes");
 	auto node_table_val = new TableVal({NewRef{}, tt->AsTableType()});
 	rval->Assign(0, node_table_val);

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -1230,7 +1230,7 @@ bool Supervisor::SupervisedNode::InitCluster() const
 		cluster_nodes->Assign(key.get(), std::move(val));
 		}
 
-	cluster_manager_is_logger_id->SetVal({AdoptRef{}, val_mgr->GetBool(! has_logger)});
+	cluster_manager_is_logger_id->SetVal(val_mgr->Bool(! has_logger));
 	return true;
 	}
 

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -1121,7 +1121,7 @@ IntrusivePtr<RecordVal> Supervisor::NodeConfig::ToRecord() const
 		rval->Assign(rt->FieldOffset("stderr_file"), make_intrusive<StringVal>(*stderr_file));
 
 	if ( cpu_affinity )
-		rval->Assign(rt->FieldOffset("cpu_affinity"), val_mgr->GetInt(*cpu_affinity));
+		rval->Assign(rt->FieldOffset("cpu_affinity"), val_mgr->Int(*cpu_affinity));
 
 	auto st = BifType::Record::Supervisor::NodeConfig->FieldType("scripts");
 	auto scripts_val = new VectorVal(st->AsVectorType());
@@ -1163,7 +1163,7 @@ IntrusivePtr<RecordVal> Supervisor::Node::ToRecord() const
 	rval->Assign(rt->FieldOffset("node"), config.ToRecord());
 
 	if ( pid )
-		rval->Assign(rt->FieldOffset("pid"), val_mgr->GetInt(pid));
+		rval->Assign(rt->FieldOffset("pid"), val_mgr->Int(pid));
 
 	return rval;
 	}

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -1144,7 +1144,7 @@ IntrusivePtr<RecordVal> Supervisor::NodeConfig::ToRecord() const
 
 		val->Assign(ept->FieldOffset("role"), BifType::Enum::Supervisor::ClusterRole->GetVal(ep.role));
 		val->Assign(ept->FieldOffset("host"), make_intrusive<AddrVal>(ep.host));
-		val->Assign(ept->FieldOffset("p"), val_mgr->GetPort(ep.port, TRANSPORT_TCP));
+		val->Assign(ept->FieldOffset("p"), val_mgr->Port(ep.port, TRANSPORT_TCP));
 
 		if ( ep.interface )
 			val->Assign(ept->FieldOffset("interface"), make_intrusive<StringVal>(*ep.interface));
@@ -1217,7 +1217,7 @@ bool Supervisor::SupervisedNode::InitCluster() const
 		auto node_type = supervisor_role_to_cluster_node_type(ep.role);
 		val->Assign(cluster_node_type->FieldOffset("node_type"), std::move(node_type));
 		val->Assign(cluster_node_type->FieldOffset("ip"), make_intrusive<AddrVal>(ep.host));
-		val->Assign(cluster_node_type->FieldOffset("p"), val_mgr->GetPort(ep.port, TRANSPORT_TCP));
+		val->Assign(cluster_node_type->FieldOffset("p"), val_mgr->Port(ep.port, TRANSPORT_TCP));
 
 		if ( ep.interface )
 			val->Assign(cluster_node_type->FieldOffset("interface"),

--- a/src/supervisor/Supervisor.h
+++ b/src/supervisor/Supervisor.h
@@ -311,7 +311,7 @@ public:
 	 * @return  script-layer Supervisor::Status record value describing the
 	 * status of a node or set of nodes.
 	 */
-	RecordVal* Status(std::string_view node_name);
+	IntrusivePtr<RecordVal> Status(std::string_view node_name);
 
 	/**
 	 * Create a new supervised node.

--- a/src/supervisor/supervisor.bif
+++ b/src/supervisor/supervisor.bif
@@ -47,11 +47,11 @@ function Supervisor::__destroy%(node: string%): bool
 	if ( ! zeek::supervisor_mgr )
 		{
 		builtin_error("supervisor mode not enabled");
-		return val_mgr->GetBool(false);
+		return val_mgr->Bool(false);
 		}
 
 	auto rval = zeek::supervisor_mgr->Destroy(node->CheckString());
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 function Supervisor::__restart%(node: string%): bool
@@ -59,24 +59,24 @@ function Supervisor::__restart%(node: string%): bool
 	if ( ! zeek::supervisor_mgr )
 		{
 		builtin_error("supervisor mode not enabled");
-		return val_mgr->GetBool(false);
+		return val_mgr->Bool(false);
 		}
 
 	auto rval = zeek::supervisor_mgr->Restart(node->CheckString());
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 function Supervisor::__init_cluster%(%): bool
 	%{
 	if ( zeek::Supervisor::ThisNode() )
-		return val_mgr->GetBool(zeek::Supervisor::ThisNode()->InitCluster());
+		return val_mgr->Bool(zeek::Supervisor::ThisNode()->InitCluster());
 
-	return val_mgr->GetBool(false);
+	return val_mgr->Bool(false);
 	%}
 
 function Supervisor::__is_supervised%(%): bool
 	%{
-	return val_mgr->GetBool(zeek::Supervisor::ThisNode().has_value());
+	return val_mgr->Bool(zeek::Supervisor::ThisNode().has_value());
 	%}
 
 function Supervisor::__node%(%): Supervisor::NodeConfig
@@ -96,7 +96,7 @@ function Supervisor::__node%(%): Supervisor::NodeConfig
 
 function Supervisor::__is_supervisor%(%): bool
 	%{
-	return val_mgr->GetBool(zeek::supervisor_mgr != nullptr);
+	return val_mgr->Bool(zeek::supervisor_mgr != nullptr);
 	%}
 
 function Supervisor::__stem_pid%(%): int

--- a/src/supervisor/supervisor.bif
+++ b/src/supervisor/supervisor.bif
@@ -102,11 +102,11 @@ function Supervisor::__is_supervisor%(%): bool
 function Supervisor::__stem_pid%(%): int
 	%{
 	if ( zeek::supervisor_mgr )
-		return val_mgr->GetInt(zeek::supervisor_mgr->StemPID());
+		return val_mgr->Int(zeek::supervisor_mgr->StemPID());
 
 	if ( zeek::Supervisor::ThisNode() )
-		return val_mgr->GetInt(zeek::Supervisor::ThisNode()->parent_pid);
+		return val_mgr->Int(zeek::Supervisor::ThisNode()->parent_pid);
 
 	builtin_error("supervisor mode not enabled and not a supervised node");
-	return val_mgr->GetInt(-1);
+	return val_mgr->Int(-1);
 	%}

--- a/src/supervisor/supervisor.bif
+++ b/src/supervisor/supervisor.bif
@@ -24,7 +24,7 @@ function Supervisor::__status%(node: string%): Supervisor::Status
 	if ( ! zeek::supervisor_mgr )
 		{
 		builtin_error("supervisor mode not enabled");
-		return new RecordVal(BifType::Record::Supervisor::Status);
+		return make_intrusive<RecordVal>(BifType::Record::Supervisor::Status);
 		}
 
 	return zeek::supervisor_mgr->Status(node->CheckString());
@@ -35,11 +35,11 @@ function Supervisor::__create%(node: Supervisor::NodeConfig%): string
 	if ( ! zeek::supervisor_mgr )
 		{
 		builtin_error("supervisor mode not enabled");
-		return new StringVal("supervisor mode not enabled");
+		return make_intrusive<StringVal>("supervisor mode not enabled");
 		}
 
 	auto rval = zeek::supervisor_mgr->Create(node->AsRecordVal());
-	return new StringVal(rval);
+	return make_intrusive<StringVal>(rval);
 	%}
 
 function Supervisor::__destroy%(node: string%): bool
@@ -87,11 +87,11 @@ function Supervisor::__node%(%): Supervisor::NodeConfig
 		auto rt = BifType::Record::Supervisor::NodeConfig;
 		auto rval = make_intrusive<RecordVal>(rt);
 		rval->Assign(rt->FieldOffset("name"), new StringVal("<invalid>"));
-		return rval.release();
+		return rval;
 		}
 
 	auto rval = zeek::Supervisor::ThisNode()->config.ToRecord();
-	return rval.release();
+	return rval;
 	%}
 
 function Supervisor::__is_supervisor%(%): bool

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -3300,7 +3300,7 @@ function lookup_connection%(cid: conn_id%): connection
 	%{
 	Connection* conn = sessions->FindConnection(cid);
 	if ( conn )
-		return IntrusivePtr{AdoptRef{}, conn->BuildConnVal()};
+		return conn->ConnVal();
 
 	builtin_error("connection ID not a known connection", cid);
 

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -318,7 +318,7 @@ static int next_fmt(const char*& fmt, const zeek::Args* args, ODesc* d, int& n)
 ## .. zeek:see:: network_time
 function current_time%(%): time
 	%{
-	return new Val(current_time(), TYPE_TIME);
+	return make_intrusive<Val>(current_time(), TYPE_TIME);
 	%}
 
 ## Returns the timestamp of the last packet processed. This function returns
@@ -330,7 +330,7 @@ function current_time%(%): time
 ## .. zeek:see:: current_time
 function network_time%(%): time
 	%{
-	return new Val(network_time, TYPE_TIME);
+	return make_intrusive<Val>(network_time, TYPE_TIME);
 	%}
 
 ## Returns a system environment variable.
@@ -346,7 +346,7 @@ function getenv%(var: string%): string
 	const char* env_val = zeekenv(var->CheckString());
 	if ( ! env_val )
 		env_val = "";	// ###
-	return new StringVal(env_val);
+	return make_intrusive<StringVal>(env_val);
 	%}
 
 ## Sets a system environment variable.
@@ -376,7 +376,7 @@ function setenv%(var: string, val: string%): bool
 function exit%(code: int%): any
 	%{
 	exit(code);
-	return 0;
+	return nullptr;
 	%}
 
 ## Gracefully shut down Zeek by terminating outstanding processing.
@@ -560,7 +560,7 @@ function md5_hash%(...%): string
 	%{
 	unsigned char digest[MD5_DIGEST_LENGTH];
 	MD5Val::digest(@ARG@, digest);
-	return new StringVal(md5_digest_print(digest));
+	return make_intrusive<StringVal>(md5_digest_print(digest));
 	%}
 
 ## Computes the SHA1 hash value of the provided list of arguments.
@@ -580,7 +580,7 @@ function sha1_hash%(...%): string
 	%{
 	unsigned char digest[SHA_DIGEST_LENGTH];
 	SHA1Val::digest(@ARG@, digest);
-	return new StringVal(sha1_digest_print(digest));
+	return make_intrusive<StringVal>(sha1_digest_print(digest));
 	%}
 
 ## Computes the SHA256 hash value of the provided list of arguments.
@@ -600,7 +600,7 @@ function sha256_hash%(...%): string
 	%{
 	unsigned char digest[SHA256_DIGEST_LENGTH];
 	SHA256Val::digest(@ARG@, digest);
-	return new StringVal(sha256_digest_print(digest));
+	return make_intrusive<StringVal>(sha256_digest_print(digest));
 	%}
 
 ## Computes an HMAC-MD5 hash value of the provided list of arguments. The HMAC
@@ -616,7 +616,7 @@ function md5_hmac%(...%): string
 	%{
 	unsigned char hmac[MD5_DIGEST_LENGTH];
 	MD5Val::hmac(@ARG@, shared_hmac_md5_key, hmac);
-	return new StringVal(md5_digest_print(hmac));
+	return make_intrusive<StringVal>(md5_digest_print(hmac));
 	%}
 
 ## Constructs an MD5 handle to enable incremental hash computation. You can
@@ -762,7 +762,7 @@ function sha256_hash_update%(handle: opaque of sha256, data: string%): bool
 ##    sha256_hash sha256_hash_init sha256_hash_update sha256_hash_finish
 function md5_hash_finish%(handle: opaque of md5%): string
 	%{
-	return static_cast<HashVal*>(handle)->Get().release();
+	return static_cast<HashVal*>(handle)->Get();
 	%}
 
 ## Returns the final SHA1 digest of an incremental hash computation.
@@ -776,7 +776,7 @@ function md5_hash_finish%(handle: opaque of md5%): string
 ##    sha256_hash sha256_hash_init sha256_hash_update sha256_hash_finish
 function sha1_hash_finish%(handle: opaque of sha1%): string
 	%{
-	return static_cast<HashVal*>(handle)->Get().release();
+	return static_cast<HashVal*>(handle)->Get();
 	%}
 
 ## Returns the final SHA256 digest of an incremental hash computation.
@@ -790,7 +790,7 @@ function sha1_hash_finish%(handle: opaque of sha1%): string
 ##    sha256_hash sha256_hash_init sha256_hash_update
 function sha256_hash_finish%(handle: opaque of sha256%): string
 	%{
-	return static_cast<HashVal*>(handle)->Get().release();
+	return static_cast<HashVal*>(handle)->Get();
 	%}
 
 ## Initializes and returns a new paraglob.
@@ -821,7 +821,7 @@ function paraglob_init%(v: any%) : opaque of paraglob
 	try
 		{
 		std::unique_ptr<paraglob::Paraglob> p (new paraglob::Paraglob(patterns));
-		return new ParaglobVal(std::move(p));
+		return make_intrusive<ParaglobVal>(std::move(p));
 		}
 	// Thrown if paraglob fails to add a pattern.
 	catch (const paraglob::add_error& e)
@@ -842,7 +842,7 @@ function paraglob_init%(v: any%) : opaque of paraglob
 ## ## .. zeek:see::paraglob_add paraglob_equals paraglob_init
 function paraglob_match%(handle: opaque of paraglob, match: string%): string_vec
 	%{
-	return static_cast<ParaglobVal*>(handle)->Get(match).release();
+	return static_cast<ParaglobVal*>(handle)->Get(match);
 	%}
 
 ## Compares two paraglobs for equality.
@@ -946,7 +946,7 @@ function rand%(max: count%): count
 function srand%(seed: count%): any
 	%{
 	bro_srandom(seed);
-	return 0;
+	return nullptr;
 	%}
 
 %%{
@@ -959,7 +959,7 @@ function srand%(seed: count%): any
 function syslog%(s: string%): any
 	%{
 	reporter->Syslog("%s", s->CheckString());
-	return 0;
+	return nullptr;
 	%}
 
 ## Determines the MIME type of a piece of data using Zeek's file magic
@@ -982,9 +982,9 @@ function identify_data%(data: string, return_mime: bool &default=T%): string
 	string strongest_match = file_mgr->DetectMIME(data->Bytes(), data->Len());
 
 	if ( strongest_match.empty() )
-		return new StringVal("<unknown>");
+		return make_intrusive<StringVal>("<unknown>");
 
-	return new StringVal(strongest_match);
+	return make_intrusive<StringVal>(strongest_match);
 	%}
 
 ## Determines the MIME type of a piece of data using Zeek's file magic
@@ -1066,7 +1066,7 @@ function find_entropy%(data: string%): entropy_test_result
 ## .. zeek:see:: find_entropy entropy_test_add entropy_test_finish
 function entropy_test_init%(%): opaque of entropy
 	%{
-	return new EntropyVal();
+	return make_intrusive<EntropyVal>();
 	%}
 
 ## Adds data to an incremental entropy calculation.
@@ -1121,7 +1121,7 @@ function unique_id%(prefix: string%) : string
 	%{
 	char tmp[20];
 	uint64_t uid = calculate_unique_id(UID_POOL_DEFAULT_SCRIPT);
-	return new StringVal(uitoa_n(uid, tmp, sizeof(tmp), 62, prefix->CheckString()));
+	return make_intrusive<StringVal>(uitoa_n(uid, tmp, sizeof(tmp), 62, prefix->CheckString()));
 	%}
 
 ## Creates an identifier that is unique with high probability.
@@ -1139,7 +1139,7 @@ function unique_id_from%(pool: int, prefix: string%) : string
 
 	char tmp[20];
 	uint64_t uid = calculate_unique_id(pool);
-	return new StringVal(uitoa_n(uid, tmp, sizeof(tmp), 62, prefix->CheckString()));
+	return make_intrusive<StringVal>(uitoa_n(uid, tmp, sizeof(tmp), 62, prefix->CheckString()));
 	%}
 
 # ===========================================================================
@@ -1158,7 +1158,7 @@ function clear_table%(v: any%): any
 	else
 		builtin_error("clear_table() requires a table/set argument");
 
-	return 0;
+	return nullptr;
 	%}
 
 ## Gets all subnets that contain a given subnet from a set/table[subnet].
@@ -1176,7 +1176,7 @@ function matching_subnets%(search: subnet, t: any%): subnet_vec
 		return nullptr;
 		}
 
-	return t->AsTableVal()->LookupSubnets(search).release();
+	return t->AsTableVal()->LookupSubnets(search);
 	%}
 
 ## For a set[subnet]/table[subnet], create a new table that contains all entries
@@ -1195,7 +1195,7 @@ function filter_subnet_table%(search: subnet, t: any%): any
 		return nullptr;
 		}
 
-	return t->AsTableVal()->LookupSubnetValues(search).release();
+	return t->AsTableVal()->LookupSubnetValues(search);
 	%}
 
 ## Checks if a specific subnet is a member of a set/table[subnet].
@@ -1263,7 +1263,7 @@ function resize%(aggr: any, newsize: count%) : count
 	if ( aggr->Type()->Tag() != TYPE_VECTOR )
 		{
 		builtin_error("resize() operates on vectors");
-		return 0;
+		return nullptr;
 		}
 
 	return val_mgr->Count(aggr->AsVectorVal()->Resize(newsize));
@@ -1569,7 +1569,7 @@ function cat%(...%): string
 	BroString* s = new BroString(1, d.TakeBytes(), d.Len());
 	s->SetUseFreeToDelete(true);
 
-	return new StringVal(s);
+	return make_intrusive<StringVal>(s);
 	%}
 
 ## Concatenates all arguments, with a separator placed between each one. This
@@ -1611,7 +1611,7 @@ function cat_sep%(sep: string, def: string, ...%): string
 	BroString* s = new BroString(1, d.TakeBytes(), d.Len());
 	s->SetUseFreeToDelete(true);
 
-	return new StringVal(s);
+	return make_intrusive<StringVal>(s);
 	%}
 
 ## Produces a formatted string à la ``printf``. The first argument is the
@@ -1686,7 +1686,7 @@ function fmt%(...%): string
 	BroString* s = new BroString(1, d.TakeBytes(), d.Len());
 	s->SetUseFreeToDelete(true);
 
-	return new StringVal(s);
+	return make_intrusive<StringVal>(s);
 	%}
 
 ## Renders a sequence of values to a string of bytes and outputs them directly
@@ -1722,7 +1722,7 @@ function print_raw%(...%): bool
 ## .. zeek:see:: sqrt exp ln log10
 function floor%(d: double%): double
 	%{
-	return new Val(floor(d), TYPE_DOUBLE);
+	return make_intrusive<Val>(floor(d), TYPE_DOUBLE);
 	%}
 
 ## Computes the square root of a :zeek:type:`double`.
@@ -1737,10 +1737,10 @@ function sqrt%(x: double%): double
 	if ( x < 0 )
 		{
 		reporter->Error("negative sqrt argument");
-		return new Val(-1.0, TYPE_DOUBLE);
+		return make_intrusive<Val>(-1.0, TYPE_DOUBLE);
 		}
 
-	return new Val(sqrt(x), TYPE_DOUBLE);
+	return make_intrusive<Val>(sqrt(x), TYPE_DOUBLE);
 	%}
 
 ## Computes the exponential function.
@@ -1752,7 +1752,7 @@ function sqrt%(x: double%): double
 ## .. zeek:see:: floor sqrt ln log10
 function exp%(d: double%): double
 	%{
-	return new Val(exp(d), TYPE_DOUBLE);
+	return make_intrusive<Val>(exp(d), TYPE_DOUBLE);
 	%}
 
 ## Computes the natural logarithm of a number.
@@ -1764,7 +1764,7 @@ function exp%(d: double%): double
 ## .. zeek:see:: exp floor sqrt log10
 function ln%(d: double%): double
 	%{
-	return new Val(log(d), TYPE_DOUBLE);
+	return make_intrusive<Val>(log(d), TYPE_DOUBLE);
 	%}
 
 ## Computes the common logarithm of a number.
@@ -1776,7 +1776,7 @@ function ln%(d: double%): double
 ## .. zeek:see:: exp floor sqrt ln
 function log10%(d: double%): double
 	%{
-	return new Val(log10(d), TYPE_DOUBLE);
+	return make_intrusive<Val>(log10(d), TYPE_DOUBLE);
 	%}
 
 # ===========================================================================
@@ -1811,7 +1811,7 @@ extern const char* zeek_version();
 ## Returns: Zeek's version, e.g., 2.0-beta-47-debug.
 function zeek_version%(%): string
 	%{
-	return new StringVal(zeek_version());
+	return make_intrusive<StringVal>(zeek_version());
 	%}
 
 ## Converts a record type name to a vector of strings, where each element is
@@ -1849,7 +1849,7 @@ function type_name%(t: any%): string
 	BroString* s = new BroString(1, d.TakeBytes(), d.Len());
 	s->SetUseFreeToDelete(true);
 
-	return new StringVal(s);
+	return make_intrusive<StringVal>(s);
 	%}
 
 ## Returns: list of command-line arguments (``argv``) used to run Zeek.
@@ -1861,7 +1861,7 @@ function zeek_args%(%): string_vec
 	for ( auto i = 0; i < bro_argc; ++i )
 		rval->Assign(rval->Size(), make_intrusive<StringVal>(bro_argv[i]));
 
-	return rval.release();
+	return rval;
 	%}
 
 ## Checks whether Zeek reads traffic from one or more network interfaces (as
@@ -1897,7 +1897,7 @@ function packet_source%(%): PacketSource
 	auto ps = iosource_mgr->GetPktSrc();
 	auto r = make_intrusive<RecordVal>(ps_type);
 
-        if ( ps )
+	if ( ps )
 		{
 		r->Assign(0, val_mgr->Bool(ps->IsLive()));
 		r->Assign(1, make_intrusive<StringVal>(ps->Path()));
@@ -1905,7 +1905,7 @@ function packet_source%(%): PacketSource
 		r->Assign(3, val_mgr->Count(ps->Netmask()));
 		}
 
-	return r.release();
+	return r;
 	%}
 
 ## Generates a table of the size of all global variables. The table index is
@@ -1982,12 +1982,12 @@ function lookup_ID%(id: string%) : any
 	%{
 	ID* i = global_scope()->Lookup(id->CheckString());
 	if ( ! i )
-		return new StringVal("<unknown id>");
+		return make_intrusive<StringVal>("<unknown id>");
 
 	if ( ! i->ID_Val() )
-		return new StringVal("<no ID value>");
+		return make_intrusive<StringVal>("<no ID value>");
 
-	return i->ID_Val()->Ref();
+	return IntrusivePtr{NewRef{}, i->ID_Val()};
 	%}
 
 ## Generates metadata about a record's fields. The returned information
@@ -2006,13 +2006,14 @@ function record_fields%(rec: any%): record_field_table
 		if ( ! id || ! id->AsType() || id->AsType()->Tag() != TYPE_RECORD )
 			{
 			reporter->Error("record_fields string argument does not name a record type");
-			return new TableVal({NewRef{}, internal_type("record_field_table")->AsTableType()});
+			IntrusivePtr<TableType> tt{NewRef{}, internal_type("record_field_table")->AsTableType()};
+			return make_intrusive<TableVal>(std::move(tt));
 			}
 
-		return id->AsType()->AsRecordType()->GetRecordFieldsVal().release();
+		return id->AsType()->AsRecordType()->GetRecordFieldsVal();
 		}
 
-	return rec->GetRecordFields().release();
+	return rec->GetRecordFields();
 	%}
 
 ## Enables detailed collection of profiling statistics. Statistics include
@@ -2036,7 +2037,7 @@ function do_profiling%(%) : any
 	if ( profiling_logger )
 		profiling_logger->Log();
 
-	return 0;
+	return nullptr;
 	%}
 
 ## Checks whether a given IP address belongs to a local interface.
@@ -2121,7 +2122,7 @@ function gethostname%(%) : string
 		strcpy(buffer, "<unknown>");
 
 	buffer[MAXHOSTNAMELEN-1] = '\0';
-	return new StringVal(buffer);
+	return make_intrusive<StringVal>(buffer);
 	%}
 
 ## Returns whether an address is IPv4 or not.
@@ -2245,21 +2246,21 @@ function counts_to_addr%(v: index_vec%): addr
 	%{
 	if ( v->AsVector()->size() == 1 )
 		{
-		return new AddrVal(htonl((*v->AsVector())[0]->AsCount()));
+		return make_intrusive<AddrVal>(htonl((*v->AsVector())[0]->AsCount()));
 		}
 	else if ( v->AsVector()->size() == 4 )
 		{
 		uint32_t bytes[4];
 		for ( int i = 0; i < 4; ++i )
 			bytes[i] = htonl((*v->AsVector())[i]->AsCount());
-		return new AddrVal(bytes);
+		return make_intrusive<AddrVal>(bytes);
 		}
 	else
 		{
 		builtin_error("invalid vector size", @ARG@[0]);
 		uint32_t bytes[4];
 		memset(bytes, 0, sizeof(bytes));
-		return new AddrVal(bytes);
+		return make_intrusive<AddrVal>(bytes);
 		}
 	%}
 
@@ -2367,7 +2368,7 @@ function to_count%(str: string%): count
 ## .. zeek:see:: double_to_interval
 function interval_to_double%(i: interval%): double
 	%{
-	return new Val(i, TYPE_DOUBLE);
+	return make_intrusive<Val>(i, TYPE_DOUBLE);
 	%}
 
 ## Converts a :zeek:type:`time` value to a :zeek:type:`double`.
@@ -2379,7 +2380,7 @@ function interval_to_double%(i: interval%): double
 ## .. zeek:see:: double_to_time
 function time_to_double%(t: time%): double
 	%{
-	return new Val(t, TYPE_DOUBLE);
+	return make_intrusive<Val>(t, TYPE_DOUBLE);
 	%}
 
 ## Converts a :zeek:type:`double` value to a :zeek:type:`time`.
@@ -2391,7 +2392,7 @@ function time_to_double%(t: time%): double
 ## .. zeek:see:: time_to_double double_to_count
 function double_to_time%(d: double%): time
 	%{
-	return new Val(d, TYPE_TIME);
+	return make_intrusive<Val>(d, TYPE_TIME);
 	%}
 
 ## Converts a :zeek:type:`double` to an :zeek:type:`interval`.
@@ -2403,7 +2404,7 @@ function double_to_time%(d: double%): time
 ## .. zeek:see:: interval_to_double
 function double_to_interval%(d: double%): interval
 	%{
-	return new Val(d, TYPE_INTERVAL);
+	return make_intrusive<Val>(d, TYPE_INTERVAL);
 	%}
 
 ## Converts a :zeek:type:`port` to a :zeek:type:`count`.
@@ -2504,7 +2505,7 @@ function to_subnet%(sn: string%): subnet
 function addr_to_subnet%(a: addr%): subnet
 	%{
 	int width = (a->AsAddr().GetFamily() == IPv4 ? 32 : 128);
-	return new SubNetVal(a->AsAddr(), width);
+	return make_intrusive<SubNetVal>(a->AsAddr(), width);
 	%}
 
 ## Converts a :zeek:type:`subnet` to an :zeek:type:`addr` by
@@ -2517,7 +2518,7 @@ function addr_to_subnet%(a: addr%): subnet
 ## .. zeek:see:: to_subnet
 function subnet_to_addr%(sn: subnet%): addr
 	%{
-	return new AddrVal(sn->Prefix());
+	return make_intrusive<AddrVal>(sn->Prefix());
 	%}
 
 ## Returns the width of a :zeek:type:`subnet`.
@@ -2552,7 +2553,7 @@ function to_double%(str: string%): double
 		d = 0;
 		}
 
-	return new Val(d, TYPE_DOUBLE);
+	return make_intrusive<Val>(d, TYPE_DOUBLE);
 	%}
 
 ## Converts a :zeek:type:`count` to an :zeek:type:`addr`.
@@ -2567,10 +2568,10 @@ function count_to_v4_addr%(ip: count%): addr
 	if ( ip > 4294967295LU )
 		{
 		builtin_error("conversion of non-IPv4 count to addr", @ARG@[0]);
-		return new AddrVal(uint32_t(0));
+		return make_intrusive<AddrVal>(uint32_t(0));
 		}
 
-	return new AddrVal(htonl(uint32_t(ip)));
+	return make_intrusive<AddrVal>(htonl(uint32_t(ip)));
 	%}
 
 ## Converts a :zeek:type:`string` of bytes into an IPv4 address. In particular,
@@ -2595,7 +2596,7 @@ function raw_bytes_to_v4_addr%(b: string%): addr
 		a = (bp[0] << 24) | (bp[1] << 16) | (bp[2] << 8) | bp[3];
 		}
 
-	return new AddrVal(htonl(a));
+	return make_intrusive<AddrVal>(htonl(a));
 	%}
 
 ## Converts a :zeek:type:`string` to a :zeek:type:`port`.
@@ -2641,13 +2642,13 @@ function bytestring_to_double%(s: string%): double
 	if ( s->Len() != sizeof(double) )
 		{
 		builtin_error("bad conversion to double");
-		return new Val(0.0, TYPE_DOUBLE);
+		return make_intrusive<Val>(0.0, TYPE_DOUBLE);
 		}
 
 	// See #908 for a discussion of portability.
 	double d;
 	memcpy(&d, s->Bytes(), sizeof(double));
-	return new Val(ntohd(d), TYPE_DOUBLE);
+	return make_intrusive<Val>(ntohd(d), TYPE_DOUBLE);
 	%}
 
 ## Converts a string of bytes to a :zeek:type:`count`.
@@ -2768,7 +2769,7 @@ function ptr_name_to_addr%(s: string%): addr
 		else
 			addr = (a[3] << 24) | (a[2] << 16) | (a[1] << 8) | a[0];
 
-		return new AddrVal(htonl(addr));
+		return make_intrusive<AddrVal>(htonl(addr));
 		}
 	else
 		{
@@ -2801,7 +2802,7 @@ function ptr_name_to_addr%(s: string%): addr
 				}
 			}
 
-		return new AddrVal(addr6);
+		return make_intrusive<AddrVal>(addr6);
 		}
 	%}
 
@@ -2815,7 +2816,7 @@ function ptr_name_to_addr%(s: string%): addr
 ## .. zeek:see:: ptr_name_to_addr to_addr
 function addr_to_ptr_name%(a: addr%): string
 	%{
-	return new StringVal(a->AsAddr().PtrName().c_str());
+	return make_intrusive<StringVal>(a->AsAddr().PtrName().c_str());
 	%}
 
 ## Converts a string of bytes into its hexadecimal representation.
@@ -2837,7 +2838,7 @@ function bytestring_to_hexstr%(bytestring: string%): string
 	for ( bro_uint_t i = 0; i < len; ++i )
 		snprintf(hexstr + (2 * i), 3, "%.2hhx", bytes[i]);
 
-	return new StringVal(hexstr);
+	return make_intrusive<StringVal>(hexstr);
 	%}
 
 ## Converts a hex-string into its binary representation.
@@ -2884,7 +2885,7 @@ function hexstr_to_bytestring%(hexstr: string%): string
 
 		}
 
-	return new StringVal(outlen, bytestring);
+	return make_intrusive<StringVal>(outlen, bytestring);
 	%}
 
 ## Encodes a Base64-encoded string.
@@ -2901,7 +2902,7 @@ function encode_base64%(s: string, a: string &default=""%): string
 	%{
 	BroString* t = encode_base64(s->AsString(), a->AsString());
 	if ( t )
-		return new StringVal(t);
+		return make_intrusive<StringVal>(t);
 	else
 		{
 		reporter->Error("Broker query has an invalid data store");
@@ -2923,7 +2924,7 @@ function decode_base64%(s: string, a: string &default=""%): string
 	%{
 	BroString* t = decode_base64(s->AsString(), a->AsString());
 	if ( t )
-		return new StringVal(t);
+		return make_intrusive<StringVal>(t);
 	else
 		{
 		reporter->Error("error in decoding string %s", s->CheckString());
@@ -2956,7 +2957,7 @@ function decode_base64_conn%(cid: conn_id, s: string, a: string &default=""%): s
 
 	BroString* t = decode_base64(s->AsString(), a->AsString(), conn);
 	if ( t )
-		return new StringVal(t);
+		return make_intrusive<StringVal>(t);
 	else
 		{
 		reporter->Error("error in decoding string %s", s->CheckString());
@@ -2986,7 +2987,7 @@ typedef struct {
 function uuid_to_string%(uuid: string%): string
 	%{
 	if ( uuid->Len() != 16 )
-		return new StringVal("<Invalid UUID>");
+		return make_intrusive<StringVal>("<Invalid UUID>");
 
 	bro_uuid_t* id = (bro_uuid_t*) uuid->Bytes();
 
@@ -3004,7 +3005,7 @@ function uuid_to_string%(uuid: string%): string
 		id->node[4],
 		id->node[5]);
 
-	return new StringVal(s);
+	return make_intrusive<StringVal>(s);
 	%}
 
 %%{
@@ -3078,7 +3079,7 @@ function string_to_pattern%(s: string, convert: bool%): pattern
 	RE_Matcher* re = new RE_Matcher(pat);
 	delete [] pat;
 	re->Compile();
-	return new PatternVal(re);
+	return make_intrusive<PatternVal>(re);
 	%}
 
 ## Formats a given time value according to a format string.
@@ -3097,9 +3098,9 @@ function strftime%(fmt: string, d: time%) : string
 
 	if ( ! localtime_r(&timeval, &t) ||
 	     ! strftime(buffer, 128, fmt->CheckString(), &t) )
-		return new StringVal("<strftime error>");
+		return make_intrusive<StringVal>("<strftime error>");
 
-	return new StringVal(buffer);
+	return make_intrusive<StringVal>(buffer);
 	%}
 
 
@@ -3120,11 +3121,11 @@ function strptime%(fmt: string, d: string%) : time
 	     ! strptime(d->CheckString(), fmt->CheckString(), &t) )
 		{
 		reporter->Warning("strptime conversion failed: fmt:%s d:%s", fmt->CheckString(), d->CheckString());
-		return new Val(0.0, TYPE_TIME);
+		return make_intrusive<Val>(0.0, TYPE_TIME);
 		}
 
 	double ret = mktime(&t);
-	return new Val(ret, TYPE_TIME);
+	return make_intrusive<Val>(ret, TYPE_TIME);
 	%}
 
 
@@ -3147,7 +3148,7 @@ function strptime%(fmt: string, d: string%) : time
 ## .. zeek:see:: remask_addr
 function mask_addr%(a: addr, top_bits_to_keep: count%): subnet
 	%{
-	return new SubNetVal(a->AsAddr(), top_bits_to_keep);
+	return make_intrusive<SubNetVal>(a->AsAddr(), top_bits_to_keep);
 	%}
 
 ## Takes some top bits (such as a subnet address) from one address and the other
@@ -3173,7 +3174,7 @@ function remask_addr%(a1: addr, a2: addr, top_bits_from_a1: count%): addr
 	addr1.Mask(top_bits_from_a1);
 	IPAddr addr2(a2->AsAddr());
 	addr2.ReverseMask(top_bits_from_a1);
-	return new AddrVal(addr1|addr2);
+	return make_intrusive<AddrVal>(addr1|addr2);
 	%}
 
 ## Checks whether a given :zeek:type:`port` has TCP as transport protocol.
@@ -3213,20 +3214,20 @@ function is_icmp_port%(p: port%): bool
 	%}
 
 %%{
-EnumVal* map_conn_type(TransportProto tp)
+static IntrusivePtr<EnumVal> map_conn_type(TransportProto tp)
 	{
 	switch ( tp ) {
 	case TRANSPORT_UNKNOWN:
-		return transport_proto->GetVal(0).release();
+		return transport_proto->GetVal(0);
 
 	case TRANSPORT_TCP:
-		return transport_proto->GetVal(1).release();
+		return transport_proto->GetVal(1);
 
 	case TRANSPORT_UDP:
-		return transport_proto->GetVal(2).release();
+		return transport_proto->GetVal(2);
 
 	case TRANSPORT_ICMP:
-		return transport_proto->GetVal(3).release();
+		return transport_proto->GetVal(3);
 
 	default:
 		reporter->InternalError("bad connection type in map_conn_type()");
@@ -3234,7 +3235,7 @@ EnumVal* map_conn_type(TransportProto tp)
 
 	// Cannot be reached;
 	assert(false);
-	return 0; // Make compiler happy.
+	return nullptr; // Make compiler happy.
 	}
 %%}
 
@@ -3252,7 +3253,7 @@ function get_conn_transport_proto%(cid: conn_id%): transport_proto
 	if ( ! c )
 		{
 		builtin_error("unknown connection id in get_conn_transport_proto()", cid);
-		return transport_proto->GetVal(0).release();
+		return transport_proto->GetVal(0);
 		}
 
 	return map_conn_type(c->ConnTransport());
@@ -3299,19 +3300,19 @@ function lookup_connection%(cid: conn_id%): connection
 	%{
 	Connection* conn = sessions->FindConnection(cid);
 	if ( conn )
-		return conn->BuildConnVal();
+		return IntrusivePtr{AdoptRef{}, conn->BuildConnVal()};
 
 	builtin_error("connection ID not a known connection", cid);
 
 	// Return a dummy connection record.
-	RecordVal* c = new RecordVal(connection_type);
+	auto c = make_intrusive<RecordVal>(connection_type);
 
-	RecordVal* id_val = new RecordVal(conn_id);
+	auto id_val = make_intrusive<RecordVal>(conn_id);
 	id_val->Assign(0, make_intrusive<AddrVal>((unsigned int) 0));
 	id_val->Assign(1, val_mgr->Port(ntohs(0), TRANSPORT_UDP));
 	id_val->Assign(2, make_intrusive<AddrVal>((unsigned int) 0));
 	id_val->Assign(3, val_mgr->Port(ntohs(0), TRANSPORT_UDP));
-	c->Assign(0, id_val);
+	c->Assign(0, std::move(id_val));
 
 	auto orig_endp = make_intrusive<RecordVal>(endpoint);
 	orig_endp->Assign(0, val_mgr->Count(0));
@@ -3426,10 +3427,10 @@ function get_current_packet_header%(%) : raw_pkt_hdr
 	if ( current_pktsrc &&
 	     current_pktsrc->GetCurrentPacket(&p) )
 		{
-		return p->BuildPktHdrVal();
+		return IntrusivePtr{AdoptRef{}, p->BuildPktHdrVal()};
 		}
 
-	RecordVal* hdr = new RecordVal(raw_pkt_hdr_type);
+	auto hdr = make_intrusive<RecordVal>(raw_pkt_hdr_type);
 	return hdr;
 	%}
 
@@ -3558,7 +3559,7 @@ function lookup_addr%(host: addr%) : string
 	if ( ! trigger)
 		{
 		builtin_error("lookup_addr() can only be called inside a when-condition");
-		return new StringVal("<error>");
+		return make_intrusive<StringVal>("<error>");
 		}
 
 	frame->SetDelayed();
@@ -3566,7 +3567,7 @@ function lookup_addr%(host: addr%) : string
 
 	dns_mgr->AsyncLookupAddr(host->AsAddr(),
 			new LookupHostCallback(trigger, frame->GetCall(), true));
-	return 0;
+	return nullptr;
 	%}
 
 ## Issues an asynchronous TEXT DNS lookup and delays the function result.
@@ -3587,7 +3588,7 @@ function lookup_hostname_txt%(host: string%) : string
 	if ( ! trigger)
 		{
 		builtin_error("lookup_hostname_txt() can only be called inside a when-condition");
-		return new StringVal("<error>");
+		return make_intrusive<StringVal>("<error>");
 		}
 
 	frame->SetDelayed();
@@ -3595,7 +3596,7 @@ function lookup_hostname_txt%(host: string%) : string
 
 	dns_mgr->AsyncLookupNameText(host->CheckString(),
 				 new LookupHostCallback(trigger, frame->GetCall(), true));
-	return 0;
+	return nullptr;
 	%}
 
 ## Issues an asynchronous DNS lookup and delays the function result.
@@ -3616,7 +3617,7 @@ function lookup_hostname%(host: string%) : addr_set
 	if ( ! trigger)
 		{
 		builtin_error("lookup_hostname() can only be called inside a when-condition");
-		return new StringVal("<error>");
+		return make_intrusive<StringVal>("<error>");
 		}
 
 	frame->SetDelayed();
@@ -3624,7 +3625,7 @@ function lookup_hostname%(host: string%) : addr_set
 
 	dns_mgr->AsyncLookupName(host->CheckString(),
 			new LookupHostCallback(trigger, frame->GetCall(), false));
-	return 0;
+	return nullptr;
 	%}
 
 %%{
@@ -4132,7 +4133,7 @@ function haversine_distance%(lat1: double, long1: double, lat2: double, long2: d
 	double a = s1 * s1 + cos(lat1 * PI/180) * cos(lat2 * PI/180) * s2 * s2;
 	double distance = 2 * RADIUS * asin(sqrt(a));
 
-	return new Val(distance, TYPE_DOUBLE);
+	return make_intrusive<Val>(distance, TYPE_DOUBLE);
 	%}
 
 ## Converts UNIX file permissions given by a mode to an ASCII string.
@@ -4224,7 +4225,7 @@ function file_mode%(mode: count%): string
 
 	*p = '\0';
 
-	return new StringVal(str);
+	return make_intrusive<StringVal>(str);
 	%}
 
 # ===========================================================================
@@ -4345,12 +4346,12 @@ function set_inactivity_timeout%(cid: conn_id, t: interval%): interval
 	%{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return new Val(0.0, TYPE_INTERVAL);
+		return make_intrusive<Val>(0.0, TYPE_INTERVAL);
 
 	double old_timeout = c->InactivityTimeout();
 	c->SetInactivityTimeout(t);
 
-	return new Val(old_timeout, TYPE_INTERVAL);
+	return make_intrusive<Val>(old_timeout, TYPE_INTERVAL);
 	%}
 
 # ===========================================================================
@@ -4374,9 +4375,9 @@ function open%(f: string%): file
 	const char* file = f->CheckString();
 
 	if ( streq(file, "-") )
-		return new Val(new BroFile(stdout, "-", "w"));
+		return make_intrusive<Val>(new BroFile(stdout, "-", "w"));
 	else
-		return new Val(new BroFile(file, "w"));
+		return make_intrusive<Val>(new BroFile(file, "w"));
 	%}
 
 ## Opens a file for writing or appending. If a file with the same name already
@@ -4391,7 +4392,7 @@ function open%(f: string%): file
 ##              rmdir unlink rename
 function open_for_append%(f: string%): file
 	%{
-	return new Val(new BroFile(f->CheckString(), "a"));
+	return make_intrusive<Val>(new BroFile(f->CheckString(), "a"));
 	%}
 
 ## Closes an open file and flushes any buffered content.
@@ -4587,7 +4588,7 @@ function get_file_name%(f: file%): string
 	if ( ! f )
 		return val_mgr->EmptyString();
 
-	return new StringVal(f->Name());
+	return make_intrusive<StringVal>(f->Name());
 	%}
 
 ## Rotates a file.
@@ -4682,7 +4683,7 @@ function calc_next_rotate%(i: interval%) : interval
 		log_rotate_base_time->AsString()->CheckString() : 0;
 
 	double base = parse_rotate_base_time(base_time);
-	return new Val(calc_next_rotate(network_time, i, base), TYPE_INTERVAL);
+	return make_intrusive<Val>(calc_next_rotate(network_time, i, base), TYPE_INTERVAL);
 	%}
 
 ## Returns the size of a given file.
@@ -4695,9 +4696,9 @@ function file_size%(f: string%) : double
 	struct stat s;
 
 	if ( stat(f->CheckString(), &s) < 0 )
-		return new Val(-1.0, TYPE_DOUBLE);
+		return make_intrusive<Val>(-1.0, TYPE_DOUBLE);
 
-	return new Val(double(s.st_size), TYPE_DOUBLE);
+	return make_intrusive<Val>(double(s.st_size), TYPE_DOUBLE);
 	%}
 
 ## Prevents escaping of non-ASCII characters when writing to a file.
@@ -4707,7 +4708,7 @@ function file_size%(f: string%) : double
 function enable_raw_output%(f: file%): any
 	%{
 	f->EnableRawOutput();
-	return 0;
+	return nullptr;
 	%}
 
 # ===========================================================================
@@ -4941,7 +4942,7 @@ function is_remote_event%(%) : bool
 function suspend_processing%(%) : any
 	%{
 	net_suspend_processing();
-	return 0;
+	return nullptr;
 	%}
 
 ## Resumes Zeek's packet processing.
@@ -4950,7 +4951,7 @@ function suspend_processing%(%) : any
 function continue_processing%(%) : any
 	%{
 	net_continue_processing();
-	return 0;
+	return nullptr;
 	%}
 
 # ===========================================================================
@@ -5012,7 +5013,7 @@ function preserve_prefix%(a: addr, width: count%): any
 		}
 
 
-	return 0;
+	return nullptr;
 	%}
 
 ## Preserves the prefix of a subnet in anonymization.
@@ -5038,7 +5039,7 @@ function preserve_subnet%(a: subnet%): any
 			}
 		}
 
-	return 0;
+	return nullptr;
 	%}
 
 ## Anonymizes an IP address.
@@ -5067,13 +5068,13 @@ function anonymize_addr%(a: addr, cl: IPAddrAnonymizationClass%): addr
 	if ( a->AsAddr().GetFamily() == IPv6 )
 		{
 		builtin_error("anonymize_addr() not supported for IPv6 addresses");
-		return 0;
+		return nullptr;
 		}
 	else
 		{
 		const uint32_t* bytes;
 		a->AsAddr().GetBytes(&bytes);
-		return new AddrVal(anonymize_ip(*bytes,
+		return make_intrusive<AddrVal>(anonymize_ip(*bytes,
 			(enum ip_addr_anonymization_class_t) anon_class));
 		}
 	%}
@@ -5090,5 +5091,5 @@ function anonymize_addr%(a: addr, cl: IPAddrAnonymizationClass%): addr
 ## .. zeek:see:: fmt cat cat_sep string_cat print_raw
 function to_json%(val: any, only_loggable: bool &default=F, field_escape_pattern: pattern &default=/^_/%): string
 	%{
-	return val->ToJSON(only_loggable, field_escape_pattern).release();
+	return val->ToJSON(only_loggable, field_escape_pattern);
 	%}

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -2429,7 +2429,7 @@ function port_to_count%(p: port%): count
 ## .. zeek:see:: port_to_count
 function count_to_port%(num: count, proto: transport_proto%): port
 	%{
-	return val_mgr->GetPort(num, (TransportProto)proto->AsEnum());
+	return val_mgr->Port(num, (TransportProto)proto->AsEnum());
 	%}
 
 ## Converts a :zeek:type:`string` to an :zeek:type:`addr`.
@@ -2617,16 +2617,16 @@ function to_port%(s: string%): port
             {
             ++slash;
             if ( streq(slash, "tcp") )
-                return val_mgr->GetPort(port, TRANSPORT_TCP);
+                return val_mgr->Port(port, TRANSPORT_TCP);
             else if ( streq(slash, "udp") )
-                return val_mgr->GetPort(port, TRANSPORT_UDP);
+                return val_mgr->Port(port, TRANSPORT_UDP);
             else if ( streq(slash, "icmp") )
-                return val_mgr->GetPort(port, TRANSPORT_ICMP);
+                return val_mgr->Port(port, TRANSPORT_ICMP);
             }
         }
 
     builtin_error("wrong port format, must be /[0-9]{1,5}\\/(tcp|udp|icmp)/");
-    return val_mgr->GetPort(port, TRANSPORT_UNKNOWN);
+    return val_mgr->Port(port, TRANSPORT_UNKNOWN);
 	%}
 
 ## Converts a string of bytes (in network byte order) to a :zeek:type:`double`.
@@ -3308,9 +3308,9 @@ function lookup_connection%(cid: conn_id%): connection
 
 	RecordVal* id_val = new RecordVal(conn_id);
 	id_val->Assign(0, make_intrusive<AddrVal>((unsigned int) 0));
-	id_val->Assign(1, val_mgr->GetPort(ntohs(0), TRANSPORT_UDP));
+	id_val->Assign(1, val_mgr->Port(ntohs(0), TRANSPORT_UDP));
 	id_val->Assign(2, make_intrusive<AddrVal>((unsigned int) 0));
-	id_val->Assign(3, val_mgr->GetPort(ntohs(0), TRANSPORT_UDP));
+	id_val->Assign(3, val_mgr->Port(ntohs(0), TRANSPORT_UDP));
 	c->Assign(0, id_val);
 
 	auto orig_endp = make_intrusive<RecordVal>(endpoint);

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -468,7 +468,7 @@ static int do_system(const char* s)
 function system%(str: string%): int
 	%{
 	int result = do_system(str->CheckString());
-	return val_mgr->GetInt(result);
+	return val_mgr->Int(result);
 	%}
 
 ## Invokes a command via the ``system`` function of the OS with a prepared
@@ -489,17 +489,17 @@ function system_env%(str: string, env: table_string_of_string%): int
 	if ( env->Type()->Tag() != TYPE_TABLE )
 		{
 		builtin_error("system_env() requires a table argument");
-		return val_mgr->GetInt(-1);
+		return val_mgr->Int(-1);
 		}
 
 	if ( ! prepare_environment(env->AsTableVal(), true) )
-		return val_mgr->GetInt(-1);
+		return val_mgr->Int(-1);
 
 	int result = do_system(str->CheckString());
 
 	prepare_environment(env->AsTableVal(), false);
 
-	return val_mgr->GetInt(result);
+	return val_mgr->Int(result);
 	%}
 
 ## Opens a program with ``popen`` and writes a given string to the returned
@@ -1901,7 +1901,7 @@ function packet_source%(%): PacketSource
 		{
 		r->Assign(0, val_mgr->Bool(ps->IsLive()));
 		r->Assign(1, make_intrusive<StringVal>(ps->Path()));
-		r->Assign(2, val_mgr->GetInt(ps->LinkType()));
+		r->Assign(2, val_mgr->Int(ps->LinkType()));
 		r->Assign(3, val_mgr->GetCount(ps->Netmask()));
 		}
 
@@ -2273,10 +2273,10 @@ function enum_to_int%(e: any%): int
 	if ( e->Type()->Tag() != TYPE_ENUM )
 		{
 		builtin_error("enum_to_int() requires enum value");
-		return val_mgr->GetInt(-1);
+		return val_mgr->Int(-1);
 		}
 
-	return val_mgr->GetInt(e->AsEnum());
+	return val_mgr->Int(e->AsEnum());
 	%}
 
 ## Converts a :zeek:type:`string` to an :zeek:type:`int`.
@@ -2300,7 +2300,7 @@ function to_int%(str: string%): int
 		builtin_error("bad conversion to integer", @ARG@[0]);
 #endif
 
-	return val_mgr->GetInt(i);
+	return val_mgr->Int(i);
 	%}
 
 

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -1655,7 +1655,7 @@ function cat_sep%(sep: string, def: string, ...%): string
 function fmt%(...%): string
 	%{
 	if ( @ARGC@ == 0 )
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 
 	Val* fmt_v = @ARG@[0].get();
 
@@ -1674,13 +1674,13 @@ function fmt%(...%): string
 	if ( n < static_cast<int>(@ARGC@) - 1 )
 		{
 		builtin_error("too many arguments for format", fmt_v);
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	else if ( n >= static_cast<int>(@ARGC@) )
 		{
 		builtin_error("too few arguments for format", fmt_v);
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	BroString* s = new BroString(1, d.TakeBytes(), d.Len());
@@ -2857,7 +2857,7 @@ function hexstr_to_bytestring%(hexstr: string%): string
 	if ( len % 2 != 0 )
 		{
 		reporter->Error("Hex string '%s' has invalid length (not divisible by 2)", hexstr->CheckString());
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	const char* bytes = hexstr->AsString()->CheckString();
@@ -2873,13 +2873,13 @@ function hexstr_to_bytestring%(hexstr: string%): string
 		if ( res == EOF )
 			{
 			reporter->Error("Hex string %s contains invalid input: %s", hexstr->CheckString(), strerror(errno));
-			return val_mgr->GetEmptyString();
+			return val_mgr->EmptyString();
 			}
 
 		else if ( res != 1 )
 			{
 			reporter->Error("Could not read hex element from input %s", hexstr->CheckString());
-			return val_mgr->GetEmptyString();
+			return val_mgr->EmptyString();
 			}
 
 		}
@@ -2905,7 +2905,7 @@ function encode_base64%(s: string, a: string &default=""%): string
 	else
 		{
 		reporter->Error("Broker query has an invalid data store");
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 	%}
 
@@ -2927,7 +2927,7 @@ function decode_base64%(s: string, a: string &default=""%): string
 	else
 		{
 		reporter->Error("error in decoding string %s", s->CheckString());
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 	%}
 
@@ -2951,7 +2951,7 @@ function decode_base64_conn%(cid: conn_id, s: string, a: string &default=""%): s
 	if ( ! conn )
 		{
 		builtin_error("connection ID not a known connection", cid);
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 
 	BroString* t = decode_base64(s->AsString(), a->AsString(), conn);
@@ -2960,7 +2960,7 @@ function decode_base64_conn%(cid: conn_id, s: string, a: string &default=""%): s
 	else
 		{
 		reporter->Error("error in decoding string %s", s->CheckString());
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 		}
 	%}
 
@@ -3327,7 +3327,7 @@ function lookup_connection%(cid: conn_id%): connection
 	c->Assign(3, make_intrusive<Val>(network_time, TYPE_TIME));
 	c->Assign(4, make_intrusive<Val>(0.0, TYPE_INTERVAL));
 	c->Assign(5, make_intrusive<TableVal>(IntrusivePtr{NewRef{}, string_set}));	// service
-	c->Assign(6, val_mgr->GetEmptyString());	// history
+	c->Assign(6, val_mgr->EmptyString());	// history
 
 	return c;
 	%}
@@ -3398,7 +3398,7 @@ function get_current_packet%(%) : pcap_packet
 		pkt->Assign(1, val_mgr->Count(0));
 		pkt->Assign(2, val_mgr->Count(0));
 		pkt->Assign(3, val_mgr->Count(0));
-		pkt->Assign(4, val_mgr->GetEmptyString());
+		pkt->Assign(4, val_mgr->EmptyString());
 		pkt->Assign(5, BifType::Enum::link_encap->GetVal(BifEnum::LINK_UNKNOWN));
 		return pkt;
 		}
@@ -4585,7 +4585,7 @@ function active_file%(f: file%): bool
 function get_file_name%(f: file%): string
 	%{
 	if ( ! f )
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 
 	return new StringVal(f->Name());
 	%}
@@ -4606,8 +4606,8 @@ function rotate_file%(f: file%): rotate_info
 
 	// Record indicating error.
 	info = new RecordVal(rotate_info);
-	info->Assign(0, val_mgr->GetEmptyString());
-	info->Assign(1, val_mgr->GetEmptyString());
+	info->Assign(0, val_mgr->EmptyString());
+	info->Assign(1, val_mgr->EmptyString());
 	info->Assign(2, make_intrusive<Val>(0.0, TYPE_TIME));
 	info->Assign(3, make_intrusive<Val>(0.0, TYPE_TIME));
 
@@ -4647,8 +4647,8 @@ function rotate_file_by_name%(f: string%): rotate_info
 	if ( ! file )
 		{
 		// Record indicating error.
-		info->Assign(0, val_mgr->GetEmptyString());
-		info->Assign(1, val_mgr->GetEmptyString());
+		info->Assign(0, val_mgr->EmptyString());
+		info->Assign(1, val_mgr->EmptyString());
 		info->Assign(2, make_intrusive<Val>(0.0, TYPE_TIME));
 		info->Assign(3, make_intrusive<Val>(0.0, TYPE_TIME));
 		return info;

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -885,7 +885,7 @@ function fnv1a32%(input: any%): count
 		rval *= prime32;
 		}
 
-	return val_mgr->GetCount(rval);
+	return val_mgr->Count(rval);
 	%}
 
 ## Calculates a weight value for use in a Rendezvous Hashing algorithm.
@@ -912,7 +912,7 @@ function hrw_weight%(key_digest: count, site_id: count%): count
 
 	uint32_t rval = (a * ((a * si + b) ^ d) + b) % m;
 
-	return val_mgr->GetCount(rval);
+	return val_mgr->Count(rval);
 	%}
 
 ## Generates a random number.
@@ -930,7 +930,7 @@ function hrw_weight%(key_digest: count, site_id: count%): count
 function rand%(max: count%): count
 	%{
 	auto result = bro_uint_t(double(max) * double(bro_random()) / (RAND_MAX + 1.0));
-	return val_mgr->GetCount(result);
+	return val_mgr->Count(result);
 	%}
 
 ## Sets the seed for subsequent :zeek:id:`rand` calls.
@@ -1248,7 +1248,7 @@ function same_object%(o1: any, o2: any%): bool
 ## Returns: The number of bytes that *v* occupies.
 function val_size%(v: any%): count
 	%{
-	return val_mgr->GetCount(v->MemoryAllocation());
+	return val_mgr->Count(v->MemoryAllocation());
 	%}
 
 ## Resizes a vector.
@@ -1266,7 +1266,7 @@ function resize%(aggr: any, newsize: count%) : count
 		return 0;
 		}
 
-	return val_mgr->GetCount(aggr->AsVectorVal()->Resize(newsize));
+	return val_mgr->Count(aggr->AsVectorVal()->Resize(newsize));
 	%}
 
 ## Tests whether a boolean vector (``vector of bool``) has *any* true
@@ -1541,7 +1541,7 @@ function order%(v: any, ...%) : index_vec
 	for ( i = 0; i < n; ++i )
 		{
 		int ind = ind_vv[i];
-		result_v->Assign(i, val_mgr->GetCount(ind));
+		result_v->Assign(i, val_mgr->Count(ind));
 		}
 
 	return result_v;
@@ -1791,7 +1791,7 @@ function log10%(d: double%): double
 ##          none.
 function current_analyzer%(%) : count
 	%{
-	return val_mgr->GetCount(mgr.CurrentAnalyzer());
+	return val_mgr->Count(mgr.CurrentAnalyzer());
 	%}
 
 ## Returns Zeek's process ID.
@@ -1799,7 +1799,7 @@ function current_analyzer%(%) : count
 ## Returns: Zeek's process ID.
 function getpid%(%) : count
 	%{
-	return val_mgr->GetCount(getpid());
+	return val_mgr->Count(getpid());
 	%}
 
 %%{
@@ -1902,7 +1902,7 @@ function packet_source%(%): PacketSource
 		r->Assign(0, val_mgr->Bool(ps->IsLive()));
 		r->Assign(1, make_intrusive<StringVal>(ps->Path()));
 		r->Assign(2, val_mgr->Int(ps->LinkType()));
-		r->Assign(3, val_mgr->GetCount(ps->Netmask()));
+		r->Assign(3, val_mgr->Count(ps->Netmask()));
 		}
 
 	return r.release();
@@ -1925,8 +1925,8 @@ function global_sizes%(%): var_sizes
 		if ( id->HasVal() )
 			{
 			Val* id_name = new StringVal(id->Name());
-			Val* id_size = val_mgr->GetCount(id->ID_Val()->MemoryAllocation());
-			sizes->Assign(id_name, id_size);
+			auto id_size = val_mgr->Count(id->ID_Val()->MemoryAllocation());
+			sizes->Assign(id_name, std::move(id_size));
 			Unref(id_name);
 			}
 		}
@@ -2228,7 +2228,7 @@ function addr_to_counts%(a: addr%): index_vec
 	int len = a->AsAddr().GetBytes(&bytes);
 
 	for ( int i = 0; i < len; ++i )
-		rval->Assign(i, val_mgr->GetCount(ntohl(bytes[i])));
+		rval->Assign(i, val_mgr->Count(ntohl(bytes[i])));
 
 	return rval;
 	%}
@@ -2316,7 +2316,7 @@ function int_to_count%(n: int%): count
 		builtin_error("bad conversion to count", @ARG@[0]);
 		n = 0;
 		}
-	return val_mgr->GetCount(n);
+	return val_mgr->Count(n);
 	%}
 
 ## Converts a :zeek:type:`double` to a :zeek:type:`count`.
@@ -2331,7 +2331,7 @@ function double_to_count%(d: double%): count
 	if ( d < 0.0 )
 		builtin_error("bad conversion to count", @ARG@[0]);
 
-	return val_mgr->GetCount(bro_uint_t(rint(d)));
+	return val_mgr->Count(bro_uint_t(rint(d)));
 	%}
 
 ## Converts a :zeek:type:`string` to a :zeek:type:`count`.
@@ -2355,7 +2355,7 @@ function to_count%(str: string%): count
         u = 0;
         }
 
-	return val_mgr->GetCount(u);
+	return val_mgr->Count(u);
 	%}
 
 ## Converts an :zeek:type:`interval` to a :zeek:type:`double`.
@@ -2415,7 +2415,7 @@ function double_to_interval%(d: double%): interval
 ## .. zeek:see:: count_to_port
 function port_to_count%(p: port%): count
 	%{
-	return val_mgr->GetCount(p->Port());
+	return val_mgr->Count(p->Port());
 	%}
 
 ## Converts a :zeek:type:`count` and ``transport_proto`` to a :zeek:type:`port`.
@@ -2529,7 +2529,7 @@ function subnet_to_addr%(sn: subnet%): addr
 ## .. zeek:see:: to_subnet
 function subnet_width%(sn: subnet%): count
 	%{
-	return val_mgr->GetCount(sn->Width());
+	return val_mgr->Count(sn->Width());
 	%}
 
 ## Converts a :zeek:type:`string` to a :zeek:type:`double`.
@@ -2673,7 +2673,7 @@ function bytestring_to_count%(s: string, is_le: bool &default=F%): count
 		{
 		uint8_t value = 0;
 		memcpy(&value, p, sizeof(uint8_t));
-		return val_mgr->GetCount(value);
+		return val_mgr->Count(value);
 		}
 
 	case sizeof(uint16_t):
@@ -2693,7 +2693,7 @@ function bytestring_to_count%(s: string, is_le: bool &default=F%): count
 		else
 			memcpy(&value, p, sizeof(uint16_t));
 
-		return val_mgr->GetCount(value);
+		return val_mgr->Count(value);
 		}
 
 	case sizeof(uint32_t):
@@ -2713,7 +2713,7 @@ function bytestring_to_count%(s: string, is_le: bool &default=F%): count
 		else
 			memcpy(&value, p, sizeof(uint32_t));
 
-		return val_mgr->GetCount(value);
+		return val_mgr->Count(value);
 		}
 
 	case sizeof(uint64_t):
@@ -2733,12 +2733,12 @@ function bytestring_to_count%(s: string, is_le: bool &default=F%): count
 		else
 			memcpy(&value, p, sizeof(uint64_t));
 
-		return val_mgr->GetCount(value);
+		return val_mgr->Count(value);
 		}
 	}
 
 	builtin_error("unsupported byte length for bytestring_to_count");
-	return val_mgr->GetCount(0);
+	return val_mgr->Count(0);
 	%}
 
 ## Converts a reverse pointer name to an address. For example,
@@ -3314,12 +3314,12 @@ function lookup_connection%(cid: conn_id%): connection
 	c->Assign(0, id_val);
 
 	auto orig_endp = make_intrusive<RecordVal>(endpoint);
-	orig_endp->Assign(0, val_mgr->GetCount(0));
-	orig_endp->Assign(1, val_mgr->GetCount(int(0)));
+	orig_endp->Assign(0, val_mgr->Count(0));
+	orig_endp->Assign(1, val_mgr->Count(int(0)));
 
 	auto resp_endp = make_intrusive<RecordVal>(endpoint);
-	resp_endp->Assign(0, val_mgr->GetCount(0));
-	resp_endp->Assign(1, val_mgr->GetCount(int(0)));
+	resp_endp->Assign(0, val_mgr->Count(0));
+	resp_endp->Assign(1, val_mgr->Count(int(0)));
 
 	c->Assign(1, std::move(orig_endp));
 	c->Assign(2, std::move(resp_endp));
@@ -3394,19 +3394,19 @@ function get_current_packet%(%) : pcap_packet
 	if ( ! current_pktsrc ||
 	     ! current_pktsrc->GetCurrentPacket(&p) )
 		{
-		pkt->Assign(0, val_mgr->GetCount(0));
-		pkt->Assign(1, val_mgr->GetCount(0));
-		pkt->Assign(2, val_mgr->GetCount(0));
-		pkt->Assign(3, val_mgr->GetCount(0));
+		pkt->Assign(0, val_mgr->Count(0));
+		pkt->Assign(1, val_mgr->Count(0));
+		pkt->Assign(2, val_mgr->Count(0));
+		pkt->Assign(3, val_mgr->Count(0));
 		pkt->Assign(4, val_mgr->GetEmptyString());
 		pkt->Assign(5, BifType::Enum::link_encap->GetVal(BifEnum::LINK_UNKNOWN));
 		return pkt;
 		}
 
-	pkt->Assign(0, val_mgr->GetCount(uint32_t(p->ts.tv_sec)));
-	pkt->Assign(1, val_mgr->GetCount(uint32_t(p->ts.tv_usec)));
-	pkt->Assign(2, val_mgr->GetCount(p->cap_len));
-	pkt->Assign(3, val_mgr->GetCount(p->len));
+	pkt->Assign(0, val_mgr->Count(uint32_t(p->ts.tv_sec)));
+	pkt->Assign(1, val_mgr->Count(uint32_t(p->ts.tv_usec)));
+	pkt->Assign(2, val_mgr->Count(p->cap_len));
+	pkt->Assign(3, val_mgr->Count(p->len));
 	pkt->Assign(4, make_intrusive<StringVal>(p->cap_len, (const char*)p->data));
 	pkt->Assign(5, BifType::Enum::link_encap->GetVal(p->link_type));
 
@@ -3860,7 +3860,7 @@ static Val* mmdb_getvalue(MMDB_entry_data_s* entry_data, int status,
 						break;
 
 					case MMDB_DATA_TYPE_UINT32:
-						return val_mgr->GetCount(entry_data->uint32);
+						return val_mgr->Count(entry_data->uint32);
 
 					default:
 						break;
@@ -4072,7 +4072,7 @@ function lookup_asn%(a: addr%) : count
 				builtin_error("Failed to open GeoIP ASN database");
 				}
 
-			return val_mgr->GetCount(0);
+			return val_mgr->Count(0);
 			}
 		}
 
@@ -4087,7 +4087,7 @@ function lookup_asn%(a: addr%) : count
 		status = MMDB_get_value(&result.entry, &entry_data,
 		                        "autonomous_system_number", nullptr);
 		Val* asn = mmdb_getvalue(&entry_data, status, MMDB_DATA_TYPE_UINT32);
-		return asn == nullptr ? val_mgr->GetCount(0) : asn;
+		return asn == nullptr ? val_mgr->Count(0) : asn;
 		}
 
 #else // not USE_GEOIP
@@ -4103,7 +4103,7 @@ function lookup_asn%(a: addr%) : count
 	// We can get here even if we have GeoIP support, if we weren't
 	// able to initialize it or it didn't return any information for
 	// the address.
-	return val_mgr->GetCount(0);
+	return val_mgr->Count(0);
 	%}
 
 ## Calculates distance between two geographic locations using the haversine

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -364,8 +364,8 @@ function setenv%(var: string, val: string%): bool
 	                    val->AsString()->CheckString(), 1);
 
 	if ( result < 0 )
-		return val_mgr->GetFalse();
-	return val_mgr->GetTrue();
+		return val_mgr->False();
+	return val_mgr->True();
 	%}
 
 ## Shuts down the Zeek process immediately.
@@ -388,10 +388,10 @@ function exit%(code: int%): any
 function terminate%(%): bool
 	%{
 	if ( terminating )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	terminate_processing();
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 %%{
@@ -520,7 +520,7 @@ function piped_exec%(program: string, to_write: string%): bool
 	if ( ! f )
 		{
 		reporter->Error("Failed to popen %s", prog);
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	const u_char* input_data = to_write->Bytes();
@@ -533,10 +533,10 @@ function piped_exec%(program: string, to_write: string%): bool
 	if ( bytes_written != input_data_len )
 		{
 		reporter->Error("Failed to write all given data to %s", prog);
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 %%{
@@ -710,7 +710,7 @@ function sha256_hash_init%(%): opaque of sha256
 function md5_hash_update%(handle: opaque of md5, data: string%): bool
 	%{
 	bool rc = static_cast<HashVal*>(handle)->Feed(data->Bytes(), data->Len());
-	return val_mgr->GetBool(rc);
+	return val_mgr->Bool(rc);
 	%}
 
 ## Updates the SHA1 value associated with a given index. It is required to
@@ -729,7 +729,7 @@ function md5_hash_update%(handle: opaque of md5, data: string%): bool
 function sha1_hash_update%(handle: opaque of sha1, data: string%): bool
 	%{
 	bool rc = static_cast<HashVal*>(handle)->Feed(data->Bytes(), data->Len());
-	return val_mgr->GetBool(rc);
+	return val_mgr->Bool(rc);
 	%}
 
 ## Updates the SHA256 value associated with a given index. It is required to
@@ -748,7 +748,7 @@ function sha1_hash_update%(handle: opaque of sha1, data: string%): bool
 function sha256_hash_update%(handle: opaque of sha256, data: string%): bool
 	%{
 	bool rc = static_cast<HashVal*>(handle)->Feed(data->Bytes(), data->Len());
-	return val_mgr->GetBool(rc);
+	return val_mgr->Bool(rc);
 	%}
 
 ## Returns the final MD5 digest of an incremental hash computation.
@@ -856,7 +856,7 @@ function paraglob_match%(handle: opaque of paraglob, match: string%): string_vec
 ## ## .. zeek:see::paraglob_add paraglob_match paraglob_init
 function paraglob_equals%(p_one: opaque of paraglob, p_two: opaque of paraglob%) : bool
 	%{
-	return val_mgr->GetBool(
+	return val_mgr->Bool(
 		*(static_cast<ParaglobVal*>(p_one)) ==  *(static_cast<ParaglobVal*>(p_two))
 	);
 	%}
@@ -1082,7 +1082,7 @@ function entropy_test_add%(handle: opaque of entropy, data: string%): bool
 	%{
 	bool status = static_cast<EntropyVal*>(handle)->Feed(data->Bytes(),
 	                                                     data->Len());
-	return val_mgr->GetBool(status);
+	return val_mgr->Bool(status);
 	%}
 
 ## Finishes an incremental entropy calculation. Before using this function,
@@ -1224,7 +1224,7 @@ function check_subnet%(search: subnet, t: any%): bool
 
 	void* res = pt->Lookup(search, true);
 
-	return val_mgr->GetBool(res != nullptr);
+	return val_mgr->Bool(res != nullptr);
 	%}
 
 ## Checks whether two objects reference the same internal object. This function
@@ -1238,7 +1238,7 @@ function check_subnet%(search: subnet, t: any%): bool
 ## Returns: True if *o1* and *o2* are equal.
 function same_object%(o1: any, o2: any%): bool
 	%{
-	return val_mgr->GetBool(o1 == o2);
+	return val_mgr->Bool(o1 == o2);
 	%}
 
 ## Returns the number of bytes that a value occupies in memory.
@@ -1283,15 +1283,15 @@ function any_set%(v: any%) : bool
 	     v->Type()->YieldType()->Tag() != TYPE_BOOL )
 		{
 		builtin_error("any_set() requires vector of bool");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	VectorVal* vv = v->AsVectorVal();
 	for ( unsigned int i = 0; i < vv->Size(); ++i )
 		if ( vv->Lookup(i) && vv->Lookup(i)->AsBool() )
-			return val_mgr->GetTrue();
+			return val_mgr->True();
 
-	return val_mgr->GetFalse();
+	return val_mgr->False();
 	%}
 
 ## Tests whether *all* elements of a boolean vector (``vector of bool``) are
@@ -1312,15 +1312,15 @@ function all_set%(v: any%) : bool
 	     v->Type()->YieldType()->Tag() != TYPE_BOOL )
 		{
 		builtin_error("all_set() requires vector of bool");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	VectorVal* vv = v->AsVectorVal();
 	for ( unsigned int i = 0; i < vv->Size(); ++i )
 		if ( ! vv->Lookup(i) || ! vv->Lookup(i)->AsBool() )
-			return val_mgr->GetFalse();
+			return val_mgr->False();
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 %%{
@@ -1702,7 +1702,7 @@ function print_raw%(...%): bool
 	d.SetStyle(RAW_STYLE);
 	describe_vals(@ARG@, &d, 0);
 	printf("%.*s", d.Len(), d.Description());
-	return val_mgr->GetBool(true);
+	return val_mgr->Bool(true);
 	%}
 
 # ===========================================================================
@@ -1874,7 +1874,7 @@ function zeek_args%(%): string_vec
 ## .. zeek:see:: reading_traces packet_source
 function reading_live_traffic%(%): bool
 	%{
-	return val_mgr->GetBool(reading_live);
+	return val_mgr->Bool(reading_live);
 	%}
 
 ## Checks whether Zeek reads traffic from a trace file (as opposed to from a
@@ -1885,7 +1885,7 @@ function reading_live_traffic%(%): bool
 ## .. zeek:see:: reading_live_traffic packet_source
 function reading_traces%(%): bool
 	%{
-	return val_mgr->GetBool(reading_traces);
+	return val_mgr->Bool(reading_traces);
 	%}
 
 ## Returns: the packet source being read by Zeek.
@@ -1899,7 +1899,7 @@ function packet_source%(%): PacketSource
 
         if ( ps )
 		{
-		r->Assign(0, val_mgr->GetBool(ps->IsLive()));
+		r->Assign(0, val_mgr->Bool(ps->IsLive()));
 		r->Assign(1, make_intrusive<StringVal>(ps->Path()));
 		r->Assign(2, val_mgr->GetInt(ps->LinkType()));
 		r->Assign(3, val_mgr->GetCount(ps->Netmask()));
@@ -1952,11 +1952,11 @@ function global_ids%(%): id_table
 		ID* id = global.second.get();
 		auto rec = make_intrusive<RecordVal>(script_id);
 		rec->Assign(0, make_intrusive<StringVal>(type_name(id->Type()->Tag())));
-		rec->Assign(1, val_mgr->GetBool(id->IsExport()));
-		rec->Assign(2, val_mgr->GetBool(id->IsConst()));
-		rec->Assign(3, val_mgr->GetBool(id->IsEnumConst()));
-		rec->Assign(4, val_mgr->GetBool(id->IsOption()));
-		rec->Assign(5, val_mgr->GetBool(id->IsRedefinable()));
+		rec->Assign(1, val_mgr->Bool(id->IsExport()));
+		rec->Assign(2, val_mgr->Bool(id->IsConst()));
+		rec->Assign(3, val_mgr->Bool(id->IsEnumConst()));
+		rec->Assign(4, val_mgr->Bool(id->IsOption()));
+		rec->Assign(5, val_mgr->Bool(id->IsRedefinable()));
 
 		if ( id->HasVal() )
 			{
@@ -2047,7 +2047,7 @@ function do_profiling%(%) : any
 function is_local_interface%(ip: addr%) : bool
 	%{
 	if ( ip->AsAddr().IsLoopback() )
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 
 	list<IPAddr> addrs;
 
@@ -2079,10 +2079,10 @@ function is_local_interface%(ip: addr%) : bool
 	for ( it = addrs.begin(); it != addrs.end(); ++it )
 		{
 		if ( *it == ip->AsAddr() )
-			return val_mgr->GetTrue();
+			return val_mgr->True();
 		}
 
-	return val_mgr->GetFalse();
+	return val_mgr->False();
 	%}
 
 ## Write rule matcher statistics (DFA states, transitions, memory usage, cache
@@ -2098,7 +2098,7 @@ function dump_rule_stats%(f: file%): bool
 	if ( rule_matcher )
 		rule_matcher->DumpStats(f);
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Checks if Zeek is terminating.
@@ -2108,7 +2108,7 @@ function dump_rule_stats%(f: file%): bool
 ## .. zeek:see:: terminate
 function zeek_is_terminating%(%): bool
 	%{
-	return val_mgr->GetBool(terminating);
+	return val_mgr->Bool(terminating);
 	%}
 
 ## Returns the hostname of the machine Zeek runs on.
@@ -2132,9 +2132,9 @@ function gethostname%(%) : string
 function is_v4_addr%(a: addr%): bool
 	%{
 	if ( a->AsAddr().GetFamily() == IPv4 )
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 	else
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 	%}
 
 ## Returns whether an address is IPv6 or not.
@@ -2145,9 +2145,9 @@ function is_v4_addr%(a: addr%): bool
 function is_v6_addr%(a: addr%): bool
 	%{
 	if ( a->AsAddr().GetFamily() == IPv6 )
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 	else
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 	%}
 
 ## Returns whether a subnet specification is IPv4 or not.
@@ -2158,9 +2158,9 @@ function is_v6_addr%(a: addr%): bool
 function is_v4_subnet%(s: subnet%): bool
 	%{
 	if ( s->AsSubNet().Prefix().GetFamily() == IPv4 )
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 	else
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 	%}
 
 ## Returns whether a subnet specification is IPv6 or not.
@@ -2171,9 +2171,9 @@ function is_v4_subnet%(s: subnet%): bool
 function is_v6_subnet%(s: subnet%): bool
 	%{
 	if ( s->AsSubNet().Prefix().GetFamily() == IPv6 )
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 	else
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 	%}
 
 
@@ -2469,7 +2469,7 @@ function is_valid_ip%(ip: string%): bool
 	char* s = ip->AsString()->Render();
 	auto rval = IPAddr::IsValid(s);
 	delete [] s;
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 ## Converts a :zeek:type:`string` to a :zeek:type:`subnet`.
@@ -3185,7 +3185,7 @@ function remask_addr%(a1: addr, a2: addr, top_bits_from_a1: count%): addr
 ## .. zeek:see:: is_udp_port is_icmp_port
 function is_tcp_port%(p: port%): bool
 	%{
-	return val_mgr->GetBool(p->IsTCP());
+	return val_mgr->Bool(p->IsTCP());
 	%}
 
 ## Checks whether a given :zeek:type:`port` has UDP as transport protocol.
@@ -3197,7 +3197,7 @@ function is_tcp_port%(p: port%): bool
 ## .. zeek:see:: is_icmp_port is_tcp_port
 function is_udp_port%(p: port%): bool
 	%{
-	return val_mgr->GetBool(p->IsUDP());
+	return val_mgr->Bool(p->IsUDP());
 	%}
 
 ## Checks whether a given :zeek:type:`port` has ICMP as transport protocol.
@@ -3209,7 +3209,7 @@ function is_udp_port%(p: port%): bool
 ## .. zeek:see:: is_tcp_port is_udp_port
 function is_icmp_port%(p: port%): bool
 	%{
-	return val_mgr->GetBool(p->IsICMP());
+	return val_mgr->Bool(p->IsICMP());
 	%}
 
 %%{
@@ -3281,9 +3281,9 @@ function get_port_transport_proto%(p: port%): transport_proto
 function connection_exists%(c: conn_id%): bool
 	%{
 	if ( sessions->FindConnection(c) )
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 	else
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 	%}
 
 ## Returns the :zeek:type:`connection` record for a given connection identifier.
@@ -3361,7 +3361,7 @@ function dump_current_packet%(file_name: string%) : bool
 
 	if ( ! current_pktsrc ||
 	     ! current_pktsrc->GetCurrentPacket(&pkt) )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	if ( addl_pkt_dumper && addl_pkt_dumper->Path() != file_name->CheckString())
 		{
@@ -3377,7 +3377,7 @@ function dump_current_packet%(file_name: string%) : bool
 		addl_pkt_dumper->Dump(pkt);
 		}
 
-	return val_mgr->GetBool( addl_pkt_dumper && ! addl_pkt_dumper->IsError());
+	return val_mgr->Bool( addl_pkt_dumper && ! addl_pkt_dumper->IsError());
 	%}
 
 ## Returns the currently processed PCAP packet.
@@ -3472,7 +3472,7 @@ function dump_packet%(pkt: pcap_packet, file_name: string%) : bool
 		addl_pkt_dumper->Dump(&p);
 		}
 
-	return val_mgr->GetBool(addl_pkt_dumper && ! addl_pkt_dumper->IsError());
+	return val_mgr->Bool(addl_pkt_dumper && ! addl_pkt_dumper->IsError());
 	%}
 
 %%{
@@ -3944,7 +3944,7 @@ function mmdb_open_location_db%(f: string%) : bool
 #ifdef USE_GEOIP
 	return val_mgr->GetBool(mmdb_open_loc(f->CheckString()));
 #else
-        return val_mgr->GetFalse();
+	return val_mgr->False();
 #endif
 	%}
 
@@ -3961,7 +3961,7 @@ function mmdb_open_asn_db%(f: string%) : bool
 #ifdef USE_GEOIP
 	return val_mgr->GetBool(mmdb_open_asn(f->CheckString()));
 #else
-	return val_mgr->GetFalse();
+	return val_mgr->False();
 #endif
 	%}
 
@@ -4261,7 +4261,7 @@ function disable_analyzer%(cid: conn_id, aid: count, err_if_no_conn: bool &defau
 	if ( ! c )
 		{
 		reporter->Error("cannot find connection");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	analyzer::Analyzer* a = c->FindAnalyzer(aid);
@@ -4269,7 +4269,7 @@ function disable_analyzer%(cid: conn_id, aid: count, err_if_no_conn: bool &defau
 		{
 		if ( err_if_no_conn )
 			reporter->Error("connection does not have analyzer specified to disable");
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 
 	if ( prevent )
@@ -4297,10 +4297,10 @@ function skip_further_processing%(cid: conn_id%): bool
 	%{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	c->SetSkip(1);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Controls whether packet contents belonging to a connection should be
@@ -4327,10 +4327,10 @@ function set_record_packets%(cid: conn_id, do_record: bool%): bool
 	%{
 	Connection* c = sessions->FindConnection(cid);
 	if ( ! c )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	c->SetRecordPackets(do_record);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Sets an individual inactivity timeout for a connection and thus
@@ -4422,7 +4422,7 @@ function close%(f: file%): bool
 function write_file%(f: file, data: string%): bool
 	%{
 	if ( ! f )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	return val_mgr->GetBool(f->Write((const char*) data->Bytes(), data->Len()));
 	%}
@@ -4442,7 +4442,7 @@ function write_file%(f: file, data: string%): bool
 function set_buf%(f: file, buffered: bool%): any
 	%{
 	f->SetBuf(buffered);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Flushes all open files to disk.
@@ -4478,14 +4478,14 @@ function mkdir%(f: string%): bool
 		// check if already exists and is directory.
 		if ( errno == EEXIST && stat(filename, &filestat) == 0
 		     && S_ISDIR(filestat.st_mode) )
-			return val_mgr->GetTrue();
+			return val_mgr->True();
 
 		builtin_error(fmt("cannot create directory '%s': %s", filename,
 		                  strerror(error)));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 	else
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 	%}
 
 
@@ -4507,10 +4507,10 @@ function rmdir%(d: string%): bool
 		{
 		builtin_error(fmt("cannot remove directory '%s': %s", dirname,
 		                  strerror(errno)));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 	else
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 	%}
 
 ## Removes a file from a directory.
@@ -4531,10 +4531,10 @@ function unlink%(f: string%): bool
 		{
 		builtin_error(fmt("cannot unlink file '%s': %s", filename,
 		                  strerror(errno)));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 	else
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 	%}
 
 ## Renames a file from src_f to dst_f.
@@ -4557,10 +4557,10 @@ function rename%(src_f: string, dst_f: string%): bool
 		{
 		builtin_error(fmt("cannot rename file '%s' to '%s': %s", src_filename,
 		                  dst_filename, strerror(errno)));
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 		}
 	else
-		return val_mgr->GetTrue();
+		return val_mgr->True();
 	%}
 
 ## Checks whether a given file is open.
@@ -4745,7 +4745,7 @@ function enable_raw_output%(f: file%): any
 function install_src_addr_filter%(ip: addr, tcp_flags: count, prob: double%) : bool
 	%{
 	sessions->GetPacketFilter()->AddSrc(ip->AsAddr(), tcp_flags, prob);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Installs a filter to drop packets originating from a given subnet with
@@ -4775,7 +4775,7 @@ function install_src_addr_filter%(ip: addr, tcp_flags: count, prob: double%) : b
 function install_src_net_filter%(snet: subnet, tcp_flags: count, prob: double%) : bool
 	%{
 	sessions->GetPacketFilter()->AddSrc(snet, tcp_flags, prob);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Removes a source address filter.
@@ -4850,7 +4850,7 @@ function uninstall_src_net_filter%(snet: subnet%) : bool
 function install_dst_addr_filter%(ip: addr, tcp_flags: count, prob: double%) : bool
 	%{
 	sessions->GetPacketFilter()->AddDst(ip->AsAddr(), tcp_flags, prob);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Installs a filter to drop packets destined to a given subnet with
@@ -4880,7 +4880,7 @@ function install_dst_addr_filter%(ip: addr, tcp_flags: count, prob: double%) : b
 function install_dst_net_filter%(snet: subnet, tcp_flags: count, prob: double%) : bool
 	%{
 	sessions->GetPacketFilter()->AddDst(snet, tcp_flags, prob);
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 ## Removes a destination address filter.
@@ -4966,12 +4966,12 @@ function match_signatures%(c: connection, pattern_type: int, s: string,
 				from_orig: bool, clear: bool%) : bool
 	%{
 	if ( ! rule_matcher )
-		return val_mgr->GetFalse();
+		return val_mgr->False();
 
 	c->Match((Rule::PatternType) pattern_type, s->Bytes(), s->Len(),
 			from_orig, bol, eol, clear);
 
-	return val_mgr->GetTrue();
+	return val_mgr->True();
 	%}
 
 # ===========================================================================

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -3942,7 +3942,7 @@ static bool mmdb_try_open_asn ()
 function mmdb_open_location_db%(f: string%) : bool
 	%{
 #ifdef USE_GEOIP
-	return val_mgr->GetBool(mmdb_open_loc(f->CheckString()));
+	return val_mgr->Bool(mmdb_open_loc(f->CheckString()));
 #else
 	return val_mgr->False();
 #endif
@@ -3959,7 +3959,7 @@ function mmdb_open_location_db%(f: string%) : bool
 function mmdb_open_asn_db%(f: string%) : bool
 	%{
 #ifdef USE_GEOIP
-	return val_mgr->GetBool(mmdb_open_asn(f->CheckString()));
+	return val_mgr->Bool(mmdb_open_asn(f->CheckString()));
 #else
 	return val_mgr->False();
 #endif
@@ -4276,7 +4276,7 @@ function disable_analyzer%(cid: conn_id, aid: count, err_if_no_conn: bool &defau
 		a->Parent()->PreventChildren(a->GetAnalyzerTag());
 
 	auto rval = a->Remove();
-	return val_mgr->GetBool(rval);
+	return val_mgr->Bool(rval);
 	%}
 
 ## Informs Zeek that it should skip any further processing of the contents of
@@ -4405,7 +4405,7 @@ function open_for_append%(f: string%): file
 ##              rmdir unlink rename
 function close%(f: file%): bool
 	%{
-	return val_mgr->GetBool(f->Close());
+	return val_mgr->Bool(f->Close());
 	%}
 
 ## Writes data to an open file.
@@ -4424,7 +4424,7 @@ function write_file%(f: file, data: string%): bool
 	if ( ! f )
 		return val_mgr->False();
 
-	return val_mgr->GetBool(f->Write((const char*) data->Bytes(), data->Len()));
+	return val_mgr->Bool(f->Write((const char*) data->Bytes(), data->Len()));
 	%}
 
 ## Alters the buffering behavior of a file.
@@ -4454,7 +4454,7 @@ function set_buf%(f: file, buffered: bool%): any
 ##              rmdir unlink rename
 function flush_all%(%): bool
 	%{
-	return val_mgr->GetBool(fflush(0) == 0);
+	return val_mgr->Bool(fflush(0) == 0);
 	%}
 
 ## Creates a new directory.
@@ -4572,7 +4572,7 @@ function rename%(src_f: string, dst_f: string%): bool
 ## .. todo:: Rename to ``is_open``.
 function active_file%(f: file%): bool
 	%{
-	return val_mgr->GetBool(f->IsOpen());
+	return val_mgr->Bool(f->IsOpen());
 	%}
 
 ## Gets the filename associated with a file handle.
@@ -4796,7 +4796,7 @@ function install_src_net_filter%(snet: subnet, tcp_flags: count, prob: double%) 
 ##              Pcap::error
 function uninstall_src_addr_filter%(ip: addr%) : bool
 	%{
-	return val_mgr->GetBool(sessions->GetPacketFilter()->RemoveSrc(ip->AsAddr()));
+	return val_mgr->Bool(sessions->GetPacketFilter()->RemoveSrc(ip->AsAddr()));
 	%}
 
 ## Removes a source subnet filter.
@@ -4817,7 +4817,7 @@ function uninstall_src_addr_filter%(ip: addr%) : bool
 ##              Pcap::error
 function uninstall_src_net_filter%(snet: subnet%) : bool
 	%{
-	return val_mgr->GetBool(sessions->GetPacketFilter()->RemoveSrc(snet));
+	return val_mgr->Bool(sessions->GetPacketFilter()->RemoveSrc(snet));
 	%}
 
 ## Installs a filter to drop packets destined to a given IP address with
@@ -4901,7 +4901,7 @@ function install_dst_net_filter%(snet: subnet, tcp_flags: count, prob: double%) 
 ##              Pcap::error
 function uninstall_dst_addr_filter%(ip: addr%) : bool
 	%{
-	return val_mgr->GetBool(sessions->GetPacketFilter()->RemoveDst(ip->AsAddr()));
+	return val_mgr->Bool(sessions->GetPacketFilter()->RemoveDst(ip->AsAddr()));
 	%}
 
 ## Removes a destination subnet filter.
@@ -4922,7 +4922,7 @@ function uninstall_dst_addr_filter%(ip: addr%) : bool
 ##              Pcap::error
 function uninstall_dst_net_filter%(snet: subnet%) : bool
 	%{
-	return val_mgr->GetBool(sessions->GetPacketFilter()->RemoveDst(snet));
+	return val_mgr->Bool(sessions->GetPacketFilter()->RemoveDst(snet));
 	%}
 
 ## Checks whether the last raised event came from a remote peer.
@@ -4930,7 +4930,7 @@ function uninstall_dst_net_filter%(snet: subnet%) : bool
 ## Returns: True if the last raised event came from a remote peer.
 function is_remote_event%(%) : bool
 	%{
-	return val_mgr->GetBool(mgr.CurrentSource() != SOURCE_LOCAL);
+	return val_mgr->Bool(mgr.CurrentSource() != SOURCE_LOCAL);
 	%}
 
 ## Stops Zeek's packet processing. This function is used to synchronize

--- a/src/zeekygen/zeekygen.bif
+++ b/src/zeekygen/zeekygen.bif
@@ -9,9 +9,9 @@
 #include "zeekygen/ScriptInfo.h"
 #include "util.h"
 
-static StringVal* comments_to_val(const vector<string>& comments)
+static IntrusivePtr<StringVal> comments_to_val(const vector<string>& comments)
 	{
-	return new StringVal(implode_string_vector(comments));
+	return make_intrusive<StringVal>(implode_string_vector(comments));
 	}
 %%}
 

--- a/src/zeekygen/zeekygen.bif
+++ b/src/zeekygen/zeekygen.bif
@@ -28,7 +28,7 @@ function get_identifier_comments%(name: string%): string
 	IdentifierInfo* d = zeekygen_mgr->GetIdentifierInfo(name->CheckString());
 
 	if ( ! d )
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 
 	return comments_to_val(d->GetComments());
 	%}
@@ -48,7 +48,7 @@ function get_script_comments%(name: string%): string
 	ScriptInfo* d = zeekygen_mgr->GetScriptInfo(name->CheckString());
 
 	if ( ! d )
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 
 	return comments_to_val(d->GetComments());
 	%}
@@ -66,7 +66,7 @@ function get_package_readme%(name: string%): string
 	PackageInfo* d = zeekygen_mgr->GetPackageInfo(name->CheckString());
 
 	if ( ! d )
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 
 	return comments_to_val(d->GetReadme());
 	%}
@@ -86,14 +86,14 @@ function get_record_field_comments%(name: string%): string
 	size_t i = accessor.find('$');
 
 	if ( i > accessor.size() - 2 )
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 
 	string id = accessor.substr(0, i);
 
 	IdentifierInfo* d = zeekygen_mgr->GetIdentifierInfo(id);
 
 	if ( ! d )
-		return val_mgr->GetEmptyString();
+		return val_mgr->EmptyString();
 
 	string field = accessor.substr(i + 1);
 	return comments_to_val(d->GetFieldComments(field));

--- a/testing/btest/plugins/protocol-plugin/src/foo-analyzer.pac
+++ b/testing/btest/plugins/protocol-plugin/src/foo-analyzer.pac
@@ -3,8 +3,8 @@ refine connection Foo_Conn += {
 
 	function Foo_data(msg: Foo_Message): bool
 		%{
-		StringVal* data = new StringVal(${msg.data}.length(), (const char*) ${msg.data}.data());
-		BifEvent::generate_foo_message(bro_analyzer(), bro_analyzer()->Conn(), data);
+		auto data = make_intrusive<StringVal>(${msg.data}.length(), (const char*) ${msg.data}.data());
+		BifEvent::enqueue_foo_message(bro_analyzer(), bro_analyzer()->Conn(), std::move(data));
 		return true;
 		%}
 


### PR DESCRIPTION
This chunk moves some commonly-travelled pieces over to IntrusivePtr:

* The BIF interfacing bits: return values and `BifEvent::generate_*` functions
* `ValManager` "Get" methods
* A few misc. "Val building/converting" methods

The same branch in `bifcl` needs to get merged with this: https://github.com/zeek/bifcl/pull/6
