### PR TITLE
Remove error message from empty bloomfilter lookups

### DIFF
--- a/src/probabilistic/bloom-filter.bif
+++ b/src/probabilistic/bloom-filter.bif
@@ -174,7 +174,7 @@ function bloomfilter_lookup%(bf: opaque of bloomfilter, x: any%): count
 	const BloomFilterVal* bfv = static_cast<const BloomFilterVal*>(bf);
 
 	if ( ! bfv->Type() )
-		reporter->Error("cannot perform lookup on untyped Bloom filter");
+		return val_mgr->GetCount(0);
 
 	else if ( ! same_type(bfv->Type(), x->Type()) )
 		reporter->Error("incompatible Bloom filter types");

--- a/testing/btest/Baseline/bifs.bloomfilter/output
+++ b/testing/btest/Baseline/bifs.bloomfilter/output
@@ -17,6 +17,7 @@ error: false-positive rate must take value between 0 and 1
 1
 1
 1
+0
 1
 1
 2

--- a/testing/btest/bifs/bloomfilter.zeek
+++ b/testing/btest/bifs/bloomfilter.zeek
@@ -55,6 +55,7 @@ function test_basic_bloom_filter()
 
   #empty filter tests
   local bf_empty = bloomfilter_basic_init(0.1, 1000);
+  print bloomfilter_lookup(bf_empty, 42);
   local bf_empty_merged = bloomfilter_merge(bf_merged, bf_empty);
   print bloomfilter_lookup(bf_empty_merged, 42);
   }


### PR DESCRIPTION
If a bloomfilter doesn't have a type, that just means no
bloomfilter_add() has been called yet, so seems undesirable to emit an
error for a lookup against something that's known to be empty.

(Never looked too closely at the bloomfilter code before, so helpful to do a closer sanity check on this to make sure I didn't miss an edge case).