### PR TITLE
Add network_time_init event.

### DIFF
--- a/src/Net.cc
+++ b/src/Net.cc
@@ -223,7 +223,11 @@ void expire_timers(iosource::PktSrc* src_ps)
 void net_packet_dispatch(double t, const Packet* pkt, iosource::PktSrc* src_ps)
 	{
 	if ( ! bro_start_network_time )
+		{
 		bro_start_network_time = t;
+		if ( network_time_init )
+			mgr.Enqueue(network_time_init, zeek::Args{});
+		}
 
 	// network_time never goes back.
 	net_update_time(timer_mgr->Time() < t ? t : timer_mgr->Time());

--- a/src/event.bif
+++ b/src/event.bif
@@ -35,7 +35,7 @@
 ## one-time initialization code at startup. At the time a handler runs, Zeek will
 ## have executed any global initializations and statements.
 ##
-## .. zeek:see:: zeek_done
+## .. zeek:see:: zeek_done, network_time_init
 ##
 ## .. note::
 ##
@@ -60,6 +60,14 @@ event zeek_init%(%);
 ##    If Zeek terminates due to an invocation of :zeek:id:`exit`, then this event
 ##    is not generated.
 event zeek_done%(%);
+
+## Generated when network time is initialized. The event engine generates this
+## event after the network time has been determined but before processing of
+## packets is started.
+##
+## .. zeek:see:: zeek_init, network_time
+##
+event network_time_init%(%);
 
 ## Generated for every new connection. This event is raised with the first
 ## packet of a previously unknown connection. Zeek uses a flow-based definition

--- a/src/event.bif
+++ b/src/event.bif
@@ -35,7 +35,7 @@
 ## one-time initialization code at startup. At the time a handler runs, Zeek will
 ## have executed any global initializations and statements.
 ##
-## .. zeek:see:: zeek_done, network_time_init
+## .. zeek:see:: zeek_done network_time_init
 ##
 ## .. note::
 ##
@@ -65,7 +65,7 @@ event zeek_done%(%);
 ## event after the network time has been determined but before processing of
 ## packets is started.
 ##
-## .. zeek:see:: zeek_init, network_time
+## .. zeek:see:: zeek_init network_time
 ##
 event network_time_init%(%);
 

--- a/testing/btest/Baseline/core.network-time/output
+++ b/testing/btest/Baseline/core.network-time/output
@@ -1,0 +1,8 @@
+zeek_init:               1970-01-01-00:00:00.000000000
+scheduled_event:         1970-01-01-00:00:00.000000000
+network_time_init:       2011-03-18-19:06:07.096534967
+Processing packet  25 at 2011-03-18-19:06:08.858649015
+Processing packet  50 at 2011-03-18-19:06:08.915958881
+Processing packet  75 at 2011-03-18-19:06:08.976326942
+Processing packet  100 at 2011-03-18-19:06:09.073806047
+scheduled_delayed_event: 2011-03-18-19:06:09.073806047

--- a/testing/btest/core/network-time.zeek
+++ b/testing/btest/core/network-time.zeek
@@ -1,0 +1,38 @@
+# @TEST-EXEC: zeek -b -C -r $TRACES/wikipedia.trace %INPUT > output
+# @TEST-EXEC: btest-diff output
+
+redef exit_only_after_terminate = T;
+
+event scheduled_delayed_event()
+	{
+	print fmt("scheduled_delayed_event: %T", network_time());
+	}
+
+event scheduled_event()
+	{
+	print fmt("scheduled_event:         %T", network_time());
+	schedule 1sec { scheduled_delayed_event() };
+	}
+
+event zeek_init()
+	{
+	print fmt("zeek_init:               %T", network_time());
+	schedule 0sec { scheduled_event() };
+	}
+
+event network_time_init()
+	{
+	print fmt("network_time_init:       %T", network_time());
+	}
+
+global pkt_count: count = 0;
+
+event new_packet(c: connection, p: pkt_hdr) &priority=10
+	{
+	pkt_count += 1;
+	if ( pkt_count % 25 == 0 )
+		print fmt("Processing packet  %s at %T", pkt_count, network_time());
+
+	if ( pkt_count == 100)
+		terminate();
+	}

--- a/testing/btest/core/network-time.zeek
+++ b/testing/btest/core/network-time.zeek
@@ -3,25 +3,40 @@
 
 redef exit_only_after_terminate = T;
 
+global sde_init: bool = F;
+
 event scheduled_delayed_event()
 	{
-	print fmt("scheduled_delayed_event: %T", network_time());
+	if ( !sde_init )
+		{
+		# When network_time is set we (usually) leap forward and the event
+		# fires with the first packet. Thus, we reschedule.
+		sde_init = T;
+		schedule 2sec { scheduled_delayed_event() };
+		}
+	else
+		{
+		print fmt("scheduled_delayed_event: %T", network_time());
+		}
 	}
 
 event scheduled_event()
 	{
+	# This event is immediately executed
 	print fmt("scheduled_event:         %T", network_time());
-	schedule 1sec { scheduled_delayed_event() };
 	}
 
 event zeek_init()
 	{
+	# Reading a PCAP network_time is not initialized yet
 	print fmt("zeek_init:               %T", network_time());
 	schedule 0sec { scheduled_event() };
+	schedule 2sec { scheduled_delayed_event() };
 	}
 
 event network_time_init()
 	{
+	# This event is executed when network_time is initialized
 	print fmt("network_time_init:       %T", network_time());
 	}
 


### PR DESCRIPTION
This adds a network_time_init event as suggested in #938. While the new event works as intended, the included testcase does not produce the expected results for `scheduled_delayed_event`.