### PR TITLE
Add ability for lists to be unordered, plus a few other fixes

### DIFF
--- a/src/BroList.h
+++ b/src/BroList.h
@@ -23,4 +23,4 @@ class Attr;
 typedef PList<Attr> attr_list;
 
 class Timer;
-typedef PList<Timer> timer_list;
+typedef PList<Timer, LIST_UNORDERED> timer_list;

--- a/src/BroList.h
+++ b/src/BroList.h
@@ -23,4 +23,4 @@ class Attr;
 typedef PList<Attr> attr_list;
 
 class Timer;
-typedef PList<Timer, LIST_UNORDERED> timer_list;
+typedef PList<Timer, ListOrder::UNORDERED> timer_list;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -246,6 +246,7 @@ set(MAIN_SRCS
     IntSet.cc
     IP.cc
     IPAddr.cc
+    List.cc
     Reporter.cc
     NFA.cc
     Net.cc

--- a/src/List.cc
+++ b/src/List.cc
@@ -114,3 +114,17 @@ TEST_CASE("plists")
 		delete v;
 	list.clear();
 	}
+
+TEST_CASE("unordered list operation")
+	{
+	List<int, LIST_UNORDERED> list({1, 2, 3, 4});
+	CHECK(list.size() == 4);
+
+	// An unordered list doesn't maintain the ordering of the elements when
+	// one is removed. It just swaps the last element into the hole.
+	list.remove(2);
+	CHECK(list.size() == 3);
+	CHECK(list[0] == 1);
+	CHECK(list[1] == 4);
+	CHECK(list[2] == 3);
+	}

--- a/src/List.cc
+++ b/src/List.cc
@@ -1,0 +1,116 @@
+#include <List.h>
+#include <3rdparty/doctest.h>
+
+TEST_CASE("list construction")
+	{
+	List<int> list;
+	CHECK(list.empty());
+
+	List<int> list2(10);
+	CHECK(list2.empty());
+	CHECK(list2.max() == 10);
+	}
+
+TEST_CASE("list operation")
+	{
+	List<int> list({ 1, 2, 3 });
+	CHECK(list.size() == 3);
+	CHECK(list.max() == 3);
+	CHECK(list[0] == 1);
+	CHECK(list[1] == 2);
+	CHECK(list[2] == 3);
+
+	// push_back forces a resize of the list here, which grows the list
+	// by a growth factor. That makes the max elements equal to 6.
+	list.push_back(4);
+	CHECK(list.size() == 4);
+	CHECK(list.max() == 6);
+	CHECK(list[3] == 4);
+
+	CHECK(list.front() == 1);
+	CHECK(list.back() == 4);
+
+	list.pop_front();
+	CHECK(list.size() == 3);
+	CHECK(list.front() == 2);
+
+	list.pop_back();
+	CHECK(list.size() == 2);
+	CHECK(list.back() == 3);
+
+	list.push_back(4);
+	CHECK(list.is_member(2));
+	CHECK(list.member_pos(2) == 0);
+
+	list.remove(2);
+	CHECK(list.size() == 2);
+	CHECK(list[0] == 3);
+	CHECK(list[1] == 4);
+
+	// Squash the list down to the existing elements.
+	list.resize();
+	CHECK(list.size() == 2);
+	CHECK(list.max() == 2);
+
+	// Attempt replacing a known position.
+	int old = list.replace(0, 10);
+	CHECK(list.size() == 2);
+	CHECK(list.max() == 2);
+	CHECK(old == 3);
+	CHECK(list[0] == 10);
+	CHECK(list[1] == 4);
+
+	// Attempt replacing an element off the end of the list, which
+	// causes a resize.
+	old = list.replace(3, 5);
+	CHECK(list.size() == 4);
+	CHECK(list.max() == 4);
+	CHECK(old == 0);
+	CHECK(list[0] == 10);
+	CHECK(list[1] == 4);
+	CHECK(list[2] == 0);
+	CHECK(list[3] == 5);
+
+	// Attempt replacing an element with a negative index, which returns the
+	// default value for the list type.
+	old = list.replace(-1, 50);
+	CHECK(list.size() == 4);
+	CHECK(list.max() == 4);
+	CHECK(old == 0);
+
+	list.clear();
+	CHECK(list.size() == 0);
+	CHECK(list.max() == 0);
+	}
+
+TEST_CASE("list iteration")
+	{
+	List<int> list({ 1, 2, 3, 4});
+
+	int index = 1;
+	for ( int v : list )
+		CHECK(v == index++);
+
+	index = 1;
+	for ( auto it = list.begin(); it != list.end(); index++, ++it)
+		CHECK(*it == index);
+	}
+
+TEST_CASE("plists")
+	{
+	PList<int> list;
+	list.push_back(new int(1));
+	list.push_back(new int(2));
+	list.push_back(new int(3));
+
+	CHECK(*list[0] == 1);
+
+	int* new_val = new int(5);
+	auto old = list.replace(-1, new_val);
+	delete new_val;
+	CHECK(old == nullptr);
+
+	for ( auto v : list )
+		delete v;
+	list.clear();
+	}

--- a/src/List.cc
+++ b/src/List.cc
@@ -117,7 +117,7 @@ TEST_CASE("plists")
 
 TEST_CASE("unordered list operation")
 	{
-	List<int, LIST_UNORDERED> list({1, 2, 3, 4});
+	List<int, ListOrder::UNORDERED> list({1, 2, 3, 4});
 	CHECK(list.size() == 4);
 
 	// An unordered list doesn't maintain the ordering of the elements when

--- a/src/List.h
+++ b/src/List.h
@@ -240,16 +240,16 @@ public:
 	T replace(int ent_index, const T& new_ent)	// replace entry #i with a new value
 		{
 		if ( ent_index < 0 )
-			return 0;
+			return get_default_value();
 
-		T old_ent = nullptr;
+		T old_ent = get_default_value();
 
 		if ( ent_index > num_entries - 1 )
 			{ // replacement beyond the end of the list
 			resize(ent_index + 1);
 
 			for ( int i = num_entries; i < max_entries; ++i )
-				entries[i] = nullptr;
+				entries[i] = get_default_value();
 			num_entries = max_entries;
 			}
 		else
@@ -286,6 +286,20 @@ public:
 	const_reverse_iterator crend() const { return rend(); }
 
 protected:
+
+	T get_default_value()
+		{
+		if constexpr ( std::is_pointer_v<T> )
+			return nullptr;
+		else if constexpr ( std::is_integral_v<T> )
+			return 0;
+		else if constexpr ( std::is_floating_point_v<T> )
+			return 0.0;
+		else
+			// TODO: Should this return an error at compile time that we don't
+			// know what this type is?
+			return T();
+		}
 
 	// This could essentially be an std::vector if we wanted.  Some
 	// reasons to maybe not refactor to use std::vector ?

--- a/src/List.h
+++ b/src/List.h
@@ -29,9 +29,9 @@
 // TODO: this can be removed in v3.1 when List::sort() is removed
 typedef int (*list_cmp_func)(const void* v1, const void* v2);
 
-enum list_order { LIST_ORDERED, LIST_UNORDERED };
+enum class ListOrder : int { ORDERED, UNORDERED };
 
-template<typename T, list_order Order = LIST_ORDERED>
+template<typename T, ListOrder Order = ListOrder::ORDERED>
 class List {
 public:
 
@@ -216,7 +216,7 @@ public:
 		// For data where we don't care about ordering, we don't care about keeping
 		// the list in the same order when removing an element. Just swap the last
 		// element with the element being removed.
-		if ( Order == LIST_ORDERED )
+		if constexpr ( Order == ListOrder::ORDERED )
 			{
 			--num_entries;
 
@@ -252,16 +252,16 @@ public:
 	T replace(int ent_index, const T& new_ent)	// replace entry #i with a new value
 		{
 		if ( ent_index < 0 )
-			return get_default_value();
+			return T{};
 
-		T old_ent = get_default_value();
+		T old_ent{};
 
 		if ( ent_index > num_entries - 1 )
 			{ // replacement beyond the end of the list
 			resize(ent_index + 1);
 
 			for ( int i = num_entries; i < max_entries; ++i )
-				entries[i] = get_default_value();
+				entries[i] = T{};
 			num_entries = max_entries;
 			}
 		else
@@ -299,20 +299,6 @@ public:
 
 protected:
 
-	T get_default_value()
-		{
-		if constexpr ( std::is_pointer_v<T> )
-			return nullptr;
-		else if constexpr ( std::is_integral_v<T> )
-			return 0;
-		else if constexpr ( std::is_floating_point_v<T> )
-			return 0.0;
-		else
-			// TODO: Should this return an error at compile time that we don't
-			// know what this type is?
-			return T();
-		}
-
 	// This could essentially be an std::vector if we wanted.  Some
 	// reasons to maybe not refactor to use std::vector ?
 	//
@@ -344,7 +330,7 @@ protected:
 
 
 // Specialization of the List class to store pointers of a type.
-template<typename T, list_order Order = LIST_ORDERED>
+template<typename T, ListOrder Order = ListOrder::ORDERED>
 using PList = List<T*, Order>;
 
 // Popular type of list: list of strings.


### PR DESCRIPTION
@JustinAzoff and I noticed the other day that removing an element from a list can be an O(n) operation, since it will remove an element and then move all of the items in the list down to fill the new hole in the list. This doesn't necessarily need to happen if the creator of the list doesn't care what order the elements are in after removal. This case is true of the list of timers that `Conn` holds, for example.

This PR adds the ability for lists to be unordered at definition-time, along with a bunch of unit testing that was missing for `List`. It also fixes a bug with `List::replace()` if you tried to use it with a type that wasn't a pointer (i.e. not a `PList`).