### PR TITLE
avoid scheduling redundant inactivity timers

### DIFF
--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -308,9 +308,10 @@ void Connection::RemoveConnectionTimer(double t)
 
 void Connection::SetInactivityTimeout(double timeout)
 	{
-	// We add a new inactivity timer even if there already is one.  When
-	// it fires, we always use the current value to check for inactivity.
-	if ( timeout )
+	// We add a new inactivity timer if there is no current timeout or if the
+	// new timeout is lower than the old one.  When it fires, we always use the
+	// current value to check for inactivity and re-schedule the next timer.
+	if ( timeout && (inactivity_timeout == 0 || timeout < inactivity_timeout) )
 		ADD_TIMER(&Connection::InactivityTimer,
 				last_time + timeout, 0, TIMER_CONN_INACTIVITY);
 


### PR DESCRIPTION
When setting the inactivity timeout, don't schedule a new timer if the
new one would be redundant.

You can see the impact if this if you load this script on a pcap with large connections

```
event new_packet(c: connection, p: pkt_hdr)
{
    set_inactivity_timeout(c$id, 10secs);
}

event new_connection(c: connection)
{
    print c$id;
}
```

without the patch it will slow to a crawl.  This is partially related too https://github.com/zeek/zeek/pull/947  I believe it's the other side of that issue, how we could end up with 20,000 connection timers  in the first place.