### PR TITLE
Disable broker tests and documentation examples from building on CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,8 @@ btest_jobs: &BTEST_JOBS 8
 btest_retries: &BTEST_RETRIES 2
 memory: &MEMORY 6GB
 
-config: &CONFIG --build-type=release --enable-cpp-tests
-memcheck_config: &MEMCHECK_CONFIG --build-type=debug --enable-cpp-tests --sanitizers=address
+config: &CONFIG --build-type=release --enable-cpp-tests --disable-broker-tests
+memcheck_config: &MEMCHECK_CONFIG --build-type=debug --enable-cpp-tests --disable-broker-tests --sanitizers=address
 
 resources_template: &RESOURCES_TEMPLATE
   cpu: *CPUS

--- a/configure
+++ b/configure
@@ -267,7 +267,8 @@ while [ $# -ne 0 ]; do
             append_cache_entry DISABLE_PYTHON_BINDINGS     BOOL   true
             ;;
         --disable-broker-tests)
-            append_cache_entry BROKER_DISABLE_TESTS     BOOL   true
+            append_cache_entry BROKER_DISABLE_TESTS        BOOL true
+            append_cache_entry BROKER_DISABLE_DOC_EXAMPLES BOOL true
             ;;
         --with-openssl=*)
             append_cache_entry OPENSSL_ROOT_DIR PATH $optarg


### PR DESCRIPTION
This requires https://github.com/zeek/broker/pull/114 to be merged as well.

This change results in a roughly 10% build time improvement on CI.