### PR TITLE
Speed up ChunkCount validity check

### DIFF
--- a/src/fuzzers/FuzzBuffer.cc
+++ b/src/fuzzers/FuzzBuffer.cc
@@ -14,18 +14,18 @@ bool zeek::detail::FuzzBuffer::Valid(int chunk_count_limit) const
 	if ( memcmp(begin, PKT_MAGIC, PKT_MAGIC_LEN) != 0)
 		return false;
 
-	if ( ChunkCount() > chunk_count_limit )
+	if ( ChunkCount(chunk_count_limit + 1) > chunk_count_limit )
 		return false;
 
 	return true;
 	}
 
-int zeek::detail::FuzzBuffer::ChunkCount() const
+int zeek::detail::FuzzBuffer::ChunkCount(int chunk_count_limit) const
 	{
 	auto pos = begin;
 	int chunks = 0;
 
-	while ( pos < end )
+	while ( pos < end && (chunk_count_limit == 0 || chunks < chunk_count_limit) )
 		{
 		pos = (const unsigned char*)memmem(pos, end - pos,
 		                                   PKT_MAGIC, PKT_MAGIC_LEN);

--- a/src/fuzzers/FuzzBuffer.h
+++ b/src/fuzzers/FuzzBuffer.h
@@ -49,7 +49,7 @@ public:
 	/**
 	 * @return  the number of chunks in the fuzz buffer object
 	 */
-	int ChunkCount() const;
+	int ChunkCount(int chunk_count_limit = 0) const;
 
 	/**
 	 * @return  the next chunk to deliver, if one could be extracted


### PR DESCRIPTION
When counting chunks for the purpose of a Valid check, only count up to
chunk_count_limit + 1 chunks.  This speeds up the skipping of the 70,000
chunk test file considerably.

Before:
    Processed 1 inputs in 0.025517s

After:
    Processed 1 inputs in 0.000620s