### PR TITLE
add: two new RDP scriptland events for negotiation flags

### DIFF
--- a/src/analyzer/protocol/rdp/events.bif
+++ b/src/analyzer/protocol/rdp/events.bif
@@ -42,12 +42,26 @@ event rdp_native_encrypted_data%(c: connection, orig: bool, len: count%);
 ## cookie: The cookie included in the request.
 event rdp_connect_request%(c: connection, cookie: string%);
 
+## Generated for X.224 client requests.
+##
+## c: The connection record for the underlying transport-layer session/flow.
+##
+## flags: The flags set by the client.
+event rdp_connect_request_flags%(c: connection, flags: count%);
+
 ## Generated for RDP Negotiation Response messages.
 ##
 ## c: The connection record for the underlying transport-layer session/flow.
 ##
 ## security_protocol: The security protocol selected by the server.
 event rdp_negotiation_response%(c: connection, security_protocol: count%);
+
+## Generated for RDP Negotiation Response messages.
+##
+## c: The connection record for the underlying transport-layer session/flow.
+##
+## flags: The flags set by the server.
+event rdp_negotiation_response_flags%(c: connection, flags: count%);
 
 ## Generated for RDP Negotiation Failure messages.
 ##

--- a/src/analyzer/protocol/rdp/events.bif
+++ b/src/analyzer/protocol/rdp/events.bif
@@ -40,34 +40,29 @@ event rdp_native_encrypted_data%(c: connection, orig: bool, len: count%);
 ## c: The connection record for the underlying transport-layer session/flow.
 ##
 ## cookie: The cookie included in the request.
-event rdp_connect_request%(c: connection, cookie: string%);
-
-## Generated for X.224 client requests.
-##
-## c: The connection record for the underlying transport-layer session/flow.
 ##
 ## flags: The flags set by the client.
-event rdp_connect_request_flags%(c: connection, flags: count%);
+event rdp_connect_request%(c: connection, cookie: string, flags: count%);
+event rdp_connect_request%(c: connection, cookie: string%);
 
 ## Generated for RDP Negotiation Response messages.
 ##
 ## c: The connection record for the underlying transport-layer session/flow.
 ##
 ## security_protocol: The security protocol selected by the server.
-event rdp_negotiation_response%(c: connection, security_protocol: count%);
-
-## Generated for RDP Negotiation Response messages.
-##
-## c: The connection record for the underlying transport-layer session/flow.
 ##
 ## flags: The flags set by the server.
-event rdp_negotiation_response_flags%(c: connection, flags: count%);
+event rdp_negotiation_response%(c: connection, security_protocol: count, flags: count%);
+event rdp_negotiation_response%(c: connection, security_protocol: count%);
 
 ## Generated for RDP Negotiation Failure messages.
 ##
 ## c: The connection record for the underlying transport-layer session/flow.
 ##
 ## failure_code: The failure code sent by the server.
+##
+## flags: The flags set by the server.
+event rdp_negotiation_failure%(c: connection, failure_code: count, flags: count%);
 event rdp_negotiation_failure%(c: connection, failure_code: count%);
 
 ## Generated for MCS client requests.

--- a/src/analyzer/protocol/rdp/rdp-analyzer.pac
+++ b/src/analyzer/protocol/rdp/rdp-analyzer.pac
@@ -12,6 +12,9 @@ refine flow RDP_Flow += {
 			BifEvent::enqueue_rdp_connect_request(connection()->bro_analyzer(),
 			                                      connection()->bro_analyzer()->Conn(),
 			                                      to_stringval(${cr.cookie_value}));
+			BifEvent::enqueue_rdp_connect_request_flags(connection()->bro_analyzer(),
+			                                      connection()->bro_analyzer()->Conn(),
+			                                      ${cr.rdp_neg_req.flags});
 			}
 
 		return true;
@@ -24,6 +27,9 @@ refine flow RDP_Flow += {
 			BifEvent::enqueue_rdp_negotiation_response(connection()->bro_analyzer(),
 			                                           connection()->bro_analyzer()->Conn(),
 			                                           ${nr.selected_protocol});
+			BifEvent::enqueue_rdp_negotiation_response_flags(connection()->bro_analyzer(),
+			                                           connection()->bro_analyzer()->Conn(),
+			                                           ${nr.flags});
 			}
 
 		return true;

--- a/src/analyzer/protocol/rdp/rdp-analyzer.pac
+++ b/src/analyzer/protocol/rdp/rdp-analyzer.pac
@@ -11,9 +11,7 @@ refine flow RDP_Flow += {
 			{
 			BifEvent::enqueue_rdp_connect_request(connection()->bro_analyzer(),
 			                                      connection()->bro_analyzer()->Conn(),
-			                                      to_stringval(${cr.cookie_value}));
-			BifEvent::enqueue_rdp_connect_request_flags(connection()->bro_analyzer(),
-			                                      connection()->bro_analyzer()->Conn(),
+			                                      to_stringval(${cr.cookie_value}),
 			                                      ${cr.rdp_neg_req.flags});
 			}
 
@@ -26,9 +24,7 @@ refine flow RDP_Flow += {
 			{
 			BifEvent::enqueue_rdp_negotiation_response(connection()->bro_analyzer(),
 			                                           connection()->bro_analyzer()->Conn(),
-			                                           ${nr.selected_protocol});
-			BifEvent::enqueue_rdp_negotiation_response_flags(connection()->bro_analyzer(),
-			                                           connection()->bro_analyzer()->Conn(),
+			                                           ${nr.selected_protocol},
 			                                           ${nr.flags});
 			}
 
@@ -41,7 +37,8 @@ refine flow RDP_Flow += {
 			{
 			BifEvent::enqueue_rdp_negotiation_failure(connection()->bro_analyzer(),
 			                                          connection()->bro_analyzer()->Conn(),
-			                                          ${nf.failure_code});
+			                                          ${nf.failure_code},
+			                                          ${nf.flags});
 			}
 
 		return true;


### PR DESCRIPTION
This is a pretty simple change. 2 new events are raised by the RDP analyzer.

`rdp_connect_request_flags` is raised in tandem with the `rdp_connect_request` event and `rdp_negotiation_response_flags` is raised in tandem with `rdp_negotiation_response`.

Ideally, `rdp_connect_request` and `rdp_negotiation_response` parameters would be extended to include the flags included in each of those PDUs but I believe that may break things.