### PR TITLE
[RFC] Warn on circular `@load`

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -631,9 +631,6 @@ static int load_files(const char* orig_file)
 
 	assert(rc == -1); // No plugin in charge of this file.
 
-	// Whether we pushed on a FileInfo that will restore the
-	// current module after the final file has been scanned.
-	bool did_module_restore = false;
 	FILE* f = 0;
 
 	if ( streq(orig_file, "-") )
@@ -684,18 +681,9 @@ static int load_files(const char* orig_file)
 		LoadPolicyFileText(file_path.c_str());
 		}
 
-	// Remember where we were.  If this is the first
-	// file being pushed on the stack, i.e., the *last*
-	// one that will be processed, then we want to
-	// restore the module scope in which this @load
-	// was done when we're finished processing it.
-	if ( ! did_module_restore )
-		{
-		file_stack.push_back(new FileInfo(current_module));
-		did_module_restore = true;
-		}
-	else
-		file_stack.push_back(new FileInfo);
+	// Remember where we were to restore the module scope in which
+	// this @load was done when we're finished processing it.
+	file_stack.push_back(new FileInfo(current_module));
 
 	zeekygen_mgr->Script(file_path);
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -125,7 +125,7 @@ static ZeekINode get_inode(const std::string& path)
 
 class FileInfo {
 public:
-	FileInfo(std::string restore_module = "");
+	FileInfo(std::string arg_restore_module, dev_t arg_dev, ino_t arg_ino);
 	~FileInfo();
 
 	YY_BUFFER_STATE buffer_state;
@@ -133,6 +133,8 @@ public:
 	const char* name;
 	int line;
 	int level;
+	dev_t dev;
+	ino_t ino;
 };
 
 // A stack of input buffers we're scanning.  file_stack[len-1] is the
@@ -610,6 +612,15 @@ static bool already_scanned(const std::string& path)
 	return already_scanned(get_inode(path));
 	}
 
+static bool currently_scanning(ZeekINode in)
+	{
+	for (const auto it: file_stack)
+		if ( it->dev == in.dev && it->ino == in.ino )
+			return true;
+
+	return false;
+	}
+
 static int load_files(const char* orig_file)
 	{
 	std::string file_path = find_relative_script_file(orig_file);
@@ -661,6 +672,14 @@ static int load_files(const char* orig_file)
 
 	auto i = get_inode(f, file_path);
 
+	if (currently_scanning(i))
+		{
+		reporter->Warning("Detected circular @load of %s from:", file_path.c_str());
+		reporter->Warning("  %s:%d", ::filename, ::line_number);
+		for ( auto fi = file_stack.rbegin(); fi != file_stack.rend(); ++fi )
+			reporter->Warning("  %s:%d", (*fi)->name, (*fi)->line);
+		}
+
 	if ( already_scanned(i) )
 		{
 		if ( f != stdin )
@@ -683,7 +702,7 @@ static int load_files(const char* orig_file)
 
 	// Remember where we were to restore the module scope in which
 	// this @load was done when we're finished processing it.
-	file_stack.push_back(new FileInfo(current_module));
+	file_stack.push_back(new FileInfo(current_module, i.dev, i.ino));
 
 	zeekygen_mgr->Script(file_path);
 
@@ -1030,12 +1049,14 @@ int yywrap()
 	return 1;
 	}
 
-FileInfo::FileInfo(std::string arg_restore_module)
+FileInfo::FileInfo(std::string arg_restore_module, dev_t arg_dev, ino_t arg_ino)
 	{
 	buffer_state = YY_CURRENT_BUFFER;
 	restore_module = arg_restore_module;
 	name = ::filename;
 	line = ::line_number;
+	dev = arg_dev;
+	ino = arg_ino;
 	}
 
 FileInfo::~FileInfo()

--- a/testing/btest/Baseline/core.load-circular/.stderr
+++ b/testing/btest/Baseline/core.load-circular/.stderr
@@ -1,0 +1,6 @@
+warning in /home/awelzel/projects/zeek/testing/btest/.tmp/core.load-circular/././cluster.zeek, line 1: Detected circular @load of /home/awelzel/projects/zeek/testing/btest/.tmp/core.load-circular/./././notice.zeek from:
+warning in /home/awelzel/projects/zeek/testing/btest/.tmp/core.load-circular/././cluster.zeek, line 1:   /home/awelzel/projects/zeek/testing/btest/.tmp/core.load-circular/././cluster.zeek:1
+warning in /home/awelzel/projects/zeek/testing/btest/.tmp/core.load-circular/././cluster.zeek, line 1:   /home/awelzel/projects/zeek/testing/btest/.tmp/core.load-circular/./notice.zeek:1
+warning in /home/awelzel/projects/zeek/testing/btest/.tmp/core.load-circular/././cluster.zeek, line 1:   /home/awelzel/projects/zeek/testing/btest/.tmp/core.load-circular/load-circular.zeek:6
+warning in /home/awelzel/projects/zeek/testing/btest/.tmp/core.load-circular/././cluster.zeek, line 1:   (null):1
+fatal error in /home/awelzel/projects/zeek/testing/btest/.tmp/core.load-circular/././cluster.zeek, line 5: unknown enum identifier "XNotice::XType"

--- a/testing/btest/core/load-circular.zeek
+++ b/testing/btest/core/load-circular.zeek
@@ -1,0 +1,34 @@
+# This tests Zeek's mechanism to detect circular @loads
+#
+# @TEST-EXEC-FAIL: zeek -b %INPUT
+# @TEST-EXEC: btest-diff .stderr
+
+@load ./notice
+
+event zeek_init() {
+    print("Never run");
+}
+
+# Extra files
+# @TEST-START-FILE notice.zeek
+@load ./cluster
+
+module XNotice;
+
+export {
+	type XType: enum {
+		Tally,
+	};
+}
+# @TEST-END-FILE
+
+# @TEST-START-FILE cluster.zeek
+@load ./notice
+
+module XCluster;
+export {
+	redef enum XNotice::XType += {
+		Second,
+	};
+}
+# @TEST-END-FILE


### PR DESCRIPTION
Hey,

as detailed in the second commit, I added `@load policy/misc/load-balancing` to a custom `cluster-layout.zeek` file during experimentation - which isn't sensible now that I understand what's going on - but the error doesn't immediately point at the problem:
```
    error in /usr/local/zeek/share/zeek/base/frameworks/packet-filter/./main.zeek, line 18: unknown identifier (Notice::Type)t
```
The cause is a circular `@load` triggered by loading `notice` from `cluster-layout`.

This PR adds verbose warning in such situations. It triggers on a few base scripts, however, so not sure this is actually considered an issue in general or would make sense to have?