### PR TITLE
Reduce some #includes, speed up builds

### DIFF
--- a/src/Anon.cc
+++ b/src/Anon.cc
@@ -12,7 +12,7 @@
 #include "Reporter.h"
 #include "Scope.h"
 #include "ID.h"
-
+#include "IPAddr.h"
 
 AnonymizeIPAddr* ip_anonymizer[NUM_ADDR_ANONYMIZATION_METHODS] = {nullptr};
 

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -2,6 +2,9 @@
 
 #include "zeek-config.h"
 
+#include <vector>
+#include <map>
+
 #include "CompHash.h"
 #include "BroString.h"
 #include "Dict.h"
@@ -9,9 +12,7 @@
 #include "RE.h"
 #include "Reporter.h"
 #include "Func.h"
-
-#include <vector>
-#include <map>
+#include "IPAddr.h"
 
 CompositeHash::CompositeHash(IntrusivePtr<TypeList> composite_type)
 	: type(std::move(composite_type))

--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -11,6 +11,7 @@
 #include "File.h"
 #include "Reporter.h"
 #include "ConvertUTF.h"
+#include "IPAddr.h"
 
 #define DEFAULT_SIZE 128
 #define SLOP 10

--- a/src/IPAddr.h
+++ b/src/IPAddr.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "threading/SerialTypes.h"
+#include "IPAddr.h"
 
 struct ConnID;
 class BroString;

--- a/src/NetVar.h
+++ b/src/NetVar.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "Val.h"
-#include "Func.h"
 #include "EventRegistry.h"
 #include "Stats.h"
 

--- a/src/Reporter.h
+++ b/src/Reporter.h
@@ -11,7 +11,7 @@
 #include <unordered_set>
 #include <unordered_map>
 
-#include "IPAddr.h"
+#include "BroList.h"
 
 namespace analyzer { class Analyzer; }
 namespace file_analysis { class File; }
@@ -34,6 +34,9 @@ protected:
 	friend class Reporter;
 	InterpreterException()	{}
 };
+
+class IPAddr;
+class Expr;
 
 #define FMT_ATTR __attribute__((format(printf, 2, 3))) // sic! 1st is "this" I guess.
 

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -21,6 +21,7 @@
 #include "Reporter.h"
 #include "module_util.h"
 #include "Var.h"
+#include "IPAddr.h"
 
 using namespace std;
 

--- a/src/SerializationFormat.cc
+++ b/src/SerializationFormat.cc
@@ -5,6 +5,7 @@
 #include "DebugLogger.h"
 #include "Reporter.h"
 #include "net_util.h"
+#include "IPAddr.h"
 
 const float SerializationFormat::GROWTH_FACTOR = 2.5;
 
@@ -435,4 +436,3 @@ bool BinarySerializationFormat::Write(const char* buf, int len, const char* tag)
 	uint32_t l = htonl(len);
 	return WriteData(&l, sizeof(l)) && WriteData(buf, len);
 	}
-

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -13,6 +13,7 @@
 #include "threading/Manager.h"
 #include "broker/Manager.h"
 #include "input.h"
+#include "Func.h"
 
 uint64_t killed_by_inactivity = 0;
 

--- a/src/analyzer/protocol/mime/MIME.h
+++ b/src/analyzer/protocol/mime/MIME.h
@@ -10,6 +10,7 @@
 #include "Reporter.h"
 #include "analyzer/Analyzer.h"
 
+class TableVal;
 class StringVal;
 class Base64Converter;
 

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.cc
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.cc
@@ -1,5 +1,7 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
+#include <errno.h>
+
 #include "Net.h"
 #include "NetVar.h"
 #include "analyzer/protocol/tcp/TCP.h"

--- a/src/bro-bif.h
+++ b/src/bro-bif.h
@@ -1,8 +1,6 @@
-
 #pragma once
 
 // Headers to include by generated BiF code.
-#include "analyzer/Analyzer.h"
 #include "Conn.h"
 #include "NetVar.h"
 #include "Event.h"

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -1,3 +1,11 @@
+#include <caf/stream_serializer.hpp>
+#include <caf/stream_deserializer.hpp>
+#include <caf/streambuf.hpp>
+
+#include <broker/error.hh>
+#include "broker/data.bif.h"
+#include "3rdparty/doctest.h"
+
 #include "Data.h"
 #include "File.h"
 #include "Desc.h"
@@ -5,15 +13,8 @@
 #include "RE.h"
 #include "ID.h"
 #include "Scope.h"
+#include "Func.h"
 #include "module_util.h"
-#include "3rdparty/doctest.h"
-#include "broker/data.bif.h"
-
-#include <broker/error.hh>
-
-#include <caf/stream_serializer.hpp>
-#include <caf/stream_deserializer.hpp>
-#include <caf/streambuf.hpp>
 
 using namespace std;
 

--- a/src/broker/Data.h
+++ b/src/broker/Data.h
@@ -10,6 +10,11 @@ class IntrusivePtr;
 
 class ODesc;
 
+namespace threading {
+struct Value;
+struct Field;
+}
+
 namespace bro_broker {
 
 extern IntrusivePtr<OpaqueType> opaque_of_data_type;

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <unistd.h>
 
+#include "Func.h"
 #include "Data.h"
 #include "Store.h"
 #include "util.h"

--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -23,6 +23,7 @@
 
 class Frame;
 class Func;
+class VectorType;
 
 namespace bro_broker {
 

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -17,6 +17,7 @@
 #include "NetVar.h"
 #include "Net.h"
 #include "CompHash.h"
+#include "Func.h"
 
 #include "../file_analysis/Manager.h"
 #include "../threading/SerialTypes.h"

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -12,6 +12,7 @@
 #include "File.h"
 #include "input.h"
 #include "IntrusivePtr.h"
+#include "Func.h"
 
 #include "broker/Manager.h"
 #include "threading/Manager.h"

--- a/src/threading/Manager.cc
+++ b/src/threading/Manager.cc
@@ -6,6 +6,7 @@
 #include "NetVar.h"
 #include "iosource/Manager.h"
 #include "Event.h"
+#include "IPAddr.h"
 
 using namespace threading;
 

--- a/src/threading/MsgThread.h
+++ b/src/threading/MsgThread.h
@@ -8,11 +8,15 @@
 #include "iosource/IOSource.h"
 #include "Flare.h"
 
+class BroObj;
+
 namespace threading {
 
 class BasicInputMessage;
 class BasicOutputMessage;
 class HeartbeatMessage;
+struct Value;
+struct Field;
 
 /**
  * A specialized thread that provides bi-directional message passing between

--- a/src/threading/SerialTypes.cc
+++ b/src/threading/SerialTypes.cc
@@ -12,6 +12,7 @@
 #include "ID.h"
 #include "Expr.h"
 #include "Scope.h"
+#include "IPAddr.h"
 
 using namespace threading;
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -20,10 +20,6 @@
 #include <mach/mach_init.h>
 #endif
 
-#include <string>
-#include <array>
-#include <vector>
-#include <algorithm>
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,6 +38,12 @@
 #ifdef HAVE_MALLINFO
 # include <malloc.h>
 #endif
+
+#include <string>
+#include <array>
+#include <vector>
+#include <algorithm>
+#include <iostream>
 
 #include "Desc.h"
 #include "Dict.h"

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -45,6 +45,7 @@ extern "C" {
 #include "Traverse.h"
 #include "Trigger.h"
 #include "Hash.h"
+#include "Func.h"
 
 #include "supervisor/Supervisor.h"
 #include "threading/Manager.h"

--- a/src/zeekygen/ScriptInfo.cc
+++ b/src/zeekygen/ScriptInfo.cc
@@ -10,6 +10,7 @@
 
 #include "Reporter.h"
 #include "Desc.h"
+#include "Type.h"
 
 using namespace std;
 using namespace zeekygen;


### PR DESCRIPTION
Results a ~5% build time improvement on my local machine. Most of that is reducing the cascading includes from Func.h, which gets included by every BIF header via NetVar.h.