### PR TITLE
Fix Coverity Scan build

### DIFF
--- a/src/BifReturnVal.cc
+++ b/src/BifReturnVal.cc
@@ -1,0 +1,11 @@
+// See the file "COPYING" in the main distribution directory for copyright.
+
+#include "BifReturnVal.h"
+#include "Val.h"
+
+BifReturnVal::BifReturnVal(std::nullptr_t) noexcept
+	{}
+
+BifReturnVal::BifReturnVal(Val* v) noexcept
+	: rval(AdoptRef{}, v)
+	{}

--- a/src/BifReturnVal.h
+++ b/src/BifReturnVal.h
@@ -1,0 +1,28 @@
+// See the file "COPYING" in the main distribution directory for copyright.
+
+#pragma once
+
+#include "IntrusivePtr.h"
+
+class Val;
+
+/**
+ * A simple wrapper class to use for the return value of BIFs so that
+ * they may return either a Val* or IntrusivePtr<Val> (the former could
+ * potentially be deprecated).
+ */
+class BifReturnVal {
+public:
+
+	template <typename T>
+	BifReturnVal(IntrusivePtr<T> v) noexcept
+		: rval(AdoptRef{}, v.release())
+		{ }
+
+	BifReturnVal(std::nullptr_t) noexcept;
+
+	[[deprecated("Remove in v4.1.  Return an IntrusivePtr instead.")]]
+	BifReturnVal(Val* v) noexcept;
+
+	IntrusivePtr<Val> rval;
+};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -218,6 +218,7 @@ set(MAIN_SRCS
     Anon.cc
     Attr.cc
     Base64.cc
+    BifReturnVal.cc
     Brofiler.cc
     BroString.cc
     CCL.cc

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -2,6 +2,7 @@
 
 #include "zeek-config.h"
 
+#include <cstring>
 #include <vector>
 #include <map>
 

--- a/src/EventHandler.cc
+++ b/src/EventHandler.cc
@@ -44,6 +44,12 @@ const IntrusivePtr<FuncType>& EventHandler::GetType(bool check_export)
 	return type;
 	}
 
+void EventHandler::SetFunc(IntrusivePtr<Func> f)
+	{ local = std::move(f); }
+
+void EventHandler::SetLocalHandler(Func* f)
+	{ SetFunc({NewRef{}, f}); }
+
 void EventHandler::Call(zeek::Args* vl, bool no_remote)
 	{
 #ifdef PROFILE_BRO_FUNCTIONS

--- a/src/EventHandler.h
+++ b/src/EventHandler.h
@@ -5,10 +5,11 @@
 #include "BroList.h"
 #include "ZeekArgs.h"
 #include "Type.h"
-#include "Func.h"
 
 #include <unordered_set>
 #include <string>
+
+class Func;
 
 class EventHandler {
 public:
@@ -28,12 +29,10 @@ public:
 	FuncType* FType(bool check_export = true)
 		{ return GetType().get(); }
 
-	void SetFunc(IntrusivePtr<Func> f)
-		{ local = std::move(f); }
+	void SetFunc(IntrusivePtr<Func> f);
 
 	[[deprecated("Remove in v4.1.  Use SetFunc().")]]
-	void SetLocalHandler(Func* f)
-		{ SetFunc({NewRef{}, f}); }
+	void SetLocalHandler(Func* f);
 
 	void AutoPublish(std::string topic)
 		{

--- a/src/EventRegistry.cc
+++ b/src/EventRegistry.cc
@@ -1,5 +1,6 @@
 #include "EventRegistry.h"
 #include "EventHandler.h"
+#include "Func.h"
 #include "RE.h"
 #include "Reporter.h"
 

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -892,10 +892,3 @@ function_ingredients::function_ingredients(IntrusivePtr<Scope> scope, IntrusiveP
 	priority = (attrs ? get_func_priority(*attrs) : 0);
 	this->body = std::move(body);
 	}
-
-BifReturnVal::BifReturnVal(std::nullptr_t) noexcept
-	{ }
-
-BifReturnVal::BifReturnVal(Val* v) noexcept
-	: rval(AdoptRef{}, v)
-	{ }

--- a/src/Func.h
+++ b/src/Func.h
@@ -9,15 +9,13 @@
 #include <tuple>
 #include <type_traits>
 
-#include <broker/data.hh>
-#include <broker/expected.hh>
-
 #include "BroList.h"
 #include "Obj.h"
 #include "IntrusivePtr.h"
 #include "Type.h" /* for function_flavor */
 #include "TraverseTypes.h"
 #include "ZeekArgs.h"
+#include "BifReturnVal.h"
 
 class Val;
 class ListExpr;
@@ -27,6 +25,16 @@ class Frame;
 class ID;
 class CallExpr;
 class Scope;
+
+namespace caf {
+template <class> class expected;
+}
+
+namespace broker {
+class data;
+using vector = std::vector<data>;
+using caf::expected;
+}
 
 class Func : public BroObj {
 public:
@@ -203,27 +211,6 @@ private:
 	// The frame the BroFunc was initialized in.
 	Frame* closure = nullptr;
 	bool weak_closure_ref = false;
-};
-
-/**
- * A simple wrapper class to use for the return value of BIFs so that
- * they may return either a Val* or IntrusivePtr<Val> (the former could
- * potentially be deprecated).
- */
-class BifReturnVal {
-public:
-
-	template <typename T>
-	BifReturnVal(IntrusivePtr<T> v) noexcept
-		: rval(AdoptRef{}, v.release())
-		{ }
-
-	BifReturnVal(std::nullptr_t) noexcept;
-
-	[[deprecated("Remove in v4.1.  Return an IntrusivePtr instead.")]]
-	BifReturnVal(Val* v) noexcept;
-
-	IntrusivePtr<Val> rval;
 };
 
 using built_in_func = BifReturnVal (*)(Frame* frame, const zeek::Args* args);

--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -13,6 +13,10 @@
 #include "highwayhash/highwayhash_target.h"
 #include "highwayhash/instruction_sets.h"
 
+alignas(32) uint64_t KeyedHash::shared_highwayhash_key[4];
+alignas(32) uint64_t KeyedHash::cluster_highwayhash_key[4];
+alignas(16) unsigned long long KeyedHash::shared_siphash_key[2];
+
 // we use the following lines to not pull in the highwayhash headers in Hash.h - but to check the types did not change underneath us.
 static_assert(std::is_same<hash64_t, highwayhash::HHResult64>::value, "Highwayhash return values must match hash_x_t");
 static_assert(std::is_same<hash128_t, highwayhash::HHResult128>::value, "Highwayhash return values must match hash_x_t");

--- a/src/Hash.h
+++ b/src/Hash.h
@@ -186,11 +186,11 @@ public:
 
 private:
 	// actually HHKey. This key changes each start (unless a seed is specified)
-	alignas(32) inline static uint64_t shared_highwayhash_key[4];
+	alignas(32) static uint64_t shared_highwayhash_key[4];
 	// actually HHKey. This key is installation specific and sourced from the digest_salt script-level const.
-	alignas(32) inline static uint64_t cluster_highwayhash_key[4];
+	alignas(32) static uint64_t cluster_highwayhash_key[4];
 	// actually HH_U64, which has the same type. This key changes each start (unless a seed is specified)
-	alignas(16) inline static unsigned long long shared_siphash_key[2];
+	alignas(16) static unsigned long long shared_siphash_key[2];
 	// This key changes each start (unless a seed is specified)
 	inline static uint8_t shared_hmac_md5_key[16];
 	inline static bool seeds_initialized = false;

--- a/src/bro-bif.h
+++ b/src/bro-bif.h
@@ -7,3 +7,4 @@
 #include "Reporter.h"
 #include "ID.h"
 #include "EventRegistry.h"
+#include "BifReturnVal.h"

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -12,6 +12,8 @@
 #include "file_analysis/Manager.h"
 
 #include <broker/error.hh>
+#include <broker/expected.hh>
+#include <broker/data.hh>
 
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>


### PR DESCRIPTION
These changes should reduce the number of catastrophic errors the Coverity build has so that a bit more than the required 85% of compilation units succeed.

The first commit is generally Good for us anyway since it reduces header dependencies.  The second commit doesn't benefit us and would rather see a fix on Coverity's end, but it's also not a huge burden to just avoid the `alignas` + `static inline` for the moment.