### PR TITLE
Change Connection to derive from RecordVal

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -107,6 +107,9 @@ Changed Functionality
 - ``Attributes::Attrs()`` now returns ``const std::vector<IntrusivePtr<Attr>>&``
   instead of ``attr_list*``
 
+- ``RecordVal::GetOrigin()`` and ``RecordVal::SetOrigin()`` were removed and
+  instead ``Connection`` is now a subclass of ``RecordVal``.
+
 Removed Functionality
 ---------------------
 

--- a/NEWS
+++ b/NEWS
@@ -150,9 +150,9 @@ Deprecated Functionality
 - All ``val_mgr`` methods starting with "Get" are deprecated, use the new
   ``val_mgr`` methods that return ``IntrusivePtr``.
 
-- ``Connection::BuildConnVal()`` is deprecated, use ``Connection::ConnVal()``.
+- ``Connection::BuildConnVal()`` is deprecated, use ``Connection::UpdatedConnVal()``.
 
-- ``Analyzer::BuildConnVal()`` is deprecated, use ``Analyzer::ConnVal()``.
+- ``Analyzer::BuildConnVal()`` is deprecated, use ``Analyzer::UpdatedConnVal()``.
 
 - ``BifEvent::generate_`` functions are deprecated, use ``zeek::BifEvent::enqueue_``.
 

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -58,6 +58,12 @@ static inline int addr_port_canon_lt(const IPAddr& addr1, uint32_t p1,
 
 namespace analyzer { class Analyzer; }
 
+/**
+ * While a Connection object derives from RecordVal so that it's closely
+ * associated with the script-layer "connection" record type, note that
+ * the fields are not automatically populated/up-to-date unless one calls
+ * UpdatedConnVal().
+ */
 class Connection final : public RecordVal {
 public:
 	Connection(NetSessions* s, const ConnIDKey& k, double t, const ConnID* id,
@@ -162,14 +168,13 @@ public:
 	// Activate connection_status_update timer.
 	void EnableStatusUpdateTimer();
 
-	[[deprecated("Remove in v4.1.  Use ConnVal() instead.")]]
+	[[deprecated("Remove in v4.1.  Use UpdatedConnVal() instead.")]]
 	RecordVal* BuildConnVal();
 
 	/**
-	 * Returns the associated "connection" record with all fields
-	 * populated and up-to-date.
+	 * Returns this "connection" record with all fields populated/up-to-date.
 	 */
-	IntrusivePtr<RecordVal> ConnVal();
+	IntrusivePtr<RecordVal> UpdatedConnVal();
 
 	void AppendAddl(const char* str);
 

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -8,6 +8,7 @@
 #include <tuple>
 #include <type_traits>
 
+#include "Val.h"
 #include "Dict.h"
 #include "Timer.h"
 #include "Rule.h"
@@ -29,8 +30,6 @@ class RuleHdrTest;
 class Specific_RE_Matcher;
 class RuleEndpointState;
 class EncapsulationStack;
-class Val;
-class RecordVal;
 
 namespace analyzer { class TransportLayerAnalyzer; }
 
@@ -59,7 +58,7 @@ static inline int addr_port_canon_lt(const IPAddr& addr1, uint32_t p1,
 
 namespace analyzer { class Analyzer; }
 
-class Connection final : public BroObj {
+class Connection final : public RecordVal {
 public:
 	Connection(NetSessions* s, const ConnIDKey& k, double t, const ConnID* id,
 	           uint32_t flow, const Packet* pkt, const EncapsulationStack* arg_encap);
@@ -167,9 +166,10 @@ public:
 	RecordVal* BuildConnVal();
 
 	/**
-	 * Returns the associated "connection" record.
+	 * Returns the associated "connection" record with all fields
+	 * populated and up-to-date.
 	 */
-	const IntrusivePtr<RecordVal>& ConnVal();
+	IntrusivePtr<RecordVal> ConnVal();
 
 	void AppendAddl(const char* str);
 
@@ -263,7 +263,7 @@ public:
 	// Statistics.
 
 	// Just a lower bound.
-	unsigned int MemoryAllocation() const;
+	unsigned int MemoryAllocation() const override;
 	unsigned int MemoryAllocationConnVal() const;
 
 	static uint64_t TotalConnections()
@@ -342,6 +342,7 @@ protected:
 	NetSessions* sessions;
 	ConnIDKey key;
 	bool key_valid;
+	bool populated = false;
 
 	timer_list timers;
 
@@ -355,7 +356,6 @@ protected:
 	u_char resp_l2_addr[Packet::l2_addr_len];	// Link-layer responder address, if available
 	double start_time, last_time;
 	double inactivity_timeout;
-	IntrusivePtr<RecordVal> conn_val;
 	LoginConn* login_conn;	// either nil, or this
 	const EncapsulationStack* encapsulation; // tunnels
 	int suppress_event;	// suppress certain events to once per conn.

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -364,7 +364,7 @@ void Reporter::Weird(Connection* conn, const char* name, const char* addl)
 			return;
 		}
 
-	WeirdHelper(conn_weird, {conn->ConnVal()->Ref(), new StringVal(addl)},
+	WeirdHelper(conn_weird, {conn->UpdatedConnVal().release(), new StringVal(addl)},
 	            "%s", name);
 	}
 
@@ -501,7 +501,7 @@ void Reporter::DoLog(const char* prefix, EventHandlerPtr event, FILE* out,
 			vl.emplace_back(make_intrusive<StringVal>(loc_str.c_str()));
 
 		if ( conn )
-			vl.emplace_back(conn->ConnVal());
+			vl.emplace_back(conn->UpdatedConnVal());
 
 		if ( addl )
 			for ( auto v : *addl )

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -84,7 +84,7 @@ Val* RuleMatcher::BuildRuleStateValue(const Rule* rule,
 	static auto signature_state = zeek::id::find_type<RecordType>("signature_state");
 	RecordVal* val = new RecordVal(signature_state);
 	val->Assign(0, make_intrusive<StringVal>(rule->ID()));
-	val->Assign(1, state->GetAnalyzer()->ConnVal());
+	val->Assign(1, state->GetAnalyzer()->UpdatedConnVal());
 	val->Assign(2, val_mgr->Bool(state->is_orig));
 	val->Assign(3, val_mgr->Count(state->payload_size));
 	return val;

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -708,12 +708,12 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 	if ( ipv6_ext_headers && ip_hdr->NumHeaders() > 1 )
 		{
 		pkt_hdr_val = ip_hdr->ToPktHdrVal();
-		conn->EnqueueEvent(ipv6_ext_headers, nullptr, conn->ConnVal(),
+		conn->EnqueueEvent(ipv6_ext_headers, nullptr, conn->UpdatedConnVal(),
 		                   pkt_hdr_val);
 		}
 
 	if ( new_packet )
-		conn->EnqueueEvent(new_packet, nullptr, conn->ConnVal(), pkt_hdr_val ?
+		conn->EnqueueEvent(new_packet, nullptr, conn->UpdatedConnVal(), pkt_hdr_val ?
 		                   std::move(pkt_hdr_val) : ip_hdr->ToPktHdrVal());
 
 	conn->NextPacket(t, is_orig, ip_hdr, len, caplen, data,

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -2693,7 +2693,6 @@ RecordVal::RecordVal(RecordType* t, bool init_fields)
 
 RecordVal::RecordVal(IntrusivePtr<RecordType> t, bool init_fields) : Val(std::move(t))
 	{
-	origin = nullptr;
 	auto rt = GetType()->AsRecordType();
 	int n = rt->NumFields();
 	auto vl = val.record_val = new std::vector<IntrusivePtr<Val>>;
@@ -2971,13 +2970,7 @@ void RecordVal::DescribeReST(ODesc* d) const
 
 IntrusivePtr<Val> RecordVal::DoClone(CloneState* state)
 	{
-	// We set origin to 0 here.  Origin only seems to be used for exactly one
-	// purpose - to find the connection record that is associated with a
-	// record. As we cannot guarantee that it will ber zeroed out at the
-	// approproate time (as it seems to be guaranteed for the original record)
-	// we don't touch it.
 	auto rv = make_intrusive<RecordVal>(GetType<RecordType>(), false);
-	rv->origin = nullptr;
 	state->NewClone(this, rv);
 
 	for ( const auto& vlv : *val.record_val)

--- a/src/Val.h
+++ b/src/Val.h
@@ -1064,7 +1064,7 @@ protected:
 	static ParseTimeTableStates parse_time_table_states;
 };
 
-class RecordVal final : public Val, public notifier::Modifiable {
+class RecordVal : public Val, public notifier::Modifiable {
 public:
 	[[deprecated("Remove in v4.1.  Construct from IntrusivePtr instead.")]]
 	explicit RecordVal(RecordType* t, bool init_fields = true);
@@ -1192,11 +1192,6 @@ public:
 	 */
 	IntrusivePtr<TableVal> GetRecordFieldsVal() const;
 
-	// This is an experiment to associate a BroObj within the
-	// event engine to a record value in bro script.
-	void SetOrigin(BroObj* o)	{ origin = o; }
-	BroObj* GetOrigin() const	{ return origin; }
-
 	// Returns a new value representing the value coerced to the given
 	// type. If coercion is not possible, returns 0. The non-const
 	// version may return the current value ref'ed if its type matches
@@ -1228,8 +1223,6 @@ public:
 
 protected:
 	IntrusivePtr<Val> DoClone(CloneState* state) override;
-
-	BroObj* origin;
 
 	using RecordTypeValMap = std::unordered_map<RecordType*, std::vector<IntrusivePtr<RecordVal>>>;
 	static RecordTypeValMap parse_time_records;

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -702,7 +702,7 @@ void Analyzer::ProtocolConfirmation(Tag arg_tag)
 		return;
 
 	const auto& tval = arg_tag ? arg_tag.AsVal() : tag.AsVal();
-	mgr.Enqueue(protocol_confirmation, ConnVal(), tval, val_mgr->Count(id));
+	mgr.Enqueue(protocol_confirmation, UpdatedConnVal(), tval, val_mgr->Count(id));
 	}
 
 void Analyzer::ProtocolViolation(const char* reason, const char* data, int len)
@@ -724,7 +724,7 @@ void Analyzer::ProtocolViolation(const char* reason, const char* data, int len)
 		r = make_intrusive<StringVal>(reason);
 
 	const auto& tval = tag.AsVal();
-	mgr.Enqueue(protocol_violation, ConnVal(), tval, val_mgr->Count(id), std::move(r));
+	mgr.Enqueue(protocol_violation, UpdatedConnVal(), tval, val_mgr->Count(id), std::move(r));
 	}
 
 void Analyzer::AddTimer(analyzer_timer_func timer, double t,
@@ -791,12 +791,12 @@ void Analyzer::UpdateConnVal(RecordVal *conn_val)
 
 RecordVal* Analyzer::BuildConnVal()
 	{
-	return conn->ConnVal().release();
+	return conn->UpdatedConnVal().release();
 	}
 
-IntrusivePtr<RecordVal> Analyzer::ConnVal()
+IntrusivePtr<RecordVal> Analyzer::UpdatedConnVal()
 	{
-	return conn->ConnVal();
+	return conn->UpdatedConnVal();
 	}
 
 void Analyzer::Event(EventHandlerPtr f, const char* name)
@@ -810,7 +810,7 @@ void Analyzer::Event(EventHandlerPtr f, Val* v1, Val* v2)
 	IntrusivePtr val2{AdoptRef{}, v2};
 
 	if ( f )
-		conn->EnqueueEvent(f, this, conn->ConnVal(), std::move(val1), std::move(val2));
+		conn->EnqueueEvent(f, this, conn->UpdatedConnVal(), std::move(val1), std::move(val2));
 	}
 
 void Analyzer::ConnectionEvent(EventHandlerPtr f, val_list* vl)
@@ -943,6 +943,6 @@ void TransportLayerAnalyzer::PacketContents(const u_char* data, int len)
 		{
 		BroString* cbs = new BroString(data, len, true);
 		auto contents = make_intrusive<StringVal>(cbs);
-		EnqueueConnEvent(packet_contents, ConnVal(), std::move(contents));
+		EnqueueConnEvent(packet_contents, UpdatedConnVal(), std::move(contents));
 		}
 	}

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -791,10 +791,10 @@ void Analyzer::UpdateConnVal(RecordVal *conn_val)
 
 RecordVal* Analyzer::BuildConnVal()
 	{
-	return conn->ConnVal()->Ref()->AsRecordVal();
+	return conn->ConnVal().release();
 	}
 
-const IntrusivePtr<RecordVal>& Analyzer::ConnVal()
+IntrusivePtr<RecordVal> Analyzer::ConnVal()
 	{
 	return conn->ConnVal();
 	}

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -538,7 +538,7 @@ public:
 	 * Called whenever the connection value is updated. Per default, this
 	 * method will be called for each analyzer in the tree. Analyzers can
 	 * use this method to attach additional data to the connections. A
-	 * call to BuildConnVal() will in turn trigger a call to
+	 * call to UpdatedConnVal() will in turn trigger a call to
 	 * UpdateConnVal().
 	 *
 	 * @param conn_val The connenction value being updated.
@@ -547,16 +547,16 @@ public:
 
 	/**
 	 * Convenience function that forwards directly to
-	 * Connection::BuildConnVal().
+	 * Connection::UpdatedConnVal().
 	 */
-	[[deprecated("Remove in v4.1.  Use ConnVal() instead.")]]
+	[[deprecated("Remove in v4.1.  Use UpdatedConnVal() instead.")]]
 	RecordVal* BuildConnVal();
 
 	/**
 	 * Convenience function that forwards directly to
-	 * Connection::ConnVal().
+	 * Connection::UpdatedConnVal().
 	 */
-	IntrusivePtr<RecordVal> ConnVal();
+	IntrusivePtr<RecordVal> UpdatedConnVal();
 
 	/**
 	 * Convenience function that forwards directly to the corresponding

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -556,7 +556,7 @@ public:
 	 * Convenience function that forwards directly to
 	 * Connection::ConnVal().
 	 */
-	const IntrusivePtr<RecordVal>& ConnVal();
+	IntrusivePtr<RecordVal> ConnVal();
 
 	/**
 	 * Convenience function that forwards directly to the corresponding

--- a/src/analyzer/Manager.cc
+++ b/src/analyzer/Manager.cc
@@ -629,7 +629,7 @@ bool Manager::ApplyScheduledAnalyzers(Connection* conn, bool init, TransportLaye
 
 		if ( scheduled_analyzer_applied )
 			conn->EnqueueEvent(scheduled_analyzer_applied, nullptr,
-			                   conn->ConnVal(), it->AsVal());
+			                   conn->UpdatedConnVal(), it->AsVal());
 
 		DBG_ANALYZER_ARGS(conn, "activated %s analyzer as scheduled",
 		                  analyzer_mgr->GetComponentName(*it).c_str());

--- a/src/analyzer/protocol/bittorrent/BitTorrent.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrent.cc
@@ -120,7 +120,7 @@ void BitTorrent_Analyzer::DeliverWeird(const char* msg, bool orig)
 	{
 	if ( bittorrent_peer_weird )
 		EnqueueConnEvent(bittorrent_peer_weird,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(msg)
 		);

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -246,7 +246,7 @@ void BitTorrentTracker_Analyzer::DeliverWeird(const char* msg, bool orig)
 	{
 	if ( bt_tracker_weird )
 		EnqueueConnEvent(bt_tracker_weird,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(msg)
 		);
@@ -347,7 +347,7 @@ void BitTorrentTracker_Analyzer::EmitRequest(void)
 
 	if ( bt_tracker_request )
 		EnqueueConnEvent(bt_tracker_request,
-			ConnVal(),
+			UpdatedConnVal(),
 			IntrusivePtr{AdoptRef{}, req_val_uri},
 			IntrusivePtr{AdoptRef{}, req_val_headers}
 		);
@@ -401,7 +401,7 @@ bool BitTorrentTracker_Analyzer::ParseResponse(char* line)
 				{
 				if ( bt_tracker_response_not_ok )
 					EnqueueConnEvent(bt_tracker_response_not_ok,
-						ConnVal(),
+						UpdatedConnVal(),
 						val_mgr->Count(res_status),
 						IntrusivePtr{AdoptRef{}, res_val_headers}
 					);
@@ -782,7 +782,7 @@ void BitTorrentTracker_Analyzer::EmitResponse(void)
 
 	if ( bt_tracker_response )
 		EnqueueConnEvent(bt_tracker_response,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Count(res_status),
 			IntrusivePtr{AdoptRef{}, res_val_headers},
 			IntrusivePtr{AdoptRef{}, res_val_peers},

--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -51,7 +51,7 @@ void ConnSize_Analyzer::ThresholdEvent(EventHandlerPtr f, uint64_t threshold, bo
 		return;
 
 	EnqueueConnEvent(f,
-		ConnVal(),
+		UpdatedConnVal(),
 		val_mgr->Count(threshold),
 		val_mgr->Bool(is_orig)
 	);
@@ -93,7 +93,7 @@ void ConnSize_Analyzer::CheckThresholds(bool is_orig)
 		if ( ( network_time - start_time ) > duration_thresh && conn_duration_threshold_crossed )
 			{
 			EnqueueConnEvent(conn_duration_threshold_crossed,
-					ConnVal(),
+					UpdatedConnVal(),
 					make_intrusive<IntervalVal>(duration_thresh),
 					val_mgr->Bool(is_orig)
 			);

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -49,7 +49,7 @@ void DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query)
 
 	if ( dns_message )
 		analyzer->EnqueueConnEvent(dns_message,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Bool(is_query),
 			msg.BuildHdrVal(),
 			val_mgr->Count(len)
@@ -136,7 +136,7 @@ void DNS_Interpreter::EndMessage(DNS_MsgInfo* msg)
 	{
 	if ( dns_end )
 		analyzer->EnqueueConnEvent(dns_end,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal()
 		);
 	}
@@ -338,7 +338,7 @@ bool DNS_Interpreter::ParseAnswer(DNS_MsgInfo* msg,
 
 			if ( dns_unknown_reply && ! msg->skip_event )
 				analyzer->EnqueueConnEvent(dns_unknown_reply,
-					analyzer->ConnVal(),
+					analyzer->UpdatedConnVal(),
 					msg->BuildHdrVal(),
 					msg->BuildAnswerVal()
 				);
@@ -551,7 +551,7 @@ bool DNS_Interpreter::ParseRR_Name(DNS_MsgInfo* msg,
 
 	if ( reply_event && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(reply_event,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			make_intrusive<StringVal>(new BroString(name, name_end - name, true))
@@ -605,7 +605,7 @@ bool DNS_Interpreter::ParseRR_SOA(DNS_MsgInfo* msg,
 		r->Assign(6, make_intrusive<IntervalVal>(double(minimum), Seconds));
 
 		analyzer->EnqueueConnEvent(dns_SOA_reply,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			std::move(r)
@@ -635,7 +635,7 @@ bool DNS_Interpreter::ParseRR_MX(DNS_MsgInfo* msg,
 
 	if ( dns_MX_reply && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(dns_MX_reply,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
@@ -676,7 +676,7 @@ bool DNS_Interpreter::ParseRR_SRV(DNS_MsgInfo* msg,
 
 	if ( dns_SRV_reply && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(dns_SRV_reply,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
@@ -697,7 +697,7 @@ bool DNS_Interpreter::ParseRR_EDNS(DNS_MsgInfo* msg,
 
 	if ( dns_EDNS_addl && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(dns_EDNS_addl,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildEDNS_Val()
 		);
@@ -774,7 +774,7 @@ bool DNS_Interpreter::ParseRR_TSIG(DNS_MsgInfo* msg,
 		tsig.rr_error = rr_error;
 
 		analyzer->EnqueueConnEvent(dns_TSIG_addl,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildTSIG_Val(&tsig)
 		);
@@ -875,7 +875,7 @@ bool DNS_Interpreter::ParseRR_RRSIG(DNS_MsgInfo* msg,
 		rrsig.signature = sign;
 
 		analyzer->EnqueueConnEvent(dns_RRSIG,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			msg->BuildRRSIG_Val(&rrsig)
@@ -970,7 +970,7 @@ bool DNS_Interpreter::ParseRR_DNSKEY(DNS_MsgInfo* msg,
 		dnskey.public_key = key;
 
 		analyzer->EnqueueConnEvent(dns_DNSKEY,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			msg->BuildDNSKEY_Val(&dnskey)
@@ -1022,7 +1022,7 @@ bool DNS_Interpreter::ParseRR_NSEC(DNS_MsgInfo* msg,
 
 	if ( dns_NSEC )
 		analyzer->EnqueueConnEvent(dns_NSEC,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			make_intrusive<StringVal>(new BroString(name, name_end - name, true)),
@@ -1108,7 +1108,7 @@ bool DNS_Interpreter::ParseRR_NSEC3(DNS_MsgInfo* msg,
 		nsec3.bitmaps = std::move(char_strings);
 
 		analyzer->EnqueueConnEvent(dns_NSEC3,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			msg->BuildNSEC3_Val(&nsec3)
@@ -1166,7 +1166,7 @@ bool DNS_Interpreter::ParseRR_DS(DNS_MsgInfo* msg,
 		ds.digest_val = ds_digest;
 
 		analyzer->EnqueueConnEvent(dns_DS,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			msg->BuildDS_Val(&ds)
@@ -1189,7 +1189,7 @@ bool DNS_Interpreter::ParseRR_A(DNS_MsgInfo* msg,
 
 	if ( dns_A_reply && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(dns_A_reply,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			make_intrusive<AddrVal>(htonl(addr))
@@ -1225,7 +1225,7 @@ bool DNS_Interpreter::ParseRR_AAAA(DNS_MsgInfo* msg,
 
 	if ( event && ! msg->skip_event )
 		analyzer->EnqueueConnEvent(event,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			make_intrusive<AddrVal>(addr)
@@ -1299,7 +1299,7 @@ bool DNS_Interpreter::ParseRR_TXT(DNS_MsgInfo* msg,
 
 	if ( dns_TXT_reply )
 		analyzer->EnqueueConnEvent(dns_TXT_reply,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			std::move(char_strings)
@@ -1327,7 +1327,7 @@ bool DNS_Interpreter::ParseRR_SPF(DNS_MsgInfo* msg,
 
 	if ( dns_SPF_reply )
 		analyzer->EnqueueConnEvent(dns_SPF_reply,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			std::move(char_strings)
@@ -1368,7 +1368,7 @@ bool DNS_Interpreter::ParseRR_CAA(DNS_MsgInfo* msg,
 
 	if ( dns_CAA_reply )
 		analyzer->EnqueueConnEvent(dns_CAA_reply,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			msg->BuildHdrVal(),
 			msg->BuildAnswerVal(),
 			val_mgr->Count(flags),
@@ -1396,7 +1396,7 @@ void DNS_Interpreter::SendReplyOrRejectEvent(DNS_MsgInfo* msg,
 	assert(event);
 
 	analyzer->EnqueueConnEvent(event,
-		analyzer->ConnVal(),
+		analyzer->UpdatedConnVal(),
 		msg->BuildHdrVal(),
 		make_intrusive<StringVal>(question_name),
 		val_mgr->Count(qtype),

--- a/src/analyzer/protocol/file/File.cc
+++ b/src/analyzer/protocol/file/File.cc
@@ -80,7 +80,7 @@ void File_Analyzer::Identify()
 
 	if ( file_transferred )
 		EnqueueConnEvent(file_transferred,
-			ConnVal(),
+			UpdatedConnVal(),
 			make_intrusive<StringVal>(buffer_len, buffer),
 			make_intrusive<StringVal>("<unknown>"),
 			make_intrusive<StringVal>(match)

--- a/src/analyzer/protocol/finger/Finger.cc
+++ b/src/analyzer/protocol/finger/Finger.cc
@@ -68,7 +68,7 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 
 		if ( finger_request )
 			EnqueueConnEvent(finger_request,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(long_cnt),
 				make_intrusive<StringVal>(at - line, line),
 				make_intrusive<StringVal>(end_of_line - host, host)
@@ -86,7 +86,7 @@ void Finger_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig
 			return;
 
 		EnqueueConnEvent(finger_reply,
-			ConnVal(),
+			UpdatedConnVal(),
 			make_intrusive<StringVal>(end_of_line - line, line)
 		);
 		}

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -97,7 +97,7 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 			cmd_str = (new StringVal(cmd_len, cmd))->ToUpper();
 
 		vl = {
-			ConnVal(),
+			UpdatedConnVal(),
 			IntrusivePtr{AdoptRef{}, cmd_str},
 			make_intrusive<StringVal>(end_of_line - line, line),
 		};
@@ -176,7 +176,7 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig)
 			}
 
 		vl = {
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Count(reply_code),
 			make_intrusive<StringVal>(end_of_line - line, line),
 			val_mgr->Bool(cont_resp)

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -59,9 +59,9 @@ void Gnutella_Analyzer::Done()
 	if ( ! sent_establish && (gnutella_establish || gnutella_not_establish) )
 		{
 		if ( Established() && gnutella_establish )
-			EnqueueConnEvent(gnutella_establish, ConnVal());
+			EnqueueConnEvent(gnutella_establish, UpdatedConnVal());
 		else if ( ! Established () && gnutella_not_establish )
-			EnqueueConnEvent(gnutella_not_establish, ConnVal());
+			EnqueueConnEvent(gnutella_not_establish, UpdatedConnVal());
 		}
 
 	if ( gnutella_partial_binary_msg )
@@ -72,7 +72,7 @@ void Gnutella_Analyzer::Done()
 			{
 			if ( ! p->msg_sent && p->msg_pos )
 				EnqueueConnEvent(gnutella_partial_binary_msg,
-					ConnVal(),
+					UpdatedConnVal(),
 					make_intrusive<StringVal>(p->msg),
 					val_mgr->Bool((i == 0)),
 					val_mgr->Count(p->msg_pos)
@@ -118,7 +118,7 @@ bool Gnutella_Analyzer::IsHTTP(std::string header)
 		return false;
 
 	if ( gnutella_http_notify )
-		EnqueueConnEvent(gnutella_http_notify, ConnVal());
+		EnqueueConnEvent(gnutella_http_notify, UpdatedConnVal());
 
 	analyzer::Analyzer* a = analyzer_mgr->InstantiateAnalyzer("HTTP", Conn());
 
@@ -177,7 +177,7 @@ void Gnutella_Analyzer::DeliverLines(int len, const u_char* data, bool orig)
 			{
 			if ( gnutella_text_msg )
 				EnqueueConnEvent(gnutella_text_msg,
-					ConnVal(),
+					UpdatedConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(ms->headers.data())
 				);
@@ -189,7 +189,7 @@ void Gnutella_Analyzer::DeliverLines(int len, const u_char* data, bool orig)
 				{
 				sent_establish = 1;
 
-				EnqueueConnEvent(gnutella_establish, ConnVal());
+				EnqueueConnEvent(gnutella_establish, UpdatedConnVal());
 				}
 			}
 		}
@@ -215,7 +215,7 @@ void Gnutella_Analyzer::SendEvents(GnutellaMsgState* p, bool is_orig)
 
 	if ( gnutella_binary_msg )
 		EnqueueConnEvent(gnutella_binary_msg,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(is_orig),
 			val_mgr->Count(p->msg_type),
 			val_mgr->Count(p->msg_ttl),

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -651,7 +651,7 @@ void HTTP_Message::Done(bool interrupted, const char* detail)
 
 	if ( http_message_done )
 		GetAnalyzer()->EnqueueConnEvent(http_message_done,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Bool(is_orig),
 			BuildMessageStat(interrupted, detail)
 		);
@@ -682,7 +682,7 @@ void HTTP_Message::BeginEntity(mime::MIME_Entity* entity)
 
 	if ( http_begin_entity )
 		analyzer->EnqueueConnEvent(http_begin_entity,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Bool(is_orig)
 		);
 	}
@@ -697,7 +697,7 @@ void HTTP_Message::EndEntity(mime::MIME_Entity* entity)
 
 	if ( http_end_entity )
 		analyzer->EnqueueConnEvent(http_end_entity,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Bool(is_orig)
 		);
 
@@ -736,14 +736,14 @@ void HTTP_Message::SubmitAllHeaders(mime::MIME_HeaderList& hlist)
 	{
 	if ( http_all_headers )
 		analyzer->EnqueueConnEvent(http_all_headers,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Bool(is_orig),
 			ToHeaderTable(hlist)
 		);
 
 	if ( http_content_type )
 		analyzer->EnqueueConnEvent(http_content_type,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Bool(is_orig),
 			current_entity->GetContentType(),
 			current_entity->GetContentSubType()
@@ -1160,7 +1160,7 @@ void HTTP_Analyzer::GenStats()
 		r->Assign(3, make_intrusive<DoubleVal>(reply_version.ToDouble()));
 
 		// DEBUG_MSG("%.6f http_stats\n", network_time);
-		EnqueueConnEvent(http_stats, ConnVal(), std::move(r));
+		EnqueueConnEvent(http_stats, UpdatedConnVal(), std::move(r));
 		}
 	}
 
@@ -1360,7 +1360,7 @@ void HTTP_Analyzer::HTTP_Event(const char* category, IntrusivePtr<StringVal> det
 	if ( http_event )
 		// DEBUG_MSG("%.6f http_event\n", network_time);
 		EnqueueConnEvent(http_event,
-			ConnVal(),
+			UpdatedConnVal(),
 			make_intrusive<StringVal>(category),
 			std::move(detail));
 	}
@@ -1394,7 +1394,7 @@ void HTTP_Analyzer::HTTP_Request()
 	if ( http_request )
 		// DEBUG_MSG("%.6f http_request\n", network_time);
 		EnqueueConnEvent(http_request,
-			ConnVal(),
+			UpdatedConnVal(),
 			request_method,
 			TruncateURI(request_URI),
 			TruncateURI(unescaped_URI),
@@ -1406,7 +1406,7 @@ void HTTP_Analyzer::HTTP_Reply()
 	{
 	if ( http_reply )
 		EnqueueConnEvent(http_reply,
-			ConnVal(),
+			UpdatedConnVal(),
 			make_intrusive<StringVal>(fmt("%.1f", reply_version.ToDouble())),
 			val_mgr->Count(reply_code),
 			reply_reason_phrase ?
@@ -1472,7 +1472,7 @@ void HTTP_Analyzer::ReplyMade(bool interrupted, const char* msg)
 
 		if ( http_connection_upgrade )
 			EnqueueConnEvent(http_connection_upgrade,
-				ConnVal(),
+				UpdatedConnVal(),
 				make_intrusive<StringVal>(upgrade_protocol)
 			);
 		}
@@ -1639,7 +1639,7 @@ void HTTP_Analyzer::HTTP_Header(bool is_orig, mime::MIME_Header* h)
 		upper_hn->ToUpper();
 
 		EnqueueConnEvent(http_header,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(is_orig),
 			mime::to_string_val(h->get_name()),
 			std::move(upper_hn),
@@ -1652,7 +1652,7 @@ void HTTP_Analyzer::HTTP_EntityData(bool is_orig, BroString* entity_data)
 	{
 	if ( http_entity_data )
 		EnqueueConnEvent(http_entity_data,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(is_orig),
 			val_mgr->Count(entity_data->Len()),
 			make_intrusive<StringVal>(entity_data)

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -203,7 +203,7 @@ void ICMP_Analyzer::ICMP_Sent(const struct icmp* icmpp, int len, int caplen,
     {
 	if ( icmp_sent )
 		EnqueueConnEvent(icmp_sent,
-			ConnVal(),
+			UpdatedConnVal(),
 			BuildICMPVal(icmpp, len, icmpv6, ip_hdr)
 		);
 
@@ -212,7 +212,7 @@ void ICMP_Analyzer::ICMP_Sent(const struct icmp* icmpp, int len, int caplen,
 		BroString* payload = new BroString(data, std::min(len, caplen), false);
 
 		EnqueueConnEvent(icmp_sent_payload,
-			ConnVal(),
+			UpdatedConnVal(),
 			BuildICMPVal(icmpp, len, icmpv6, ip_hdr),
 			make_intrusive<StringVal>(payload)
 		);
@@ -519,7 +519,7 @@ void ICMP_Analyzer::Echo(double t, const struct icmp* icmpp, int len,
 	BroString* payload = new BroString(data, caplen, false);
 
 	EnqueueConnEvent(f,
-		ConnVal(),
+		UpdatedConnVal(),
 		BuildICMPVal(icmpp, len, ip_hdr->NextProto() != IPPROTO_ICMP, ip_hdr),
 		val_mgr->Count(iid),
 		val_mgr->Count(iseq),
@@ -547,7 +547,7 @@ void ICMP_Analyzer::RouterAdvert(double t, const struct icmp* icmpp, int len,
 	int opt_offset = sizeof(reachable) + sizeof(retrans);
 
 	EnqueueConnEvent(f,
-		ConnVal(),
+		UpdatedConnVal(),
 		BuildICMPVal(icmpp, len, 1, ip_hdr),
 		val_mgr->Count(icmpp->icmp_num_addrs), // Cur Hop Limit
 		val_mgr->Bool(icmpp->icmp_wpa & 0x80), // Managed
@@ -580,7 +580,7 @@ void ICMP_Analyzer::NeighborAdvert(double t, const struct icmp* icmpp, int len,
 	int opt_offset = sizeof(in6_addr);
 
 	EnqueueConnEvent(f,
-		ConnVal(),
+		UpdatedConnVal(),
 		BuildICMPVal(icmpp, len, 1, ip_hdr),
 		val_mgr->Bool(icmpp->icmp_num_addrs & 0x80), // Router
 		val_mgr->Bool(icmpp->icmp_num_addrs & 0x40), // Solicited
@@ -607,7 +607,7 @@ void ICMP_Analyzer::NeighborSolicit(double t, const struct icmp* icmpp, int len,
 	int opt_offset = sizeof(in6_addr);
 
 	EnqueueConnEvent(f,
-		ConnVal(),
+		UpdatedConnVal(),
 		BuildICMPVal(icmpp, len, 1, ip_hdr),
 		make_intrusive<AddrVal>(tgtaddr),
 		BuildNDOptionsVal(caplen - opt_offset, data + opt_offset)
@@ -634,7 +634,7 @@ void ICMP_Analyzer::Redirect(double t, const struct icmp* icmpp, int len,
 	int opt_offset = 2 * sizeof(in6_addr);
 
 	EnqueueConnEvent(f,
-		ConnVal(),
+		UpdatedConnVal(),
 		BuildICMPVal(icmpp, len, 1, ip_hdr),
 		make_intrusive<AddrVal>(tgtaddr),
 		make_intrusive<AddrVal>(dstaddr),
@@ -652,7 +652,7 @@ void ICMP_Analyzer::RouterSolicit(double t, const struct icmp* icmpp, int len,
 		return;
 
 	EnqueueConnEvent(f,
-		ConnVal(),
+		UpdatedConnVal(),
 		BuildICMPVal(icmpp, len, 1, ip_hdr),
 		BuildNDOptionsVal(caplen, data)
 	);
@@ -677,7 +677,7 @@ void ICMP_Analyzer::Context4(double t, const struct icmp* icmpp,
 
 	if ( f )
 		EnqueueConnEvent(f,
-			ConnVal(),
+			UpdatedConnVal(),
 			BuildICMPVal(icmpp, len, 0, ip_hdr),
 			val_mgr->Count(icmpp->icmp_code),
 			ExtractICMP4Context(caplen, data)
@@ -715,7 +715,7 @@ void ICMP_Analyzer::Context6(double t, const struct icmp* icmpp,
 
 	if ( f )
 		EnqueueConnEvent(f,
-			ConnVal(),
+			UpdatedConnVal(),
 			BuildICMPVal(icmpp, len, 1, ip_hdr),
 			val_mgr->Count(icmpp->icmp_code),
 			ExtractICMP6Context(caplen, data)

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -85,7 +85,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 			}
 
 		EnqueueConnEvent(ident_request,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Port(local_port, TRANSPORT_TCP),
 			val_mgr->Port(remote_port, TRANSPORT_TCP)
 		);
@@ -146,7 +146,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 			{
 			if ( ident_error )
 				EnqueueConnEvent(ident_error,
-					ConnVal(),
+					UpdatedConnVal(),
 					val_mgr->Port(local_port, TRANSPORT_TCP),
 					val_mgr->Port(remote_port, TRANSPORT_TCP),
 					make_intrusive<StringVal>(end_of_line - line, line)
@@ -179,7 +179,7 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
 			line = skip_whitespace(colon + 1, end_of_line);
 
 			EnqueueConnEvent(ident_reply,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Port(local_port, TRANSPORT_TCP),
 				val_mgr->Port(remote_port, TRANSPORT_TCP),
 				make_intrusive<StringVal>(end_of_line - line, line),

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -237,7 +237,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_network_info,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				val_mgr->Int(users),
 				val_mgr->Int(services),
@@ -284,7 +284,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_names_info,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(type.c_str()),
 				make_intrusive<StringVal>(channel.c_str()),
@@ -318,7 +318,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_server_info,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				val_mgr->Int(users),
 				val_mgr->Int(services),
@@ -340,7 +340,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 					channels = atoi(parts[i - 1].c_str());
 
 			EnqueueConnEvent(irc_channel_info,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				val_mgr->Int(channels)
 			);
@@ -372,7 +372,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_global_users,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(eop - prefix, prefix),
 				make_intrusive<StringVal>(++msg)
@@ -398,7 +398,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			zeek::Args vl;
 			vl.reserve(6);
-			vl.emplace_back(ConnVal());
+			vl.emplace_back(UpdatedConnVal());
 			vl.emplace_back(val_mgr->Bool(orig));
 			vl.emplace_back(make_intrusive<StringVal>(parts[0].c_str()));
 			vl.emplace_back(make_intrusive<StringVal>(parts[1].c_str()));
@@ -437,7 +437,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_whois_operator_line,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(parts[0].c_str())
 			);
@@ -475,7 +475,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				}
 
 			EnqueueConnEvent(irc_whois_channel_line,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(nick.c_str()),
 				std::move(set)
@@ -506,7 +506,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 					++t;
 
 				EnqueueConnEvent(irc_channel_topic,
-					ConnVal(),
+					UpdatedConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(parts[1].c_str()),
 					make_intrusive<StringVal>(t)
@@ -540,7 +540,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				parts[7] = parts[7].substr(1);
 
 			EnqueueConnEvent(irc_who_line,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(parts[0].c_str()),
 				make_intrusive<StringVal>(parts[1].c_str()),
@@ -562,7 +562,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		case 436:
 			if ( irc_invalid_nick )
 				EnqueueConnEvent(irc_invalid_nick,
-					ConnVal(),
+					UpdatedConnVal(),
 					val_mgr->Bool(orig)
 				);
 			break;
@@ -572,7 +572,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		case 491:  // user is not operator
 			if ( irc_oper_response )
 				EnqueueConnEvent(irc_oper_response,
-					ConnVal(),
+					UpdatedConnVal(),
 					val_mgr->Bool(orig),
 					val_mgr->Bool(code == 381)
 				);
@@ -587,7 +587,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		default:
 			if ( irc_reply )
 				EnqueueConnEvent(irc_reply,
-					ConnVal(),
+					UpdatedConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(prefix.c_str()),
 					val_mgr->Count(code),
@@ -658,7 +658,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			if ( irc_dcc_message )
 				EnqueueConnEvent(irc_dcc_message,
-					ConnVal(),
+					UpdatedConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(prefix.c_str()),
 					make_intrusive<StringVal>(target.c_str()),
@@ -674,7 +674,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			{
 			if ( irc_privmsg_message )
 				EnqueueConnEvent(irc_privmsg_message,
-					ConnVal(),
+					UpdatedConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(prefix.c_str()),
 					make_intrusive<StringVal>(target.c_str()),
@@ -699,7 +699,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			message = message.substr(1);
 
 		EnqueueConnEvent(irc_notice_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(target.c_str()),
@@ -723,7 +723,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			message = message.substr(1);
 
 		EnqueueConnEvent(irc_squery_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(target.c_str()),
@@ -737,7 +737,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		vector<string> parts = SplitWords(params, ' ');
 		zeek::Args vl;
 		vl.reserve(6);
-		vl.emplace_back(ConnVal());
+		vl.emplace_back(UpdatedConnVal());
 		vl.emplace_back(val_mgr->Bool(orig));
 
 		if ( parts.size() > 0 )
@@ -772,7 +772,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		vector<string> parts = SplitWords(params, ' ');
 		if ( parts.size() == 2 )
 			EnqueueConnEvent(irc_oper_message,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(parts[0].c_str()),
 				make_intrusive<StringVal>(parts[1].c_str())
@@ -794,7 +794,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 		zeek::Args vl;
 		vl.reserve(6);
-		vl.emplace_back(ConnVal());
+		vl.emplace_back(UpdatedConnVal());
 		vl.emplace_back(val_mgr->Bool(orig));
 		vl.emplace_back(make_intrusive<StringVal>(prefix.c_str()));
 		vl.emplace_back(make_intrusive<StringVal>(parts[0].c_str()));
@@ -862,7 +862,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		EnqueueConnEvent(irc_join_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			std::move(list)
 		);
@@ -922,7 +922,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		EnqueueConnEvent(irc_join_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			std::move(list)
 		);
@@ -961,7 +961,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		EnqueueConnEvent(irc_part_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(nick.c_str()),
 			std::move(set),
@@ -984,7 +984,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		EnqueueConnEvent(irc_quit_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(nickname.c_str()),
 			make_intrusive<StringVal>(message.c_str())
@@ -998,7 +998,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			nick = nick.substr(1);
 
 		EnqueueConnEvent(irc_nick_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(nick.c_str())
@@ -1023,7 +1023,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			parts[0] = parts[0].substr(1);
 
 		EnqueueConnEvent(irc_who_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			parts.size() > 0 ?
 				make_intrusive<StringVal>(parts[0].c_str()) :
@@ -1053,7 +1053,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			users = parts[0];
 
 		EnqueueConnEvent(irc_whois_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(server.c_str()),
 			make_intrusive<StringVal>(users.c_str())
@@ -1066,7 +1066,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			params = params.substr(1);
 
 		EnqueueConnEvent(irc_error_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(params.c_str())
@@ -1082,7 +1082,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 				parts[1] = parts[1].substr(1);
 
 			EnqueueConnEvent(irc_invite_message,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(parts[0].c_str()),
@@ -1097,7 +1097,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		{
 		if ( params.size() > 0 )
 			EnqueueConnEvent(irc_mode_message,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(params.c_str())
@@ -1110,7 +1110,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 	else if ( irc_password_message && command == "PASS" )
 		{
 		EnqueueConnEvent(irc_password_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(params.c_str())
 		);
@@ -1132,7 +1132,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			}
 
 		EnqueueConnEvent(irc_squit_message,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig),
 			make_intrusive<StringVal>(prefix.c_str()),
 			make_intrusive<StringVal>(server.c_str()),
@@ -1146,7 +1146,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( irc_request )
 			{
 			EnqueueConnEvent(irc_request,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(command.c_str()),
@@ -1160,7 +1160,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( irc_message )
 			{
 			EnqueueConnEvent(irc_message,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(orig),
 				make_intrusive<StringVal>(prefix.c_str()),
 				make_intrusive<StringVal>(command.c_str()),
@@ -1195,7 +1195,7 @@ void IRC_Analyzer::StartTLS()
 		AddChildAnalyzer(ssl);
 
 	if ( irc_starttls )
-		EnqueueConnEvent(irc_starttls, ConnVal());
+		EnqueueConnEvent(irc_starttls, UpdatedConnVal());
 	}
 
 vector<string> IRC_Analyzer::SplitWords(const string& input, char split)

--- a/src/analyzer/protocol/login/Login.cc
+++ b/src/analyzer/protocol/login/Login.cc
@@ -299,7 +299,7 @@ void Login_Analyzer::AuthenticationDialog(bool orig, char* line)
 	else if ( IsSkipAuthentication(line) )
 		{
 		if ( authentication_skipped )
-			EnqueueConnEvent(authentication_skipped, ConnVal());
+			EnqueueConnEvent(authentication_skipped, UpdatedConnVal());
 
 		state = LOGIN_STATE_SKIP;
 		SetSkip(true);
@@ -341,19 +341,19 @@ void Login_Analyzer::SetEnv(bool orig, char* name, char* val)
 
 		else if ( login_terminal && streq(name, "TERM") )
 			EnqueueConnEvent(login_terminal,
-				ConnVal(),
+				UpdatedConnVal(),
 				make_intrusive<StringVal>(val)
 			);
 
 		else if ( login_display && streq(name, "DISPLAY") )
 			EnqueueConnEvent(login_display,
-				ConnVal(),
+				UpdatedConnVal(),
 				make_intrusive<StringVal>(val)
 			);
 
 		else if ( login_prompt && streq(name, "TTYPROMPT") )
 			EnqueueConnEvent(login_prompt,
-				ConnVal(),
+				UpdatedConnVal(),
 				make_intrusive<StringVal>(val)
 			);
 		}
@@ -429,7 +429,7 @@ void Login_Analyzer::LoginEvent(EventHandlerPtr f, const char* line,
 				PopUserTextVal() : new StringVal("<none>");
 
 	EnqueueConnEvent(f,
-		ConnVal(),
+		UpdatedConnVal(),
 		IntrusivePtr{NewRef{}, username},
 		client_name ? IntrusivePtr{NewRef{}, client_name}
 		            : val_mgr->EmptyString(),
@@ -452,7 +452,7 @@ void Login_Analyzer::LineEvent(EventHandlerPtr f, const char* line)
 		return;
 
 	EnqueueConnEvent(f,
-		ConnVal(),
+		UpdatedConnVal(),
 		make_intrusive<StringVal>(line)
 	);
 	}
@@ -464,7 +464,7 @@ void Login_Analyzer::Confused(const char* msg, const char* line)
 
 	if ( login_confused )
 		EnqueueConnEvent(login_confused,
-			ConnVal(),
+			UpdatedConnVal(),
 			make_intrusive<StringVal>(msg),
 			make_intrusive<StringVal>(line)
 		);
@@ -488,7 +488,7 @@ void Login_Analyzer::ConfusionText(const char* line)
 	{
 	if ( login_confused_text )
 		EnqueueConnEvent(login_confused_text,
-			ConnVal(),
+			UpdatedConnVal(),
 			make_intrusive<StringVal>(line)
 		);
 	}

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -460,7 +460,7 @@ void NVT_Analyzer::SetTerminal(const u_char* terminal, int len)
 	{
 	if ( login_terminal )
 		EnqueueConnEvent(login_terminal,
-			ConnVal(),
+			UpdatedConnVal(),
 			make_intrusive<StringVal>(new BroString(terminal, len, false))
 		);
 	}

--- a/src/analyzer/protocol/login/RSH.cc
+++ b/src/analyzer/protocol/login/RSH.cc
@@ -172,7 +172,7 @@ void Rsh_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	vl.reserve(4 + orig);
 	const char* line = (const char*) data;
 	line = skip_whitespace(line);
-	vl.emplace_back(ConnVal());
+	vl.emplace_back(UpdatedConnVal());
 
 	if ( client_name )
 		vl.emplace_back(NewRef{}, client_name);

--- a/src/analyzer/protocol/login/Rlogin.cc
+++ b/src/analyzer/protocol/login/Rlogin.cc
@@ -245,7 +245,7 @@ void Rlogin_Analyzer::TerminalType(const char* s)
 	{
 	if ( login_terminal )
 		EnqueueConnEvent(login_terminal,
-			ConnVal(),
+			UpdatedConnVal(),
 			make_intrusive<StringVal>(s)
 		);
 	}

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -1381,7 +1381,7 @@ void MIME_Mail::Done()
 		md5_hash = nullptr;
 
 		analyzer->EnqueueConnEvent(mime_content_hash,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Count(content_hash_length),
 			make_intrusive<StringVal>(new BroString(true, digest, 16))
 		);
@@ -1408,7 +1408,7 @@ void MIME_Mail::BeginEntity(MIME_Entity* /* entity */)
 	cur_entity_id.clear();
 
 	if ( mime_begin_entity )
-		analyzer->EnqueueConnEvent(mime_begin_entity, analyzer->ConnVal());
+		analyzer->EnqueueConnEvent(mime_begin_entity, analyzer->UpdatedConnVal());
 
 	buffer_start = data_start = 0;
 	ASSERT(entity_content.size() == 0);
@@ -1421,7 +1421,7 @@ void MIME_Mail::EndEntity(MIME_Entity* /* entity */)
 		BroString* s = concatenate(entity_content);
 
 		analyzer->EnqueueConnEvent(mime_entity_data,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Count(s->Len()),
 			make_intrusive<StringVal>(s)
 		);
@@ -1433,7 +1433,7 @@ void MIME_Mail::EndEntity(MIME_Entity* /* entity */)
 		}
 
 	if ( mime_end_entity )
-		analyzer->EnqueueConnEvent(mime_end_entity, analyzer->ConnVal());
+		analyzer->EnqueueConnEvent(mime_end_entity, analyzer->UpdatedConnVal());
 
 	file_mgr->EndOfFile(analyzer->GetAnalyzerTag(), analyzer->Conn());
 	cur_entity_id.clear();
@@ -1443,7 +1443,7 @@ void MIME_Mail::SubmitHeader(MIME_Header* h)
 	{
 	if ( mime_one_header )
 		analyzer->EnqueueConnEvent(mime_one_header,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			ToHeaderVal(h)
 		);
 	}
@@ -1452,7 +1452,7 @@ void MIME_Mail::SubmitAllHeaders(MIME_HeaderList& hlist)
 	{
 	if ( mime_all_headers )
 		analyzer->EnqueueConnEvent(mime_all_headers,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			ToHeaderTable(hlist)
 		);
 	}
@@ -1488,7 +1488,7 @@ void MIME_Mail::SubmitData(int len, const char* buf)
 		int data_len = (buf + len) - data;
 
 		analyzer->EnqueueConnEvent(mime_segment_data,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Count(data_len),
 			make_intrusive<StringVal>(data_len, data)
 		);
@@ -1535,7 +1535,7 @@ void MIME_Mail::SubmitAllData()
 		delete_strings(all_content);
 
 		analyzer->EnqueueConnEvent(mime_all_data,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Count(s->Len()),
 			make_intrusive<StringVal>(s)
 		);
@@ -1563,7 +1563,7 @@ void MIME_Mail::SubmitEvent(int event_type, const char* detail)
 
 	if ( mime_event )
 		analyzer->EnqueueConnEvent(mime_event,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			make_intrusive<StringVal>(category),
 			make_intrusive<StringVal>(detail)
 		);

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -63,14 +63,14 @@ void NCP_Session::DeliverFrame(const binpac::NCP::ncp_frame* frame)
 		{
 		if ( frame->is_orig() )
 			analyzer->EnqueueConnEvent(f,
-				analyzer->ConnVal(),
+				analyzer->UpdatedConnVal(),
 				val_mgr->Count(frame->frame_type()),
 				val_mgr->Count(frame->body_length()),
 				val_mgr->Count(req_func)
 			);
 		else
 			analyzer->EnqueueConnEvent(f,
-				analyzer->ConnVal(),
+				analyzer->UpdatedConnVal(),
 				val_mgr->Count(frame->frame_type()),
 				val_mgr->Count(frame->body_length()),
 				val_mgr->Count(req_frame_type),

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -60,7 +60,7 @@ void NetbiosSSN_Interpreter::ParseMessage(unsigned int type, unsigned int flags,
 	{
 	if ( netbios_session_message )
 		analyzer->EnqueueConnEvent(netbios_session_message,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Bool(is_query),
 			val_mgr->Count(type),
 			val_mgr->Count(len)
@@ -322,13 +322,13 @@ void NetbiosSSN_Interpreter::Event(EventHandlerPtr event, const u_char* data,
 
 	if ( is_orig >= 0 )
 		analyzer->EnqueueConnEvent(event,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Bool(is_orig),
 			make_intrusive<StringVal>(new BroString(data, len, false))
 		);
 	else
 		analyzer->EnqueueConnEvent(event,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			make_intrusive<StringVal>(new BroString(data, len, false))
 		);
 	}

--- a/src/analyzer/protocol/pia/PIA.cc
+++ b/src/analyzer/protocol/pia/PIA.cc
@@ -160,7 +160,7 @@ void PIA_UDP::ActivateAnalyzer(analyzer::Tag tag, const Rule* rule)
 				tag = GetAnalyzerTag();
 
 			const auto& tval = tag.AsVal();
-			mgr.Enqueue(protocol_late_match, ConnVal(), tval);
+			mgr.Enqueue(protocol_late_match, UpdatedConnVal(), tval);
 			}
 
 		pkt_buffer.state = dpd_late_match_stop ? SKIPPING : MATCHING_ONLY;
@@ -307,7 +307,7 @@ void PIA_TCP::ActivateAnalyzer(analyzer::Tag tag, const Rule* rule)
 				tag = GetAnalyzerTag();
 
 			const auto& tval = tag.AsVal();
-			mgr.Enqueue(protocol_late_match, ConnVal(), tval);
+			mgr.Enqueue(protocol_late_match, UpdatedConnVal(), tval);
 			}
 
 		stream_buffer.state = dpd_late_match_stop ? SKIPPING : MATCHING_ONLY;

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -826,7 +826,7 @@ void POP3_Analyzer::StartTLS()
 		AddChildAnalyzer(ssl);
 
 	if ( pop3_starttls )
-		EnqueueConnEvent(pop3_starttls, ConnVal());
+		EnqueueConnEvent(pop3_starttls, UpdatedConnVal());
 	}
 
 void POP3_Analyzer::AuthSuccessfull()
@@ -919,7 +919,7 @@ void POP3_Analyzer::POP3Event(EventHandlerPtr event, bool is_orig,
 	zeek::Args vl;
 	vl.reserve(2 + (bool)arg1 + (bool)arg2);
 
-	vl.emplace_back(ConnVal());
+	vl.emplace_back(UpdatedConnVal());
 	vl.emplace_back(val_mgr->Bool(is_orig));
 
 	if ( arg1 )

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -176,7 +176,7 @@ zeek::Args MOUNT_Interp::event_common_vl(RPC_CallInfo *c,
 	// These are the first parameters for each mount_* event ...
 	zeek::Args vl;
 	vl.reserve(2 + extra_elements);
-	vl.emplace_back(analyzer->ConnVal());
+	vl.emplace_back(analyzer->UpdatedConnVal());
 	auto auxgids = make_intrusive<VectorVal>(zeek::id::index_vec);
 
 	for (size_t i = 0; i < c->AuxGIDs().size(); ++i)

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -311,7 +311,7 @@ zeek::Args NFS_Interp::event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_
 	// These are the first parameters for each nfs_* event ...
 	zeek::Args vl;
 	vl.reserve(2 + extra_elements);
-	vl.emplace_back(analyzer->ConnVal());
+	vl.emplace_back(analyzer->UpdatedConnVal());
 	auto auxgids = make_intrusive<VectorVal>(zeek::id::index_vec);
 
 	for ( size_t i = 0; i < c->AuxGIDs().size(); ++i )

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -251,7 +251,7 @@ uint32_t PortmapperInterp::CheckPort(uint32_t port)
 		if ( pm_bad_port )
 			{
 			analyzer->EnqueueConnEvent(pm_bad_port,
-				analyzer->ConnVal(),
+				analyzer->UpdatedConnVal(),
 				val_mgr->Count(port)
 			);
 			}
@@ -269,7 +269,7 @@ void PortmapperInterp::Event(EventHandlerPtr f, IntrusivePtr<Val> request, BifEn
 
 	zeek::Args vl;
 
-	vl.emplace_back(analyzer->ConnVal());
+	vl.emplace_back(analyzer->UpdatedConnVal());
 
 	if ( status == BifEnum::RPC_SUCCESS )
 		{

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -337,7 +337,7 @@ void RPC_Interpreter::Event_RPC_Dialogue(RPC_CallInfo* c, BifEnum::rpc_status st
 	{
 	if ( rpc_dialogue )
 		analyzer->EnqueueConnEvent(rpc_dialogue,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Count(c->Program()),
 			val_mgr->Count(c->Version()),
 			val_mgr->Count(c->Proc()),
@@ -352,7 +352,7 @@ void RPC_Interpreter::Event_RPC_Call(RPC_CallInfo* c)
 	{
 	if ( rpc_call )
 		analyzer->EnqueueConnEvent(rpc_call,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Count(c->XID()),
 			val_mgr->Count(c->Program()),
 			val_mgr->Count(c->Version()),
@@ -365,7 +365,7 @@ void RPC_Interpreter::Event_RPC_Reply(uint32_t xid, BifEnum::rpc_status status, 
 	{
 	if ( rpc_reply )
 		analyzer->EnqueueConnEvent(rpc_reply,
-			analyzer->ConnVal(),
+			analyzer->UpdatedConnVal(),
 			val_mgr->Count(xid),
 			zeek::BifType::Enum::rpc_status->GetVal(status),
 			val_mgr->Count(reply_len)

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -220,7 +220,7 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 			if ( smtp_data && ! skip_data )
 				{
 				EnqueueConnEvent(smtp_data,
-					ConnVal(),
+					UpdatedConnVal(),
 					val_mgr->Bool(orig),
 					make_intrusive<StringVal>(data_len, line)
 				);
@@ -350,7 +350,7 @@ void SMTP_Analyzer::ProcessLine(int length, const char* line, bool orig)
 				}
 
 				EnqueueConnEvent(smtp_reply,
-					ConnVal(),
+					UpdatedConnVal(),
 					val_mgr->Bool(orig),
 					val_mgr->Count(reply_code),
 					make_intrusive<StringVal>(cmd),
@@ -410,7 +410,7 @@ void SMTP_Analyzer::StartTLS()
 		AddChildAnalyzer(ssl);
 
 	if ( smtp_starttls )
-		EnqueueConnEvent(smtp_starttls, ConnVal());
+		EnqueueConnEvent(smtp_starttls, UpdatedConnVal());
 	}
 
 
@@ -859,7 +859,7 @@ void SMTP_Analyzer::RequestEvent(int cmd_len, const char* cmd,
 		cmd_arg->ToUpper();
 
 		EnqueueConnEvent(smtp_request,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(orig_is_sender),
 			std::move(cmd_arg),
 			make_intrusive<StringVal>(arg_len, arg)
@@ -880,7 +880,7 @@ void SMTP_Analyzer::Unexpected(bool is_sender, const char* msg,
 			is_orig = ! is_orig;
 
 		EnqueueConnEvent(smtp_unexpected,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(is_orig),
 			make_intrusive<StringVal>(msg),
 			make_intrusive<StringVal>(detail_len, detail)

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -146,7 +146,7 @@ void SteppingStoneEndpoint::CreateEndpEvent(bool is_orig)
 		return;
 
 	endp->TCP()->EnqueueConnEvent(stp_create_endp,
-		endp->TCP()->ConnVal(),
+		endp->TCP()->UpdatedConnVal(),
 		val_mgr->Int(stp_id),
 		val_mgr->Bool(is_orig)
 	);

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -787,7 +787,7 @@ void TCP_Analyzer::GeneratePacketEvent(
 					bool is_orig, TCP_Flags flags)
 	{
 	EnqueueConnEvent(tcp_packet,
-		ConnVal(),
+		UpdatedConnVal(),
 		val_mgr->Bool(is_orig),
 		make_intrusive<StringVal>(flags.AsString()),
 		val_mgr->Count(rel_seq),
@@ -1103,7 +1103,7 @@ void TCP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 
 		if ( connection_SYN_packet )
 			EnqueueConnEvent(connection_SYN_packet,
-				ConnVal(),
+				UpdatedConnVal(),
 				IntrusivePtr{NewRef{}, SYN_vals}
 			);
 
@@ -1347,7 +1347,7 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 			auto kind = o[0];
 			auto length = kind < 2 ? 1 : o[1];
 			EnqueueConnEvent(tcp_option,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(is_orig),
 				val_mgr->Count(kind),
 				val_mgr->Count(length)
@@ -1460,7 +1460,7 @@ int TCP_Analyzer::ParseTCPOptions(const struct tcphdr* tcp, bool is_orig)
 			}
 
 		EnqueueConnEvent(tcp_options,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(is_orig),
 			std::move(option_list)
 			);
@@ -1782,7 +1782,7 @@ void TCP_Analyzer::EndpointEOF(TCP_Reassembler* endp)
 	{
 	if ( connection_EOF )
 		EnqueueConnEvent(connection_EOF,
-			ConnVal(),
+			UpdatedConnVal(),
 			val_mgr->Bool(endp->IsOrig())
 		);
 
@@ -2062,7 +2062,7 @@ bool TCPStats_Endpoint::DataSent(double /* t */, uint64_t seq, int len, int capl
 
 		if ( tcp_rexmit )
 			endp->TCP()->EnqueueConnEvent(tcp_rexmit,
-				endp->TCP()->ConnVal(),
+				endp->TCP()->UpdatedConnVal(),
 				val_mgr->Bool(endp->IsOrig()),
 				val_mgr->Count(seq),
 				val_mgr->Count(len),
@@ -2118,7 +2118,7 @@ void TCPStats_Analyzer::Done()
 
 	if ( conn_stats )
 		EnqueueConnEvent(conn_stats,
-			ConnVal(),
+			UpdatedConnVal(),
 			IntrusivePtr{AdoptRef{}, orig_stats->BuildStats()},
 			IntrusivePtr{AdoptRef{}, resp_stats->BuildStats()}
 		);

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.cc
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.cc
@@ -238,7 +238,7 @@ bool TCP_Endpoint::DataSent(double t, uint64_t seq, int len, int caplen,
 
 			if ( contents_file_write_failure )
 				tcp_analyzer->EnqueueConnEvent(contents_file_write_failure,
-					Conn()->ConnVal(),
+					Conn()->UpdatedConnVal(),
 					val_mgr->Bool(IsOrig()),
 					make_intrusive<StringVal>(buf)
 				);

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -147,7 +147,7 @@ void TCP_Reassembler::Gap(uint64_t seq, uint64_t len)
 
 	if ( report_gap(endp, endp->peer) )
 		dst_analyzer->EnqueueConnEvent(content_gap,
-			dst_analyzer->ConnVal(),
+			dst_analyzer->UpdatedConnVal(),
 			val_mgr->Bool(IsOrig()),
 			val_mgr->Count(seq),
 			val_mgr->Count(len)
@@ -357,7 +357,7 @@ void TCP_Reassembler::RecordBlock(const DataBlock& b, const IntrusivePtr<BroFile
 
 	if ( contents_file_write_failure )
 		tcp_analyzer->EnqueueConnEvent(contents_file_write_failure,
-			Endpoint()->Conn()->ConnVal(),
+			Endpoint()->Conn()->UpdatedConnVal(),
 			val_mgr->Bool(IsOrig()),
 			make_intrusive<StringVal>("TCP reassembler content write failure")
 		);
@@ -372,7 +372,7 @@ void TCP_Reassembler::RecordGap(uint64_t start_seq, uint64_t upper_seq, const In
 
 	if ( contents_file_write_failure )
 		tcp_analyzer->EnqueueConnEvent(contents_file_write_failure,
-			Endpoint()->Conn()->ConnVal(),
+			Endpoint()->Conn()->UpdatedConnVal(),
 			val_mgr->Bool(IsOrig()),
 			make_intrusive<StringVal>("TCP reassembler gap write failure")
 		);
@@ -452,7 +452,7 @@ void TCP_Reassembler::Overlap(const u_char* b1, const u_char* b2, uint64_t n)
 		BroString* b2_s = new BroString((const u_char*) b2, n, false);
 
 		tcp_analyzer->EnqueueConnEvent(rexmit_inconsistency,
-			tcp_analyzer->ConnVal(),
+			tcp_analyzer->UpdatedConnVal(),
 			make_intrusive<StringVal>(b1_s),
 			make_intrusive<StringVal>(b2_s),
 			make_intrusive<StringVal>(flags.AsString())
@@ -608,7 +608,7 @@ void TCP_Reassembler::DeliverBlock(uint64_t seq, int len, const u_char* data)
 
 	if ( deliver_tcp_contents )
 		tcp_analyzer->EnqueueConnEvent(tcp_contents,
-			tcp_analyzer->ConnVal(),
+			tcp_analyzer->UpdatedConnVal(),
 			val_mgr->Bool(IsOrig()),
 			val_mgr->Count(seq),
 			make_intrusive<StringVal>(len, (const char*) data)

--- a/src/analyzer/protocol/teredo/Teredo.cc
+++ b/src/analyzer/protocol/teredo/Teredo.cc
@@ -199,7 +199,7 @@ void Teredo_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 	if ( teredo_packet )
 		{
 		teredo_hdr = te.BuildVal(inner);
-		Conn()->EnqueueEvent(teredo_packet, nullptr, ConnVal(), teredo_hdr);
+		Conn()->EnqueueEvent(teredo_packet, nullptr, UpdatedConnVal(), teredo_hdr);
 		}
 
 	if ( te.Authentication() && teredo_authentication )
@@ -207,7 +207,7 @@ void Teredo_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 		if ( ! teredo_hdr )
 			teredo_hdr = te.BuildVal(inner);
 
-		Conn()->EnqueueEvent(teredo_authentication, nullptr, ConnVal(), teredo_hdr);
+		Conn()->EnqueueEvent(teredo_authentication, nullptr, UpdatedConnVal(), teredo_hdr);
 		}
 
 	if ( te.OriginIndication() && teredo_origin_indication )
@@ -215,7 +215,7 @@ void Teredo_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 		if ( ! teredo_hdr )
 			teredo_hdr = te.BuildVal(inner);
 
-		Conn()->EnqueueEvent(teredo_origin_indication, nullptr, ConnVal(), teredo_hdr);
+		Conn()->EnqueueEvent(teredo_origin_indication, nullptr, UpdatedConnVal(), teredo_hdr);
 		}
 
 	if ( inner->NextProto() == IPPROTO_NONE && teredo_bubble )
@@ -223,7 +223,7 @@ void Teredo_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 		if ( ! teredo_hdr )
 			teredo_hdr = te.BuildVal(inner);
 
-		Conn()->EnqueueEvent(teredo_bubble, nullptr, ConnVal(), teredo_hdr);
+		Conn()->EnqueueEvent(teredo_bubble, nullptr, UpdatedConnVal(), teredo_hdr);
 		}
 
 	EncapsulatingConn ec(Conn(), BifEnum::Tunnel::TEREDO);

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -168,7 +168,7 @@ void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 
 		if ( do_udp_contents )
 			EnqueueConnEvent(udp_contents,
-				ConnVal(),
+				UpdatedConnVal(),
 				val_mgr->Bool(is_orig),
 				make_intrusive<StringVal>(len, (const char*) data)
 			);

--- a/src/analyzer/protocol/vxlan/VXLAN.cc
+++ b/src/analyzer/protocol/vxlan/VXLAN.cc
@@ -101,7 +101,7 @@ void VXLAN_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 	ProtocolConfirmation();
 
 	if ( vxlan_packet )
-		Conn()->EnqueueEvent(vxlan_packet, nullptr, ConnVal(),
+		Conn()->EnqueueEvent(vxlan_packet, nullptr, UpdatedConnVal(),
 		                     inner->ToPktHdrVal(), val_mgr->Count(vni));
 
 	EncapsulatingConn ec(Conn(), BifEnum::Tunnel::VXLAN);

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -142,7 +142,7 @@ bool File::UpdateConnectionFields(Connection* conn, bool is_orig)
 	if ( conns->AsTableVal()->FindOrDefault(idx) )
 		return false;
 
-	conns->AsTableVal()->Assign(std::move(idx), conn->ConnVal());
+	conns->AsTableVal()->Assign(std::move(idx), conn->UpdatedConnVal());
 	return true;
 	}
 
@@ -152,7 +152,7 @@ void File::RaiseFileOverNewConnection(Connection* conn, bool is_orig)
 		{
 		FileEvent(file_over_new_connection, {
 			val,
-			conn->ConnVal(),
+			conn->UpdatedConnVal(),
 			val_mgr->Bool(is_orig),
 		});
 		}

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -435,7 +435,7 @@ string Manager::GetFileID(const analyzer::Tag& tag, Connection* c, bool is_orig)
 
 	const auto& tagval = tag.AsVal();
 
-	mgr.Enqueue(get_file_handle, tagval, c->ConnVal(), val_mgr->Bool(is_orig));
+	mgr.Enqueue(get_file_handle, tagval, c->UpdatedConnVal(), val_mgr->Bool(is_orig));
 	mgr.Drain(); // need file handle immediately so we don't have to buffer data
 	return current_file_id;
 	}

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -3295,7 +3295,7 @@ function lookup_connection%(cid: conn_id%): connection
 	%{
 	Connection* conn = sessions->FindConnection(cid);
 	if ( conn )
-		return conn->ConnVal();
+		return conn->UpdatedConnVal();
 
 	builtin_error("connection ID not a known connection", cid);
 

--- a/testing/btest/Baseline/core.connection-record-lifetime/out
+++ b/testing/btest/Baseline/core.connection-record-lifetime/out
@@ -1,0 +1,1 @@
+conn_weird, test!, test2, [orig_h=192.168.1.200, orig_p=49206/tcp, resp_h=192.168.1.150, resp_p=3389/tcp]

--- a/testing/btest/core/connection-record-lifetime.zeek
+++ b/testing/btest/core/connection-record-lifetime.zeek
@@ -1,0 +1,17 @@
+# @TEST-EXEC: zeek -b -r $TRACES/rdp/rdp-to-ssl.pcap %INPUT >out
+# @TEST-EXEC: btest-diff out
+
+event my_event(c: connection)
+	{
+	Reporter::conn_weird("test!", c, "test2");
+	}
+
+event connection_state_remove(c: connection)
+	{
+	schedule 1sec { my_event(c) };
+	}
+
+event conn_weird(name: string, c: connection, addl: string)
+	{
+	print "conn_weird", name, addl, c$id;
+	}


### PR DESCRIPTION
Fixes #998 

Branch is also in `bifcl` repo

It's still a bit weird how there's a distinct method (now `UpdatedConnVal()`) to populate the record fields when one might see `Connection` is already `RecordVal`, but the pitfalls are still the same as before and the hesitation to change fields to auto-repopulate whenever the underlying/associated data changes could be the performance concern of allocating new fields per packet if they're never used at that frequency.