### PR TITLE
Remove last_access_time from TableEntryVal.

### DIFF
--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1307,7 +1307,6 @@ unsigned int ListVal::MemoryAllocation() const
 TableEntryVal* TableEntryVal::Clone(Val::CloneState* state)
 	{
 	auto rval = new TableEntryVal(val ? val->Clone(state) : nullptr);
-	rval->last_access_time = last_access_time;
 	rval->expire_access_time = expire_access_time;
 	return rval;
 	}

--- a/src/Val.h
+++ b/src/Val.h
@@ -722,7 +722,6 @@ public:
 	explicit TableEntryVal(IntrusivePtr<Val> v)
 		: val(std::move(v))
 		{
-		last_access_time = network_time;
 		expire_access_time =
 			int(network_time - bro_start_network_time);
 		}
@@ -745,8 +744,6 @@ protected:
 	friend class TableVal;
 
 	IntrusivePtr<Val> val;
-	double last_access_time;
-
 	// The next entry stores seconds since Bro's start.  We use ints here
 	// to save a few bytes, as we do not need a high resolution for these
 	// anyway.


### PR DESCRIPTION
Turns out - this was no longer used. And it takes up at least 8 bytes of space for every single table/set entry.