### PR TITLE
Fix several issues with command-line option redefs

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -984,34 +984,54 @@ int yywrap()
 
 		for ( unsigned int i = 0; i < params.size(); ++i )
 			{
-			char* param = copy_string(params[i].c_str());
-			char* eq = strchr(param, '=');
-			char* val = eq + 1;
+			std::string pi = params[i];
+			auto first_non_id_char = 0;
 
-			*eq = '\0';
-
-			if ( strlen(val) == 0 )
+			for ( size_t j = 0; j < pi.size(); ++j )
 				{
-				delete [] param;
+				if ( ! isalnum(pi[j]) && pi[j] != '_' && pi[j] != ':' )
+					break;
+
+				++first_non_id_char;
+				}
+
+			auto eq_idx = pi.find('=', first_non_id_char);
+			// Omit the '=' from op just to make fmt string below clearer.
+			auto op = pi.substr(first_non_id_char, eq_idx - first_non_id_char);
+			auto id_str = pi.substr(0, first_non_id_char);
+			auto val_str = pi.substr(eq_idx + 1);
+			const auto& id = zeek::id::find(id_str);
+
+			if ( ! id )
+				{
+				reporter->Error("unknown identifier '%s' in command-line options",
+				                id_str.data());
 				continue;
 				}
 
-			// Try to find the type of the param, and interpret
-			// the value intelligently for that type.  (So far,
-			// that just means quoting the value if it's a
-			// string type.)  If no type is found, the value
-			// is left unchanged.
-			std::string opt_quote;	// no optional quote by default
-			const auto& param_id = lookup_ID(param, GLOBAL_MODULE_NAME);
-			Val* v = param_id ? param_id->GetVal().get() : nullptr;
+			// Interpret the value based on the identifier's type.
+			// So far, that just means quoting the value for strings types.
+			const auto& type = id->GetType();
 
-			if ( v && v->GetType() && v->GetType()->Tag() == zeek::TYPE_STRING )
-				opt_quote = "\"";	// use quotes
+			if ( ! type )
+				{
+				reporter->Error("can't set value of '%s' in command-line "
+				                "options: unknown type", id_str.data());
+				continue;
+				}
 
-			policy += std::string("redef ") + param + "="
-					+ opt_quote + val + opt_quote + ";";
+			if ( val_str.empty() && ! zeek::IsString(type->Tag()) )
+				{
+				reporter->Error("must assign non-empty value to '%s' in "
+				                "command-line options", id_str.data());
+				continue;
+				}
 
-			delete [] param;
+			auto use_quotes = zeek::IsString(type->Tag());
+			auto fmt_str = use_quotes ? "redef %s %s= \"%s\";"
+			                          : "redef %s %s= %s;";
+
+			policy += fmt(fmt_str, id_str.data(), op.data(), val_str.data());
 			}
 
 		params.clear();

--- a/src/scan.l
+++ b/src/scan.l
@@ -978,23 +978,17 @@ int yywrap()
 		return 0;
 
 	// Add redef statements for any X=Y command line parameters.
-	if ( params.size() > 0 )
+	if ( ! params.empty() )
 		{
 		std::string policy;
 
-		for ( unsigned int i = 0; i < params.size(); ++i )
+		for ( const auto& pi : params )
 			{
-			std::string pi = params[i];
-			auto first_non_id_char = 0;
+			auto p = pi.data();
 
-			for ( size_t j = 0; j < pi.size(); ++j )
-				{
-				if ( ! isalnum(pi[j]) && pi[j] != '_' && pi[j] != ':' )
-					break;
+			while ( isalnum(*p) || *p == '_' || *p == ':' ) ++p;
 
-				++first_non_id_char;
-				}
-
+			auto first_non_id_char = p - pi.data();
 			auto eq_idx = pi.find('=', first_non_id_char);
 			// Omit the '=' from op just to make fmt string below clearer.
 			auto op = pi.substr(first_non_id_char, eq_idx - first_non_id_char);
@@ -1010,7 +1004,7 @@ int yywrap()
 				}
 
 			// Interpret the value based on the identifier's type.
-			// So far, that just means quoting the value for strings types.
+			// So far, that just means quoting the value for string types.
 			const auto& type = id->GetType();
 
 			if ( ! type )

--- a/testing/btest/Baseline/core.command-line-option-redefs/1.out
+++ b/testing/btest/Baseline/core.command-line-option-redefs/1.out
@@ -1,0 +1,4 @@
+mystr, 
+mynum, 0
+mytable, {"one":"1"}
+MyMod::str, Good

--- a/testing/btest/Baseline/core.command-line-option-redefs/2.out
+++ b/testing/btest/Baseline/core.command-line-option-redefs/2.out
@@ -1,0 +1,4 @@
+mystr, default
+mynum, 0
+mytable, {"zero":"0","one":"1"}
+MyMod::str, def

--- a/testing/btest/Baseline/core.command-line-option-redefs/3.out
+++ b/testing/btest/Baseline/core.command-line-option-redefs/3.out
@@ -1,0 +1,1 @@
+error: unknown identifier 'no_such_var' in command-line options

--- a/testing/btest/Baseline/core.command-line-option-redefs/4.out
+++ b/testing/btest/Baseline/core.command-line-option-redefs/4.out
@@ -1,0 +1,2 @@
+error: must assign non-empty value to 'mynum' in command-line options
+error: must assign non-empty value to 'mytable' in command-line options

--- a/testing/btest/core/command-line-option-redefs.zeek
+++ b/testing/btest/core/command-line-option-redefs.zeek
@@ -1,0 +1,27 @@
+# @TEST-EXEC: zeek -b %INPUT mynum=0 mytable='{["one"] = "1"}' mystr="" MyMod::str="Good" >1.out
+# @TEST-EXEC: zeek -b %INPUT mynum=0 mytable+='{["one"] = "1"}' >2.out
+
+# @TEST-EXEC-FAIL: zeek -b %INPUT no_such_var=13 >3.out 2>&1
+# @TEST-EXEC-FAIL: zeek -b %INPUT mynum="" mytable="" >4.out 2>&1
+
+# @TEST-EXEC: btest-diff 1.out
+# @TEST-EXEC: btest-diff 2.out
+# @TEST-EXEC: btest-diff 3.out
+# @TEST-EXEC: btest-diff 4.out
+
+const mynum: count &redef;
+const mytable: table[string] of string = {["zero"] = "0"} &redef;
+option mystr="default";
+
+module MyMod;
+export { option str="def"; }
+module GLOBAL;
+
+event zeek_init()
+	{
+	print "mystr", mystr;
+	print "mynum", mynum;
+	print "mytable", to_json(mytable);
+	print "MyMod::str", MyMod::str;
+	}
+


### PR DESCRIPTION
* Variables of `string` type can now be set to an empty string

* Trying to set a variable with non-`string` type to an empty value
  now emits an error instead of silently doing nothing

* Providing an invalid identifier now emits an "unknown identifier"
  error instead of silently doing nothing