### PR TITLE
Fix "possibly-truncated" compiler warning in BuildJSON snprintf()

### DIFF
--- a/src/threading/formatters/JSON.cc
+++ b/src/threading/formatters/JSON.cc
@@ -132,7 +132,7 @@ void JSON::BuildJSON(NullDoubleWriter& writer, Value* val, const std::string& na
 			if ( timestamps == TS_ISO8601 )
 				{
 				char buffer[40];
-				char buffer2[40];
+				char buffer2[48];
 				time_t the_time = time_t(floor(val->val.double_val));
 				struct tm t;
 


### PR DESCRIPTION
```
../src/threading/formatters/JSON.cc:155:45: warning: ‘%06.0f’ directive output may be truncated writing between 6 and 310 bytes into a region of size between 0 and 39 [-Wformat-truncation=]
  155 |      snprintf(buffer2, sizeof(buffer2), "%s.%06.0fZ", buffer, fabs(frac) * 1000000);
      |                                             ^~~~~~
```