### PR TITLE
change system() command to rename to avoid PID leaks

### DIFF
--- a/scripts/base/frameworks/logging/writers/ascii.zeek
+++ b/scripts/base/frameworks/logging/writers/ascii.zeek
@@ -103,7 +103,7 @@ function default_rotation_postprocessor_func(info: Log::RotationInfo) : bool
 	local dst = fmt("%s.%s.%s%s", info$path,
 			strftime(Log::default_rotation_date_format, info$open), bls, gz);
 
-	system(fmt("/bin/mv %s %s", info$fname, dst));
+	rename(info$fname, dst);
 
 	# Run default postprocessor.
 	return Log::run_rotation_postprocessor_cmd(info, dst);


### PR DESCRIPTION
What is happening:

When running zeek in a docker container with the default ascii logger, the default ascii logger executes a `system()` to rotate files.  As a result the child process of `mv` is never reaped, resulting in PID leaks.

I rotate files pretty quickly and over a long time it actually exhausts the pids.

I am running inside docker and directly invoking zeek via: `zeek -W -C -i p1p1 /main.zeek`

my main.zeek file is as follows:
```
redef Log::default_rotation_interval = 600 secs;
```

This is a pretty minor stop gap that will fix a very basic leak on the default case.  There is a greater issue that `system` does not reap children and the `waitpid` system call is not exposed.  I will create an issue to expose the `waidpid` system call so that scripts can actually reap child processes.