### PR TITLE
Fix shadowed variable that breaks lookup_hostname()

### DIFF
--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -283,7 +283,7 @@ IntrusivePtr<ListVal> DNS_Mapping::Addrs()
 
 	if ( ! addrs_val )
 		{
-		auto addrs_val = make_intrusive<ListVal>(zeek::TYPE_ADDR);
+		addrs_val = make_intrusive<ListVal>(zeek::TYPE_ADDR);
 
 		for ( int i = 0; i < num_addrs; ++i )
 			addrs_val->Append(make_intrusive<AddrVal>(addrs[i]));


### PR DESCRIPTION
A bug introduced in b62727a7facea200776627dcb7a099c62d8d3b3c

Manually, the test case is just:

```zeek
redef exit_only_after_terminate=T;

event zeek_init()
	{
	when ( local r = lookup_hostname("zeek.org") )
		{ print "result", r; }
	}
```