### PR TITLE
change print.log to log network time instead of current

### DIFF
--- a/scripts/base/frameworks/logging/main.zeek
+++ b/scripts/base/frameworks/logging/main.zeek
@@ -80,7 +80,7 @@ export {
 	## If :zeek:see:`Log::print_to_log` is set to redirect, ``print`` statements will
 	## automatically populate log entries with the fields contained in this record.
 	type PrintLogInfo: record {
-		## Current timestamp.
+		## The network time at which the print statement was executed.
 		ts:                  time              &log;
 		## Set of strings passed to the print statement.
 		vals:                string_vec        &log;

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -215,7 +215,7 @@ static void print_log(const std::vector<IntrusivePtr<Val>>& vals)
 		vec->Assign(vec->Size(), make_intrusive<StringVal>(d.Description()));
 		}
 
-	record->Assign(0, make_intrusive<TimeVal>(current_time()));
+	record->Assign(0, make_intrusive<TimeVal>(network_time));
 	record->Assign(1, std::move(vec));
 	log_mgr->Write(plval.get(), record.get());
 	}


### PR DESCRIPTION
Fixes #1036 
Need to generate docs upon merge

The logged field was previously documented as explicitly being current time, but just to check if there's differing opinion on changing: don't see (not remembering) how it would have been intended to be inconsistent with other logs and also don't think there would be much legit complaint from it being changed (i.e. it exists as part of debugging facilities, not meaningful content stream for production).