### PR TITLE
GH-1034: Add deprecated version of IndexType::IndexTypes()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -105,9 +105,6 @@ Changed Functionality
 
 - ``AsVector()`` has changed to return ``std::vector<IntrusivePtr<Val>>*``.
 
-- ``Attributes::Attrs()`` now returns ``const std::vector<IntrusivePtr<Attr>>&``
-  instead of ``attr_list*``
-
 - Moved a large number of classes from the global namespace into either the
   ``zeek`` or ``zeek::detail`` namespace. See https://github.com/zeek/zeek/issues/266
   for the rationale behind these changes. Most types that were moved and functions

--- a/NEWS
+++ b/NEWS
@@ -100,9 +100,6 @@ Changed Functionality
 - The DCE/RPC operation string of "NetrLogonSamLogonWithFlags" has been
   corrected from "NetrLogonSameLogonWithFlags".
 
-- ``TypeList::Types()`` and ``IndexType::IndexTypes()`` now return an
-  ``std::vector`` instead of ``type_list*``
-
 - ``AsRecord()`` and ``AsNonConstRecord()`` have changed to return
   ``std::vector<IntrusivePtr<Val>>*``.
 

--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -394,7 +394,7 @@ void Attributes::CheckAttr(Attr* a)
 				if ( atype->Tag() == TYPE_FUNC )
 					{
 					FuncType* f = atype->AsFuncType();
-					if ( ! f->CheckArgs(tt->IndexTypes()) ||
+					if ( ! f->CheckArgs(tt->GetIndexTypes()) ||
 					     ! same_type(f->Yield(), ytype) )
 						Error("&default function type clash");
 
@@ -517,7 +517,7 @@ void Attributes::CheckAttr(Attr* a)
 		if (the_table->IsUnspecifiedTable())
 			break;
 
-		const auto& func_index_types = e_ft->ParamList()->Types();
+		const auto& func_index_types = e_ft->ParamList()->GetTypes();
 		// Keep backwards compatibility with idx: any idiom.
 		if ( func_index_types.size() == 2 )
 			{
@@ -525,7 +525,7 @@ void Attributes::CheckAttr(Attr* a)
 				break;
 			}
 
-		const auto& table_index_types = the_table->IndexTypes();
+		const auto& table_index_types = the_table->GetIndexTypes();
 
 		type_list expected_args(1 + static_cast<int>(table_index_types.size()));
 		expected_args.push_back(type->AsTableType());
@@ -564,8 +564,8 @@ void Attributes::CheckAttr(Attr* a)
 		if ( the_table->IsUnspecifiedTable() )
 			break;
 
-		const auto& args = c_ft->ParamList()->Types();
-		const auto& t_indexes = the_table->IndexTypes();
+		const auto& args = c_ft->ParamList()->GetTypes();
+		const auto& t_indexes = the_table->GetIndexTypes();
 		if ( args.size() != ( type->IsSet() ? 2 : 3 ) + t_indexes.size() )
 			{
 			Error("&on_change function has incorrect number of arguments");

--- a/src/Attr.h
+++ b/src/Attr.h
@@ -76,7 +76,7 @@ public:
 	explicit Attr(::attr_tag t);
 #pragma GCC diagnostic pop
 
-	~Attr() override;
+	~Attr() override = default;
 
 	attr_tag Tag() const	{ return tag; }
 
@@ -122,6 +122,8 @@ public:
 	           bool in_record, bool is_global);
 	Attributes(IntrusivePtr<Type> t, bool in_record, bool is_global);
 
+	~Attributes() override;
+
 	void AddAttr(IntrusivePtr<Attr> a);
 
 	void AddAttrs(const IntrusivePtr<Attributes>& a);
@@ -147,7 +149,11 @@ public:
 	void Describe(ODesc* d) const override;
 	void DescribeReST(ODesc* d, bool shorten = false) const;
 
-	const std::vector<IntrusivePtr<Attr>>& Attrs() const
+	[[deprecated("Remove in v4.1. Use GetAttrs().")]]
+		const attr_list* Attrs() const
+		{ return &attrs_list; }
+
+	const std::vector<IntrusivePtr<Attr>>& GetAttrs() const
 		{ return attrs; }
 
 	bool operator==(const Attributes& other) const;
@@ -157,6 +163,9 @@ protected:
 
 	IntrusivePtr<Type> type;
 	std::vector<IntrusivePtr<Attr>> attrs;
+
+	// Remove in v4.1. This is used by Attrs(), which is deprecated.
+	attr_list attrs_list;
 	bool in_record;
 	bool global_var;
 };

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -23,9 +23,9 @@ CompositeHash::CompositeHash(IntrusivePtr<zeek::TypeList> composite_type)
 	// If the only element is a record, don't treat it as a
 	// singleton, since it needs to be evaluated specially.
 
-	if ( type->Types().size() == 1 )
+	if ( type->GetTypes().size() == 1 )
 		{
-		if ( type->Types()[0]->Tag() == zeek::TYPE_RECORD )
+		if ( type->GetTypes()[0]->Tag() == zeek::TYPE_RECORD )
 			{
 			is_complex_type = true;
 			is_singleton = false;
@@ -47,7 +47,7 @@ CompositeHash::CompositeHash(IntrusivePtr<zeek::TypeList> composite_type)
 		{
 		// Don't do any further key computations - we'll do them
 		// via the singleton later.
-		singleton_tag = type->Types()[0]->InternalType();
+		singleton_tag = type->GetTypes()[0]->InternalType();
 		size = 0;
 		key = nullptr;
 		}
@@ -367,7 +367,7 @@ std::unique_ptr<HashKey> CompositeHash::MakeHashKey(const Val& argv, bool type_c
 		type_check = false;	// no need to type-check again.
 		}
 
-	const auto& tl = type->Types();
+	const auto& tl = type->GetTypes();
 
 	if ( type_check && v->GetType()->Tag() != zeek::TYPE_LIST )
 		return nullptr;
@@ -625,7 +625,7 @@ int CompositeHash::SingleTypeKeySize(zeek::Type* bt, const Val* v,
 
 int CompositeHash::ComputeKeySize(const Val* v, bool type_check, bool calc_static_size) const
 	{
-	const auto& tl = type->Types();
+	const auto& tl = type->GetTypes();
 
 	if ( v )
 		{
@@ -712,7 +712,7 @@ int CompositeHash::SizeAlign(int offset, unsigned int size) const
 IntrusivePtr<ListVal> CompositeHash::RecoverVals(const HashKey& k) const
 	{
 	auto l = make_intrusive<ListVal>(zeek::TYPE_ANY);
-	const auto& tl = type->Types();
+	const auto& tl = type->GetTypes();
 	const char* kp = (const char*) k.Key();
 	const char* const k_end = kp + k.Size();
 
@@ -1011,7 +1011,7 @@ const char* CompositeHash::RecoverOneVal(const HashKey& k, const char* kp0,
 			for ( int i = 0; i < n; ++i )
 				{
 				IntrusivePtr<Val> v;
-				zeek::Type* it = tl->Types()[i].get();
+				zeek::Type* it = tl->GetTypes()[i].get();
 				kp1 = RecoverOneVal(k, kp1, k_end, it, &v, false);
 				lv->Append(std::move(v));
 				}

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -2076,7 +2076,7 @@ bool AssignExpr::TypeCheck(const IntrusivePtr<Attributes>& attrs)
 		std::unique_ptr<std::vector<IntrusivePtr<Attr>>> attr_copy;
 
 		if ( attrs )
-			attr_copy = std::make_unique<std::vector<IntrusivePtr<Attr>>>(attrs->Attrs());
+			attr_copy = std::make_unique<std::vector<IntrusivePtr<Attr>>>(attrs->GetAttrs());
 
 		bool empty_list_assignment = (op2->AsListExpr()->Exprs().empty());
 
@@ -2172,7 +2172,7 @@ bool AssignExpr::TypeCheck(const IntrusivePtr<Attributes>& attrs)
 
 				if ( sce->GetAttrs() )
 					{
-					const auto& a = sce->GetAttrs()->Attrs();
+					const auto& a = sce->GetAttrs()->GetAttrs();
 					attr_copy = std::make_unique<std::vector<IntrusivePtr<Attr>>>(a);
 					}
 

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -3086,7 +3086,7 @@ TableConstructorExpr::TableConstructorExpr(IntrusivePtr<ListExpr> constructor_li
 	if ( arg_attrs )
 		attrs = make_intrusive<Attributes>(std::move(*arg_attrs), type, false, false);
 
-	const auto& indices = type->AsTableType()->GetIndices()->Types();
+	const auto& indices = type->AsTableType()->GetIndices()->GetTypes();
 	const expr_list& cle = op->AsListExpr()->Exprs();
 
 	// check and promote all index expressions in ctor list
@@ -3204,7 +3204,7 @@ SetConstructorExpr::SetConstructorExpr(IntrusivePtr<ListExpr> constructor_list,
 	if ( arg_attrs )
 		attrs = make_intrusive<Attributes>(std::move(*arg_attrs), type, false, false);
 
-	const auto& indices = type->AsTableType()->GetIndices()->Types();
+	const auto& indices = type->AsTableType()->GetIndices()->GetTypes();
 	expr_list& cle = op->AsListExpr()->Exprs();
 
 	if ( indices.size() == 1 )
@@ -4471,7 +4471,7 @@ IntrusivePtr<Val> ListExpr::InitVal(const zeek::Type* t, IntrusivePtr<Val> aggr)
 	if ( ! aggr && type->AsTypeList()->AllMatch(t, true) )
 		{
 		auto v = make_intrusive<ListVal>(zeek::TYPE_ANY);
-		const auto& tl = type->AsTypeList()->Types();
+		const auto& tl = type->AsTypeList()->GetTypes();
 
 		if ( exprs.length() != static_cast<int>(tl.size()) )
 			{
@@ -4499,7 +4499,7 @@ IntrusivePtr<Val> ListExpr::InitVal(const zeek::Type* t, IntrusivePtr<Val> aggr)
 			return nullptr;
 			}
 
-		const auto& tl = t->AsTypeList()->Types();
+		const auto& tl = t->AsTypeList()->GetTypes();
 
 		if ( exprs.length() != static_cast<int>(tl.size()) )
 			{
@@ -4620,7 +4620,7 @@ IntrusivePtr<Val> ListExpr::AddSetInit(const zeek::Type* t, IntrusivePtr<Val> ag
 		else if ( expr->GetType()->Tag() == zeek::TYPE_LIST )
 			element = expr->InitVal(it, nullptr);
 		else
-			element = expr->InitVal(it->Types()[0].get(), nullptr);
+			element = expr->InitVal(it->GetTypes()[0].get(), nullptr);
 
 		if ( ! element )
 			return nullptr;
@@ -4642,7 +4642,7 @@ IntrusivePtr<Val> ListExpr::AddSetInit(const zeek::Type* t, IntrusivePtr<Val> ag
 		if ( expr->GetType()->Tag() == zeek::TYPE_LIST )
 			element = check_and_promote(std::move(element), it, true);
 		else
-			element = check_and_promote(std::move(element), it->Types()[0].get(), true);
+			element = check_and_promote(std::move(element), it->GetTypes()[0].get(), true);
 
 		if ( ! element )
 			return nullptr;
@@ -4930,7 +4930,7 @@ IntrusivePtr<Expr> check_and_promote_expr(Expr* const e, zeek::Type* t)
 bool check_and_promote_exprs(ListExpr* const elements, TypeList* types)
 	{
 	expr_list& el = elements->Exprs();
-	const auto& tl = types->Types();
+	const auto& tl = types->GetTypes();
 
 	if ( tl.size() == 1 && tl[0]->Tag() == zeek::TYPE_ANY )
 		return true;

--- a/src/RuleCondition.cc
+++ b/src/RuleCondition.cc
@@ -149,7 +149,7 @@ RuleConditionEval::RuleConditionEval(const char* func)
 		tl.Append(signature_state);
 		tl.Append(zeek::base_type(zeek::TYPE_STRING));
 
-		if ( ! f->CheckArgs(tl.Types()) )
+		if ( ! f->CheckArgs(tl.GetTypes()) )
 			rules_error("eval function parameters must be a 'signature_state' "
 			            "and a 'string' type", func);
 		}

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -1067,7 +1067,7 @@ ForStmt::ForStmt(id_list* arg_loop_vars, IntrusivePtr<Expr> loop_expr)
 
 	if ( e->GetType()->Tag() == TYPE_TABLE )
 		{
-		const auto& indices = e->GetType()->AsTableType()->IndexTypes();
+		const auto& indices = e->GetType()->AsTableType()->GetIndexTypes();
 
 		if ( static_cast<int>(indices.size()) != loop_vars->length() )
 			{

--- a/src/Type.h
+++ b/src/Type.h
@@ -416,7 +416,13 @@ public:
 		{
 		}
 
-	const std::vector<IntrusivePtr<Type>>& Types() const
+	~TypeList() override = default;
+
+	[[deprecated("Remove in v4.1. Use GetTypes() instead.")]]
+	const type_list* Types() const
+		{ return &types_list; }
+
+	const std::vector<IntrusivePtr<Type>>& GetTypes() const
 		{ return types; }
 
 	bool IsPure() const		{ return pure_type != nullptr; }
@@ -448,20 +454,28 @@ public:
 protected:
 	IntrusivePtr<Type> pure_type;
 	std::vector<IntrusivePtr<Type>> types;
+
+	// Remove in v4.1. This is used by Types(), which is deprecated.
+	type_list types_list;
 };
 
 class IndexType : public Type {
 public:
+
 	int MatchesIndex(zeek::detail::ListExpr* index) const override;
 
 	const IntrusivePtr<TypeList>& GetIndices() const
 		{ return indices; }
 
-	[[deprecated("Remove in v4.1.  Use GetIndices().")]]
+	[[deprecated("Remove in v4.1. Use GetIndices().")]]
 	TypeList* Indices() const		{ return indices.get(); }
 
-	const std::vector<IntrusivePtr<Type>>& IndexTypes() const
+	[[deprecated("Remove in v4.1. Use GetIndexTypes().")]]
+	const type_list* IndexTypes() const
 		{ return indices->Types(); }
+
+	const std::vector<IntrusivePtr<Type>>& GetIndexTypes() const
+		{ return indices->GetTypes(); }
 
 	const IntrusivePtr<Type>& Yield() const override
 		{ return yield_type; }
@@ -480,7 +494,7 @@ protected:
 		{
 		}
 
-	~IndexType() override;
+	~IndexType() override = default;
 
 	IntrusivePtr<TypeList> indices;
 	IntrusivePtr<Type> yield_type;

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -275,7 +275,7 @@ IntrusivePtr<Val> Val::SizeVal() const
 
 	case zeek::TYPE_INTERNAL_OTHER:
 		if ( type->Tag() == zeek::TYPE_FUNC )
-			return val_mgr->Count(val.func_val->GetType()->ParamList()->Types().size());
+			return val_mgr->Count(val.func_val->GetType()->ParamList()->GetTypes().size());
 
 		if ( type->Tag() == zeek::TYPE_FILE )
 			return make_intrusive<DoubleVal>(val.file_val->Size());
@@ -1357,7 +1357,7 @@ static void find_nested_record_types(const IntrusivePtr<zeek::Type>& t, std::set
 		return;
 	case zeek::TYPE_LIST:
 		{
-		for ( const auto& type : t->AsTypeList()->Types() )
+		for ( const auto& type : t->AsTypeList()->GetTypes() )
 			find_nested_record_types(type, found);
 		}
 		return;
@@ -1384,7 +1384,7 @@ TableVal::TableVal(IntrusivePtr<zeek::TableType> t, IntrusivePtr<zeek::detail::A
 	if ( ! is_parsing )
 		return;
 
-	for ( const auto& t : table_type->IndexTypes() )
+	for ( const auto& t : table_type->GetIndexTypes() )
 		{
 		std::set<zeek::RecordType*> found;
 		// TODO: this likely doesn't have to be repeated for each new TableVal,
@@ -1770,7 +1770,7 @@ bool TableVal::ExpandAndInit(IntrusivePtr<Val> index, IntrusivePtr<Val> new_val)
 	ListVal* iv = index->AsListVal();
 	if ( iv->BaseTag() != zeek::TYPE_ANY )
 		{
-		if ( table_type->GetIndices()->Types().size() != 1 )
+		if ( table_type->GetIndices()->GetTypes().size() != 1 )
 			reporter->InternalError("bad singleton list index");
 
 		for ( int i = 0; i < iv->Length(); ++i )
@@ -2179,7 +2179,7 @@ ListVal* TableVal::ConvertToList(zeek::TypeTag t) const
 
 IntrusivePtr<ListVal> TableVal::ToPureListVal() const
 	{
-	const auto& tl = table_type->GetIndices()->Types();
+	const auto& tl = table_type->GetIndices()->GetTypes();
 	if ( tl.size() != 1 )
 		{
 		InternalWarning("bad index type in TableVal::ToPureListVal");
@@ -2515,7 +2515,7 @@ double TableVal::CallExpireFunc(IntrusivePtr<ListVal> idx)
 		const Func* f = vf->AsFunc();
 		zeek::Args vl;
 
-		const auto& func_args = f->GetType()->ParamList()->Types();
+		const auto& func_args = f->GetType()->ParamList()->GetTypes();
 		// backwards compatibility with idx: any idiom
 		bool any_idiom = func_args.size() == 2 && func_args.back()->Tag() == zeek::TYPE_ANY;
 

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -208,7 +208,7 @@ struct val_converter {
 
 		for ( auto& item : a )
 			{
-			const auto& expected_index_types = tt->GetIndices()->Types();
+			const auto& expected_index_types = tt->GetIndices()->GetTypes();
 			broker::vector composite_key;
 			auto indices = caf::get_if<broker::vector>(&item);
 
@@ -267,7 +267,7 @@ struct val_converter {
 
 		for ( auto& item : a )
 			{
-			const auto& expected_index_types = tt->GetIndices()->Types();
+			const auto& expected_index_types = tt->GetIndices()->GetTypes();
 			broker::vector composite_key;
 			auto indices = caf::get_if<broker::vector>(&item.first);
 
@@ -555,7 +555,7 @@ struct type_checker {
 
 		for ( const auto& item : a )
 			{
-			const auto& expected_index_types = tt->GetIndices()->Types();
+			const auto& expected_index_types = tt->GetIndices()->GetTypes();
 			auto indices = caf::get_if<broker::vector>(&item);
 			vector<const broker::data*> indices_to_check;
 
@@ -614,7 +614,7 @@ struct type_checker {
 
 		for ( auto& item : a )
 			{
-			const auto& expected_index_types = tt->GetIndices()->Types();
+			const auto& expected_index_types = tt->GetIndices()->GetTypes();
 			auto indices = caf::get_if<broker::vector>(&item.first);
 			vector<const broker::data*> indices_to_check;
 

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -742,7 +742,7 @@ RecordVal* Manager::MakeEvent(val_list* args, Frame* frame)
 			}
 
 		const auto& got_type = (*args)[i]->GetType();
-		const auto& expected_type = func->GetType()->ParamList()->Types()[i - 1];
+		const auto& expected_type = func->GetType()->ParamList()->GetTypes()[i - 1];
 
 		if ( ! same_type(got_type, expected_type) )
 			{
@@ -978,7 +978,7 @@ void Manager::ProcessEvent(const broker::topic& topic, broker::zeek::Event ev)
 		return;
 		}
 
-	const auto& arg_types = handler->GetType(false)->ParamList()->Types();
+	const auto& arg_types = handler->GetType(false)->ParamList()->GetTypes();
 
 	if ( arg_types.size() != args.size() )
 		{

--- a/src/broker/messaging.bif
+++ b/src/broker/messaging.bif
@@ -12,7 +12,7 @@ static bool is_string_set(const zeek::Type* type)
 	if ( ! type->IsSet() )
 		return false;
 
-	const auto& index_types = type->AsSetType()->IndexTypes();
+	const auto& index_types = type->AsSetType()->GetIndexTypes();
 
 	if ( index_types.size() != 1 )
 		return false;

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -332,7 +332,7 @@ bool Manager::CreateEventStream(RecordVal* fval)
 		return false;
 		}
 
-	const auto& args = etype->ParamList()->Types();
+	const auto& args = etype->ParamList()->GetTypes();
 
 	if ( args.size() < 2 )
 		{
@@ -482,7 +482,7 @@ bool Manager::CreateTableStream(RecordVal* fval)
 
 	// check if index fields match table description
 	size_t num = idx->NumFields();
-	const auto& tl = dst->GetType()->AsTableType()->IndexTypes();
+	const auto& tl = dst->GetType()->AsTableType()->GetIndexTypes();
 	size_t j;
 
 	for ( j = 0; j < tl.size(); ++j )
@@ -557,7 +557,7 @@ bool Manager::CreateTableStream(RecordVal* fval)
 			return false;
 			}
 
-		const auto& args = etype->ParamList()->Types();
+		const auto& args = etype->ParamList()->GetTypes();
 
 		if ( args.size() != 4 )
 			{
@@ -704,7 +704,7 @@ bool Manager::CheckErrorEventTypes(const std::string& stream_name, const Func* e
 		return false;
 		}
 
-	const auto& args = etype->ParamList()->Types();
+	const auto& args = etype->ParamList()->GetTypes();
 
 	if ( args.size() != 3 )
 		{

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -277,7 +277,7 @@ bool Manager::CreateStream(EnumVal* id, RecordVal* sval)
 			return false;
 			}
 
-		const auto& args = etype->ParamList()->Types();
+		const auto& args = etype->ParamList()->GetTypes();
 
 		if ( args.size() != 1 )
 			{

--- a/src/option.bif
+++ b/src/option.bif
@@ -15,7 +15,7 @@ static bool call_option_handlers_and_set_value(StringVal* name, const IntrusiveP
 		{
 		for ( auto handler_function : i->GetOptionHandlers() )
 			{
-			bool add_loc = handler_function->GetType()->ParamList()->Types().size() == 3;
+			bool add_loc = handler_function->GetType()->ParamList()->GetTypes().size() == 3;
 			zeek::Args vl;
 			vl.reserve(2 + add_loc);
 			vl.emplace_back(NewRef{}, name);
@@ -170,7 +170,7 @@ function Option::set_change_handler%(ID: string, on_change: any, priority: int &
 		return val_mgr->False();
 		}
 
-	const auto& args = on_change->GetType()->AsFuncType()->ParamList()->Types();
+	const auto& args = on_change->GetType()->AsFuncType()->ParamList()->GetTypes();
 	if ( args.size() < 2 || args.size() > 3 )
 		{
 		builtin_error(fmt("Wrong number of arguments for passed function in Option::on_change for ID '%s'; expected 2 or 3, got %zu",


### PR DESCRIPTION
There were deprecated versions added for most methods where just the return value changed during the conversion to IntrusivePtr. Apparently this one was missed.

Fixes #1034 