### PR TITLE
Fix deprecation on enums to not cause external breakage

### DIFF
--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -11,7 +11,7 @@
 
 namespace zeek::detail {
 
-const char* attr_name(attr_tag t)
+const char* attr_name(AttrTag t)
 	{
 	static const char* attr_names[int(NUM_ATTRS)] = {
 		"&optional", "&default", "&redef",
@@ -25,28 +25,17 @@ const char* attr_name(attr_tag t)
 	return attr_names[int(t)];
 	}
 
-Attr::Attr(attr_tag t, IntrusivePtr<Expr> e)
+Attr::Attr(AttrTag t, IntrusivePtr<Expr> e)
 	: expr(std::move(e))
 	{
 	tag = t;
 	SetLocationInfo(&start_location, &end_location);
 	}
 
-Attr::Attr(attr_tag t)
+Attr::Attr(AttrTag t)
 	: Attr(t, nullptr)
 	{
 	}
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-Attr::Attr(::attr_tag t, IntrusivePtr<Expr> e) : Attr(static_cast<attr_tag>(t), e)
-	{
-	}
-
-Attr::Attr(::attr_tag t) : Attr(static_cast<attr_tag>(t))
-	{
-	}
-#pragma GCC diagnostic pop
 
 Attr::~Attr() = default;
 
@@ -228,7 +217,7 @@ void Attributes::AddAttrs(Attributes* a)
 	Unref(a);
 	}
 
-Attr* Attributes::FindAttr(attr_tag t) const
+Attr* Attributes::FindAttr(AttrTag t) const
 	{
 	for ( const auto& a : attrs )
 		if ( a->Tag() == t )
@@ -237,7 +226,7 @@ Attr* Attributes::FindAttr(attr_tag t) const
 	return nullptr;
 	}
 
-const IntrusivePtr<Attr>& Attributes::Find(attr_tag t) const
+const IntrusivePtr<Attr>& Attributes::Find(AttrTag t) const
 	{
 	for ( const auto& a : attrs )
 		if ( a->Tag() == t )
@@ -246,7 +235,7 @@ const IntrusivePtr<Attr>& Attributes::Find(attr_tag t) const
 	return Attr::nil;
 	}
 
-void Attributes::RemoveAttr(attr_tag t)
+void Attributes::RemoveAttr(AttrTag t)
 	{
 	for ( auto it = attrs.begin(); it != attrs.end(); )
 		{
@@ -256,19 +245,6 @@ void Attributes::RemoveAttr(attr_tag t)
 			++it;
 		}
 	}
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-Attr* Attributes::FindAttr(::attr_tag t) const
-	{
-	return FindAttr(static_cast<attr_tag>(t));
-	}
-
-void Attributes::RemoveAttr(::attr_tag t)
-	{
-	RemoveAttr(static_cast<attr_tag>(t));
-	}
-#pragma GCC diagnostic pop
 
 void Attributes::Describe(ODesc* d) const
 	{

--- a/src/Attr.h
+++ b/src/Attr.h
@@ -14,31 +14,9 @@ ZEEK_FORWARD_DECLARE_NAMESPACED(Expr, zeek::detail);
 // modify expressions or supply metadata on types, and the kind that
 // are extra metadata on every variable instance.
 
-enum [[deprecated("Remove in v4.1. Use zeek::detail::attr_tag instead.")]] attr_tag {
-	ATTR_OPTIONAL,
-	ATTR_DEFAULT,
-	ATTR_REDEF,
-	ATTR_ADD_FUNC,
-	ATTR_DEL_FUNC,
-	ATTR_EXPIRE_FUNC,
-	ATTR_EXPIRE_READ,
-	ATTR_EXPIRE_WRITE,
-	ATTR_EXPIRE_CREATE,
-	ATTR_RAW_OUTPUT,
-	ATTR_PRIORITY,
-	ATTR_GROUP,
-	ATTR_LOG,
-	ATTR_ERROR_HANDLER,
-	ATTR_TYPE_COLUMN,	// for input framework
-	ATTR_TRACKED,	// hidden attribute, tracked by NotifierRegistry
-	ATTR_ON_CHANGE, // for table change tracking
-	ATTR_DEPRECATED,
-	NUM_ATTRS // this item should always be last
-};
-
 namespace zeek::detail {
 
-enum attr_tag {
+enum AttrTag {
 	ATTR_OPTIONAL,
 	ATTR_DEFAULT,
 	ATTR_REDEF,
@@ -64,21 +42,12 @@ class Attr final : public BroObj {
 public:
 	static inline const IntrusivePtr<zeek::detail::Attr> nil;
 
-	Attr(attr_tag t, IntrusivePtr<zeek::detail::Expr> e);
-	explicit Attr(attr_tag t);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use version that takes zeek::detail::attr_tag.")]]
-	Attr(::attr_tag t, IntrusivePtr<zeek::detail::Expr> e);
-
-	[[deprecated("Remove in v4.1. Use version that takes zeek::detail::attr_tag.")]]
-	explicit Attr(::attr_tag t);
-#pragma GCC diagnostic pop
+	Attr(AttrTag t, IntrusivePtr<zeek::detail::Expr> e);
+	explicit Attr(AttrTag t);
 
 	~Attr() override;
 
-	attr_tag Tag() const	{ return tag; }
+	AttrTag Tag() const	{ return tag; }
 
 	[[deprecated("Remove in v4.1.  Use GetExpr().")]]
 	zeek::detail::Expr* AttrExpr() const	{ return expr.get(); }
@@ -108,7 +77,7 @@ public:
 protected:
 	void AddTag(ODesc* d) const;
 
-	attr_tag tag;
+	AttrTag tag;
 	IntrusivePtr<Expr> expr;
 };
 
@@ -130,19 +99,11 @@ public:
 	void AddAttrs(Attributes* a);	// Unref's 'a' when done
 
 	[[deprecated("Remove in v4.1. Use Find().")]]
-	Attr* FindAttr(attr_tag t) const;
+	Attr* FindAttr(AttrTag t) const;
 
-	const IntrusivePtr<Attr>& Find(attr_tag t) const;
+	const IntrusivePtr<Attr>& Find(AttrTag t) const;
 
-	void RemoveAttr(attr_tag t);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use version that takes zeek::detail::attr_tag.")]]
-	Attr* FindAttr(::attr_tag t) const;
-	[[deprecated("Remove in v4.1. Use version that takes zeek::detail::attr_tag.")]]
-	void RemoveAttr(::attr_tag t);
-#pragma GCC diagnostic pop
+	void RemoveAttr(AttrTag t);
 
 	void Describe(ODesc* d) const override;
 	void DescribeReST(ODesc* d, bool shorten = false) const;
@@ -165,3 +126,44 @@ protected:
 
 using Attr [[deprecated("Remove in v4.1. Use zeek::detail::Attr instead.")]] = zeek::detail::Attr;
 using Attributes [[deprecated("Remove in v4.1. Use zeek::detail::Attr instead.")]] = zeek::detail::Attributes;
+
+using AttrTag [[deprecated("Remove in v4.1. Use zeek::detail::AttrTag instead.")]] = zeek::detail::AttrTag;
+
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_OPTIONAL instead.")]]
+constexpr auto ATTR_OPTIONAL = zeek::detail::ATTR_OPTIONAL;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_DEFAULT instead.")]]
+constexpr auto ATTR_DEFAULT = zeek::detail::ATTR_DEFAULT;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_REDEF instead.")]]
+constexpr auto ATTR_REDEF = zeek::detail::ATTR_REDEF;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_ADD_FUNC instead.")]]
+constexpr auto ATTR_ADD_FUNC = zeek::detail::ATTR_ADD_FUNC;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_DEL_FUNC instead.")]]
+constexpr auto ATTR_DEL_FUNC = zeek::detail::ATTR_DEL_FUNC;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_EXPIRE_FUNC instead.")]]
+constexpr auto ATTR_EXPIRE_FUNC = zeek::detail::ATTR_EXPIRE_FUNC;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_EXPIRE_READ instead.")]]
+constexpr auto ATTR_EXPIRE_READ = zeek::detail::ATTR_EXPIRE_READ;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_EXPIRE_WRITE instead.")]]
+constexpr auto ATTR_EXPIRE_WRITE = zeek::detail::ATTR_EXPIRE_WRITE;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_EXPIRE_CREATE instead.")]]
+constexpr auto ATTR_EXPIRE_CREATE = zeek::detail::ATTR_EXPIRE_CREATE;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_RAW_OUTPUT instead.")]]
+constexpr auto ATTR_RAW_OUTPUT = zeek::detail::ATTR_RAW_OUTPUT;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_PRIORITY instead.")]]
+constexpr auto ATTR_PRIORITY = zeek::detail::ATTR_PRIORITY;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_GROUP instead.")]]
+constexpr auto ATTR_GROUP = zeek::detail::ATTR_GROUP;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_LOG instead.")]]
+constexpr auto ATTR_LOG = zeek::detail::ATTR_LOG;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_ERROR_HANDLER instead.")]]
+constexpr auto ATTR_ERROR_HANDLER = zeek::detail::ATTR_ERROR_HANDLER;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_TYPE_COLUMN instead.")]]
+constexpr auto ATTR_TYPE_COLUMN = zeek::detail::ATTR_TYPE_COLUMN;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_TRACKED instead.")]]
+constexpr auto ATTR_TRACKED = zeek::detail::ATTR_TRACKED;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_ON_CHANGE instead.")]]
+constexpr auto ATTR_ON_CHANGE = zeek::detail::ATTR_ON_CHANGE;
+[[deprecated("Remove in v4.1. Use zeek::detail::ATTR_DEPRECATED instead.")]]
+constexpr auto ATTR_DEPRECATED = zeek::detail::ATTR_DEPRECATED;
+[[deprecated("Remove in v4.1. Use zeek::detail::NUM_ATTRS instead.")]]
+constexpr auto NUM_ATTRS = zeek::detail::NUM_ATTRS;

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -287,7 +287,7 @@ void ID::UpdateValAttrs()
 		}
 	}
 
-const IntrusivePtr<Attr>& ID::GetAttr(attr_tag t) const
+const IntrusivePtr<Attr>& ID::GetAttr(AttrTag t) const
 	{
 	return attrs ? attrs->Find(t) : Attr::nil;
 	}
@@ -337,19 +337,11 @@ void ID::AddAttrs(IntrusivePtr<Attributes> a)
 	UpdateValAttrs();
 	}
 
-void ID::RemoveAttr(attr_tag a)
+void ID::RemoveAttr(AttrTag a)
 	{
 	if ( attrs )
 		attrs->RemoveAttr(a);
 	}
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-void ID::RemoveAttr(::attr_tag a)
-	{
-	RemoveAttr(static_cast<attr_tag>(a));
-	}
-#pragma GCC diagnostic pop
 
 void ID::SetOption()
 	{

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -120,12 +120,6 @@ ID::ID(const char* arg_name, IDScope arg_scope, bool arg_is_export)
 	SetLocationInfo(&start_location, &end_location);
 	}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-ID::ID(const char* arg_name, ::IDScope arg_scope, bool arg_is_export) :
-	ID(arg_name, static_cast<IDScope>(arg_scope), arg_is_export) {}
-#pragma GCC diagnostic pop
-
 ID::~ID()
 	{
 	delete [] name;
@@ -175,7 +169,7 @@ void ID::SetVal(IntrusivePtr<Val> v)
 		}
 	}
 
-void ID::SetVal(IntrusivePtr<Val> v, init_class c)
+void ID::SetVal(IntrusivePtr<Val> v, InitClass c)
 	{
 	if ( c == INIT_NONE || c == INIT_FULL )
 		{
@@ -213,7 +207,7 @@ void ID::SetVal(IntrusivePtr<Val> v, init_class c)
 		}
 	}
 
-void ID::SetVal(IntrusivePtr<Expr> ev, init_class c)
+void ID::SetVal(IntrusivePtr<Expr> ev, InitClass c)
 	{
 	const auto& a = attrs->Find(c == INIT_EXTRA ? ATTR_ADD_FUNC : ATTR_DEL_FUNC);
 
@@ -222,19 +216,6 @@ void ID::SetVal(IntrusivePtr<Expr> ev, init_class c)
 
 	EvalFunc(a->GetExpr(), std::move(ev));
 	}
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-void ID::SetVal(IntrusivePtr<Val> v, ::init_class c)
-	{
-	SetVal(v, static_cast<init_class>(c));
-	}
-
-void ID::SetVal(IntrusivePtr<Expr> ev, ::init_class c)
-	{
-	SetVal(ev, static_cast<init_class>(c));
-	}
-#pragma GCC diagnostic pop
 
 bool ID::IsRedefinable() const
 	{

--- a/src/ID.h
+++ b/src/ID.h
@@ -124,12 +124,7 @@ public:
 
 	void SetAttrs(IntrusivePtr<Attributes> attr);
 	void AddAttrs(IntrusivePtr<Attributes> attr);
-	void RemoveAttr(attr_tag a);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use version that takes zeek::detail::attr_tag")]]
-	void RemoveAttr(::attr_tag a);
-#pragma GCC diagnostic pop
+	void RemoveAttr(zeek::detail::AttrTag a);
 	void UpdateValAttrs();
 
 	const IntrusivePtr<Attributes>& GetAttrs() const
@@ -138,14 +133,7 @@ public:
 	[[deprecated("Remove in 4.1.  Use GetAttrs().")]]
 	Attributes* Attrs() const	{ return attrs.get(); }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in 4.1.  Use GetAttr().")]]
-	Attr* FindAttr(::attr_tag t) const
-		{ return GetAttr(static_cast<zeek::detail::attr_tag>(t)).get(); }
-#pragma GCC diagnostic pop
-
-	const IntrusivePtr<zeek::detail::Attr>& GetAttr(zeek::detail::attr_tag t) const;
+	const IntrusivePtr<zeek::detail::Attr>& GetAttr(zeek::detail::AttrTag t) const;
 
 	bool IsDeprecated() const;
 

--- a/src/ID.h
+++ b/src/ID.h
@@ -24,15 +24,12 @@ ZEEK_FORWARD_DECLARE_NAMESPACED(TableType, zeek);
 ZEEK_FORWARD_DECLARE_NAMESPACED(VectorType, zeek);
 ZEEK_FORWARD_DECLARE_NAMESPACED(EnumType, zeek);
 
-enum [[deprecated("Remove in v4.1. Use zeek::detail::init_class instead.")]] init_class { INIT_NONE, INIT_FULL, INIT_EXTRA, INIT_REMOVE, };
-enum [[deprecated("Remove in v4.1. Use zeek::detail::IDScope instead.")]] IDScope { SCOPE_FUNCTION, SCOPE_MODULE, SCOPE_GLOBAL };
-
 namespace zeek::detail {
 
 class Attributes;
 class Expr;
 
-enum init_class { INIT_NONE, INIT_FULL, INIT_EXTRA, INIT_REMOVE, };
+enum InitClass { INIT_NONE, INIT_FULL, INIT_EXTRA, INIT_REMOVE, };
 enum IDScope { SCOPE_FUNCTION, SCOPE_MODULE, SCOPE_GLOBAL };
 
 class ID final : public BroObj, public notifier::Modifiable {
@@ -40,12 +37,6 @@ public:
 	static inline const IntrusivePtr<ID> nil;
 
 	ID(const char* name, IDScope arg_scope, bool arg_is_export);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use version that takes zeek::detail::IDScope")]]
-	ID(const char* name, ::IDScope arg_scope, bool arg_is_export);
-#pragma GCC diagnostic pop
 
 	~ID() override;
 
@@ -85,16 +76,8 @@ public:
 
 	void SetVal(IntrusivePtr<Val> v);
 
-	void SetVal(IntrusivePtr<Val> v, init_class c);
-	void SetVal(IntrusivePtr<Expr> ev, init_class c);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use version that takes zeek::detail::init_class")]]
-	void SetVal(IntrusivePtr<Val> v, ::init_class c);
-	[[deprecated("Remove in v4.1. Use version that takes zeek::detail::init_class")]]
-	void SetVal(IntrusivePtr<Expr> ev, ::init_class c);
-#pragma GCC diagnostic pop
+	void SetVal(IntrusivePtr<Val> v, InitClass c);
+	void SetVal(IntrusivePtr<Expr> ev, InitClass c);
 
 	bool HasVal() const		{ return val != nullptr; }
 
@@ -279,3 +262,21 @@ void init();
 } // namespace zeek::id::detail
 
 } // namespace zeek::id
+
+using init_class [[deprecated("Remove in v4.1. Use zeek::detail::InitClass instead.")]] = zeek::detail::InitClass;
+[[deprecated("Remove in v4.1. Use zeek::detail::INIT_NONE instead.")]]
+constexpr auto INIT_NONE = zeek::detail::INIT_NONE;
+[[deprecated("Remove in v4.1. Use zeek::detail::INIT_FULL instead.")]]
+constexpr auto INIT_FULL = zeek::detail::INIT_FULL;
+[[deprecated("Remove in v4.1. Use zeek::detail::INIT_EXTRA instead.")]]
+constexpr auto INIT_EXTRA = zeek::detail::INIT_EXTRA;
+[[deprecated("Remove in v4.1. Use zeek::detail::INIT_REMOVE instead.")]]
+constexpr auto INIT_REMOVE = zeek::detail::INIT_REMOVE;
+
+using IDScope [[deprecated("Remove in v4.1. Use zeek::detail::IDScope instead.")]] = zeek::detail::IDScope;
+[[deprecated("Remove in v4.1. Use zeek::detail::SCOPE_FUNCTION instead.")]]
+constexpr auto SCOPE_FUNCTION = zeek::detail::SCOPE_FUNCTION;
+[[deprecated("Remove in v4.1. Use zeek::detail::SCOPE_MODULE instead.")]]
+constexpr auto SCOPE_MODULE = zeek::detail::SCOPE_MODULE;
+[[deprecated("Remove in v4.1. Use zeek::detail::SCOPE_GLOBAL instead.")]]
+constexpr auto SCOPE_GLOBAL = zeek::detail::SCOPE_GLOBAL;

--- a/src/Type.h
+++ b/src/Type.h
@@ -21,49 +21,6 @@ ZEEK_FORWARD_DECLARE_NAMESPACED(Expr, zeek::detail);
 ZEEK_FORWARD_DECLARE_NAMESPACED(ListExpr, zeek::detail);
 ZEEK_FORWARD_DECLARE_NAMESPACED(Attributes, zeek::detail);
 
-enum [[deprecated("Remove in v4.1. Use zeek::TypeTag instead.")]] TypeTag {
-	TYPE_VOID,      // 0
-	TYPE_BOOL,      // 1
-	TYPE_INT,       // 2
-	TYPE_COUNT,     // 3
-	TYPE_COUNTER,   // 4
-	TYPE_DOUBLE,    // 5
-	TYPE_TIME,      // 6
-	TYPE_INTERVAL,  // 7
-	TYPE_STRING,    // 8
-	TYPE_PATTERN,   // 9
-	TYPE_ENUM,      // 10
-	TYPE_TIMER,     // 11
-	TYPE_PORT,      // 12
-	TYPE_ADDR,      // 13
-	TYPE_SUBNET,    // 14
-	TYPE_ANY,       // 15
-	TYPE_TABLE,     // 16
-	TYPE_UNION,     // 17
-	TYPE_RECORD,    // 18
-	TYPE_LIST,      // 19
-	TYPE_FUNC,      // 20
-	TYPE_FILE,      // 21
-	TYPE_VECTOR,    // 22
-	TYPE_OPAQUE,    // 23
-	TYPE_TYPE,      // 24
-	TYPE_ERROR      // 25
-#define NUM_TYPES (int(TYPE_ERROR) + 1)
-};
-
-enum [[deprecated("Remove in v4.1. Use zeek::FunctionFlavor instead.")]] function_flavor {
-	FUNC_FLAVOR_FUNCTION,
-	FUNC_FLAVOR_EVENT,
-	FUNC_FLAVOR_HOOK
-};
-
-enum [[deprecated("Remove in v4.1. Use zeek::InternalTypeTag instead.")]] InternalTypeTag : uint16_t {
-	TYPE_INTERNAL_VOID,
-	TYPE_INTERNAL_INT, TYPE_INTERNAL_UNSIGNED, TYPE_INTERNAL_DOUBLE,
-	TYPE_INTERNAL_STRING, TYPE_INTERNAL_ADDR, TYPE_INTERNAL_SUBNET,
-	TYPE_INTERNAL_OTHER, TYPE_INTERNAL_ERROR
-};
-
 namespace zeek {
 
 // BRO types.
@@ -190,14 +147,6 @@ public:
 	static inline const IntrusivePtr<Type> nil;
 
 	explicit Type(zeek::TypeTag tag, bool base_type = false);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::TypeTag instead.")]]
-	explicit Type(::TypeTag tag, bool base_type = false)
-		: Type(static_cast<zeek::TypeTag>(tag), base_type)
-		{}
-#pragma GCC diagnostic pop
 
 	// Performs a shallow clone operation of the Bro type.
 	// This especially means that especially for tables the types
@@ -532,14 +481,6 @@ public:
 	FuncType(IntrusivePtr<RecordType> args, IntrusivePtr<Type> yield,
 	         FunctionFlavor f);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::FunctionFlavor instead.")]]
-	FuncType(IntrusivePtr<RecordType> args, IntrusivePtr<Type> yield, ::function_flavor f)
-		: FuncType(args, yield, static_cast<FunctionFlavor>(f))
-		{}
-#pragma GCC diagnostic pop
-
 	IntrusivePtr<Type> ShallowClone() override;
 
 	~FuncType() override;
@@ -560,13 +501,6 @@ public:
 	// Used to convert a function type to an event or hook type.
 	void ClearYieldType(FunctionFlavor arg_flav)
 		{ yield = nullptr; flavor = arg_flav; }
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::FunctionFlavor instead.")]]
-	void ClearYieldType(::function_flavor arg_flav)
-		{ yield = nullptr; flavor = static_cast<FunctionFlavor>(arg_flav); }
-#pragma GCC diagnostic pop
 
 	int MatchesIndex(zeek::detail::ListExpr* index) const override;
 	bool CheckArgs(const type_list* args, bool is_init = false) const;
@@ -984,12 +918,8 @@ inline const IntrusivePtr<zeek::Type>& error_type()       { return base_type(TYP
 
 // Returns the basic (non-parameterized) type with the given type.
 // The reference count of the type is not increased.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-[[deprecated("Remove in v4.1.  Use zeek::base_type() instead")]]
-inline zeek::Type* base_type_no_ref(::TypeTag tag)
-	{ return zeek::base_type(static_cast<zeek::TypeTag>(tag)).get(); }
-#pragma GCC diagnostic pop
+inline zeek::Type* base_type_no_ref(zeek::TypeTag tag)
+	{ return zeek::base_type(tag).get(); }
 
 extern IntrusivePtr<zeek::OpaqueType> md5_type;
 extern IntrusivePtr<zeek::OpaqueType> sha1_type;
@@ -1038,3 +968,88 @@ constexpr auto base_type [[deprecated("Remove in v4.1. Use zeek::base_type inste
 constexpr auto error_type [[deprecated("Remove in v4.1. Use zeek::error_type instead.")]] = zeek::error_type;
 constexpr auto type_name [[deprecated("Remove in v4.1. Use zeek::type_name instead.")]] = zeek::type_name;
 constexpr auto is_network_order [[deprecated("Remove in v4.1. Use zeek::is_network_order instead.")]] = zeek::is_network_order;
+
+using TypeTag [[deprecated("Remove in v4.1. Use zeek::TypeTag instead.")]] = zeek::TypeTag;
+
+[[deprecated("Remove in v4.1. Use zeek::TYPE_VOID instead.")]]
+constexpr auto TYPE_VOID = zeek::TYPE_VOID;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_BOOL instead.")]]
+constexpr auto TYPE_BOOL = zeek::TYPE_BOOL;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INT instead.")]]
+constexpr auto TYPE_INT = zeek::TYPE_INT;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_COUNT instead.")]]
+constexpr auto TYPE_COUNT = zeek::TYPE_COUNT;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_COUNTER instead.")]]
+constexpr auto TYPE_COUNTER = zeek::TYPE_COUNTER;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_DOUBLE instead.")]]
+constexpr auto TYPE_DOUBLE = zeek::TYPE_DOUBLE;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_TIME instead.")]]
+constexpr auto TYPE_TIME = zeek::TYPE_TIME;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INTERVAL instead.")]]
+constexpr auto TYPE_INTERVAL = zeek::TYPE_INTERVAL;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_STRING instead.")]]
+constexpr auto TYPE_STRING = zeek::TYPE_STRING;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_PATTERN instead.")]]
+constexpr auto TYPE_PATTERN = zeek::TYPE_PATTERN;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_ENUM instead.")]]
+constexpr auto TYPE_ENUM = zeek::TYPE_ENUM;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_TIMER instead.")]]
+constexpr auto TYPE_TIMER = zeek::TYPE_TIMER;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_PORT instead.")]]
+constexpr auto TYPE_PORT = zeek::TYPE_PORT;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_ADDR instead.")]]
+constexpr auto TYPE_ADDR = zeek::TYPE_ADDR;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_SUBNET instead.")]]
+constexpr auto TYPE_SUBNET = zeek::TYPE_SUBNET;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_ANY instead.")]]
+constexpr auto TYPE_ANY = zeek::TYPE_ANY;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_TABLE instead.")]]
+constexpr auto TYPE_TABLE = zeek::TYPE_TABLE;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_UNION instead.")]]
+constexpr auto TYPE_UNION = zeek::TYPE_UNION;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_RECORD instead.")]]
+constexpr auto TYPE_RECORD = zeek::TYPE_RECORD;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_LIST instead.")]]
+constexpr auto TYPE_LIST = zeek::TYPE_LIST;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_FUNC instead.")]]
+constexpr auto TYPE_FUNC = zeek::TYPE_FUNC;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_FILE instead.")]]
+constexpr auto TYPE_FILE = zeek::TYPE_FILE;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_VECTOR instead.")]]
+constexpr auto TYPE_VECTOR = zeek::TYPE_VECTOR;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_OPAQUE instead.")]]
+constexpr auto TYPE_OPAQUE = zeek::TYPE_OPAQUE;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_TYPE instead.")]]
+constexpr auto TYPE_TYPE = zeek::TYPE_TYPE;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_TYPE instead.")]]
+constexpr auto TYPE_ERROR = zeek::TYPE_ERROR;
+
+using function_flavor [[deprecated("Remove in v4.1. Use zeek::FunctionFlavor instead.")]] = zeek::FunctionFlavor;
+
+[[deprecated("Remove in v4.1. Use zeek::FUNC_FLAVOR_FUNCTION instead.")]]
+constexpr auto FUNC_FLAVOR_FUNCTION = zeek::FUNC_FLAVOR_FUNCTION;
+[[deprecated("Remove in v4.1. Use zeek::FUNC_FLAVOR_EVENT instead.")]]
+constexpr auto FUNC_FLAVOR_EVENT = zeek::FUNC_FLAVOR_EVENT;
+[[deprecated("Remove in v4.1. Use zeek::FUNC_FLAVOR_HOOK instead.")]]
+constexpr auto FUNC_FLAVOR_HOOK = zeek::FUNC_FLAVOR_HOOK;
+
+using InternalTypeTag [[deprecated("Remove in v4.1. Use zeek::InteralTypeTag instead.")]] = zeek::InternalTypeTag;
+
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INTERNAL_VOID instead.")]]
+constexpr auto TYPE_INTERNAL_VOID = zeek::TYPE_INTERNAL_VOID;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INTERNAL_INT instead.")]]
+constexpr auto TYPE_INTERNAL_INT = zeek::TYPE_INTERNAL_INT;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INTERNAL_UNSIGNED instead.")]]
+constexpr auto TYPE_INTERNAL_UNSIGNED = zeek::TYPE_INTERNAL_UNSIGNED;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INTERNAL_DOUBLE instead.")]]
+constexpr auto TYPE_INTERNAL_DOUBLE = zeek::TYPE_INTERNAL_DOUBLE;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INTERNAL_STRING instead.")]]
+constexpr auto TYPE_INTERNAL_STRING = zeek::TYPE_INTERNAL_STRING;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INTERNAL_ADDR instead.")]]
+constexpr auto TYPE_INTERNAL_ADDR = zeek::TYPE_INTERNAL_ADDR;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INTERNAL_SUBNET instead.")]]
+constexpr auto TYPE_INTERNAL_SUBNET = zeek::TYPE_INTERNAL_SUBNET;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INTERNAL_OTHER instead.")]]
+constexpr auto TYPE_INTERNAL_OTHER = zeek::TYPE_INTERNAL_OTHER;
+[[deprecated("Remove in v4.1. Use zeek::TYPE_INTERNAL_ERROR instead.")]]
+constexpr auto TYPE_INTERNAL_ERROR = zeek::TYPE_INTERNAL_ERROR;

--- a/src/Type.h
+++ b/src/Type.h
@@ -638,14 +638,7 @@ public:
 	TypeDecl(const TypeDecl& other);
 	~TypeDecl();
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1.  Use GetAttr().")]]
-	const zeek::detail::Attr* FindAttr(::attr_tag a) const
-		{ return attrs ? attrs->Find(static_cast<zeek::detail::attr_tag>(a)).get() : nullptr; }
-#pragma GCC diagnostic pop
-
-	const IntrusivePtr<zeek::detail::Attr>& GetAttr(zeek::detail::attr_tag a) const
+	const IntrusivePtr<zeek::detail::Attr>& GetAttr(zeek::detail::AttrTag a) const
 		{ return attrs ? attrs->Find(a) : zeek::detail::Attr::nil; }
 
 	void DescribeReST(ODesc* d, bool roles_only = false) const;
@@ -746,20 +739,11 @@ public:
 		return decl && decl->GetAttr(zeek::detail::ATTR_DEPRECATED) != nullptr;
 		}
 
-	bool FieldHasAttr(int field, zeek::detail::attr_tag at) const
+	bool FieldHasAttr(int field, zeek::detail::AttrTag at) const
 		{
 		const TypeDecl* decl = FieldDecl(field);
 		return decl && decl->GetAttr(at) != nullptr;
 		}
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use version that takes zeek::detail::attr_tag.")]]
-	bool FieldHasAttr(int field, ::attr_tag at) const
-		{
-		return FieldHasAttr(field, static_cast<zeek::detail::attr_tag>(at));
-		}
-#pragma GCC diagnostic pop
 
 	std::string GetFieldDeprecationWarning(int field, bool has_check) const;
 

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1481,7 +1481,7 @@ void TableVal::SetAttrs(IntrusivePtr<zeek::detail::Attributes> a)
 		change_func = cf->GetExpr();
 	}
 
-void TableVal::CheckExpireAttr(zeek::detail::attr_tag at)
+void TableVal::CheckExpireAttr(zeek::detail::AttrTag at)
 	{
 	const auto& a = attrs->Find(at);
 
@@ -2194,7 +2194,7 @@ ListVal* TableVal::ConvertToPureList() const
 	return ToPureListVal().release();
 	}
 
-const IntrusivePtr<zeek::detail::Attr>& TableVal::GetAttr(zeek::detail::attr_tag t) const
+const IntrusivePtr<zeek::detail::Attr>& TableVal::GetAttr(zeek::detail::AttrTag t) const
 	{
 	return attrs ? attrs->Find(t) : zeek::detail::Attr::nil;
 	}

--- a/src/Val.h
+++ b/src/Val.h
@@ -957,14 +957,7 @@ public:
 
 	void SetAttrs(IntrusivePtr<zeek::detail::Attributes> attrs);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1.  Use GetAttr().")]]
-	Attr* FindAttr(::attr_tag t) const
-		{ return GetAttr(static_cast<zeek::detail::attr_tag>(t)).get(); }
-#pragma GCC diagnostic pop
-
-	const IntrusivePtr<zeek::detail::Attr>& GetAttr(zeek::detail::attr_tag t) const;
+	const IntrusivePtr<zeek::detail::Attr>& GetAttr(zeek::detail::AttrTag t) const;
 
 	[[deprecated("Remove in v4.1.  Use GetAttrs().")]]
 	zeek::detail::Attributes* Attrs()	{ return attrs.get(); }
@@ -1035,12 +1028,7 @@ protected:
 	ParseTimeTableState DumpTableState();
 	void RebuildTable(ParseTimeTableState ptts);
 
-	void CheckExpireAttr(zeek::detail::attr_tag at);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use version that takes zeek::detail::attr_tag.")]]
-	void CheckExpireAttr(::attr_tag at);
-#pragma GCC diagnostic pop
+	void CheckExpireAttr(zeek::detail::AttrTag at);
 	bool ExpandCompoundAndInit(ListVal* lv, int k, IntrusivePtr<Val> new_val);
 	bool CheckAndAssign(IntrusivePtr<Val> index, IntrusivePtr<Val> new_val);
 

--- a/src/Val.h
+++ b/src/Val.h
@@ -125,13 +125,6 @@ public:
 		: val(d), type(zeek::base_type(t))
 		{}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1.  Use IntervalVal(), TimeVal(), or DoubleVal() constructors.")]]
-	Val(double d, ::TypeTag t) : Val(d, static_cast<zeek::TypeTag>(t))
-		{}
-#pragma GCC diagnostic pop
-
 	[[deprecated("Remove in v4.1.  Construct from IntrusivePtr instead.")]]
 	explicit Val(Func* f);
 	explicit Val(IntrusivePtr<Func> f);
@@ -655,12 +648,6 @@ protected:
 class ListVal final : public Val {
 public:
 	explicit ListVal(zeek::TypeTag t);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::TypeTag")]]
-	explicit ListVal(::TypeTag t) : ListVal(static_cast<zeek::TypeTag>(t)) {}
-#pragma GCC diagnostic pop
 
 	~ListVal() override;
 

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -111,7 +111,7 @@ static bool add_prototype(const IntrusivePtr<zeek::detail::ID>& id, zeek::Type* 
 	}
 
 static void make_var(const IntrusivePtr<zeek::detail::ID>& id, IntrusivePtr<zeek::Type> t,
-                     zeek::detail::init_class c,
+                     zeek::detail::InitClass c,
                      IntrusivePtr<zeek::detail::Expr> init,
                      std::unique_ptr<std::vector<IntrusivePtr<zeek::detail::Attr>>> attr,
                      decl_type dt,
@@ -311,7 +311,7 @@ static void make_var(const IntrusivePtr<zeek::detail::ID>& id, IntrusivePtr<zeek
 	}
 
 void add_global(const IntrusivePtr<zeek::detail::ID>& id, IntrusivePtr<zeek::Type> t,
-                zeek::detail::init_class c, IntrusivePtr<zeek::detail::Expr> init,
+                zeek::detail::InitClass c, IntrusivePtr<zeek::detail::Expr> init,
                 std::unique_ptr<std::vector<IntrusivePtr<zeek::detail::Attr>>> attr,
                 decl_type dt)
 	{
@@ -319,9 +319,9 @@ void add_global(const IntrusivePtr<zeek::detail::ID>& id, IntrusivePtr<zeek::Typ
 	}
 
 IntrusivePtr<zeek::detail::Stmt> add_local(IntrusivePtr<zeek::detail::ID> id, IntrusivePtr<zeek::Type> t,
-                             zeek::detail::init_class c, IntrusivePtr<zeek::detail::Expr> init,
-                             std::unique_ptr<std::vector<IntrusivePtr<zeek::detail::Attr>>> attr,
-                             decl_type dt)
+                                           zeek::detail::InitClass c, IntrusivePtr<zeek::detail::Expr> init,
+                                           std::unique_ptr<std::vector<IntrusivePtr<zeek::detail::Attr>>> attr,
+                                           decl_type dt)
 	{
 	make_var(id, std::move(t), c, init, std::move(attr), dt, false);
 

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -415,7 +415,7 @@ static void transfer_arg_defaults(zeek::RecordType* args, zeek::RecordType* recv
 	}
 
 static zeek::detail::Attr* find_attr(const std::vector<IntrusivePtr<zeek::detail::Attr>>* al,
-                                     zeek::detail::attr_tag tag)
+                                     zeek::detail::AttrTag tag)
 	{
 	if ( ! al )
 		return nullptr;

--- a/src/Var.h
+++ b/src/Var.h
@@ -20,14 +20,14 @@ typedef enum { VAR_REGULAR, VAR_CONST, VAR_REDEF, VAR_OPTION, } decl_type;
 
 extern void add_global(const IntrusivePtr<zeek::detail::ID>& id,
                        IntrusivePtr<zeek::Type> t,
-                       zeek::detail::init_class c,
+                       zeek::detail::InitClass c,
                        IntrusivePtr<zeek::detail::Expr> init,
                        std::unique_ptr<std::vector<IntrusivePtr<zeek::detail::Attr>>> attr,
                        decl_type dt);
 
 extern IntrusivePtr<zeek::detail::Stmt> add_local(IntrusivePtr<zeek::detail::ID> id,
                                                   IntrusivePtr<zeek::Type> t,
-                                                  zeek::detail::init_class c,
+                                                  zeek::detail::InitClass c,
                                                   IntrusivePtr<zeek::detail::Expr> init,
                                                   std::unique_ptr<std::vector<IntrusivePtr<zeek::detail::Attr>>> attr,
                                                   decl_type dt);

--- a/src/broker/Data.h
+++ b/src/broker/Data.h
@@ -236,14 +236,6 @@ public:
 	      it(dat.begin())
 		{}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::TypeTag instead.")]]
-	SetIterator(RecordVal* v, ::TypeTag tag, Frame* f)
-		: SetIterator(v, static_cast<zeek::TypeTag>(tag), f)
-		{}
-#pragma GCC diagnostic pop
-
 	broker::set dat;
 	broker::set::iterator it;
 
@@ -263,14 +255,6 @@ public:
 	      dat(require_data_type<broker::table>(v, zeek::TYPE_TABLE, f)),
 	      it(dat.begin())
 		{}
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::TypeTag instead.")]]
-	TableIterator(RecordVal* v, ::TypeTag tag, Frame* f)
-		: TableIterator(v, static_cast<zeek::TypeTag>(tag), f)
-		{}
-#pragma GCC diagnostic pop
 
 	broker::table dat;
 	broker::table::iterator it;
@@ -292,14 +276,6 @@ public:
 	      it(dat.begin())
 		{}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::TypeTag instead.")]]
-	VectorIterator(RecordVal* v, ::TypeTag tag, Frame* f)
-		: VectorIterator(v, static_cast<zeek::TypeTag>(tag), f)
-		{}
-#pragma GCC diagnostic pop
-
 	broker::vector dat;
 	broker::vector::iterator it;
 
@@ -319,14 +295,6 @@ public:
 	      dat(require_data_type<broker::vector>(v, zeek::TYPE_RECORD, f)),
 	      it(dat.begin())
 		{}
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::TypeTag instead.")]]
-	RecordIterator(RecordVal* v, ::TypeTag tag, Frame* f)
-		: RecordIterator(v, static_cast<zeek::TypeTag>(tag), f)
-		{}
-#pragma GCC diagnostic pop
 
 	broker::vector dat;
 	broker::vector::iterator it;

--- a/src/input/readers/ascii/Ascii.h
+++ b/src/input/readers/ascii/Ascii.h
@@ -25,19 +25,6 @@ struct FieldMapping {
 	FieldMapping(const std::string& arg_name, const zeek::TypeTag& arg_type, int arg_position);
 	FieldMapping(const std::string& arg_name, const zeek::TypeTag& arg_type, const zeek::TypeTag& arg_subtype, int arg_position);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek:TypeTag.")]]
-	FieldMapping(const std::string& arg_name, const ::TypeTag& arg_type, int arg_position)
-		: FieldMapping(arg_name, static_cast<zeek::TypeTag>(arg_type), arg_position)
-		{}
-
-	[[deprecated("Remove in v4.1. Use the version that takes zeek:TypeTag.")]]
-	FieldMapping(const std::string& arg_name, const ::TypeTag& arg_type, const ::TypeTag& arg_subtype, int arg_position)
-		: FieldMapping(arg_name, static_cast<zeek::TypeTag>(arg_type), static_cast<zeek::TypeTag>(arg_subtype), arg_position)
-		{}
-#pragma GCC diagnostic pop
-
 	FieldMapping(const FieldMapping& arg);
 	FieldMapping() { position = -1; secondary_position = -1; }
 

--- a/src/iosource/Component.cc
+++ b/src/iosource/Component.cc
@@ -17,14 +17,6 @@ Component::Component(zeek::plugin::component::Type type, const std::string& name
 	{
 	}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-Component::Component(plugin::component::Type type, const std::string& name)
-	: plugin::Component(static_cast<zeek::plugin::component::Type>(type), name)
-	{
-	}
-#pragma GCC diagnostic pop
-
 Component::~Component()
 	{
 	}

--- a/src/iosource/Component.h
+++ b/src/iosource/Component.h
@@ -44,20 +44,6 @@ protected:
 	 * be unique across all components of this type.
 	 */
 	Component(zeek::plugin::component::Type type, const std::string& name);
-
-	/**
-	 * Constructor to use by derived classes.
-	 *
-	 * @param type The type of the componnent.
-	 *
-	 * @param name A descriptive name for the component.  This name must
-	 * be unique across all components of this type.
-	 */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::plugin::component::Type instead")]]
-	Component(plugin::component::Type type, const std::string& name);
-#pragma GCC diagnostic pop
 };
 
 /**

--- a/src/parse.y
+++ b/src/parse.y
@@ -251,7 +251,7 @@ static bool expr_is_table_type_name(const zeek::detail::Expr* expr)
 	zeek::detail::case_list* case_l;
 	zeek::detail::Attr* attr;
 	std::vector<IntrusivePtr<zeek::detail::Attr>>* attr_l;
-	zeek::detail::attr_tag attrtag;
+	zeek::detail::AttrTag attrtag;
 }
 
 %%

--- a/src/parse.y
+++ b/src/parse.y
@@ -234,7 +234,7 @@ static bool expr_is_table_type_name(const zeek::detail::Expr* expr)
 	char* str;
 	zeek::detail::ID* id;
 	id_list* id_l;
-	zeek::detail::init_class ic;
+	zeek::detail::InitClass ic;
 	Val* val;
 	RE_Matcher* re;
 	zeek::detail::Expr* expr;

--- a/src/plugin/Component.cc
+++ b/src/plugin/Component.cc
@@ -14,16 +14,6 @@ Component::Component(component::Type arg_type, const std::string& arg_name)
 	canon_name = canonify_name(name);
 	}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-Component::Component(::plugin::component::Type arg_type, const std::string& arg_name)
-	{
-	type = static_cast<component::Type>(arg_type);
-	name = arg_name;
-	canon_name = canonify_name(name);
-	}
-#pragma GCC diagnostic pop
-
 Component::~Component()
 	{
 	}

--- a/src/plugin/Component.h
+++ b/src/plugin/Component.h
@@ -6,20 +6,6 @@
 
 class ODesc;
 
-namespace plugin::component {
-
-enum [[deprecated("Remove in v4.1. Use zeek::plugin::component::Type instead.")]] Type {
-	READER,	/// An input reader (not currently used).
-	WRITER,	/// A logging writer (not currenly used).
-	ANALYZER,	/// A protocol analyzer.
-	FILE_ANALYZER,	/// A file analyzer.
-	IOSOURCE,	/// An I/O source, excluding packet sources.
-	PKTSRC,	/// A packet source.
-	PKTDUMPER	/// A packet dumper.
-	};
-
-}
-
 namespace zeek::plugin {
 
 namespace component {
@@ -37,7 +23,7 @@ enum Type {
 	PKTDUMPER	/// A packet dumper.
 	};
 
-}
+} // namespace component
 
 /**
  * Base class for plugin components. A component is a specific piece of
@@ -56,20 +42,6 @@ public:
 	 * be unique across all components of the same type.
 	 */
 	Component(component::Type type, const std::string& name);
-
-	/**
-	 * Constructor.
-	 *
-	 * @param type The type of the compoment.
-	 *
-	 * @param name A descriptive name for the component.  This name must
-	 * be unique across all components of the same type.
-	 */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::plugin::component::Type instead")]]
-	Component(::plugin::component::Type type, const std::string& name);
-#pragma GCC diagnostic pop
 
 	/**
 	 * Destructor.
@@ -135,6 +107,27 @@ private:
 }
 
 namespace plugin
-	{
-	using Component [[deprecated("Remove in v4.1. Use zeek::plugin::Component instead.")]] = zeek::plugin::Component;
-	}
+{
+using Component [[deprecated("Remove in v4.1. Use zeek::plugin::Component instead.")]] = zeek::plugin::Component;
+
+namespace component
+{
+
+using Type [[deprecated("Remove in v4.1. Use zeek::plugin::component::Type instead.")]] = zeek::plugin::component::Type;
+[[deprecated("Remove in v4.1. Use zeek::plugin::component::READER instead.")]]
+constexpr auto READER = zeek::plugin::component::READER;
+[[deprecated("Remove in v4.1. Use zeek::plugin::component::WRITER instead.")]]
+constexpr auto WRITER = zeek::plugin::component::WRITER;
+[[deprecated("Remove in v4.1. Use zeek::plugin::component::ANALYZER instead.")]]
+constexpr auto ANALYZER = zeek::plugin::component::ANALYZER;
+[[deprecated("Remove in v4.1. Use zeek::plugin::component::FILE_ANALYZER instead.")]]
+constexpr auto FILE_ANALYZER = zeek::plugin::component::FILE_ANALYZER;
+[[deprecated("Remove in v4.1. Use zeek::plugin::component::IOSOURCE instead.")]]
+constexpr auto IOSOURCE = zeek::plugin::component::IOSOURCE;
+[[deprecated("Remove in v4.1. Use zeek::plugin::component::PKTSRC instead.")]]
+constexpr auto PKTSRC = zeek::plugin::component::PKTSRC;
+[[deprecated("Remove in v4.1. Use zeek::plugin::component::PKTDUMPER instead.")]]
+constexpr auto PKTDUMPER = zeek::plugin::component::PKTDUMPER;
+
+} // namespace component
+} // namespace plugin

--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -571,19 +571,6 @@ void Manager::DisableHook(zeek::plugin::HookType hook, Plugin* plugin)
 		}
 	}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-void Manager::EnableHook(::plugin::HookType hook, Plugin* plugin, int prio)
-	{
-	EnableHook(static_cast<zeek::plugin::HookType>(hook), plugin, prio);
-	}
-
-void Manager::DisableHook(::plugin::HookType hook, Plugin* plugin)
-	{
-	DisableHook(static_cast<zeek::plugin::HookType>(hook), plugin);
-	}
-#pragma GCC diagnostic pop
-
 void Manager::RequestEvent(EventHandlerPtr handler, Plugin* plugin)
 	{
 	DBG_LOG(DBG_PLUGINS, "Plugin %s requested event %s",

--- a/src/plugin/Manager.h
+++ b/src/plugin/Manager.h
@@ -171,16 +171,6 @@ public:
 		return hooks[hook] != nullptr;
 		}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::plugin::HookType")]]
-	bool HavePluginForHook(::plugin::HookType hook) const
-		{
-		// Inline to avoid the function call.
-		return HavePluginForHook(static_cast<zeek::plugin::HookType>(hook));
-		}
-#pragma GCC diagnostic pop
-
 	/**
 	 * Returns all the hooks, with their priorities, that are currently
 	 * enabled for a given plugin.
@@ -208,15 +198,6 @@ public:
 	 * plugin: The plugin that used to define the hook.
 	 */
 	void DisableHook(zeek::plugin::HookType hook, Plugin* plugin);
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::plugin::HookType")]]
-	void EnableHook(::plugin::HookType hook, Plugin* plugin, int prio);
-
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::plugin::HookType")]]
-	void DisableHook(::plugin::HookType hook, Plugin* plugin);
-#pragma GCC diagnostic pop
 
 	/**
 	 * Registers interest in an event by a plugin, even if there's no handler

--- a/src/plugin/Plugin.cc
+++ b/src/plugin/Plugin.cc
@@ -42,14 +42,6 @@ static constexpr const char* hook_names[int(zeek::plugin::NUM_HOOKS) + 1] = {
 	return hook_names[int(h)];
 	}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-const char* plugin::hook_name(::plugin::HookType h)
-	{
-	return hook_name(static_cast<zeek::plugin::HookType>(h));
-	}
-#pragma GCC diagnostic pop
-
 BifItem::BifItem(const std::string& arg_id, Type arg_type)
 	{
 	id = arg_id;
@@ -358,19 +350,6 @@ Plugin::hook_list Plugin::EnabledHooks() const
 	return plugin_mgr->HooksEnabledForPlugin(this);
 	}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-void Plugin::EnableHook(::plugin::HookType hook, int priority)
-	{
-	plugin_mgr->EnableHook(static_cast<zeek::plugin::HookType>(hook), this, priority);
-	}
-
-void Plugin::DisableHook(::plugin::HookType hook)
-	{
-	plugin_mgr->DisableHook(static_cast<zeek::plugin::HookType>(hook), this);
-	}
-#pragma GCC diagnostic pop
-
 void Plugin::EnableHook(zeek::plugin::HookType hook, int priority)
 	{
 	plugin_mgr->EnableHook(hook, this, priority);
@@ -460,38 +439,19 @@ bool Plugin::HookLogWrite(const std::string& writer, const std::string& filter,
 	}
 
 bool Plugin::HookReporter(const std::string& prefix, const EventHandlerPtr event,
-			  const Connection* conn, const val_list* addl, bool location,
-			  const Location* location1, const Location* location2,
-			  bool time, const std::string& message)
+                          const Connection* conn, const val_list* addl, bool location,
+                          const Location* location1, const Location* location2,
+                          bool time, const std::string& message)
 	{
 	return true;
 	}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-void Plugin::MetaHookPre(::plugin::HookType hook, const HookArgumentList& args)
-	{
-	}
-
-void Plugin::MetaHookPost(::plugin::HookType hook, const HookArgumentList& args, HookArgument result)
-	{
-	}
-#pragma GCC diagnostic pop
-
 void Plugin::MetaHookPre(zeek::plugin::HookType hook, const HookArgumentList& args)
 	{
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	MetaHookPre(static_cast<::plugin::HookType>(hook), args);
-#pragma GCC diagnostic pop
 	}
 
 void Plugin::MetaHookPost(zeek::plugin::HookType hook, const HookArgumentList& args, HookArgument result)
 	{
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	MetaHookPost(static_cast<::plugin::HookType>(hook), args, result);
-#pragma GCC diagnostic pop
 	}
 
 void Plugin::InitializeComponents()

--- a/src/plugin/Plugin.h
+++ b/src/plugin/Plugin.h
@@ -26,44 +26,6 @@ namespace threading {
 struct Field;
 }
 
-namespace plugin {
-
-/**
- * Hook types that a plugin may define. Each label maps to the corresponding
- * virtual method in \a Plugin.
- */
-enum [[deprecated("Remove in v4.1. Use the zeek::plugin::HookType instead.")]] HookType {
-	// Note: when changing this table, update hook_name() in Plugin.cc.
-	HOOK_LOAD_FILE,			//< Activates Plugin::HookLoadFile().
-	HOOK_CALL_FUNCTION,		//< Activates Plugin::HookCallFunction().
-	HOOK_QUEUE_EVENT,		//< Activates Plugin::HookQueueEvent().
-	HOOK_DRAIN_EVENTS,		//< Activates Plugin::HookDrainEvents()
-	HOOK_UPDATE_NETWORK_TIME,	//< Activates Plugin::HookUpdateNetworkTime.
-	HOOK_BRO_OBJ_DTOR,		//< Activates Plugin::HookBroObjDtor.
-	HOOK_SETUP_ANALYZER_TREE,	//< Activates Plugin::HookAddToAnalyzerTree
-	HOOK_LOG_INIT,			//< Activates Plugin::HookLogInit
-	HOOK_LOG_WRITE,			//< Activates Plugin::HookLogWrite
-	HOOK_REPORTER,			//< Activates Plugin::HookReporter
-
-	// Meta hooks.
-	META_HOOK_PRE,			//< Activates Plugin::MetaHookPre().
-	META_HOOK_POST,			//< Activates Plugin::MetaHookPost().
-
-	// End marker.
-	NUM_HOOKS,
-};
-
-/**
- * Converts a hook type into a readable hook name.
- */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-[[deprecated("Remove in v4.1. Use the version that takes zeek::plugin:HookType instead.")]]
-extern const char* hook_name(::plugin::HookType h);
-#pragma GCC diagnostic pop
-
-}
-
 namespace zeek::plugin  {
 
 class Manager;
@@ -628,15 +590,6 @@ protected:
 	 */
 	void DisableHook(zeek::plugin::HookType hook);
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::plugin:HookType instead.")]]
-	void EnableHook(::plugin::HookType hook, int priority = 0);
-
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::plugin:HookType instead.")]]
-	void DisableHook(::plugin::HookType hook);
-#pragma GCC diagnostic pop
-
 	/**
 	 * Returns a list of hooks that are currently enabled for the plugin,
 	 * along with their priorities.
@@ -875,46 +828,7 @@ protected:
 	                          bool time, const std::string& message);
 
 	// Meta hooks.
-
-	/**
-	 * A meta hook called just before another hook gets to execute. This
-	 * will be called independent of whether there's an implementation
-	 * for the hook.
-	 *
-	 * hook: The name of the hook about the execute. This will be the
-	 * same as the corresponding method name (e.g., \c HookQueueEvent).
-	 *
-	 * hook: The type of the hook about to execute.
-	 *
-	 * args: A list of the hooks arguments.
-	 */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::plugin:HookType instead.")]]
-	virtual void MetaHookPre(::plugin::HookType hook, const HookArgumentList& args);
-#pragma GCC diagnostic pop
-
 	virtual void MetaHookPre(zeek::plugin::HookType hook, const HookArgumentList& args);
-
-	/**
-	 * A meta hook called just after another hook got to execute. This
-	 * will be called independent of whether there's an implementation
-	 * for the hook.
-	 *
-	 * hook: The type of the hook that finished executing.
-	 *
-	 * args: A list of the hooks arguments.
-	 *
-	 * result: The result that executing the hook returned. If there's no
-	 * implementation for the hook, this will be the default result. If
-	 * the hook doesn't yield a result, this will be of type VOID.
-	 */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::plugin:HookType instead.")]]
-	virtual void MetaHookPost(::plugin::HookType hook, const HookArgumentList& args, HookArgument result);
-#pragma GCC diagnostic pop
-
 	virtual void MetaHookPost(zeek::plugin::HookType hook, const HookArgumentList& args, HookArgument result);
 
 private:
@@ -969,13 +883,42 @@ private:
 	bif_item_list bif_items;	// BiF items the plugin provides.
 };
 
-}
+} // namespace zeek::plugin
 
 namespace plugin {
-	using VersionNumber [[deprecated("Remove in v4.1. Use zeek::plugin::VersionNumber instead")]] = zeek::plugin::VersionNumber;
-	using Configuration [[deprecated("Remove in v4.1. Use zeek::plugin::Configuration instead")]] = zeek::plugin::Configuration;
-	using BifItem [[deprecated("Remove in v4.1. Use zeek::plugin::BifItem instead")]] = zeek::plugin::BifItem;
-	using HookArgument [[deprecated("Remove in v4.1. Use zeek::plugin::HookArgument instead")]] = zeek::plugin::HookArgument;
-	using HookArgumentList [[deprecated("Remove in v4.1. Use zeek::plugin::HookArgumentList instead")]] = zeek::plugin::HookArgumentList;
-	using Plugin [[deprecated("Remove in v4.1. Use zeek::plugin::Plugin instead")]] = zeek::plugin::Plugin;
-}
+
+using VersionNumber [[deprecated("Remove in v4.1. Use zeek::plugin::VersionNumber instead")]] = zeek::plugin::VersionNumber;
+using Configuration [[deprecated("Remove in v4.1. Use zeek::plugin::Configuration instead")]] = zeek::plugin::Configuration;
+using BifItem [[deprecated("Remove in v4.1. Use zeek::plugin::BifItem instead")]] = zeek::plugin::BifItem;
+using HookArgument [[deprecated("Remove in v4.1. Use zeek::plugin::HookArgument instead")]] = zeek::plugin::HookArgument;
+using HookArgumentList [[deprecated("Remove in v4.1. Use zeek::plugin::HookArgumentList instead")]] = zeek::plugin::HookArgumentList;
+using Plugin [[deprecated("Remove in v4.1. Use zeek::plugin::Plugin instead")]] = zeek::plugin::Plugin;
+
+using HookType [[deprecated("Remove in v4.1. Use the zeek::plugin::HookType instead.")]] = zeek::plugin::HookType;
+
+[[deprecated("Remove in v4.1. Use zeek::plugin::HOOK_LOAD_FILE instead.")]]
+constexpr auto HOOK_LOAD_FILE = zeek::plugin::HOOK_LOAD_FILE;
+[[deprecated("Remove in v4.1. Use zeek::plugin::HOOK_CALL_FUNCTION instead.")]]
+constexpr auto HOOK_CALL_FUNCTION = zeek::plugin::HOOK_CALL_FUNCTION;
+[[deprecated("Remove in v4.1. Use zeek::plugin::HOOK_QUEUE_EVENT instead.")]]
+constexpr auto HOOK_QUEUE_EVENT = zeek::plugin::HOOK_QUEUE_EVENT;
+[[deprecated("Remove in v4.1. Use zeek::plugin::HOOK_DRAIN_EVENTS instead.")]]
+constexpr auto HOOK_DRAIN_EVENTS = zeek::plugin::HOOK_DRAIN_EVENTS;
+[[deprecated("Remove in v4.1. Use zeek::plugin::HOOK_UPDATE_NETWORK_TIME instead.")]]
+constexpr auto HOOK_UPDATE_NETWORK_TIME = zeek::plugin::HOOK_UPDATE_NETWORK_TIME;
+[[deprecated("Remove in v4.1. Use zeek::plugin::HOOK_BRO_OBJ_DTOR instead.")]]
+constexpr auto HOOK_BRO_OBJ_DTOR = zeek::plugin::HOOK_BRO_OBJ_DTOR;
+[[deprecated("Remove in v4.1. Use zeek::plugin::HOOK_SETUP_ANALYZER_TREE instead.")]]
+constexpr auto HOOK_SETUP_ANALYZER_TREE = zeek::plugin::HOOK_SETUP_ANALYZER_TREE;
+[[deprecated("Remove in v4.1. Use zeek::plugin::HOOK_LOG_INIT instead.")]]
+constexpr auto HOOK_LOG_INIT = zeek::plugin::HOOK_LOG_INIT;
+[[deprecated("Remove in v4.1. Use zeek::plugin::HOOK_LOG_WRITE instead.")]]
+constexpr auto HOOK_LOG_WRITE = zeek::plugin::HOOK_LOG_WRITE;
+[[deprecated("Remove in v4.1. Use zeek::plugin::HOOK_REPORTER instead.")]]
+constexpr auto HOOK_REPORTER = zeek::plugin::HOOK_REPORTER;
+[[deprecated("Remove in v4.1. Use zeek::plugin::META_HOOK_PRE instead.")]]
+constexpr auto META_HOOK_PRE = zeek::plugin::META_HOOK_PRE;
+[[deprecated("Remove in v4.1. Use zeek::plugin::META_HOOK_POST instead.")]]
+constexpr auto META_HOOK_POST = zeek::plugin::META_HOOK_POST;
+
+} // namespace plugin

--- a/src/threading/SerialTypes.h
+++ b/src/threading/SerialTypes.h
@@ -33,14 +33,6 @@ struct Field {
 		  secondary_name(secondary_name ? copy_string(secondary_name) : nullptr),
 		  type(type), subtype(subtype), optional(optional)	{ }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::TypeTag instead")]]
-	Field(const char* name, const char* secondary_name, ::TypeTag type, ::TypeTag subtype, bool optional) :
-		Field(name, secondary_name, static_cast<zeek::TypeTag>(type), static_cast<zeek::TypeTag>(subtype), optional)
-		{}
-#pragma GCC diagnostic pop
-
 	/**
 	 * Copy constructor.
 	 */
@@ -153,14 +145,6 @@ struct Value {
 		: type(arg_type), subtype(zeek::TYPE_VOID), present(arg_present)
 		{}
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::TypeTag.")]]
-	Value(::TypeTag arg_type, bool arg_present = true)
-		: Value(static_cast<zeek::TypeTag>(arg_type), arg_present)
-		{}
-#pragma GCC diagnostic pop
-
 	/**
 	* Constructor.
 	*
@@ -174,14 +158,6 @@ struct Value {
 	Value(zeek::TypeTag arg_type, zeek::TypeTag arg_subtype, bool arg_present = true)
 		: type(arg_type), subtype(arg_subtype), present(arg_present)
 		{}
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	[[deprecated("Remove in v4.1. Use the version that takes zeek::TypeTag.")]]
-	Value(::TypeTag arg_type, ::TypeTag arg_subtype, bool arg_present = true)
-		: Value(static_cast<zeek::TypeTag>(arg_type), static_cast<zeek::TypeTag>(arg_subtype), arg_present)
-		{}
-#pragma GCC diagnostic pop
 
 	/**
 	 * Destructor.

--- a/src/zeekygen/IdentifierInfo.cc
+++ b/src/zeekygen/IdentifierInfo.cc
@@ -31,7 +31,7 @@ IdentifierInfo::~IdentifierInfo()
 		delete it->second;
 	}
 
-void IdentifierInfo::AddRedef(const string& script, zeek::detail::init_class ic,
+void IdentifierInfo::AddRedef(const string& script, zeek::detail::InitClass ic,
                               IntrusivePtr<zeek::detail::Expr> init_expr, const vector<string>& comments)
 	{
 	Redefinition* redef = new Redefinition(script, ic, std::move(init_expr), comments);
@@ -39,8 +39,8 @@ void IdentifierInfo::AddRedef(const string& script, zeek::detail::init_class ic,
 	}
 
 void IdentifierInfo::AddRecordField(const zeek::TypeDecl* field,
-				    const string& script,
-				    vector<string>& comments)
+                                    const string& script,
+                                    vector<string>& comments)
 	{
 	RecordField* rf = new RecordField();
 	rf->field = new zeek::TypeDecl(*field);
@@ -140,14 +140,14 @@ time_t IdentifierInfo::DoGetModificationTime() const
 	}
 
 IdentifierInfo::Redefinition::Redefinition(
-                       std::string arg_script,
-                       zeek::detail::init_class arg_ic,
-                       IntrusivePtr<zeek::detail::Expr> arg_expr,
-                       std::vector<std::string> arg_comments)
-			: from_script(std::move(arg_script)),
-			  ic(arg_ic),
-			  init_expr(std::move(arg_expr)),
-			  comments(std::move(arg_comments))
+	std::string arg_script,
+	zeek::detail::InitClass arg_ic,
+	IntrusivePtr<zeek::detail::Expr> arg_expr,
+	std::vector<std::string> arg_comments)
+	: from_script(std::move(arg_script)),
+	  ic(arg_ic),
+	  init_expr(std::move(arg_expr)),
+	  comments(std::move(arg_comments))
 	{
 	}
 

--- a/src/zeekygen/IdentifierInfo.h
+++ b/src/zeekygen/IdentifierInfo.h
@@ -70,7 +70,7 @@ public:
 	 * @param init_expr The initialization expression used.
 	 * @param comments Comments associated with the redef statement.
 	 */
-	void AddRedef(const std::string& from_script, zeek::detail::init_class ic,
+	void AddRedef(const std::string& from_script, zeek::detail::InitClass ic,
 	              IntrusivePtr<zeek::detail::Expr> init_expr,
 	              const std::vector<std::string>& comments);
 
@@ -127,11 +127,11 @@ public:
 	 */
 	struct Redefinition {
 		std::string from_script; /**< Name of script doing the redef. */
-		zeek::detail::init_class ic;
+		zeek::detail::InitClass ic;
 		IntrusivePtr<zeek::detail::Expr> init_expr;
 		std::vector<std::string> comments; /**< Zeekygen comments on redef. */
 
-		Redefinition(std::string arg_script, zeek::detail::init_class arg_ic,
+		Redefinition(std::string arg_script, zeek::detail::InitClass arg_ic,
 		             IntrusivePtr<zeek::detail::Expr> arg_expr,
 		             std::vector<std::string> arg_comments);
 

--- a/src/zeekygen/Manager.cc
+++ b/src/zeekygen/Manager.cc
@@ -338,7 +338,7 @@ void Manager::Identifier(IntrusivePtr<zeek::detail::ID> id)
 	}
 
 void Manager::RecordField(const zeek::detail::ID* id, const zeek::TypeDecl* field,
-			  const string& path)
+                          const string& path)
 	{
 	if ( disabled )
 		return;
@@ -361,7 +361,7 @@ void Manager::RecordField(const zeek::detail::ID* id, const zeek::TypeDecl* fiel
 	}
 
 void Manager::Redef(const zeek::detail::ID* id, const string& path,
-	zeek::detail::init_class ic, IntrusivePtr<zeek::detail::Expr> init_expr)
+                    zeek::detail::InitClass ic, IntrusivePtr<zeek::detail::Expr> init_expr)
 	{
 	if ( disabled )
 		return;
@@ -398,7 +398,7 @@ void Manager::Redef(const zeek::detail::ID* id, const string& path,
 	}
 
 void Manager::Redef(const zeek::detail::ID* id, const std::string& path,
-	zeek::detail::init_class ic)
+                    zeek::detail::InitClass ic)
 	{
 	Redef(id, path, ic, nullptr);
 	}

--- a/src/zeekygen/Manager.h
+++ b/src/zeekygen/Manager.h
@@ -140,9 +140,9 @@ public:
 	 * @param init_expr The intiialization expression that was used.
 	 */
 	void Redef(const zeek::detail::ID* id, const std::string& path,
-		zeek::detail::init_class ic, IntrusivePtr<zeek::detail::Expr> init_expr);
+	           zeek::detail::InitClass ic, IntrusivePtr<zeek::detail::Expr> init_expr);
 	void Redef(const zeek::detail::ID* id, const std::string& path,
-		zeek::detail::init_class ic = zeek::detail::INIT_NONE);
+	           zeek::detail::InitClass ic = zeek::detail::INIT_NONE);
 
 	/**
 	 * Register Zeekygen script summary content.


### PR DESCRIPTION
This changes the way that a number of enums are deprecated, since the previous way was causing breakage of external plugins. This should be merged before https://github.com/zeek/zeek/pull/1023 so that it can be rebased on top of these changes.

Fixes #1032