### PR TITLE
GH-786: Move Type::As methods to cc file so they have type info for casting safely

### DIFF
--- a/src/Type.cc
+++ b/src/Type.cc
@@ -71,6 +71,131 @@ Type::Type(zeek::TypeTag t, bool arg_base_type)
 	{
 	}
 
+#define CHECK_TYPE_TAG(tag_type, func_name) \
+	CHECK_TAG(tag, tag_type, func_name, type_name)
+
+const TypeList* Type::AsTypeList() const
+	{
+	CHECK_TYPE_TAG(TYPE_LIST, "Type::AsTypeList");
+	return (const TypeList*) this;
+	}
+
+TypeList* Type::AsTypeList()
+	{
+	CHECK_TYPE_TAG(TYPE_LIST, "Type::AsTypeList");
+	return (TypeList*) this;
+	}
+
+const TableType* Type::AsTableType() const
+	{
+	CHECK_TYPE_TAG(TYPE_TABLE, "Type::AsTableType");
+	return (const TableType*) this;
+	}
+
+TableType* Type::AsTableType()
+	{
+	CHECK_TYPE_TAG(TYPE_TABLE, "Type::AsTableType");
+	return (TableType*) this;
+	}
+
+const SetType* Type::AsSetType() const
+	{
+	if ( ! IsSet() )
+		BadTag("Type::AsSetType", type_name(tag));
+	return (const SetType*) this;
+	}
+
+SetType* Type::AsSetType()
+	{
+	if ( ! IsSet() )
+		BadTag("Type::AsSetType", type_name(tag));
+	return (SetType*) this;
+	}
+
+const RecordType* Type::AsRecordType() const
+	{
+	CHECK_TYPE_TAG(TYPE_RECORD, "Type::AsRecordType");
+	return (const RecordType*) this;
+	}
+
+RecordType* Type::AsRecordType()
+	{
+	CHECK_TYPE_TAG(TYPE_RECORD, "Type::AsRecordType");
+	return (RecordType*) this;
+	}
+
+const SubNetType* Type::AsSubNetType() const
+	{
+	CHECK_TYPE_TAG(TYPE_SUBNET, "Type::AsSubNetType");
+	return (const SubNetType*) this;
+	}
+
+SubNetType* Type::AsSubNetType()
+	{
+	CHECK_TYPE_TAG(TYPE_SUBNET, "Type::AsSubNetType");
+	return (SubNetType*) this;
+	}
+
+const FuncType* Type::AsFuncType() const
+	{
+	CHECK_TYPE_TAG(TYPE_FUNC, "Type::AsFuncType");
+	return (const FuncType*) this;
+	}
+
+FuncType* Type::AsFuncType()
+	{
+	CHECK_TYPE_TAG(TYPE_FUNC, "Type::AsFuncType");
+	return (FuncType*) this;
+	}
+
+const EnumType* Type::AsEnumType() const
+	{
+	CHECK_TYPE_TAG(TYPE_ENUM, "Type::AsEnumType");
+	return (const EnumType*) this;
+	}
+
+EnumType* Type::AsEnumType()
+	{
+	CHECK_TYPE_TAG(TYPE_ENUM, "Type::AsEnumType");
+	return (EnumType*) this;
+	}
+
+const VectorType* Type::AsVectorType() const
+	{
+	CHECK_TYPE_TAG(TYPE_VECTOR, "Type::AsVectorType");
+	return (const VectorType*) this;
+	}
+
+VectorType* Type::AsVectorType()
+	{
+	CHECK_TYPE_TAG(TYPE_VECTOR, "Type::AsVectorType");
+	return (VectorType*) this;
+	}
+
+const OpaqueType* Type::AsOpaqueType() const
+	{
+	CHECK_TYPE_TAG(TYPE_OPAQUE, "Type::AsOpaqueType");
+	return (const OpaqueType*) this;
+	}
+
+OpaqueType* Type::AsOpaqueType()
+	{
+	CHECK_TYPE_TAG(TYPE_OPAQUE, "Type::AsOpaqueType");
+	return (OpaqueType*) this;
+	}
+
+const TypeType* Type::AsTypeType() const
+	{
+	CHECK_TYPE_TAG(TYPE_TYPE, "Type::AsTypeType");
+	return (const TypeType*) this;
+	}
+
+TypeType* Type::AsTypeType()
+	{
+	CHECK_TYPE_TAG(TYPE_TYPE, "Type::AsTypeType");
+	return (TypeType*) this;
+	}
+
 IntrusivePtr<Type> Type::ShallowClone()
 	{
 	switch ( tag ) {

--- a/src/Type.h
+++ b/src/Type.h
@@ -245,126 +245,35 @@ public:
 	[[deprecated("Remove in v4.1.  Use RecordType::GetFieldType() directly.")]]
 	virtual Type* FieldType(const char* field) const;
 
-#define CHECK_TYPE_TAG(tag_type, func_name) \
-	CHECK_TAG(tag, tag_type, func_name, type_name)
+	const TypeList* AsTypeList() const;
+	TypeList* AsTypeList();
 
-	const TypeList* AsTypeList() const
-		{
-		CHECK_TYPE_TAG(TYPE_LIST, "Type::AsTypeList");
-		return (const TypeList*) this;
-		}
-	TypeList* AsTypeList()
-		{
-		CHECK_TYPE_TAG(TYPE_LIST, "Type::AsTypeList");
-		return (TypeList*) this;
-		}
+	const TableType* AsTableType() const;
+	TableType* AsTableType();
 
-	const TableType* AsTableType() const
-		{
-		CHECK_TYPE_TAG(TYPE_TABLE, "Type::AsTableType");
-		return (const TableType*) this;
-		}
-	TableType* AsTableType()
-		{
-		CHECK_TYPE_TAG(TYPE_TABLE, "Type::AsTableType");
-		return (TableType*) this;
-		}
+	const SetType* AsSetType() const;
+	SetType* AsSetType();
 
-	SetType* AsSetType()
-		{
-		if ( ! IsSet() )
-			BadTag("Type::AsSetType", type_name(tag));
-		return (SetType*) this;
-		}
-	const SetType* AsSetType() const
-		{
-		if ( ! IsSet() )
-			BadTag("Type::AsSetType", type_name(tag));
-		return (const SetType*) this;
-		}
+	const RecordType* AsRecordType() const;
+	RecordType* AsRecordType();
 
-	const RecordType* AsRecordType() const
-		{
-		CHECK_TYPE_TAG(TYPE_RECORD, "Type::AsRecordType");
-		return (const RecordType*) this;
-		}
-	RecordType* AsRecordType()
-		{
-		CHECK_TYPE_TAG(TYPE_RECORD, "Type::AsRecordType");
-		return (RecordType*) this;
-		}
+	const SubNetType* AsSubNetType() const;
+	SubNetType* AsSubNetType();
 
-	const SubNetType* AsSubNetType() const
-		{
-		CHECK_TYPE_TAG(TYPE_SUBNET, "Type::AsSubNetType");
-		return (const SubNetType*) this;
-		}
+	const FuncType* AsFuncType() const;
+	FuncType* AsFuncType();
 
-	SubNetType* AsSubNetType()
-		{
-		CHECK_TYPE_TAG(TYPE_SUBNET, "Type::AsSubNetType");
-		return (SubNetType*) this;
-		}
+	const EnumType* AsEnumType() const;
+	EnumType* AsEnumType();
 
-	const FuncType* AsFuncType() const
-		{
-		CHECK_TYPE_TAG(TYPE_FUNC, "Type::AsFuncType");
-		return (const FuncType*) this;
-		}
+	const VectorType* AsVectorType() const;
+	VectorType* AsVectorType();
 
-	FuncType* AsFuncType()
-		{
-		CHECK_TYPE_TAG(TYPE_FUNC, "Type::AsFuncType");
-		return (FuncType*) this;
-		}
+	const OpaqueType* AsOpaqueType() const;
+	OpaqueType* AsOpaqueType();
 
-	const EnumType* AsEnumType() const
-		{
-		CHECK_TYPE_TAG(TYPE_ENUM, "Type::AsEnumType");
-		return (EnumType*) this;
-		}
-
-	EnumType* AsEnumType()
-		{
-		CHECK_TYPE_TAG(TYPE_ENUM, "Type::AsEnumType");
-		return (EnumType*) this;
-		}
-
-	const VectorType* AsVectorType() const
-		{
-		CHECK_TYPE_TAG(TYPE_VECTOR, "Type::AsVectorType");
-		return (VectorType*) this;
-		}
-
-	OpaqueType* AsOpaqueType()
-		{
-		CHECK_TYPE_TAG(TYPE_OPAQUE, "Type::AsOpaqueType");
-		return (OpaqueType*) this;
-		}
-
-	const OpaqueType* AsOpaqueType() const
-		{
-		CHECK_TYPE_TAG(TYPE_OPAQUE, "Type::AsOpaqueType");
-		return (OpaqueType*) this;
-		}
-
-	VectorType* AsVectorType()
-		{
-		CHECK_TYPE_TAG(TYPE_VECTOR, "Type::AsVectorType");
-		return (VectorType*) this;
-		}
-
-	const TypeType* AsTypeType() const
-		{
-		CHECK_TYPE_TAG(TYPE_TYPE, "Type::AsTypeType");
-		return (TypeType*) this;
-		}
-
-	TypeType* AsTypeType()
-		{
-		CHECK_TYPE_TAG(TYPE_TYPE, "Type::AsTypeType");
-		return (TypeType*) this;
-		}
+	const TypeType* AsTypeType() const;
+	TypeType* AsTypeType();
 
 	bool IsSet() const
 		{


### PR DESCRIPTION
I opted to leave these as C-style casts for the time being. I wanted to get it in before 3.2.

`dynamic_cast` would be the correct choice here based on the c++ core guidelines, but then we'd have to add null-checks to all of the places we call these methods (or add them directly in these methods). I'll open a second GHI to discuss those changes and the ones for clang-tidy's cppcoreguidelines-pro-type-static-cast-downcast checker.