### PR TITLE
Fix WhileStmt to call Stmt(Tag) ctor

### DIFF
--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -1001,7 +1001,8 @@ TraversalCode EventStmt::Traverse(TraversalCallback* cb) const
 
 WhileStmt::WhileStmt(ExprPtr arg_loop_condition,
                      StmtPtr arg_body)
-	: loop_condition(std::move(arg_loop_condition)), body(std::move(arg_body))
+	: Stmt(STMT_WHILE),
+	  loop_condition(std::move(arg_loop_condition)), body(std::move(arg_body))
 	{
 	if ( ! loop_condition->IsError() &&
 	     ! IsBool(loop_condition->GetType()->Tag()) )

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -66,7 +66,6 @@ public:
 	virtual TraversalCode Traverse(TraversalCallback* cb) const = 0;
 
 protected:
-	Stmt()	{}
 	explicit Stmt(BroStmtTag arg_tag);
 
 	void AddTag(ODesc* d) const;


### PR DESCRIPTION
Also removed Stmt() default ctor to help ensure derived classes
initialize the Stmt tag (and other members).