### PR TITLE
Deprecate icmp_conn

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -259,6 +259,19 @@ Deprecated Functionality
   that the former returns a vector with indices starting at 1 while the
   later returns a vector with indices starting at 0.
 
+- The ``icmp_conn`` parameter of ICMP events is deprecated, there's an
+  alternate version with an ``icmp_info`` parameter to use instead.
+  The ``icmp_conn`` record passed to ICMP events has always been re-used
+  amongst all events within an ICMP "connection", so the
+  ``itype``, ``icode``, ``len``, and ``hlim`` fields as inspected in
+  handlers never appears to change even if the underlying packet data
+  has different values for those fields.  However, it's not known if
+  anyone relied on that behavior, so the new ``icmp_info`` record is
+  introduced with the more-expected behavior of being created and
+  populated for each new event.  It also removes the orig_h/resp_h
+  fields since those are redundant with what's already available in
+  the connection parameter.
+
 Zeek 3.1.0
 ==========
 

--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -188,6 +188,19 @@ type icmp_conn: record {
 	v6: bool;	##< True if it's an ICMPv6 packet.
 };
 
+## Specifics about an ICMP conversation/packet.
+## ICMP events typically pass this in addition to :zeek:type:`conn_id`.
+##
+## .. zeek:see:: icmp_echo_reply icmp_echo_request icmp_redirect icmp_sent
+##    icmp_time_exceeded icmp_unreachable
+type icmp_info: record {
+	v6: bool;      ##< True if it's an ICMPv6 packet.
+	itype: count;  ##< The ICMP type of the current packet.
+	icode: count;  ##< The ICMP code of the current packet.
+	len: count;    ##< The length of the ICMP payload.
+	ttl: count;    ##< The encapsulating IP header's TTL (IPv4) or Hop Limit (IPv6).
+};
+
 ## Packet context part of an ICMP message. The fields of this record reflect the
 ## packet that is described by the context.
 ##

--- a/scripts/policy/misc/detect-traceroute/main.zeek
+++ b/scripts/policy/misc/detect-traceroute/main.zeek
@@ -95,7 +95,7 @@ event signature_match(state: signature_state, msg: string, data: string)
 		}
 	}
 
-event icmp_time_exceeded(c: connection, icmp: icmp_conn, code: count, context: icmp_context)
+event icmp_time_exceeded(c: connection, info: icmp_info, code: count, context: icmp_context)
 	{
 	SumStats::observe("traceroute.time_exceeded", [$str=cat(context$id$orig_h,"-",context$id$resp_h,"-",get_port_transport_proto(context$id$resp_p))], [$str=cat(c$id$orig_h)]);
 	}

--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -40,6 +40,18 @@ Attr::Attr(AttrTag t)
 void Attr::SetAttrExpr(ExprPtr e)
 	{ expr = std::move(e); }
 
+std::string Attr::DeprecationMessage() const
+	{
+	if ( tag != ATTR_DEPRECATED )
+		return "";
+
+	if ( ! expr )
+		return "";
+
+	auto ce = static_cast<zeek::detail::ConstExpr*>(expr.get());
+	return ce->Value()->AsStringVal()->CheckString();
+	}
+
 void Attr::Describe(ODesc* d) const
 	{
 	AddTag(d);

--- a/src/Attr.h
+++ b/src/Attr.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <vector>
+#include <string>
 
 #include "Obj.h"
 #include "BroList.h"
@@ -72,6 +73,12 @@ public:
 
 	void Describe(ODesc* d) const override;
 	void DescribeReST(ODesc* d, bool shorten = false) const;
+
+	/**
+	 * Returns the deprecation string associated with a &deprecated attribute
+	 * or an empty string if this is not such an attribute.
+	 */
+	std::string DeprecationMessage() const;
 
 	bool operator==(const Attr& other) const
 		{

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -294,14 +294,7 @@ std::string ID::GetDeprecationWarning() const
 	const auto& depr_attr = GetAttr(ATTR_DEPRECATED);
 
 	if ( depr_attr )
-		{
-		auto expr = static_cast<zeek::detail::ConstExpr*>(depr_attr->GetExpr().get());
-		if ( expr )
-			{
-			StringVal* text = expr->Value()->AsStringVal();
-			result = text->CheckString();
-			}
-		}
+		result = depr_attr->DeprecationMessage();
 
 	if ( result.empty() )
 		return fmt("deprecated (%s)", Name());

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -563,7 +563,7 @@ FuncType::FuncType(RecordTypePtr arg_args,
 		offsets[i] = i;
 		}
 
-	prototypes.emplace_back(Prototype{false, args, std::move(offsets)});
+	prototypes.emplace_back(Prototype{false, "", args, std::move(offsets)});
 	}
 
 TypePtr FuncType::ShallowClone()
@@ -1120,14 +1120,7 @@ string RecordType::GetFieldDeprecationWarning(int field, bool has_check) const
 		{
 		string result;
 		if ( const auto& deprecation = decl->GetAttr(zeek::detail::ATTR_DEPRECATED) )
-			{
-			auto expr = static_cast<zeek::detail::ConstExpr*>(deprecation->GetExpr().get());
-			if ( expr )
-				{
-				StringVal* text = expr->Value()->AsStringVal();
-				result = text->CheckString();
-				}
-			}
+			result = deprecation->DeprecationMessage();
 
 		if ( result.empty() )
 			return fmt("deprecated (%s%s$%s)", GetName().c_str(), has_check ? "?" : "",

--- a/src/Type.h
+++ b/src/Type.h
@@ -427,6 +427,7 @@ public:
 	 */
 	struct Prototype {
 		bool deprecated;
+		std::string deprecation_msg;
 		RecordTypePtr args;
 		std::map<int, int> offsets;
 	};

--- a/src/Type.h
+++ b/src/Type.h
@@ -429,6 +429,8 @@ public:
 		bool deprecated;
 		std::string deprecation_msg;
 		RecordTypePtr args;
+		// Maps from parameter index in canonical prototype to
+		// parameter index in this alternate prorotype.
 		std::map<int, int> offsets;
 	};
 

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -450,7 +450,15 @@ static std::optional<zeek::FuncType::Prototype> func_type_check(const zeek::Func
 		return {};
 		}
 
-	return decl->FindPrototype(*impl->Params());
+	auto rval = decl->FindPrototype(*impl->Params());
+
+	if ( rval )
+		for ( auto i = 0; i < rval->args->NumFields(); ++i )
+			if ( rval->args->FieldDecl(i)->GetAttr(zeek::detail::ATTR_DEPRECATED) )
+				impl->Warn(fmt("use of deprecated parameter '%s'",
+				               rval->args->FieldName(i)), decl, true);
+
+	return rval;
 	}
 
 static bool canonical_arg_types_match(const zeek::FuncType* decl, const zeek::FuncType* impl)

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -531,7 +531,8 @@ void begin_func(zeek::detail::IDPtr id, const char* module_name,
 				}
 
 			if ( prototype->deprecated )
-				t->Warn("use of deprecated prototype", id.get());
+				t->Warn(fmt("use of deprecated '%s' prototype", id->Name()),
+				        prototype->args.get(), true);
 			}
 		else
 			{

--- a/src/analyzer/protocol/icmp/ICMP.h
+++ b/src/analyzer/protocol/icmp/ICMP.h
@@ -57,6 +57,9 @@ protected:
 	zeek::RecordValPtr BuildICMPVal(const struct icmp* icmpp, int len,
 	                                int icmpv6, const IP_Hdr* ip_hdr);
 
+	zeek::RecordValPtr BuildInfo(const struct icmp* icmpp, int len,
+	                             bool icmpv6, const IP_Hdr* ip_hdr);
+
 	void NextICMP4(double t, const struct icmp* icmpp, int len, int caplen,
 	               const u_char*& data, const IP_Hdr* ip_hdr );
 

--- a/src/analyzer/protocol/icmp/events.bif
+++ b/src/analyzer/protocol/icmp/events.bif
@@ -12,8 +12,13 @@
 ## icmp: Additional ICMP-specific information augmenting the standard
 ##       connection record *c*.
 ##
+## info: Additional ICMP-specific information augmenting the standard
+##       connection record *c*.
+##
 ## .. zeek:see:: icmp_error_message icmp_sent_payload
-event icmp_sent%(c: connection, icmp: icmp_conn%);
+event icmp_sent%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info%);
+event icmp_sent%(c: connection, info: icmp_info%);
+event icmp_sent%(c: connection, icmp: icmp_conn%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## The same as :zeek:see:`icmp_sent` except containing the ICMP payload.
 ##
@@ -22,10 +27,15 @@ event icmp_sent%(c: connection, icmp: icmp_conn%);
 ## icmp: Additional ICMP-specific information augmenting the standard
 ##       connection record *c*.
 ##
+## info: Additional ICMP-specific information augmenting the standard
+##       connection record *c*.
+##
 ## payload: The payload of the ICMP message.
 ##
 ## .. zeek:see:: icmp_error_message icmp_sent_payload
-event icmp_sent_payload%(c: connection, icmp: icmp_conn, payload: string%);
+event icmp_sent_payload%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, payload: string%);
+event icmp_sent_payload%(c: connection, info: icmp_info, payload: string%);
+event icmp_sent_payload%(c: connection, icmp: icmp_conn, payload: string%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## Generated for ICMP *echo request* messages.
 ##
@@ -38,6 +48,9 @@ event icmp_sent_payload%(c: connection, icmp: icmp_conn, payload: string%);
 ## icmp: Additional ICMP-specific information augmenting the standard
 ##       connection record *c*.
 ##
+## info: Additional ICMP-specific information augmenting the standard
+##       connection record *c*.
+##
 ## id: The *echo request* identifier.
 ##
 ## seq: The *echo request* sequence number.
@@ -46,7 +59,9 @@ event icmp_sent_payload%(c: connection, icmp: icmp_conn, payload: string%);
 ##          after the first 8 bytes of the ICMP header.
 ##
 ## .. zeek:see:: icmp_echo_reply
-event icmp_echo_request%(c: connection, icmp: icmp_conn, id: count, seq: count, payload: string%);
+event icmp_echo_request%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, id: count, seq: count, payload: string%);
+event icmp_echo_request%(c: connection, info: icmp_info, id: count, seq: count, payload: string%);
+event icmp_echo_request%(c: connection, icmp: icmp_conn, id: count, seq: count, payload: string%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn.";
 
 ## Generated for ICMP *echo reply* messages.
 ##
@@ -59,6 +74,9 @@ event icmp_echo_request%(c: connection, icmp: icmp_conn, id: count, seq: count, 
 ## icmp: Additional ICMP-specific information augmenting the standard connection
 ##       record *c*.
 ##
+## info: Additional ICMP-specific information augmenting the standard
+##       connection record *c*.
+##
 ## id: The *echo reply* identifier.
 ##
 ## seq: The *echo reply* sequence number.
@@ -67,7 +85,9 @@ event icmp_echo_request%(c: connection, icmp: icmp_conn, id: count, seq: count, 
 ##          after the first 8 bytes of the ICMP header.
 ##
 ## .. zeek:see:: icmp_echo_request
-event icmp_echo_reply%(c: connection, icmp: icmp_conn, id: count, seq: count, payload: string%);
+event icmp_echo_reply%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, id: count, seq: count, payload: string%);
+event icmp_echo_reply%(c: connection, info: icmp_info, id: count, seq: count, payload: string%);
+event icmp_echo_reply%(c: connection, icmp: icmp_conn, id: count, seq: count, payload: string%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn.";
 
 ## Generated for all ICMPv6 error messages that are not handled
 ## separately with dedicated events. Zeek's ICMP analyzer handles a number
@@ -83,6 +103,9 @@ event icmp_echo_reply%(c: connection, icmp: icmp_conn, id: count, seq: count, pa
 ## icmp: Additional ICMP-specific information augmenting the standard
 ##       connection record *c*.
 ##
+## info: Additional ICMP-specific information augmenting the standard
+##       connection record *c*.
+##
 ## code: The ICMP code of the error message.
 ##
 ## context: A record with specifics of the original packet that the message
@@ -90,7 +113,9 @@ event icmp_echo_reply%(c: connection, icmp: icmp_conn, id: count, seq: count, pa
 ##
 ## .. zeek:see:: icmp_unreachable icmp_packet_too_big
 ##    icmp_time_exceeded icmp_parameter_problem
-event icmp_error_message%(c: connection, icmp: icmp_conn, code: count, context: icmp_context%);
+event icmp_error_message%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, code: count, context: icmp_context%);
+event icmp_error_message%(c: connection, info: icmp_info, code: count, context: icmp_context%);
+event icmp_error_message%(c: connection, icmp: icmp_conn, code: count, context: icmp_context%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## Generated for ICMP *destination unreachable* messages.
 ##
@@ -101,6 +126,9 @@ event icmp_error_message%(c: connection, icmp: icmp_conn, code: count, context: 
 ## c: The connection record for the corresponding ICMP flow.
 ##
 ## icmp: Additional ICMP-specific information augmenting the standard connection
+##       record *c*.
+##
+## info: Additional ICMP-specific information augmenting the standard connection
 ##       record *c*.
 ##
 ## code: The ICMP code of the *unreachable* message.
@@ -114,7 +142,9 @@ event icmp_error_message%(c: connection, icmp: icmp_conn, code: count, context: 
 ##
 ## .. zeek:see:: icmp_error_message icmp_packet_too_big
 ##    icmp_time_exceeded icmp_parameter_problem
-event icmp_unreachable%(c: connection, icmp: icmp_conn, code: count, context: icmp_context%);
+event icmp_unreachable%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, code: count, context: icmp_context%);
+event icmp_unreachable%(c: connection, info: icmp_info, code: count, context: icmp_context%);
+event icmp_unreachable%(c: connection, icmp: icmp_conn, code: count, context: icmp_context%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## Generated for ICMPv6 *packet too big* messages.
 ##
@@ -125,6 +155,9 @@ event icmp_unreachable%(c: connection, icmp: icmp_conn, code: count, context: ic
 ## c: The connection record for the corresponding ICMP flow.
 ##
 ## icmp: Additional ICMP-specific information augmenting the standard connection
+##       record *c*.
+##
+## info: Additional ICMP-specific information augmenting the standard connection
 ##       record *c*.
 ##
 ## code: The ICMP code of the *too big* message.
@@ -138,7 +171,9 @@ event icmp_unreachable%(c: connection, icmp: icmp_conn, code: count, context: ic
 ##
 ## .. zeek:see:: icmp_error_message icmp_unreachable
 ##    icmp_time_exceeded icmp_parameter_problem
-event icmp_packet_too_big%(c: connection, icmp: icmp_conn, code: count, context: icmp_context%);
+event icmp_packet_too_big%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, code: count, context: icmp_context%);
+event icmp_packet_too_big%(c: connection, info: icmp_info, code: count, context: icmp_context%);
+event icmp_packet_too_big%(c: connection, icmp: icmp_conn, code: count, context: icmp_context%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## Generated for ICMP *time exceeded* messages.
 ##
@@ -149,6 +184,9 @@ event icmp_packet_too_big%(c: connection, icmp: icmp_conn, code: count, context:
 ## c: The connection record for the corresponding ICMP flow.
 ##
 ## icmp: Additional ICMP-specific information augmenting the standard connection
+##       record *c*.
+##
+## info: Additional ICMP-specific information augmenting the standard connection
 ##       record *c*.
 ##
 ## code: The ICMP code of the *exceeded* message.
@@ -162,7 +200,9 @@ event icmp_packet_too_big%(c: connection, icmp: icmp_conn, code: count, context:
 ##
 ## .. zeek:see:: icmp_error_message icmp_unreachable icmp_packet_too_big
 ##    icmp_parameter_problem
-event icmp_time_exceeded%(c: connection, icmp: icmp_conn, code: count, context: icmp_context%);
+event icmp_time_exceeded%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, code: count, context: icmp_context%);
+event icmp_time_exceeded%(c: connection, info: icmp_info, code: count, context: icmp_context%);
+event icmp_time_exceeded%(c: connection, icmp: icmp_conn, code: count, context: icmp_context%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## Generated for ICMPv6 *parameter problem* messages.
 ##
@@ -173,6 +213,9 @@ event icmp_time_exceeded%(c: connection, icmp: icmp_conn, code: count, context: 
 ## c: The connection record for the corresponding ICMP flow.
 ##
 ## icmp: Additional ICMP-specific information augmenting the standard connection
+##       record *c*.
+##
+## info: Additional ICMP-specific information augmenting the standard connection
 ##       record *c*.
 ##
 ## code: The ICMP code of the *parameter problem* message.
@@ -186,7 +229,9 @@ event icmp_time_exceeded%(c: connection, icmp: icmp_conn, code: count, context: 
 ##
 ## .. zeek:see:: icmp_error_message icmp_unreachable icmp_packet_too_big
 ##    icmp_time_exceeded
-event icmp_parameter_problem%(c: connection, icmp: icmp_conn, code: count, context: icmp_context%);
+event icmp_parameter_problem%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, code: count, context: icmp_context%);
+event icmp_parameter_problem%(c: connection, info: icmp_info, code: count, context: icmp_context%);
+event icmp_parameter_problem%(c: connection, icmp: icmp_conn, code: count, context: icmp_context%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## Generated for ICMP *router solicitation* messages.
 ##
@@ -199,11 +244,16 @@ event icmp_parameter_problem%(c: connection, icmp: icmp_conn, code: count, conte
 ## icmp: Additional ICMP-specific information augmenting the standard connection
 ##       record *c*.
 ##
+## info: Additional ICMP-specific information augmenting the standard connection
+##       record *c*.
+##
 ## options: Any Neighbor Discovery options included with message (:rfc:`4861`).
 ##
 ## .. zeek:see:: icmp_router_advertisement
 ##    icmp_neighbor_solicitation icmp_neighbor_advertisement icmp_redirect
-event icmp_router_solicitation%(c: connection, icmp: icmp_conn, options: icmp6_nd_options%);
+event icmp_router_solicitation%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, options: icmp6_nd_options%);
+event icmp_router_solicitation%(c: connection, info: icmp_info, options: icmp6_nd_options%);
+event icmp_router_solicitation%(c: connection, icmp: icmp_conn, options: icmp6_nd_options%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## Generated for ICMP *router advertisement* messages.
 ##
@@ -214,6 +264,9 @@ event icmp_router_solicitation%(c: connection, icmp: icmp_conn, options: icmp6_n
 ## c: The connection record for the corresponding ICMP flow.
 ##
 ## icmp: Additional ICMP-specific information augmenting the standard connection
+##       record *c*.
+##
+## info: Additional ICMP-specific information augmenting the standard connection
 ##       record *c*.
 ##
 ## cur_hop_limit: The default value that should be placed in Hop Count field
@@ -241,7 +294,9 @@ event icmp_router_solicitation%(c: connection, icmp: icmp_conn, options: icmp6_n
 ##
 ## .. zeek:see:: icmp_router_solicitation
 ##    icmp_neighbor_solicitation icmp_neighbor_advertisement icmp_redirect
-event icmp_router_advertisement%(c: connection, icmp: icmp_conn, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options%);
+event icmp_router_advertisement%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options%);
+event icmp_router_advertisement%(c: connection, info: icmp_info, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options%);
+event icmp_router_advertisement%(c: connection, icmp: icmp_conn, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## Generated for ICMP *neighbor solicitation* messages.
 ##
@@ -254,13 +309,18 @@ event icmp_router_advertisement%(c: connection, icmp: icmp_conn, cur_hop_limit: 
 ## icmp: Additional ICMP-specific information augmenting the standard connection
 ##       record *c*.
 ##
+## info: Additional ICMP-specific information augmenting the standard connection
+##       record *c*.
+##
 ## tgt: The IP address of the target of the solicitation.
 ##
 ## options: Any Neighbor Discovery options included with message (:rfc:`4861`).
 ##
 ## .. zeek:see:: icmp_router_solicitation icmp_router_advertisement
 ##    icmp_neighbor_advertisement icmp_redirect
-event icmp_neighbor_solicitation%(c: connection, icmp: icmp_conn, tgt: addr, options: icmp6_nd_options%);
+event icmp_neighbor_solicitation%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, tgt: addr, options: icmp6_nd_options%);
+event icmp_neighbor_solicitation%(c: connection, info: icmp_info, tgt: addr, options: icmp6_nd_options%);
+event icmp_neighbor_solicitation%(c: connection, icmp: icmp_conn, tgt: addr, options: icmp6_nd_options%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## Generated for ICMP *neighbor advertisement* messages.
 ##
@@ -271,6 +331,9 @@ event icmp_neighbor_solicitation%(c: connection, icmp: icmp_conn, tgt: addr, opt
 ## c: The connection record for the corresponding ICMP flow.
 ##
 ## icmp: Additional ICMP-specific information augmenting the standard connection
+##       record *c*.
+##
+## info: Additional ICMP-specific information augmenting the standard connection
 ##       record *c*.
 ##
 ## router: Flag indicating the sender is a router.
@@ -286,7 +349,9 @@ event icmp_neighbor_solicitation%(c: connection, icmp: icmp_conn, tgt: addr, opt
 ##
 ## .. zeek:see:: icmp_router_solicitation icmp_router_advertisement
 ##    icmp_neighbor_solicitation icmp_redirect
-event icmp_neighbor_advertisement%(c: connection, icmp: icmp_conn, router: bool, solicited: bool, override: bool, tgt: addr, options: icmp6_nd_options%);
+event icmp_neighbor_advertisement%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, router: bool, solicited: bool, override: bool, tgt: addr, options: icmp6_nd_options%);
+event icmp_neighbor_advertisement%(c: connection, info: icmp_info, router: bool, solicited: bool, override: bool, tgt: addr, options: icmp6_nd_options%);
+event icmp_neighbor_advertisement%(c: connection, icmp: icmp_conn, router: bool, solicited: bool, override: bool, tgt: addr, options: icmp6_nd_options%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";
 
 ## Generated for ICMP *redirect* messages.
 ##
@@ -299,6 +364,9 @@ event icmp_neighbor_advertisement%(c: connection, icmp: icmp_conn, router: bool,
 ## icmp: Additional ICMP-specific information augmenting the standard connection
 ##       record *c*.
 ##
+## info: Additional ICMP-specific information augmenting the standard connection
+##       record *c*.
+##
 ## tgt: The address that is supposed to be a better first hop to use for
 ##      ICMP Destination Address.
 ##
@@ -308,5 +376,6 @@ event icmp_neighbor_advertisement%(c: connection, icmp: icmp_conn, router: bool,
 ##
 ## .. zeek:see:: icmp_router_solicitation icmp_router_advertisement
 ##    icmp_neighbor_solicitation icmp_neighbor_advertisement
-event icmp_redirect%(c: connection, icmp: icmp_conn, tgt: addr, dest: addr, options: icmp6_nd_options%);
-
+event icmp_redirect%(c: connection, icmp: icmp_conn &deprecated="Remove in v4.1", info: icmp_info, tgt: addr, dest: addr, options: icmp6_nd_options%);
+event icmp_redirect%(c: connection, info: icmp_info, tgt: addr, dest: addr, options: icmp6_nd_options%);
+event icmp_redirect%(c: connection, icmp: icmp_conn, tgt: addr, dest: addr, options: icmp6_nd_options%) &deprecated="Remove in v4.1.  The icmp_info record is replacing icmp_conn";

--- a/testing/btest/Baseline/core.icmp.icmp-context/output
+++ b/testing/btest/Baseline/core.icmp.icmp-context/output
@@ -1,12 +1,12 @@
 icmp_unreachable (code=0)
   conn_id: [orig_h=10.0.0.1, orig_p=3/icmp, resp_h=10.0.0.2, resp_p=0/icmp]
-  icmp_conn: [orig_h=10.0.0.1, resp_h=10.0.0.2, itype=3, icode=0, len=0, hlim=64, v6=F]
+  icmp_info: [v6=F, itype=3, icode=0, len=0, ttl=64]
   icmp_context: [id=[orig_h=::, orig_p=0/unknown, resp_h=::, resp_p=0/unknown], len=0, proto=0, frag_offset=0, bad_hdr_len=T, bad_checksum=F, MF=F, DF=F]
 icmp_unreachable (code=0)
   conn_id: [orig_h=10.0.0.1, orig_p=3/icmp, resp_h=10.0.0.2, resp_p=0/icmp]
-  icmp_conn: [orig_h=10.0.0.1, resp_h=10.0.0.2, itype=3, icode=0, len=20, hlim=64, v6=F]
+  icmp_info: [v6=F, itype=3, icode=0, len=20, ttl=64]
   icmp_context: [id=[orig_h=10.0.0.2, orig_p=0/unknown, resp_h=10.0.0.1, resp_p=0/unknown], len=20, proto=0, frag_offset=0, bad_hdr_len=T, bad_checksum=F, MF=F, DF=F]
 icmp_unreachable (code=3)
   conn_id: [orig_h=192.168.1.102, orig_p=3/icmp, resp_h=192.168.1.1, resp_p=3/icmp]
-  icmp_conn: [orig_h=192.168.1.102, resp_h=192.168.1.1, itype=3, icode=3, len=148, hlim=128, v6=F]
+  icmp_info: [v6=F, itype=3, icode=3, len=148, ttl=128]
   icmp_context: [id=[orig_h=192.168.1.1, orig_p=53/udp, resp_h=192.168.1.102, resp_p=59207/udp], len=163, proto=2, frag_offset=0, bad_hdr_len=F, bad_checksum=F, MF=F, DF=F]

--- a/testing/btest/Baseline/core.icmp.icmp-events/output
+++ b/testing/btest/Baseline/core.icmp.icmp-events/output
@@ -1,20 +1,20 @@
 icmp_unreachable (code=3)
   conn_id: [orig_h=192.168.1.102, orig_p=3/icmp, resp_h=192.168.1.1, resp_p=3/icmp]
-  icmp_conn: [orig_h=192.168.1.102, resp_h=192.168.1.1, itype=3, icode=3, len=148, hlim=128, v6=F]
+  icmp_info: [v6=F, itype=3, icode=3, len=148, ttl=128]
   icmp_context: [id=[orig_h=192.168.1.1, orig_p=53/udp, resp_h=192.168.1.102, resp_p=59207/udp], len=163, proto=2, frag_offset=0, bad_hdr_len=F, bad_checksum=F, MF=F, DF=F]
 icmp_time_exceeded (code=0)
   conn_id: [orig_h=10.0.0.1, orig_p=11/icmp, resp_h=10.0.0.2, resp_p=0/icmp]
-  icmp_conn: [orig_h=10.0.0.1, resp_h=10.0.0.2, itype=11, icode=0, len=32, hlim=64, v6=F]
+  icmp_info: [v6=F, itype=11, icode=0, len=32, ttl=64]
   icmp_context: [id=[orig_h=10.0.0.2, orig_p=30000/udp, resp_h=10.0.0.1, resp_p=13000/udp], len=32, proto=2, frag_offset=0, bad_hdr_len=F, bad_checksum=F, MF=F, DF=F]
 icmp_echo_request (id=34844, seq=0, payload=O\x85\xe0C\x00\x0e\xeb\xff\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&'()*+,-./01234567)
   conn_id: [orig_h=10.0.0.1, orig_p=8/icmp, resp_h=74.125.225.99, resp_p=0/icmp]
-  icmp_conn: [orig_h=10.0.0.1, resp_h=74.125.225.99, itype=8, icode=0, len=56, hlim=64, v6=F]
+  icmp_info: [v6=F, itype=8, icode=0, len=56, ttl=64]
 icmp_echo_reply (id=34844, seq=0, payload=O\x85\xe0C\x00\x0e\xeb\xff\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&'()*+,-./01234567)
   conn_id: [orig_h=10.0.0.1, orig_p=8/icmp, resp_h=74.125.225.99, resp_p=0/icmp]
-  icmp_conn: [orig_h=10.0.0.1, resp_h=74.125.225.99, itype=8, icode=0, len=56, hlim=64, v6=F]
+  icmp_info: [v6=F, itype=0, icode=0, len=56, ttl=56]
 icmp_echo_request (id=34844, seq=1, payload=O\x85\xe0D\x00\x0e\xf0}\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&'()*+,-./01234567)
   conn_id: [orig_h=10.0.0.1, orig_p=8/icmp, resp_h=74.125.225.99, resp_p=0/icmp]
-  icmp_conn: [orig_h=10.0.0.1, resp_h=74.125.225.99, itype=8, icode=0, len=56, hlim=64, v6=F]
+  icmp_info: [v6=F, itype=8, icode=0, len=56, ttl=64]
 icmp_echo_reply (id=34844, seq=1, payload=O\x85\xe0D\x00\x0e\xf0}\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&'()*+,-./01234567)
   conn_id: [orig_h=10.0.0.1, orig_p=8/icmp, resp_h=74.125.225.99, resp_p=0/icmp]
-  icmp_conn: [orig_h=10.0.0.1, resp_h=74.125.225.99, itype=8, icode=0, len=56, hlim=64, v6=F]
+  icmp_info: [v6=F, itype=0, icode=0, len=56, ttl=56]

--- a/testing/btest/Baseline/core.icmp.icmp6-context/output
+++ b/testing/btest/Baseline/core.icmp.icmp6-context/output
@@ -1,16 +1,16 @@
 icmp_unreachable (code=0)
   conn_id: [orig_h=fe80::dead, orig_p=1/icmp, resp_h=fe80::beef, resp_p=0/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=1, icode=0, len=0, hlim=64, v6=T]
+  icmp_info: [v6=T, itype=1, icode=0, len=0, ttl=64]
   icmp_context: [id=[orig_h=::, orig_p=0/unknown, resp_h=::, resp_p=0/unknown], len=0, proto=0, frag_offset=0, bad_hdr_len=T, bad_checksum=F, MF=F, DF=F]
 icmp_unreachable (code=0)
   conn_id: [orig_h=fe80::dead, orig_p=1/icmp, resp_h=fe80::beef, resp_p=0/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=1, icode=0, len=40, hlim=64, v6=T]
+  icmp_info: [v6=T, itype=1, icode=0, len=40, ttl=64]
   icmp_context: [id=[orig_h=fe80::beef, orig_p=0/unknown, resp_h=fe80::dead, resp_p=0/unknown], len=48, proto=0, frag_offset=0, bad_hdr_len=T, bad_checksum=F, MF=F, DF=F]
 icmp_unreachable (code=0)
   conn_id: [orig_h=fe80::dead, orig_p=1/icmp, resp_h=fe80::beef, resp_p=0/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=1, icode=0, len=60, hlim=64, v6=T]
+  icmp_info: [v6=T, itype=1, icode=0, len=60, ttl=64]
   icmp_context: [id=[orig_h=fe80::beef, orig_p=30000/udp, resp_h=fe80::dead, resp_p=13000/udp], len=60, proto=2, frag_offset=0, bad_hdr_len=F, bad_checksum=F, MF=F, DF=F]
 icmp_unreachable (code=0)
   conn_id: [orig_h=fe80::dead, orig_p=1/icmp, resp_h=fe80::beef, resp_p=0/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=1, icode=0, len=48, hlim=64, v6=T]
+  icmp_info: [v6=T, itype=1, icode=0, len=48, ttl=64]
   icmp_context: [id=[orig_h=fe80::beef, orig_p=0/unknown, resp_h=fe80::dead, resp_p=0/unknown], len=48, proto=0, frag_offset=0, bad_hdr_len=T, bad_checksum=F, MF=F, DF=F]

--- a/testing/btest/Baseline/core.icmp.icmp6-events/output
+++ b/testing/btest/Baseline/core.icmp.icmp6-events/output
@@ -1,46 +1,46 @@
 icmp_unreachable (code=0)
   conn_id: [orig_h=fe80::dead, orig_p=1/icmp, resp_h=fe80::beef, resp_p=0/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=1, icode=0, len=60, hlim=64, v6=T]
+  icmp_info: [v6=T, itype=1, icode=0, len=60, ttl=64]
   icmp_context: [id=[orig_h=fe80::beef, orig_p=30000/udp, resp_h=fe80::dead, resp_p=13000/udp], len=60, proto=2, frag_offset=0, bad_hdr_len=F, bad_checksum=F, MF=F, DF=F]
 icmp_packet_too_big (code=0)
   conn_id: [orig_h=fe80::dead, orig_p=2/icmp, resp_h=fe80::beef, resp_p=0/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=2, icode=0, len=52, hlim=64, v6=T]
+  icmp_info: [v6=T, itype=2, icode=0, len=52, ttl=64]
   icmp_context: [id=[orig_h=fe80::beef, orig_p=30000/udp, resp_h=fe80::dead, resp_p=13000/udp], len=52, proto=2, frag_offset=0, bad_hdr_len=F, bad_checksum=F, MF=F, DF=F]
 icmp_time_exceeded (code=0)
   conn_id: [orig_h=fe80::dead, orig_p=3/icmp, resp_h=fe80::beef, resp_p=0/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=3, icode=0, len=52, hlim=64, v6=T]
+  icmp_info: [v6=T, itype=3, icode=0, len=52, ttl=64]
   icmp_context: [id=[orig_h=fe80::beef, orig_p=30000/udp, resp_h=fe80::dead, resp_p=13000/udp], len=52, proto=2, frag_offset=0, bad_hdr_len=F, bad_checksum=F, MF=F, DF=F]
 icmp_parameter_problem (code=0)
   conn_id: [orig_h=fe80::dead, orig_p=4/icmp, resp_h=fe80::beef, resp_p=0/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=4, icode=0, len=52, hlim=64, v6=T]
+  icmp_info: [v6=T, itype=4, icode=0, len=52, ttl=64]
   icmp_context: [id=[orig_h=fe80::beef, orig_p=30000/udp, resp_h=fe80::dead, resp_p=13000/udp], len=52, proto=2, frag_offset=0, bad_hdr_len=F, bad_checksum=F, MF=F, DF=F]
 icmp_echo_request (id=1, seq=3, payload=abcdefghijklmnopqrstuvwabcdefghi)
   conn_id: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, orig_p=128/icmp, resp_h=2001:4860:8006::63, resp_p=129/icmp]
-  icmp_conn: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, resp_h=2001:4860:8006::63, itype=128, icode=0, len=32, hlim=128, v6=T]
+  icmp_info: [v6=T, itype=128, icode=0, len=32, ttl=128]
 icmp_echo_reply (id=1, seq=3, payload=abcdefghijklmnopqrstuvwabcdefghi)
   conn_id: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, orig_p=128/icmp, resp_h=2001:4860:8006::63, resp_p=129/icmp]
-  icmp_conn: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, resp_h=2001:4860:8006::63, itype=128, icode=0, len=32, hlim=128, v6=T]
+  icmp_info: [v6=T, itype=129, icode=0, len=32, ttl=47]
 icmp_echo_request (id=1, seq=4, payload=abcdefghijklmnopqrstuvwabcdefghi)
   conn_id: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, orig_p=128/icmp, resp_h=2001:4860:8006::63, resp_p=129/icmp]
-  icmp_conn: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, resp_h=2001:4860:8006::63, itype=128, icode=0, len=32, hlim=128, v6=T]
+  icmp_info: [v6=T, itype=128, icode=0, len=32, ttl=128]
 icmp_echo_reply (id=1, seq=4, payload=abcdefghijklmnopqrstuvwabcdefghi)
   conn_id: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, orig_p=128/icmp, resp_h=2001:4860:8006::63, resp_p=129/icmp]
-  icmp_conn: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, resp_h=2001:4860:8006::63, itype=128, icode=0, len=32, hlim=128, v6=T]
+  icmp_info: [v6=T, itype=129, icode=0, len=32, ttl=47]
 icmp_echo_request (id=1, seq=5, payload=abcdefghijklmnopqrstuvwabcdefghi)
   conn_id: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, orig_p=128/icmp, resp_h=2001:4860:8006::63, resp_p=129/icmp]
-  icmp_conn: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, resp_h=2001:4860:8006::63, itype=128, icode=0, len=32, hlim=128, v6=T]
+  icmp_info: [v6=T, itype=128, icode=0, len=32, ttl=128]
 icmp_echo_reply (id=1, seq=5, payload=abcdefghijklmnopqrstuvwabcdefghi)
   conn_id: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, orig_p=128/icmp, resp_h=2001:4860:8006::63, resp_p=129/icmp]
-  icmp_conn: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, resp_h=2001:4860:8006::63, itype=128, icode=0, len=32, hlim=128, v6=T]
+  icmp_info: [v6=T, itype=129, icode=0, len=32, ttl=47]
 icmp_echo_request (id=1, seq=6, payload=abcdefghijklmnopqrstuvwabcdefghi)
   conn_id: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, orig_p=128/icmp, resp_h=2001:4860:8006::63, resp_p=129/icmp]
-  icmp_conn: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, resp_h=2001:4860:8006::63, itype=128, icode=0, len=32, hlim=128, v6=T]
+  icmp_info: [v6=T, itype=128, icode=0, len=32, ttl=128]
 icmp_echo_reply (id=1, seq=6, payload=abcdefghijklmnopqrstuvwabcdefghi)
   conn_id: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, orig_p=128/icmp, resp_h=2001:4860:8006::63, resp_p=129/icmp]
-  icmp_conn: [orig_h=2620:0:e00:400e:d1d:db37:beb:5aac, resp_h=2001:4860:8006::63, itype=128, icode=0, len=32, hlim=128, v6=T]
+  icmp_info: [v6=T, itype=129, icode=0, len=32, ttl=47]
 icmp_redirect (tgt=fe80::cafe, dest=fe80::babe)
   conn_id: [orig_h=fe80::dead, orig_p=137/icmp, resp_h=fe80::beef, resp_p=0/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=137, icode=0, len=32, hlim=255, v6=T]
+  icmp_info: [v6=T, itype=137, icode=0, len=32, ttl=255]
   options: []
 icmp_router_advertisement
     cur_hop_limit=13
@@ -54,20 +54,20 @@ icmp_router_advertisement
     reachable_time=3.0 secs 700.0 msecs
     retrans_timer=1.0 sec 300.0 msecs
   conn_id: [orig_h=fe80::dead, orig_p=134/icmp, resp_h=fe80::beef, resp_p=133/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=134, icode=0, len=8, hlim=255, v6=T]
+  icmp_info: [v6=T, itype=134, icode=0, len=8, ttl=255]
   options: []
 icmp_neighbor_advertisement (tgt=fe80::babe)
     router=T
     solicited=F
     override=T
   conn_id: [orig_h=fe80::dead, orig_p=136/icmp, resp_h=fe80::beef, resp_p=135/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=136, icode=0, len=16, hlim=255, v6=T]
+  icmp_info: [v6=T, itype=136, icode=0, len=16, ttl=255]
   options: []
 icmp_router_solicitation
   conn_id: [orig_h=fe80::dead, orig_p=133/icmp, resp_h=fe80::beef, resp_p=134/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=133, icode=0, len=0, hlim=255, v6=T]
+  icmp_info: [v6=T, itype=133, icode=0, len=0, ttl=255]
   options: []
 icmp_neighbor_solicitation (tgt=fe80::babe)
   conn_id: [orig_h=fe80::dead, orig_p=135/icmp, resp_h=fe80::beef, resp_p=136/icmp]
-  icmp_conn: [orig_h=fe80::dead, resp_h=fe80::beef, itype=135, icode=0, len=16, hlim=255, v6=T]
+  icmp_info: [v6=T, itype=135, icode=0, len=16, ttl=255]
   options: []

--- a/testing/btest/Baseline/core.icmp.icmp_sent/out
+++ b/testing/btest/Baseline/core.icmp.icmp_sent/out
@@ -1,2 +1,2 @@
-icmp_sent, [orig_h=fe80::2c23:b96c:78d:e116, orig_p=143/icmp, resp_h=ff02::16, resp_p=0/icmp], [orig_h=fe80::2c23:b96c:78d:e116, resp_h=ff02::16, itype=143, icode=0, len=20, hlim=1, v6=T]
-icmp_sent_payload, [orig_h=fe80::2c23:b96c:78d:e116, orig_p=143/icmp, resp_h=ff02::16, resp_p=0/icmp], [orig_h=fe80::2c23:b96c:78d:e116, resp_h=ff02::16, itype=143, icode=0, len=20, hlim=1, v6=T], 20
+icmp_sent, [orig_h=fe80::2c23:b96c:78d:e116, orig_p=143/icmp, resp_h=ff02::16, resp_p=0/icmp], [v6=T, itype=143, icode=0, len=20, ttl=1]
+icmp_sent_payload, [orig_h=fe80::2c23:b96c:78d:e116, orig_p=143/icmp, resp_h=ff02::16, resp_p=0/icmp], [v6=T, itype=143, icode=0, len=20, ttl=1], 20

--- a/testing/btest/Baseline/language.alternate-event-hook-prototypes/out
+++ b/testing/btest/Baseline/language.alternate-event-hook-prototypes/out
@@ -1,4 +1,4 @@
-warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-event-hook-prototypes/alternate-event-hook-prototypes.zeek, line 68 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-event-hook-prototypes/alternate-event-hook-prototypes.zeek, line 10: use of deprecated prototype (hook(c:count;) : bool and my_hook)
+warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-event-hook-prototypes/alternate-event-hook-prototypes.zeek, line 68 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-event-hook-prototypes/alternate-event-hook-prototypes.zeek, line 13: use of deprecated 'my_hook' prototype (hook(c:count;) : bool)
 my_hook, infinite, 13
 my_hook, 13, infinite
 my_hook, infinite

--- a/testing/btest/Baseline/language.alternate-prototypes-deprecated-args/hidden-error
+++ b/testing/btest/Baseline/language.alternate-prototypes-deprecated-args/hidden-error
@@ -1,8 +1,3 @@
 warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 11 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 7: use of deprecated parameter 'b': Don't use 'b' (event(a:string; b:string; c:string;))
 warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 30 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 9: use of deprecated 'myev' prototype: Don't use this prototype (event(a:string; b:string;))
-myev (canon), one, two, three
-myev (new), one, three, [1, 2, 3]
-myev (new), one, three, 0
-myev (new), one, three, 1
-myev (new), one, three, 2
-myev (old), one, two
+error in ./hide.zeek, line 5: unknown identifier b, at or near "b"

--- a/testing/btest/Baseline/language.alternate-prototypes-deprecated-args/out
+++ b/testing/btest/Baseline/language.alternate-prototypes-deprecated-args/out
@@ -1,5 +1,5 @@
 warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 9 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 5: use of deprecated parameter 'b' (event(a:string; b:string; c:string;))
-warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 19 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 5: use of deprecated prototype (event(a:string; b:string;) and myev)
+warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 19 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 7: use of deprecated 'myev' prototype (event(a:string; b:string;))
 myev (canon), one, two, three
 myev (new), one, three
 myev (old), one, two

--- a/testing/btest/Baseline/language.alternate-prototypes-deprecated-args/out
+++ b/testing/btest/Baseline/language.alternate-prototypes-deprecated-args/out
@@ -1,0 +1,5 @@
+warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 9 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 5: use of deprecated parameter 'b' (event(a:string; b:string; c:string;))
+warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 19 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 5: use of deprecated prototype (event(a:string; b:string;) and myev)
+myev (canon), one, two, three
+myev (new), one, three
+myev (old), one, two

--- a/testing/btest/Baseline/language.alternate-prototypes-deprecated-args/out
+++ b/testing/btest/Baseline/language.alternate-prototypes-deprecated-args/out
@@ -1,5 +1,5 @@
-warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 9 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 5: use of deprecated parameter 'b' (event(a:string; b:string; c:string;))
-warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 19 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 7: use of deprecated 'myev' prototype (event(a:string; b:string;))
+warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 9 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 5: use of deprecated parameter 'b': Don't use 'b' (event(a:string; b:string; c:string;))
+warning in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 19 and /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.alternate-prototypes-deprecated-args/alternate-prototypes-deprecated-args.zeek, line 7: use of deprecated 'myev' prototype: Don't use this prototype (event(a:string; b:string;))
 myev (canon), one, two, three
 myev (new), one, three
 myev (old), one, two

--- a/testing/btest/bifs/get_current_packet_header.zeek
+++ b/testing/btest/bifs/get_current_packet_header.zeek
@@ -1,7 +1,7 @@
 # @TEST-EXEC: zeek -C -r $TRACES/icmp/icmp6-neighbor-solicit.pcap %INPUT > output
 # @TEST-EXEC: btest-diff output
 
-event icmp_neighbor_solicitation(c: connection, icmp: icmp_conn, tgt: addr, options: icmp6_nd_options)
+event icmp_neighbor_solicitation(c: connection, info: icmp_info, tgt: addr, options: icmp6_nd_options)
 	{
 	local hdr: raw_pkt_hdr = get_current_packet_header();
 	print fmt("%s", hdr);

--- a/testing/btest/core/icmp/icmp-context.test
+++ b/testing/btest/core/icmp/icmp-context.test
@@ -5,10 +5,10 @@
 # @TEST-EXEC: zeek -b -r $TRACES/icmp/icmp-destunreach-udp.pcap %INPUT >>output 2>&1
 # @TEST-EXEC: btest-diff output
 
-event icmp_unreachable(c: connection, icmp: icmp_conn, code: count, context: icmp_context)
+event icmp_unreachable(c: connection, info: icmp_info, code: count, context: icmp_context)
     {
     print "icmp_unreachable (code=" + fmt("%d", code) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     print "  icmp_context: " + fmt("%s", context);
     }

--- a/testing/btest/core/icmp/icmp-events.test
+++ b/testing/btest/core/icmp/icmp-events.test
@@ -6,39 +6,39 @@
 
 # @TEST-EXEC: btest-diff output
 
-event icmp_sent(c: connection, icmp: icmp_conn)
+event icmp_sent(c: connection, info: icmp_info)
     {
     print "icmp_sent";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     }
 
-event icmp_echo_request(c: connection, icmp: icmp_conn, id: count, seq: count, payload: string)
+event icmp_echo_request(c: connection, info: icmp_info, id: count, seq: count, payload: string)
     {
     print "icmp_echo_request (id=" + fmt("%d", id) + ", seq=" + fmt("%d", seq) + ", payload=" + payload + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     }
 
-event icmp_echo_reply(c: connection, icmp: icmp_conn, id: count, seq: count, payload: string)
+event icmp_echo_reply(c: connection, info: icmp_info, id: count, seq: count, payload: string)
     {
     print "icmp_echo_reply (id=" + fmt("%d", id) + ", seq=" + fmt("%d", seq) + ", payload=" + payload + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     }
 
-event icmp_unreachable(c: connection, icmp: icmp_conn, code: count, context: icmp_context)
+event icmp_unreachable(c: connection, info: icmp_info, code: count, context: icmp_context)
     {
     print "icmp_unreachable (code=" + fmt("%d", code) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     print "  icmp_context: " + fmt("%s", context);
     }
 
-event icmp_time_exceeded(c: connection, icmp: icmp_conn, code: count, context: icmp_context)
+event icmp_time_exceeded(c: connection, info: icmp_info, code: count, context: icmp_context)
     {
     print "icmp_time_exceeded (code=" + fmt("%d", code) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     print "  icmp_context: " + fmt("%s", context);
     }

--- a/testing/btest/core/icmp/icmp6-context.test
+++ b/testing/btest/core/icmp/icmp6-context.test
@@ -6,10 +6,10 @@
 # @TEST-EXEC: zeek -b -r $TRACES/icmp/icmp6-destunreach-ip6ext.pcap %INPUT >>output 2>&1
 # @TEST-EXEC: btest-diff output
 
-event icmp_unreachable(c: connection, icmp: icmp_conn, code: count, context: icmp_context)
+event icmp_unreachable(c: connection, info: icmp_info, code: count, context: icmp_context)
     {
     print "icmp_unreachable (code=" + fmt("%d", code) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     print "  icmp_context: " + fmt("%s", context);
     }

--- a/testing/btest/core/icmp/icmp6-events.test
+++ b/testing/btest/core/icmp/icmp6-events.test
@@ -13,103 +13,103 @@
 
 # @TEST-EXEC: btest-diff output
 
-event icmp_sent(c: connection, icmp: icmp_conn)
+event icmp_sent(c: connection, info: icmp_info)
     {
     print "icmp_sent";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     }
 
-event icmp_echo_request(c: connection, icmp: icmp_conn, id: count, seq: count, payload: string)
+event icmp_echo_request(c: connection, info: icmp_info, id: count, seq: count, payload: string)
     {
     print "icmp_echo_request (id=" + fmt("%d", id) + ", seq=" + fmt("%d", seq) + ", payload=" + payload + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     }
 
-event icmp_echo_reply(c: connection, icmp: icmp_conn, id: count, seq: count, payload: string)
+event icmp_echo_reply(c: connection, info: icmp_info, id: count, seq: count, payload: string)
     {
     print "icmp_echo_reply (id=" + fmt("%d", id) + ", seq=" + fmt("%d", seq) + ", payload=" + payload + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     }
 
-event icmp_unreachable(c: connection, icmp: icmp_conn, code: count, context: icmp_context)
+event icmp_unreachable(c: connection, info: icmp_info, code: count, context: icmp_context)
     {
     print "icmp_unreachable (code=" + fmt("%d", code) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     print "  icmp_context: " + fmt("%s", context);
     }
 
-event icmp_packet_too_big(c: connection, icmp: icmp_conn, code: count, context: icmp_context)
+event icmp_packet_too_big(c: connection, info: icmp_info, code: count, context: icmp_context)
     {
     print "icmp_packet_too_big (code=" + fmt("%d", code) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     print "  icmp_context: " + fmt("%s", context);
     }
 
-event icmp_time_exceeded(c: connection, icmp: icmp_conn, code: count, context: icmp_context)
+event icmp_time_exceeded(c: connection, info: icmp_info, code: count, context: icmp_context)
     {
     print "icmp_time_exceeded (code=" + fmt("%d", code) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     print "  icmp_context: " + fmt("%s", context);
     }
 
-event icmp_parameter_problem(c: connection, icmp: icmp_conn, code: count, context: icmp_context)
+event icmp_parameter_problem(c: connection, info: icmp_info, code: count, context: icmp_context)
     {
     print "icmp_parameter_problem (code=" + fmt("%d", code) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     print "  icmp_context: " + fmt("%s", context);
     }
 
-event icmp_redirect(c: connection, icmp: icmp_conn, tgt: addr, dest: addr, options: icmp6_nd_options)
+event icmp_redirect(c: connection, info: icmp_info, tgt: addr, dest: addr, options: icmp6_nd_options)
     {
     print "icmp_redirect (tgt=" + fmt("%s", tgt) + ", dest=" + fmt("%s", dest) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
 	print "  options: " + fmt("%s", options);
     }
 
-event icmp_error_message(c: connection, icmp: icmp_conn, code: count, context: icmp_context)
+event icmp_error_message(c: connection, info: icmp_info, code: count, context: icmp_context)
     {
     print "icmp_error_message (code=" + fmt("%d", code) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
     print "  icmp_context: " + fmt("%s", context);
     }
 
-event icmp_neighbor_solicitation(c: connection, icmp: icmp_conn, tgt: addr, options: icmp6_nd_options)
+event icmp_neighbor_solicitation(c: connection, info: icmp_info, tgt: addr, options: icmp6_nd_options)
     {
     print "icmp_neighbor_solicitation (tgt=" + fmt("%s", tgt) + ")";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
 	print "  options: " + fmt("%s", options);
     }
 
-event icmp_neighbor_advertisement(c: connection, icmp: icmp_conn, router: bool, solicited: bool, override: bool, tgt: addr, options: icmp6_nd_options)
+event icmp_neighbor_advertisement(c: connection, info: icmp_info, router: bool, solicited: bool, override: bool, tgt: addr, options: icmp6_nd_options)
     {
     print "icmp_neighbor_advertisement (tgt=" + fmt("%s", tgt) + ")";
 	print "    router=" + fmt("%s", router);
 	print "    solicited=" + fmt("%s", solicited);
 	print "    override=" + fmt("%s", override);
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
 	print "  options: " + fmt("%s", options);
     }
 
-event icmp_router_solicitation(c: connection, icmp: icmp_conn, options: icmp6_nd_options)
+event icmp_router_solicitation(c: connection, info: icmp_info, options: icmp6_nd_options)
     {
     print "icmp_router_solicitation";
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
 	print "  options: " + fmt("%s", options);
     }
 
-event icmp_router_advertisement(c: connection, icmp: icmp_conn, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options)
+event icmp_router_advertisement(c: connection, info: icmp_info, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options)
     {
     print "icmp_router_advertisement";
 	print "    cur_hop_limit=" + fmt("%s", cur_hop_limit);
@@ -123,6 +123,6 @@ event icmp_router_advertisement(c: connection, icmp: icmp_conn, cur_hop_limit: c
 	print "    reachable_time=" + fmt("%s", reachable_time);
 	print "    retrans_timer=" + fmt("%s", retrans_timer);
     print "  conn_id: " + fmt("%s", c$id);
-    print "  icmp_conn: " + fmt("%s", icmp);
+    print "  icmp_info: " + fmt("%s", info);
 	print "  options: " + fmt("%s", options);
     }

--- a/testing/btest/core/icmp/icmp6-nd-options.test
+++ b/testing/btest/core/icmp/icmp6-nd-options.test
@@ -5,7 +5,7 @@
 
 # @TEST-EXEC: btest-diff output
 
-event icmp_router_advertisement(c: connection, icmp: icmp_conn, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options)
+event icmp_router_advertisement(c: connection, info: icmp_info, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options)
     {
     print "icmp_router_advertisement options";
     for ( o in options )
@@ -17,7 +17,7 @@ event icmp_router_advertisement(c: connection, icmp: icmp_conn, cur_hop_limit: c
         }
     }
 
-event icmp_neighbor_advertisement(c: connection, icmp: icmp_conn, router: bool, solicited: bool, override: bool, tgt: addr, options: icmp6_nd_options)
+event icmp_neighbor_advertisement(c: connection, info: icmp_info, router: bool, solicited: bool, override: bool, tgt: addr, options: icmp6_nd_options)
     {
     print "icmp_neighbor_advertisement options";
     for ( o in options )
@@ -27,7 +27,7 @@ event icmp_neighbor_advertisement(c: connection, icmp: icmp_conn, router: bool, 
         }
     }
 
-event icmp_redirect(c: connection, icmp: icmp_conn, tgt: addr, dest: addr, options: icmp6_nd_options)
+event icmp_redirect(c: connection, info: icmp_info, tgt: addr, dest: addr, options: icmp6_nd_options)
     {
     print "icmp_redirect options";
     for ( o in options )

--- a/testing/btest/core/icmp/icmp_sent.zeek
+++ b/testing/btest/core/icmp/icmp_sent.zeek
@@ -1,12 +1,12 @@
 # @TEST-EXEC: zeek -b -r $TRACES/icmp/icmp_sent.pcap %INPUT >out
 # @TEST-EXEC: btest-diff out
 
-event icmp_sent(c: connection, icmp: icmp_conn)
+event icmp_sent(c: connection, info: icmp_info)
 	{
-	print "icmp_sent", c$id, icmp;
+	print "icmp_sent", c$id, info;
 	}
 
-event icmp_sent_payload(c: connection, icmp: icmp_conn, payload: string)
+event icmp_sent_payload(c: connection, info: icmp_info, payload: string)
 	{
-	print "icmp_sent_payload", c$id, icmp, |payload|;
+	print "icmp_sent_payload", c$id, info, |payload|;
 	}

--- a/testing/btest/core/tunnels/gre-erspan3-dot1q.zeek
+++ b/testing/btest/core/tunnels/gre-erspan3-dot1q.zeek
@@ -1,12 +1,12 @@
 # @TEST-EXEC: zeek -b -r $TRACES/tunnels/gre-erspan3-dot1q.pcap %INPUT > out
 # @TEST-EXEC: btest-diff out
 
-event icmp_echo_request(c: connection, icmp: icmp_conn, id: count, seq: count, payload: string)
+event icmp_echo_request(c: connection, info: icmp_info, id: count, seq: count, payload: string)
 	{
 	print "echo request", id, seq;
 	}
 
-event icmp_echo_reply(c: connection, icmp: icmp_conn, id: count, seq: count, payload: string)
+event icmp_echo_reply(c: connection, info: icmp_info, id: count, seq: count, payload: string)
 	{
 	print "echo reply", id, seq;
 	}

--- a/testing/btest/language/alternate-prototypes-deprecated-args.zeek
+++ b/testing/btest/language/alternate-prototypes-deprecated-args.zeek
@@ -1,0 +1,28 @@
+# @TEST-EXEC: zeek -b %INPUT >out 2>&1
+#
+# @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff out
+
+global myev: event(a: string, b: string &deprecated="Don't use 'b'", c: string);
+global myev: event(a: string, c: string);
+global myev: event(a: string, b: string) &deprecated="Don't use this prototype";
+
+event myev(a: string, b: string, c: string) &priority=11
+	{
+	print "myev (canon)", a, b, c;
+	}
+
+event myev(a: string, c: string) &priority = 7
+	{
+	print "myev (new)", a, c;
+	}
+
+event myev(a: string, b: string) &priority = 5
+	{
+	print "myev (old)", a, b;
+	}
+
+event zeek_init()
+	{
+	event myev("one", "two", "three");
+	}
+

--- a/testing/btest/language/alternate-prototypes-deprecated-args.zeek
+++ b/testing/btest/language/alternate-prototypes-deprecated-args.zeek
@@ -1,6 +1,8 @@
 # @TEST-EXEC: zeek -b %INPUT >out 2>&1
 #
+# @TEST-EXEC-FAIL: zeek -b %INPUT hide.zeek >hidden-error 2>&1
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff out
+# @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff hidden-error
 
 global myev: event(a: string, b: string &deprecated="Don't use 'b'", c: string);
 global myev: event(a: string, c: string);
@@ -13,7 +15,16 @@ event myev(a: string, b: string, c: string) &priority=11
 
 event myev(a: string, c: string) &priority = 7
 	{
-	print "myev (new)", a, c;
+	local ddd = vector(1,2,3);
+	print "myev (new)", a, c, ddd;
+	}
+
+global eee = vector(1,2,3);
+
+event myev(a: string, c: string) &priority = 6
+	{
+	for ( o in eee )
+		print "myev (new)", a, c, o;
 	}
 
 event myev(a: string, b: string) &priority = 5
@@ -26,3 +37,11 @@ event zeek_init()
 	event myev("one", "two", "three");
 	}
 
+@TEST-START-FILE hide.zeek
+event myev(a: string, c: string) &priority = 7
+	{
+	local ddd = vector(1,2,3);
+	print "myev (new)", a, c, ddd;
+	print b;
+	}
+@TEST-END-FILE


### PR DESCRIPTION
Fixes #1019 

This is based on the branch from #1057 and depends on that being merged first.

Also would need to generate `zeek-docs` on merging this.

See 8798482 commit message / NEWS for explanation of why I chose to go this route.