### PR TITLE
Deprecation fixes for Spicy

### DIFF
--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -762,7 +762,7 @@ const char* CompositeHash::RecoverOneVal(
 		kp1 = reinterpret_cast<const char*>(kp+1);
 
 		if ( tag == zeek::TYPE_ENUM )
-			*pval = t->AsEnumType()->GetVal(*kp);
+			*pval = t->AsEnumType()->GetEnumVal(*kp);
 		else if ( tag == zeek::TYPE_BOOL )
 			*pval = zeek::val_mgr->Bool(*kp);
 		else if ( tag == zeek::TYPE_INT )

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -136,6 +136,11 @@ void ID::SetType(zeek::TypePtr t)
 	type = std::move(t);
 	}
 
+void ID::SetType(zeek::Type* t)
+	{
+	SetType({AdoptRef(), t});
+	}
+
 void ID::ClearVal()
 	{
 	val = nullptr;

--- a/src/ID.h
+++ b/src/ID.h
@@ -63,7 +63,9 @@ public:
 
 	std::string ModuleName() const;
 
-	void SetType(TypePtr t);
+	void SetType(zeek::TypePtr t);
+	[[deprecated("Remove in v4.1.  Use version that takes IntrusivePtr.")]]
+	void SetType(zeek::Type* t);
 
 	[[deprecated("Remove in v4.1.  Use GetType().")]]
 	zeek::Type* Type()			{ return type.get(); }

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -201,13 +201,13 @@ using BroObj [[deprecated("Remove in v4.1. Use zeek::Obj instead.")]] = zeek::Ob
 extern void print(const zeek::Obj* obj);
 
 [[deprecated("Remove in v4.1. Use zeek::detail::set_location instead.")]]
-inline void set_location(const Location loc)
+inline void set_location(const zeek::detail::Location loc)
 	{
 	zeek::detail::set_location(loc);
 	}
 
 [[deprecated("Remove in v4.1. Use zeek::detail::set_location instead.")]]
-inline void set_location(const Location start, const Location end)
+inline void set_location(const zeek::detail::Location start, const zeek::detail::Location end)
 	{
 	zeek::detail::set_location(start, end);
 	}

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -199,3 +199,15 @@ using BroObj [[deprecated("Remove in v4.1. Use zeek::Obj instead.")]] = zeek::Ob
 
 [[deprecated("Remove in v4.1. Use zeek::Obj::Print instead.")]]
 extern void print(const zeek::Obj* obj);
+
+[[deprecated("Remove in v4.1. Use zeek::detail::set_location instead.")]]
+inline void set_location(const Location loc)
+	{
+	zeek::detail::set_location(loc);
+	}
+
+[[deprecated("Remove in v4.1. Use zeek::detail::set_location instead.")]]
+inline void set_location(const Location start, const Location end)
+	{
+	zeek::detail::set_location(start, end);
+	}

--- a/src/Scope.cc
+++ b/src/Scope.cc
@@ -223,7 +223,7 @@ Scope* global_scope()
 
 }
 
-const zeek::detail::ID* lookup_ID(
+zeek::detail::ID* lookup_ID(
 	const char* name, const char* module,
 	bool no_global,
 	bool same_module_only,

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -128,7 +128,7 @@ constexpr auto global_scope [[deprecated("Remove in v4.1 Use zeek::detail::globa
 
 // Because of the use of default arguments, this function can't be aliased like the rest.
 [[deprecated("Remove in v4.1 Use zeek::detail::lookup_ID instead.")]]
-extern const zeek::detail::ID* lookup_ID(
+extern zeek::detail::ID* lookup_ID(
 	const char* name, const char* module,
 	bool no_global = false,
 	bool same_module_only = false,

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -216,7 +216,7 @@ static EnumValPtr lookup_enum_val(const char* module_name, const char* name)
 	int index = et->Lookup(module_name, name);
 	assert(index >= 0);
 
-	return et->GetVal(index);
+	return et->GetEnumVal(index);
 	}
 
 static void print_log(const std::vector<ValPtr>& vals)

--- a/src/Tag.cc
+++ b/src/Tag.cc
@@ -10,7 +10,7 @@ Tag::Tag(const zeek::EnumTypePtr& etype, type_t arg_type, subtype_t arg_subtype)
 	type = arg_type;
 	subtype = arg_subtype;
 	int64_t i = (int64_t)(type) | ((int64_t)subtype << 31);
-	val = etype->GetVal(i);
+	val = etype->GetEnumVal(i);
 	}
 
 Tag::Tag(zeek::EnumType* etype, type_t arg_type, subtype_t arg_subtype)
@@ -77,7 +77,7 @@ const zeek::EnumValPtr& Tag::AsVal(const zeek::EnumTypePtr& etype) const
 	if ( ! val )
 		{
 		assert(type == 0 && subtype == 0);
-		val = etype->GetVal(0);
+		val = etype->GetEnumVal(0);
 		}
 
 	return val;

--- a/src/TunnelEncapsulation.cc
+++ b/src/TunnelEncapsulation.cc
@@ -26,7 +26,7 @@ zeek::RecordValPtr EncapsulatingConn::ToVal() const
 	id_val->Assign(2, zeek::make_intrusive<zeek::AddrVal>(dst_addr));
 	id_val->Assign(3, zeek::val_mgr->Port(ntohs(dst_port), proto));
 	rv->Assign(0, std::move(id_val));
-	rv->Assign(1, zeek::BifType::Enum::Tunnel::Type->GetVal(type));
+	rv->Assign(1, zeek::BifType::Enum::Tunnel::Type->GetEnumVal(type));
 
 	rv->Assign(2, zeek::make_intrusive<zeek::StringVal>(uid.Base62("C").c_str()));
 

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1330,7 +1330,7 @@ EnumType::enum_name_list EnumType::Names() const
 	return n;
 	}
 
-const EnumValPtr& EnumType::GetVal(bro_int_t i)
+const EnumValPtr& EnumType::GetEnumVal(bro_int_t i)
 	{
 	auto it = vals.find(i);
 

--- a/src/Type.h
+++ b/src/Type.h
@@ -709,7 +709,13 @@ public:
 
 	void DescribeReST(ODesc* d, bool roles_only = false) const override;
 
-	const zeek::EnumValPtr& GetVal(bro_int_t i);
+	const zeek::EnumValPtr& GetEnumVal(bro_int_t i);
+
+	[[deprecated("Remove in v4.1. Use GetEnumVal() instead.")]]
+	zeek::EnumVal* GetVal(bro_int_t i)
+		{
+		return GetEnumVal(i).get();
+		}
 
 protected:
 	void AddNameInternal(const std::string& module_name,

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -2096,16 +2096,16 @@ void TableVal::CallChangeFunc(const Val* index,
 		switch ( tpe )
 			{
 			case ELEMENT_NEW:
-				vl.emplace_back(BifType::Enum::TableChange->GetVal(BifEnum::TableChange::TABLE_ELEMENT_NEW));
+				vl.emplace_back(BifType::Enum::TableChange->GetEnumVal(BifEnum::TableChange::TABLE_ELEMENT_NEW));
 				break;
 			case ELEMENT_CHANGED:
-				vl.emplace_back(BifType::Enum::TableChange->GetVal(BifEnum::TableChange::TABLE_ELEMENT_CHANGED));
+				vl.emplace_back(BifType::Enum::TableChange->GetEnumVal(BifEnum::TableChange::TABLE_ELEMENT_CHANGED));
 				break;
 			case ELEMENT_REMOVED:
-				vl.emplace_back(BifType::Enum::TableChange->GetVal(BifEnum::TableChange::TABLE_ELEMENT_REMOVED));
+				vl.emplace_back(BifType::Enum::TableChange->GetEnumVal(BifEnum::TableChange::TABLE_ELEMENT_REMOVED));
 				break;
 			case ELEMENT_EXPIRED:
-				vl.emplace_back(BifType::Enum::TableChange->GetVal(BifEnum::TableChange::TABLE_ELEMENT_EXPIRED));
+				vl.emplace_back(BifType::Enum::TableChange->GetEnumVal(BifEnum::TableChange::TABLE_ELEMENT_EXPIRED));
 			}
 
 		for ( const auto& v : lv->Vals() )

--- a/src/analyzer/protocol/dce-rpc/dce_rpc-analyzer.pac
+++ b/src/analyzer/protocol/dce-rpc/dce_rpc-analyzer.pac
@@ -42,7 +42,7 @@ refine connection DCE_RPC_Conn += {
 			                                  ${header.is_orig},
 			                                  fid,
 			                                  ${header.PTYPE},
-			                                  zeek::BifType::Enum::DCE_RPC::PType->GetVal(${header.PTYPE}));
+			                                  zeek::BifType::Enum::DCE_RPC::PType->GetEnumVal(${header.PTYPE}));
 			}
 		return true;
 		%}

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -127,7 +127,7 @@ bool MOUNT_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_statu
 			// Otherwise DeliverRPC would complain about
 			// excess_RPC.
 			n = 0;
-			reply = zeek::BifType::Enum::MOUNT3::proc_t->GetVal(c->Proc());
+			reply = zeek::BifType::Enum::MOUNT3::proc_t->GetEnumVal(c->Proc());
 			event = mount_proc_not_implemented;
 			}
 		else
@@ -185,8 +185,8 @@ zeek::Args MOUNT_Interp::event_common_vl(RPC_CallInfo *c,
 		}
 
 	auto info = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::MOUNT3::info_t);
-	info->Assign(0, zeek::BifType::Enum::rpc_status->GetVal(rpc_status));
-	info->Assign(1, zeek::BifType::Enum::MOUNT3::status_t->GetVal(mount_status));
+	info->Assign(0, zeek::BifType::Enum::rpc_status->GetEnumVal(rpc_status));
+	info->Assign(1, zeek::BifType::Enum::MOUNT3::status_t->GetEnumVal(mount_status));
 	info->Assign(2, zeek::make_intrusive<zeek::TimeVal>(c->StartTime()));
 	info->Assign(3, zeek::make_intrusive<zeek::IntervalVal>(c->LastTime() - c->StartTime()));
 	info->Assign(4, zeek::val_mgr->Count(c->RPCLen()));
@@ -206,7 +206,7 @@ zeek::Args MOUNT_Interp::event_common_vl(RPC_CallInfo *c,
 zeek::EnumValPtr MOUNT_Interp::mount3_auth_flavor(const u_char*& buf, int& n)
     {
 	BifEnum::MOUNT3::auth_flavor_t t = (BifEnum::MOUNT3::auth_flavor_t)extract_XDR_uint32(buf, n);
-	auto rval = zeek::BifType::Enum::MOUNT3::auth_flavor_t->GetVal(t);
+	auto rval = zeek::BifType::Enum::MOUNT3::auth_flavor_t->GetEnumVal(t);
 	return rval;
     }
 

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -242,7 +242,7 @@ bool NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 			// Otherwise DeliverRPC would complain about
 			// excess_RPC.
 			n = 0;
-			reply = zeek::BifType::Enum::NFS3::proc_t->GetVal(c->Proc());
+			reply = zeek::BifType::Enum::NFS3::proc_t->GetEnumVal(c->Proc());
 			event = nfs_proc_not_implemented;
 			}
 		else
@@ -318,8 +318,8 @@ zeek::Args NFS_Interp::event_common_vl(RPC_CallInfo *c, BifEnum::rpc_status rpc_
 		auxgids->Assign(i, zeek::val_mgr->Count(c->AuxGIDs()[i]));
 
 	auto info = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::NFS3::info_t);
-	info->Assign(0, zeek::BifType::Enum::rpc_status->GetVal(rpc_status));
-	info->Assign(1, zeek::BifType::Enum::NFS3::status_t->GetVal(nfs_status));
+	info->Assign(0, zeek::BifType::Enum::rpc_status->GetEnumVal(rpc_status));
+	info->Assign(1, zeek::BifType::Enum::NFS3::status_t->GetEnumVal(nfs_status));
 	info->Assign(2, zeek::make_intrusive<zeek::TimeVal>(c->StartTime()));
 	info->Assign(3, zeek::make_intrusive<zeek::IntervalVal>(c->LastTime()-c->StartTime()));
 	info->Assign(4, zeek::val_mgr->Count(c->RPCLen()));
@@ -422,14 +422,14 @@ zeek::RecordValPtr NFS_Interp::nfs3_fattr(const u_char*& buf, int& n)
 zeek::EnumValPtr NFS_Interp::nfs3_time_how(const u_char*& buf, int& n)
 	{
 	BifEnum::NFS3::time_how_t t = (BifEnum::NFS3::time_how_t)extract_XDR_uint32(buf, n);
-	auto rval = zeek::BifType::Enum::NFS3::time_how_t->GetVal(t);
+	auto rval = zeek::BifType::Enum::NFS3::time_how_t->GetEnumVal(t);
 	return rval;
 	}
 
 zeek::EnumValPtr NFS_Interp::nfs3_ftype(const u_char*& buf, int& n)
 	{
 	BifEnum::NFS3::file_type_t t = (BifEnum::NFS3::file_type_t)extract_XDR_uint32(buf, n);
-	auto rval = zeek::BifType::Enum::NFS3::file_type_t->GetVal(t);
+	auto rval = zeek::BifType::Enum::NFS3::file_type_t->GetEnumVal(t);
 	return rval;
 	}
 
@@ -519,7 +519,7 @@ zeek::RecordValPtr NFS_Interp::nfs3_pre_op_attr(const u_char*& buf, int& n)
 zeek::EnumValPtr NFS_Interp::nfs3_stable_how(const u_char*& buf, int& n)
 	{
 	BifEnum::NFS3::stable_how_t stable = (BifEnum::NFS3::stable_how_t)extract_XDR_uint32(buf, n);
-	auto rval = zeek::BifType::Enum::NFS3::stable_how_t->GetVal(stable);
+	auto rval = zeek::BifType::Enum::NFS3::stable_how_t->GetEnumVal(stable);
 	return rval;
 	}
 

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -280,7 +280,7 @@ void PortmapperInterp::Event(EventHandlerPtr f, zeek::ValPtr request, BifEnum::r
 		}
 	else
 		{
-		vl.emplace_back(zeek::BifType::Enum::rpc_status->GetVal(status));
+		vl.emplace_back(zeek::BifType::Enum::rpc_status->GetEnumVal(status));
 
 		if ( request )
 			vl.emplace_back(std::move(request));

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -341,7 +341,7 @@ void RPC_Interpreter::Event_RPC_Dialogue(RPC_CallInfo* c, BifEnum::rpc_status st
 			zeek::val_mgr->Count(c->Program()),
 			zeek::val_mgr->Count(c->Version()),
 			zeek::val_mgr->Count(c->Proc()),
-			zeek::BifType::Enum::rpc_status->GetVal(status),
+			zeek::BifType::Enum::rpc_status->GetEnumVal(status),
 			zeek::make_intrusive<zeek::TimeVal>(c->StartTime()),
 			zeek::val_mgr->Count(c->CallLen()),
 			zeek::val_mgr->Count(reply_len)
@@ -367,7 +367,7 @@ void RPC_Interpreter::Event_RPC_Reply(uint32_t xid, BifEnum::rpc_status status, 
 		analyzer->EnqueueConnEvent(rpc_reply,
 			analyzer->ConnVal(),
 			zeek::val_mgr->Count(xid),
-			zeek::BifType::Enum::rpc_status->GetVal(status),
+			zeek::BifType::Enum::rpc_status->GetEnumVal(status),
 			zeek::val_mgr->Count(reply_len)
 		);
 	}

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -191,7 +191,7 @@ struct val_converter {
 			if ( i == -1 )
 				return nullptr;
 
-			auto rval = etype->GetVal(i);
+			auto rval = etype->GetEnumVal(i);
 			return rval;
 			}
 
@@ -1035,72 +1035,72 @@ struct data_type_getter {
 
 	result_type operator()(broker::none)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::NONE);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::NONE);
 		}
 
 	result_type operator()(bool)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::BOOL);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::BOOL);
 		}
 
 	result_type operator()(uint64_t)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::COUNT);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::COUNT);
 		}
 
 	result_type operator()(int64_t)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::INT);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::INT);
 		}
 
 	result_type operator()(double)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::DOUBLE);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::DOUBLE);
 		}
 
 	result_type operator()(const std::string&)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::STRING);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::STRING);
 		}
 
 	result_type operator()(const broker::address&)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::ADDR);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::ADDR);
 		}
 
 	result_type operator()(const broker::subnet&)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::SUBNET);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::SUBNET);
 		}
 
 	result_type operator()(const broker::port&)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::PORT);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::PORT);
 		}
 
 	result_type operator()(const broker::timestamp&)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::TIME);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::TIME);
 		}
 
 	result_type operator()(const broker::timespan&)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::INTERVAL);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::INTERVAL);
 		}
 
 	result_type operator()(const broker::enum_value&)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::ENUM);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::ENUM);
 		}
 
 	result_type operator()(const broker::set&)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::SET);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::SET);
 		}
 
 	result_type operator()(const broker::table&)
 		{
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::TABLE);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::TABLE);
 		}
 
 	result_type operator()(const broker::vector&)
@@ -1108,7 +1108,7 @@ struct data_type_getter {
 		// Note that Broker uses vectors to store record data, so there's
 		// no actual way to tell if this data was originally associated
 		// with a Bro record.
-		return zeek::BifType::Enum::Broker::DataType->GetVal(BifEnum::Broker::VECTOR);
+		return zeek::BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::VECTOR);
 		}
 };
 

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -1309,7 +1309,7 @@ void Manager::ProcessError(broker::error err)
 		}
 
 	mgr.Enqueue(Broker::error,
-		zeek::BifType::Enum::Broker::ErrorCode->GetVal(ec),
+		zeek::BifType::Enum::Broker::ErrorCode->GetEnumVal(ec),
 	            zeek::make_intrusive<zeek::StringVal>(msg)
 	);
 	}

--- a/src/broker/Store.cc
+++ b/src/broker/Store.cc
@@ -20,7 +20,7 @@ zeek::EnumValPtr query_status(bool success)
 		failure_val = store_query_status->Lookup("Broker", "FAILURE");
 		}
 
-	auto rval = store_query_status->GetVal(success ? success_val : failure_val);
+	auto rval = store_query_status->GetEnumVal(success ? success_val : failure_val);
 	return rval;
 	}
 

--- a/src/broker/comm.bif
+++ b/src/broker/comm.bif
@@ -131,7 +131,7 @@ function Broker::__peers%(%): PeerInfos
 
 		auto ps = (BifEnum::Broker::PeerStatus)p.status;
 		peer_info->Assign(0, std::move(endpoint_info));
-		peer_info->Assign(1, zeek::BifType::Enum::Broker::PeerStatus->GetVal(ps));
+		peer_info->Assign(1, zeek::BifType::Enum::Broker::PeerStatus->GetEnumVal(ps));
 
 		rval->Assign(i, std::move(peer_info));
 		++i;

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -1065,7 +1065,7 @@ void Manager::SendEntry(ReaderFrontend* reader, Value* *vals)
 
 	else if ( i->stream_type == EVENT_STREAM )
 		{
-		auto type = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_NEW);
+		auto type = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_NEW);
 		readFields = SendEventStreamEvent(i, type.release(), vals);
 		}
 
@@ -1170,9 +1170,9 @@ int Manager::SendEntryTable(Stream* i, const Value* const *vals)
 		if ( ! pred_convert_error )
 			{
 			if ( updated )
-				ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_CHANGED);
+				ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_CHANGED);
 			else
-				ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_NEW);
+				ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_NEW);
 
 			bool result;
 			if ( stream->num_val_fields > 0 ) // we have values
@@ -1270,13 +1270,13 @@ int Manager::SendEntryTable(Stream* i, const Value* const *vals)
 		else if ( updated )
 			{ // in case of update send back the old value.
 			assert ( stream->num_val_fields > 0 );
-			auto ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_CHANGED);
+			auto ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_CHANGED);
 			assert ( oldval != nullptr );
 			SendEvent(stream->event, 4, stream->description->Ref(), ev.release(), predidx, oldval.release());
 			}
 		else
 			{
-			auto ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_NEW);
+			auto ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_NEW);
 			if ( stream->num_val_fields == 0 )
 				{
 				Ref(stream->description);
@@ -1338,7 +1338,7 @@ void Manager::EndCurrentSend(ReaderFrontend* reader)
 			val = stream->tab->FindOrDefault(idx);
 			assert(val != nullptr);
 			predidx = {zeek::AdoptRef{}, ListValToRecordVal(idx.get(), stream->itype, &startpos)};
-			ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_REMOVED);
+			ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_REMOVED);
 			}
 
 		if ( stream->pred )
@@ -1432,7 +1432,7 @@ void Manager::Put(ReaderFrontend* reader, Value* *vals)
 
 	else if ( i->stream_type == EVENT_STREAM )
 		{
-		auto type = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_NEW);
+		auto type = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_NEW);
 		readFields = SendEventStreamEvent(i, type.release(), vals);
 		}
 
@@ -1569,9 +1569,9 @@ int Manager::PutTable(Stream* i, const Value* const *vals)
 			else
 				{
 				if ( updated )
-					ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_CHANGED);
+					ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_CHANGED);
 				else
-					ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_NEW);
+					ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_NEW);
 
 				bool result;
 				if ( stream->num_val_fields > 0 ) // we have values
@@ -1609,14 +1609,14 @@ int Manager::PutTable(Stream* i, const Value* const *vals)
 					{
 					// in case of update send back the old value.
 					assert ( stream->num_val_fields > 0 );
-					auto ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_CHANGED);
+					auto ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_CHANGED);
 					assert ( oldval != nullptr );
 					SendEvent(stream->event, 4, stream->description->Ref(),
 					          ev.release(), predidx, oldval.release());
 					}
 				else
 					{
-					auto ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_NEW);
+					auto ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_NEW);
 					if ( stream->num_val_fields == 0 )
 						SendEvent(stream->event, 4, stream->description->Ref(),
 								ev.release(), predidx);
@@ -1701,7 +1701,7 @@ bool Manager::Delete(ReaderFrontend* reader, Value* *vals)
 					Unref(predidx);
 				else
 					{
-					auto ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_REMOVED);
+					auto ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_REMOVED);
 
 					streamresult = CallPred(stream->pred, 3, ev.release(), predidx, zeek::IntrusivePtr{val}.release());
 
@@ -1720,7 +1720,7 @@ bool Manager::Delete(ReaderFrontend* reader, Value* *vals)
 				{
 				Ref(idxval);
 				assert(val != nullptr);
-				auto ev = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_REMOVED);
+				auto ev = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_REMOVED);
 				SendEvent(stream->event, 4, stream->description->Ref(), ev.release(), idxval, zeek::IntrusivePtr{val}.release());
 				}
 			}
@@ -1735,7 +1735,7 @@ bool Manager::Delete(ReaderFrontend* reader, Value* *vals)
 
 	else if ( i->stream_type == EVENT_STREAM  )
 		{
-		auto type = zeek::BifType::Enum::Input::Event->GetVal(BifEnum::Input::EVENT_REMOVED);
+		auto type = zeek::BifType::Enum::Input::Event->GetEnumVal(BifEnum::Input::EVENT_REMOVED);
 		readVals = SendEventStreamEvent(i, type.release(), vals);
 		success = true;
 		}
@@ -2306,7 +2306,7 @@ zeek::Val* Manager::ValueToVal(const Stream* i, const Value* val, zeek::Type* re
 			return nullptr;
 			}
 
-		auto rval = request_type->AsEnumType()->GetVal(index);
+		auto rval = request_type->AsEnumType()->GetEnumVal(index);
 		return rval.release();
 		}
 
@@ -2439,15 +2439,15 @@ void Manager::ErrorHandler(const Stream* i, ErrorType et, bool reporter_send, co
 		switch (et)
 			{
 			case ErrorType::INFO:
-				ev = zeek::BifType::Enum::Reporter::Level->GetVal(BifEnum::Reporter::INFO);
+				ev = zeek::BifType::Enum::Reporter::Level->GetEnumVal(BifEnum::Reporter::INFO);
 				break;
 
 			case ErrorType::WARNING:
-				ev = zeek::BifType::Enum::Reporter::Level->GetVal(BifEnum::Reporter::WARNING);
+				ev = zeek::BifType::Enum::Reporter::Level->GetEnumVal(BifEnum::Reporter::WARNING);
 				break;
 
 			case ErrorType::ERROR:
-				ev = zeek::BifType::Enum::Reporter::Level->GetVal(BifEnum::Reporter::ERROR);
+				ev = zeek::BifType::Enum::Reporter::Level->GetEnumVal(BifEnum::Reporter::ERROR);
 				break;
 
 			default:

--- a/src/iosource/Packet.cc
+++ b/src/iosource/Packet.cc
@@ -626,7 +626,7 @@ zeek::RecordValPtr Packet::ToRawPktHdrVal() const
 		{
 		// Ethernet header layout is:
 		//    dst[6bytes] src[6bytes] ethertype[2bytes]...
-		l2_hdr->Assign(0, zeek::BifType::Enum::link_encap->GetVal(BifEnum::LINK_ETHERNET));
+		l2_hdr->Assign(0, zeek::BifType::Enum::link_encap->GetEnumVal(BifEnum::LINK_ETHERNET));
 		l2_hdr->Assign(3, FmtEUI48(data + 6));	// src
 		l2_hdr->Assign(4, FmtEUI48(data));  	// dst
 
@@ -643,12 +643,12 @@ zeek::RecordValPtr Packet::ToRawPktHdrVal() const
 			l3 = BifEnum::L3_ARP;
 		}
 	else
-		l2_hdr->Assign(0, zeek::BifType::Enum::link_encap->GetVal(BifEnum::LINK_UNKNOWN));
+		l2_hdr->Assign(0, zeek::BifType::Enum::link_encap->GetEnumVal(BifEnum::LINK_UNKNOWN));
 
 	l2_hdr->Assign(1, zeek::val_mgr->Count(len));
 	l2_hdr->Assign(2, zeek::val_mgr->Count(cap_len));
 
-	l2_hdr->Assign(8, zeek::BifType::Enum::layer3_proto->GetVal(l3));
+	l2_hdr->Assign(8, zeek::BifType::Enum::layer3_proto->GetEnumVal(l3));
 
 	pkt_hdr->Assign(0, std::move(l2_hdr));
 

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -1307,7 +1307,7 @@ void Manager::SendAllWritersTo(const broker::endpoint_info& ei)
 		      i != stream->writers.end(); i++ )
 			{
 			WriterFrontend* writer = i->second->writer;
-			const auto& writer_val = et->GetVal(i->first.first);
+			const auto& writer_val = et->GetEnumVal(i->first.first);
 			broker_mgr->PublishLogCreate((*s)->id,
 						     writer_val.get(),
 						     *i->second->info,

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -764,7 +764,7 @@ void Ascii::RotateLeftoverLogs()
 		static auto rot_info_type = zeek::id::find_type<zeek::RecordType>("Log::RotationInfo");
 		static auto writer_type = zeek::id::find_type<zeek::EnumType>("Log::Writer");
 		static auto writer_idx = writer_type->Lookup("Log", "WRITER_ASCII");
-		static auto writer_val = writer_type->GetVal(writer_idx);
+		static auto writer_val = writer_type->GetEnumVal(writer_idx);
 		static auto default_ppf = zeek::id::find_func("Log::__default_rotation_postprocessor");
 		assert(default_ppf);
 
@@ -908,4 +908,3 @@ bool Ascii::InternalClose(int fd)
 
 	return false;
 	}
-

--- a/src/parse.y
+++ b/src/parse.y
@@ -695,7 +695,7 @@ expr:
 					auto intval = t->Lookup(id->ModuleName(), id->Name());
 					if ( intval < 0 )
 						reporter->InternalError("enum value not found for %s", id->Name());
-					$$ = new zeek::detail::ConstExpr(t->GetVal(intval));
+					$$ = new zeek::detail::ConstExpr(t->GetEnumVal(intval));
 					}
 				else
 					{

--- a/src/parse.y
+++ b/src/parse.y
@@ -265,7 +265,7 @@ bro:
 
 			// Any objects creates from here on out should not
 			// have file positions associated with them.
-			set_location(zeek::detail::no_location);
+			zeek::detail::set_location(zeek::detail::no_location);
 			}
 	|
 		/* Silly way of allowing the debugger to call yyparse()
@@ -292,169 +292,169 @@ opt_expr:
 expr:
 		'(' expr ')'
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = $2; $$->MarkParen();
 			}
 
 	|	TOK_COPY '(' expr ')'
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			$$ = new zeek::detail::CloneExpr({zeek::AdoptRef{}, $3});
 			}
 
 	|	TOK_INCR expr
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::IncrExpr(zeek::detail::EXPR_INCR, {zeek::AdoptRef{}, $2});
 			}
 
 	|	TOK_DECR expr
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::IncrExpr(zeek::detail::EXPR_DECR, {zeek::AdoptRef{}, $2});
 			}
 
 	|	'!' expr
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::NotExpr({zeek::AdoptRef{}, $2});
 			}
 
 	|	'~' expr
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::ComplementExpr({zeek::AdoptRef{}, $2});
 			}
 
 	|	'-' expr	%prec '!'
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::NegExpr({zeek::AdoptRef{}, $2});
 			}
 
 	|	'+' expr	%prec '!'
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::PosExpr({zeek::AdoptRef{}, $2});
 			}
 
 	|	expr '+' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::AddExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr TOK_ADD_TO expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::AddToExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr '-' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::SubExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr TOK_REMOVE_FROM expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::RemoveFromExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr '*' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::TimesExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr '/' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::DivideExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr '%' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::ModExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr '&' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::BitExpr(zeek::detail::EXPR_AND, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr '|' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::BitExpr(zeek::detail::EXPR_OR, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr '^' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::BitExpr(zeek::detail::EXPR_XOR, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr TOK_AND_AND expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::BoolExpr(zeek::detail::EXPR_AND_AND, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr TOK_OR_OR expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::BoolExpr(zeek::detail::EXPR_OR_OR, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr TOK_EQ expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::EqExpr(zeek::detail::EXPR_EQ, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr TOK_NE expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::EqExpr(zeek::detail::EXPR_NE, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr '<' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::RelExpr(zeek::detail::EXPR_LT, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr TOK_LE expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::RelExpr(zeek::detail::EXPR_LE, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr '>' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::RelExpr(zeek::detail::EXPR_GT, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr TOK_GE expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::RelExpr(zeek::detail::EXPR_GE, {zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr '?' expr ':' expr
 			{
-			set_location(@1, @5);
+			zeek::detail::set_location(@1, @5);
 			$$ = new zeek::detail::CondExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3}, {zeek::AdoptRef{}, $5});
 			}
 
 	|	expr '=' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 
 			if ( $1->Tag() == zeek::detail::EXPR_INDEX && $1->AsIndexExpr()->IsSlice() )
 				reporter->Error("index slice assignment may not be used"
@@ -466,14 +466,14 @@ expr:
 
 	|	TOK_LOCAL local_id '=' expr
 			{
-			set_location(@2, @4);
+			zeek::detail::set_location(@2, @4);
 			$$ = add_and_assign_local({zeek::AdoptRef{}, $2}, {zeek::AdoptRef{}, $4},
 			                          zeek::val_mgr->True()).release();
 			}
 
 	|	expr '[' expr_list ']'
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			$$ = new zeek::detail::IndexExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
@@ -481,13 +481,13 @@ expr:
 
 	|	expr '$' TOK_ID
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::FieldExpr({zeek::AdoptRef{}, $1}, $3);
 			}
 
 	|	'$' TOK_ID '=' expr
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			$$ = new zeek::detail::FieldAssignExpr($2, {zeek::AdoptRef{}, $4});
 			}
 
@@ -507,13 +507,13 @@ expr:
 
 	|	expr TOK_IN expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::InExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|	expr TOK_NOT_IN expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::NotExpr(zeek::make_intrusive<zeek::detail::InExpr>(
 			        zeek::detail::ExprPtr{zeek::AdoptRef{}, $1},
 			        zeek::detail::ExprPtr{zeek::AdoptRef{}, $3}));
@@ -521,7 +521,7 @@ expr:
 
 	|	'[' expr_list ']'
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 
 			bool is_record_ctor = true;
 
@@ -553,28 +553,28 @@ expr:
 
 	|	TOK_RECORD '(' expr_list ')'
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			$$ = new zeek::detail::RecordConstructorExpr({zeek::AdoptRef{}, $3});
 			}
 
 	|	TOK_TABLE '(' { ++in_init; } opt_expr_list ')' { --in_init; }
 		opt_attr
 			{ // the ++in_init fixes up the parsing of "[x] = y"
-			set_location(@1, @5);
+			zeek::detail::set_location(@1, @5);
 			std::unique_ptr<std::vector<zeek::detail::AttrPtr>> attrs{$7};
 			$$ = new zeek::detail::TableConstructorExpr({zeek::AdoptRef{}, $4}, std::move(attrs));
 			}
 
 	|	TOK_SET '(' opt_expr_list ')' opt_attr
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			std::unique_ptr<std::vector<zeek::detail::AttrPtr>> attrs{$5};
 			$$ = new zeek::detail::SetConstructorExpr({zeek::AdoptRef{}, $3}, std::move(attrs));
 			}
 
 	|	TOK_VECTOR '(' opt_expr_list ')'
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			$$ = new zeek::detail::VectorConstructorExpr({zeek::AdoptRef{}, $3});
 			}
 
@@ -592,7 +592,7 @@ expr:
 
 		')'
 			{
-			set_location(@1, @6);
+			zeek::detail::set_location(@1, @6);
 
 			if ( $1->Tag() == zeek::detail::EXPR_NAME && $1->AsNameExpr()->Id()->IsType() )
 				{
@@ -633,7 +633,7 @@ expr:
 	|	TOK_HOOK { ++in_hook; } expr
 			{
 			--in_hook;
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			if ( $3->Tag() != zeek::detail::EXPR_CALL )
 				$3->Error("not a valid hook call expression");
 			$$ = $3;
@@ -641,7 +641,7 @@ expr:
 
 	|	expr TOK_HAS_FIELD TOK_ID
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::HasFieldExpr({zeek::AdoptRef{}, $1}, $3);
 			}
 
@@ -650,13 +650,13 @@ expr:
 
 	|	TOK_SCHEDULE expr '{' event '}'
 			{
-			set_location(@1, @5);
+			zeek::detail::set_location(@1, @5);
 			$$ = new zeek::detail::ScheduleExpr({zeek::AdoptRef{}, $2}, {zeek::AdoptRef{}, $4});
 			}
 
 	|	TOK_ID
 			{
-			set_location(@1);
+			zeek::detail::set_location(@1);
 			auto id = zeek::detail::lookup_ID($1, zeek::detail::current_module.c_str());
 
 			if ( ! id )
@@ -706,13 +706,13 @@ expr:
 
 	|	TOK_CONSTANT
 			{
-			set_location(@1);
+			zeek::detail::set_location(@1);
 			$$ = new zeek::detail::ConstExpr({zeek::AdoptRef{}, $1});
 			}
 
 	|	'/' { begin_RE(); } TOK_PATTERN_TEXT TOK_PATTERN_END
 			{
-			set_location(@3);
+			zeek::detail::set_location(@3);
 
 			RE_Matcher* re = new RE_Matcher($3);
 			delete [] $3;
@@ -726,7 +726,7 @@ expr:
 
 	|       '|' expr '|'	%prec '('
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			zeek::detail::ExprPtr e{zeek::AdoptRef{}, $2};
 
 			if ( zeek::IsIntegral(e->GetType()->Tag()) )
@@ -737,13 +737,13 @@ expr:
 
 	|       expr TOK_AS type
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::CastExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 
 	|       expr TOK_IS type
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::IsExpr({zeek::AdoptRef{}, $1}, {zeek::AdoptRef{}, $3});
 			}
 	;
@@ -751,13 +751,13 @@ expr:
 expr_list:
 		expr_list ',' expr
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$1->Append({zeek::AdoptRef{}, $3});
 			}
 
 	|	expr
 			{
-			set_location(@1);
+			zeek::detail::set_location(@1);
 			$$ = new zeek::detail::ListExpr({zeek::AdoptRef{}, $1});
 			}
 	;
@@ -796,7 +796,7 @@ enum_body_elem:
 		*/
 		TOK_ID '=' TOK_CONSTANT opt_deprecated
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			assert(cur_enum_type);
 
 			if ( $3->GetType()->Tag() != zeek::TYPE_COUNT )
@@ -817,7 +817,7 @@ enum_body_elem:
 
 	|	TOK_ID opt_deprecated
 			{
-			set_location(@1);
+			zeek::detail::set_location(@1);
 			assert(cur_enum_type);
 			cur_enum_type->AddName(zeek::detail::current_module, $1, is_export, $2);
 			}
@@ -825,84 +825,84 @@ enum_body_elem:
 
 type:
 		TOK_BOOL	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_BOOL)->Ref();
 				}
 
 	|	TOK_INT		{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_INT)->Ref();
 				}
 
 	|	TOK_COUNT	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_COUNT)->Ref();
 				}
 
 	|	TOK_COUNTER	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_COUNTER)->Ref();
 				}
 
 	|	TOK_DOUBLE	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_DOUBLE)->Ref();
 				}
 
 	|	TOK_TIME	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_TIME)->Ref();
 				}
 
 	|	TOK_INTERVAL	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_INTERVAL)->Ref();
 				}
 
 	|	TOK_STRING	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_STRING)->Ref();
 				}
 
 	|	TOK_PATTERN	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_PATTERN)->Ref();
 				}
 
 	|	TOK_TIMER	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_TIMER)->Ref();
 				}
 
 	|	TOK_PORT	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_PORT)->Ref();
 				}
 
 	|	TOK_ADDR	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_ADDR)->Ref();
 				}
 
 	|	TOK_SUBNET	{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_SUBNET)->Ref();
 				}
 
 	|	TOK_ANY		{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = zeek::base_type(zeek::TYPE_ANY)->Ref();
 				}
 
 	|	TOK_TABLE '[' type_list ']' TOK_OF type
 				{
-				set_location(@1, @6);
+				zeek::detail::set_location(@1, @6);
 				$$ = new zeek::TableType({zeek::AdoptRef{}, $3}, {zeek::AdoptRef{}, $6});
 				}
 
 	|	TOK_SET '[' type_list ']'
 				{
-				set_location(@1, @4);
+				zeek::detail::set_location(@1, @4);
 				$$ = new zeek::SetType({zeek::AdoptRef{}, $3}, nullptr);
 				}
 
@@ -912,27 +912,27 @@ type:
 			{ --in_record; }
 		'}'
 				{
-				set_location(@1, @5);
+				zeek::detail::set_location(@1, @5);
 				$$ = new zeek::RecordType($4);
 				}
 
 	|	TOK_UNION '{' type_list '}'
 				{
-				set_location(@1, @4);
+				zeek::detail::set_location(@1, @4);
 				reporter->Error("union type not implemented");
 				$$ = 0;
 				}
 
-	|	TOK_ENUM '{' { set_location(@1); parser_new_enum(); } enum_body '}'
+	|	TOK_ENUM '{' { zeek::detail::set_location(@1); parser_new_enum(); } enum_body '}'
 				{
-				set_location(@1, @5);
+				zeek::detail::set_location(@1, @5);
 				$4->UpdateLocationEndInfo(@5);
 				$$ = $4;
 				}
 
 	|	TOK_LIST
 				{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				// $$ = new TypeList();
 				reporter->Error("list type not implemented");
 				$$ = 0;
@@ -940,7 +940,7 @@ type:
 
 	|	TOK_LIST TOK_OF type
 				{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				// $$ = new TypeList($3);
 				reporter->Error("list type not implemented");
 				$$ = 0;
@@ -948,43 +948,43 @@ type:
 
 	|	TOK_VECTOR TOK_OF type
 				{
-				set_location(@1, @3);
+				zeek::detail::set_location(@1, @3);
 				$$ = new zeek::VectorType({zeek::AdoptRef{}, $3});
 				}
 
 	|	TOK_FUNCTION func_params
 				{
-				set_location(@1, @2);
+				zeek::detail::set_location(@1, @2);
 				$$ = $2;
 				}
 
 	|	TOK_EVENT '(' formal_args ')'
 				{
-				set_location(@1, @3);
+				zeek::detail::set_location(@1, @3);
 				$$ = new zeek::FuncType({zeek::AdoptRef{}, $3}, nullptr, zeek::FUNC_FLAVOR_EVENT);
 				}
 
 	|	TOK_HOOK '(' formal_args ')'
 				{
-				set_location(@1, @3);
+				zeek::detail::set_location(@1, @3);
 				$$ = new zeek::FuncType({zeek::AdoptRef{}, $3}, zeek::base_type(zeek::TYPE_BOOL), zeek::FUNC_FLAVOR_HOOK);
 				}
 
 	|	TOK_FILE TOK_OF type
 				{
-				set_location(@1, @3);
+				zeek::detail::set_location(@1, @3);
 				$$ = new zeek::FileType({zeek::AdoptRef{}, $3});
 				}
 
 	|	TOK_FILE
 				{
-				set_location(@1);
+				zeek::detail::set_location(@1);
 				$$ = new zeek::FileType(zeek::base_type(zeek::TYPE_STRING));
 				}
 
 	|	TOK_OPAQUE TOK_OF TOK_ID
 				{
-				set_location(@1, @3);
+				zeek::detail::set_location(@1, @3);
 				$$ = new zeek::OpaqueType($3);
 				}
 
@@ -1031,7 +1031,7 @@ type_decl_list:
 type_decl:
 		TOK_ID ':' type opt_attr ';'
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			auto attrs = make_attributes($4, {zeek::NewRef{}, $3}, in_record > 0, false);
 			$$ = new zeek::TypeDecl($1, {zeek::AdoptRef{}, $3}, std::move(attrs));
 
@@ -1061,7 +1061,7 @@ formal_args_decl_list:
 formal_args_decl:
 		TOK_ID ':' type opt_attr
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			auto attrs = make_attributes($4, {zeek::NewRef{}, $3}, true, false);
 			$$ = new zeek::TypeDecl($1, {zeek::AdoptRef{}, $3}, std::move(attrs));
 			}
@@ -1230,7 +1230,7 @@ func_body:
 
 		'}'
 			{
-			set_location(func_hdr_location, @5);
+			zeek::detail::set_location(func_hdr_location, @5);
 			end_func({zeek::AdoptRef{}, $3});
 			}
 	;
@@ -1250,7 +1250,7 @@ lambda_body:
 
 		'}'
 			{
-			set_location(@1, @5);
+			zeek::detail::set_location(@1, @5);
 
 			// Code duplication here is sad but needed. end_func actually instantiates the function
 			// and associates it with an ID. We perform that association later and need to return
@@ -1319,7 +1319,7 @@ init:
 index_slice:
 		expr '[' opt_expr ':' opt_expr ']'
 			{
-			set_location(@1, @6);
+			zeek::detail::set_location(@1, @6);
 
 			auto low = $3 ? zeek::detail::ExprPtr{zeek::AdoptRef{}, $3} :
 			                zeek::make_intrusive<zeek::detail::ConstExpr>(zeek::val_mgr->Count(0));
@@ -1406,7 +1406,7 @@ attr:
 stmt:
 		'{' opt_no_test_block stmt_list '}'
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			$$ = $3;
 			if ( $2 )
 			    brofiler.DecIgnoreDepth();
@@ -1414,7 +1414,7 @@ stmt:
 
 	|	TOK_PRINT expr_list ';' opt_no_test
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::PrintStmt(zeek::IntrusivePtr{zeek::AdoptRef{}, $2});
 			if ( ! $4 )
 			    brofiler.AddStmt($$);
@@ -1422,7 +1422,7 @@ stmt:
 
 	|	TOK_EVENT event ';' opt_no_test
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::EventStmt({zeek::AdoptRef{}, $2});
 			if ( ! $4 )
 			    brofiler.AddStmt($$);
@@ -1430,19 +1430,19 @@ stmt:
 
 	|	TOK_IF '(' expr ')' stmt
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			$$ = new zeek::detail::IfStmt({zeek::AdoptRef{}, $3}, {zeek::AdoptRef{}, $5}, zeek::make_intrusive<zeek::detail::NullStmt>());
 			}
 
 	|	TOK_IF '(' expr ')' stmt TOK_ELSE stmt
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			$$ = new zeek::detail::IfStmt({zeek::AdoptRef{}, $3}, {zeek::AdoptRef{}, $5}, {zeek::AdoptRef{}, $7});
 			}
 
 	|	TOK_SWITCH expr '{' case_list '}'
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::SwitchStmt({zeek::AdoptRef{}, $2}, $4);
 			}
 
@@ -1458,7 +1458,7 @@ stmt:
 
 	|	TOK_NEXT ';' opt_no_test
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::NextStmt;
 			if ( ! $3 )
 			    brofiler.AddStmt($$);
@@ -1466,7 +1466,7 @@ stmt:
 
 	|	TOK_BREAK ';' opt_no_test
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::BreakStmt;
 			if ( ! $3 )
 			    brofiler.AddStmt($$);
@@ -1474,7 +1474,7 @@ stmt:
 
 	|	TOK_FALLTHROUGH ';' opt_no_test
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::FallthroughStmt;
 			if ( ! $3 )
 				brofiler.AddStmt($$);
@@ -1482,7 +1482,7 @@ stmt:
 
 	|	TOK_RETURN ';' opt_no_test
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::ReturnStmt(0);
 			if ( ! $3 )
 			    brofiler.AddStmt($$);
@@ -1490,7 +1490,7 @@ stmt:
 
 	|	TOK_RETURN expr ';' opt_no_test
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::ReturnStmt({zeek::AdoptRef{}, $2});
 			if ( ! $4 )
 			    brofiler.AddStmt($$);
@@ -1498,7 +1498,7 @@ stmt:
 
 	|	TOK_ADD expr ';' opt_no_test
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::AddStmt({zeek::AdoptRef{}, $2});
 			if ( ! $4 )
 			    brofiler.AddStmt($$);
@@ -1506,7 +1506,7 @@ stmt:
 
 	|	TOK_DELETE expr ';' opt_no_test
 			{
-			set_location(@1, @3);
+			zeek::detail::set_location(@1, @3);
 			$$ = new zeek::detail::DelStmt({zeek::AdoptRef{}, $2});
 			if ( ! $4 )
 			    brofiler.AddStmt($$);
@@ -1514,7 +1514,7 @@ stmt:
 
 	|	TOK_LOCAL local_id opt_type init_class opt_init opt_attr ';' opt_no_test
 			{
-			set_location(@1, @7);
+			zeek::detail::set_location(@1, @7);
 			$$ = add_local({zeek::AdoptRef{}, $2}, {zeek::AdoptRef{}, $3}, $4,
 			               {zeek::AdoptRef{}, $5},
 			               std::unique_ptr<std::vector<zeek::detail::AttrPtr>>{$6},
@@ -1525,7 +1525,7 @@ stmt:
 
 	|	TOK_CONST local_id opt_type init_class opt_init opt_attr ';' opt_no_test
 			{
-			set_location(@1, @6);
+			zeek::detail::set_location(@1, @6);
 			$$ = add_local({zeek::AdoptRef{}, $2}, {zeek::AdoptRef{}, $3}, $4,
 			               {zeek::AdoptRef{}, $5},
 			               std::unique_ptr<std::vector<zeek::detail::AttrPtr>>{$6},
@@ -1536,14 +1536,14 @@ stmt:
 
 	|	TOK_WHEN '(' expr ')' stmt
 			{
-			set_location(@3, @5);
+			zeek::detail::set_location(@3, @5);
 			$$ = new zeek::detail::WhenStmt({zeek::AdoptRef{}, $3}, {zeek::AdoptRef{}, $5},
 			                                  nullptr, nullptr, false);
 			}
 
 	|	TOK_WHEN '(' expr ')' stmt TOK_TIMEOUT expr '{' opt_no_test_block stmt_list '}'
 			{
-			set_location(@3, @9);
+			zeek::detail::set_location(@3, @9);
 			$$ = new zeek::detail::WhenStmt({zeek::AdoptRef{}, $3}, {zeek::AdoptRef{}, $5},
 			                                  {zeek::AdoptRef{}, $10}, {zeek::AdoptRef{}, $7}, false);
 			if ( $9 )
@@ -1553,14 +1553,14 @@ stmt:
 
 	|	TOK_RETURN TOK_WHEN '(' expr ')' stmt
 			{
-			set_location(@4, @6);
+			zeek::detail::set_location(@4, @6);
 			$$ = new zeek::detail::WhenStmt({zeek::AdoptRef{}, $4}, {zeek::AdoptRef{}, $6}, nullptr,
 			                  nullptr, true);
 			}
 
 	|	TOK_RETURN TOK_WHEN '(' expr ')' stmt TOK_TIMEOUT expr '{' opt_no_test_block stmt_list '}'
 			{
-			set_location(@4, @10);
+			zeek::detail::set_location(@4, @10);
 			$$ = new zeek::detail::WhenStmt({zeek::AdoptRef{}, $4}, {zeek::AdoptRef{}, $6},
 			                                  {zeek::AdoptRef{}, $11}, {zeek::AdoptRef{}, $8}, true);
 			if ( $10 )
@@ -1569,7 +1569,7 @@ stmt:
 
 	|	index_slice '=' expr ';' opt_no_test
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			$$ = new zeek::detail::ExprStmt(zeek::detail::get_assign_expr({zeek::AdoptRef{}, $1},
 			                                  {zeek::AdoptRef{}, $3}, in_init));
 
@@ -1579,7 +1579,7 @@ stmt:
 
 	|	expr ';' opt_no_test
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$$ = new zeek::detail::ExprStmt({zeek::AdoptRef{}, $1});
 			if ( ! $3 )
 			    brofiler.AddStmt($$);
@@ -1587,7 +1587,7 @@ stmt:
 
 	|	';'
 			{
-			set_location(@1, @1);
+			zeek::detail::set_location(@1, @1);
 			$$ = new zeek::detail::NullStmt;
 			}
 
@@ -1598,7 +1598,7 @@ stmt:
 stmt_list:
 		stmt_list stmt
 			{
-			set_location(@1, @2);
+			zeek::detail::set_location(@1, @2);
 			$1->AsStmtList()->Stmts().push_back($2);
 			$1->UpdateLocationEndInfo(@2);
 			}
@@ -1609,7 +1609,7 @@ stmt_list:
 event:
 		TOK_ID '(' opt_expr_list ')'
 			{
-			set_location(@1, @4);
+			zeek::detail::set_location(@1, @4);
 			const auto& id = zeek::detail::lookup_ID($1, zeek::detail::current_module.c_str());
 
 			if ( id )
@@ -1683,7 +1683,7 @@ case_type:
 for_head:
 		TOK_FOR '(' TOK_ID TOK_IN expr ')'
 			{
-			set_location(@1, @6);
+			zeek::detail::set_location(@1, @6);
 
 			// This rule needs to be separate from the loop
 			// body so that we execute these actions - defining
@@ -1716,7 +1716,7 @@ for_head:
 	|
 		TOK_FOR '(' TOK_ID ',' TOK_ID TOK_IN expr ')'
 			{
-			set_location(@1, @8);
+			zeek::detail::set_location(@1, @8);
 			const char* module = zeek::detail::current_module.c_str();
 
 			// Check for previous definitions of key and
@@ -1749,7 +1749,7 @@ for_head:
 	|
 		TOK_FOR '(' '[' local_id_list ']' ',' TOK_ID TOK_IN expr ')'
 			{
-			set_location(@1, @10);
+			zeek::detail::set_location(@1, @10);
 			const char* module = zeek::detail::current_module.c_str();
 
 			// Validate value variable
@@ -1780,7 +1780,7 @@ local_id_list:
 local_id:
 		TOK_ID
 			{
-			set_location(@1);
+			zeek::detail::set_location(@1);
 			auto id = zeek::detail::lookup_ID($1, zeek::detail::current_module.c_str());
 			$$ = id.release();
 
@@ -1817,7 +1817,7 @@ event_id:
 global_or_event_id:
 		TOK_ID
 			{
-			set_location(@1);
+			zeek::detail::set_location(@1);
 			auto id = zeek::detail::lookup_ID($1, zeek::detail::current_module.c_str(), false,
 			                    defining_global_ID);
 			$$ = id.release();
@@ -1855,7 +1855,7 @@ global_or_event_id:
 resolve_id:
 		TOK_ID
 			{
-			set_location(@1);
+			zeek::detail::set_location(@1);
 			auto id = zeek::detail::lookup_ID($1, zeek::detail::current_module.c_str());
 			$$ = id.release();
 

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -1386,7 +1386,7 @@ RecordValPtr Supervisor::NodeConfig::ToRecord() const
 		const auto& ept = zeek::BifType::Record::Supervisor::ClusterEndpoint;
 		auto val = zeek::make_intrusive<zeek::RecordVal>(ept);
 
-		val->Assign(ept->FieldOffset("role"), zeek::BifType::Enum::Supervisor::ClusterRole->GetVal(ep.role));
+		val->Assign(ept->FieldOffset("role"), zeek::BifType::Enum::Supervisor::ClusterRole->GetEnumVal(ep.role));
 		val->Assign(ept->FieldOffset("host"), zeek::make_intrusive<zeek::AddrVal>(ep.host));
 		val->Assign(ept->FieldOffset("p"), zeek::val_mgr->Port(ep.port, TRANSPORT_TCP));
 
@@ -1419,15 +1419,15 @@ static ValPtr supervisor_role_to_cluster_node_type(BifEnum::Supervisor::ClusterR
 
 	switch ( role ) {
 	case BifEnum::Supervisor::LOGGER:
-		return node_type->GetVal(node_type->Lookup("Cluster", "LOGGER"));
+		return node_type->GetEnumVal(node_type->Lookup("Cluster", "LOGGER"));
 	case BifEnum::Supervisor::MANAGER:
-		return node_type->GetVal(node_type->Lookup("Cluster", "MANAGER"));
+		return node_type->GetEnumVal(node_type->Lookup("Cluster", "MANAGER"));
 	case BifEnum::Supervisor::PROXY:
-		return node_type->GetVal(node_type->Lookup("Cluster", "PROXY"));
+		return node_type->GetEnumVal(node_type->Lookup("Cluster", "PROXY"));
 	case BifEnum::Supervisor::WORKER:
-		return node_type->GetVal(node_type->Lookup("Cluster", "WORKER"));
+		return node_type->GetEnumVal(node_type->Lookup("Cluster", "WORKER"));
 	default:
-		return node_type->GetVal(node_type->Lookup("Cluster", "NONE"));
+		return node_type->GetEnumVal(node_type->Lookup("Cluster", "NONE"));
 	}
 	}
 

--- a/src/threading/SerialTypes.cc
+++ b/src/threading/SerialTypes.cc
@@ -629,7 +629,7 @@ zeek::Val* Value::ValueToVal(const std::string& source, const Value* val, bool& 
 				return nullptr;
 				}
 
-			auto rval = t->GetVal(intval);
+			auto rval = t->GetEnumVal(intval);
 			return rval.release();
 			}
 

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -3253,16 +3253,16 @@ static zeek::EnumValPtr map_conn_type(TransportProto tp)
 	{
 	switch ( tp ) {
 	case TRANSPORT_UNKNOWN:
-		return zeek::id::transport_proto->GetVal(0);
+		return zeek::id::transport_proto->GetEnumVal(0);
 
 	case TRANSPORT_TCP:
-		return zeek::id::transport_proto->GetVal(1);
+		return zeek::id::transport_proto->GetEnumVal(1);
 
 	case TRANSPORT_UDP:
-		return zeek::id::transport_proto->GetVal(2);
+		return zeek::id::transport_proto->GetEnumVal(2);
 
 	case TRANSPORT_ICMP:
-		return zeek::id::transport_proto->GetVal(3);
+		return zeek::id::transport_proto->GetEnumVal(3);
 
 	default:
 		reporter->InternalError("bad connection type in map_conn_type()");
@@ -3288,7 +3288,7 @@ function get_conn_transport_proto%(cid: conn_id%): transport_proto
 	if ( ! c )
 		{
 		zeek::emit_builtin_error("unknown connection id in get_conn_transport_proto()", cid);
-		return zeek::id::transport_proto->GetVal(0);
+		return zeek::id::transport_proto->GetEnumVal(0);
 		}
 
 	return map_conn_type(c->ConnTransport());
@@ -3436,7 +3436,7 @@ function get_current_packet%(%) : pcap_packet
 		pkt->Assign(2, zeek::val_mgr->Count(0));
 		pkt->Assign(3, zeek::val_mgr->Count(0));
 		pkt->Assign(4, zeek::val_mgr->EmptyString());
-		pkt->Assign(5, zeek::BifType::Enum::link_encap->GetVal(BifEnum::LINK_UNKNOWN));
+		pkt->Assign(5, zeek::BifType::Enum::link_encap->GetEnumVal(BifEnum::LINK_UNKNOWN));
 		return pkt;
 		}
 
@@ -3445,7 +3445,7 @@ function get_current_packet%(%) : pcap_packet
 	pkt->Assign(2, zeek::val_mgr->Count(p->cap_len));
 	pkt->Assign(3, zeek::val_mgr->Count(p->len));
 	pkt->Assign(4, zeek::make_intrusive<zeek::StringVal>(p->cap_len, (const char*)p->data));
-	pkt->Assign(5, zeek::BifType::Enum::link_encap->GetVal(p->link_type));
+	pkt->Assign(5, zeek::BifType::Enum::link_encap->GetEnumVal(p->link_type));
 
 	return pkt;
 	%}
@@ -3945,7 +3945,7 @@ static zeek::ValPtr mmdb_getvalue(MMDB_entry_data_s* entry_data, int status,
 static bool mmdb_try_open_loc ()
 	{
 	// City database is always preferred over Country database.
-	const auto& mmdb_dir_val = zeek::detail::global_scope()->Find("mmdb_dir")->GetVal();
+	const auto& mmdb_dir_val = zeek::detail::global_scope()->Find("mmdb_dir")->GetEnumVal();
 	std::string mmdb_dir = mmdb_dir_val->AsString()->CheckString();
 
 	if ( ! mmdb_dir.empty() )
@@ -3973,7 +3973,7 @@ static bool mmdb_try_open_loc ()
 
 static bool mmdb_try_open_asn ()
 	{
-	const auto& mmdb_dir_val = zeek::detail::global_scope()->Find("mmdb_dir")->GetVal();
+	const auto& mmdb_dir_val = zeek::detail::global_scope()->Find("mmdb_dir")->GetEnumVal();
 	std::string mmdb_dir = mmdb_dir_val->AsString()->CheckString();
 
 	if ( ! mmdb_dir.empty() )


### PR DESCRIPTION
Spicy currently fails to build against Zeek's master because of a few changes made during both the IntrusivePtr work and the deprecation changes. This PR fixes most of the failures. There will be a follow-on PR for Spicy that fixes the remainder of them there.