### PR TITLE
Add zeek-archiver tool as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "auxil/highwayhash"]
 	path = auxil/highwayhash
 	url = https://github.com/zeek/highwayhash
+[submodule "auxil/zeek-archiver"]
+	path = auxil/zeek-archiver
+	url = https://github.com/zeek/zeek-archiver

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,7 @@ include(CheckOptionalBuildSources)
 
 CheckOptionalBuildSources(auxil/zeekctl   ZeekControl INSTALL_ZEEKCTL)
 CheckOptionalBuildSources(auxil/zeek-aux  Zeek-Aux  INSTALL_AUX_TOOLS)
+CheckOptionalBuildSources(auxil/zeek-archiver ZeekArchiver INSTALL_ZEEK_ARCHIVER)
 
 ########################################################################
 ## Packaging Setup

--- a/configure
+++ b/configure
@@ -58,6 +58,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --enable-rocksdb       try to find a RocksDB installation for use in Broker
     --disable-zeekctl      don't install ZeekControl
     --disable-auxtools     don't build or install auxiliary tools
+    --disable-archiver     don't build or install zeek-archiver tool
     --disable-python       don't try to build python bindings for Broker
     --disable-broker-tests don't try to build Broker unit tests
 
@@ -155,6 +156,7 @@ append_cache_entry ENABLE_PERFTOOLS     BOOL   false
 append_cache_entry ENABLE_JEMALLOC      BOOL   false
 append_cache_entry BUILD_SHARED_LIBS    BOOL   true
 append_cache_entry INSTALL_AUX_TOOLS    BOOL   true
+append_cache_entry INSTALL_ZEEK_ARCHIVER BOOL  true
 append_cache_entry INSTALL_ZEEKCTL      BOOL   true
 append_cache_entry CPACK_SOURCE_IGNORE_FILES STRING
 append_cache_entry ENABLE_MOBILE_IPV6   BOOL   false
@@ -266,6 +268,9 @@ while [ $# -ne 0 ]; do
             ;;
         --disable-auxtools)
             append_cache_entry INSTALL_AUX_TOOLS    BOOL   false
+            ;;
+        --disable-archiver)
+            append_cache_entry INSTALL_ZEEK_ARCHIVER    BOOL   false
             ;;
         --disable-python)
             append_cache_entry DISABLE_PYTHON_BINDINGS     BOOL   true


### PR DESCRIPTION
This is added to the default Zeek build as a convenience since it's the
new suggested method for archiving the logs produced by a Supervised
Zeek Cluster.

(Any review  of the `zeek-archiver` code itself helps, too).