### PR TITLE
Resolve a few clang-tidy warnings

### DIFF
--- a/src/Anon.cc
+++ b/src/Anon.cc
@@ -146,8 +146,8 @@ ipaddr32_t AnonymizeIPAddr_PrefixMD5::anonymize(ipaddr32_t input)
 
 AnonymizeIPAddr_A50::~AnonymizeIPAddr_A50()
 	{
-	for ( unsigned int i = 0; i < blocks.size(); ++i )
-		delete [] blocks[i];
+	for ( auto& b : blocks )
+		delete [] b;
 	}
 
 void AnonymizeIPAddr_A50::init()

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -82,8 +82,8 @@ static void choose_global_symbols_regex(const string& regex, vector<zeek::detail
 		{
 		debug_msg("There were multiple matches, please choose:\n");
 
-		for ( unsigned int i = 0; i < choices.size(); ++i )
-			debug_msg("[%d] %s\n", i+1, choices[i]->Name());
+		for ( size_t i = 0; i < choices.size(); i++ )
+			debug_msg("[%lu] %s\n", i+1, choices[i]->Name());
 
 		debug_msg("[a] All of the above\n");
 		debug_msg("[n] None of the above\n");
@@ -412,11 +412,11 @@ int dbg_cmd_break(DebugCmd cmd, const vector<string>& args)
 				  locstrings[strindex].c_str());
 			vector<ParseLocationRec> plrs =
 				parse_location_string(locstrings[strindex]);
-			for ( unsigned int i = 0; i < plrs.size(); ++i )
+			for ( const auto& plr : plrs )
 				{
 				DbgBreakpoint* bp = new DbgBreakpoint();
 				bp->SetID(g_debugger_state.NextBPID());
-				if ( ! bp->SetLocation(plrs[i], locstrings[strindex]) )
+				if ( ! bp->SetLocation(plr, locstrings[strindex]) )
 					{
 					debug_msg("Breakpoint not set.\n");
 					delete bp;
@@ -435,18 +435,18 @@ int dbg_cmd_break(DebugCmd cmd, const vector<string>& args)
 		{
 		// ### Implement conditions
 		string cond;
-		for ( int i = cond_index; i < int(args.size()); ++i )
+		for ( const auto& arg : args )
 			{
-			cond += args[i];
+			cond += arg;
 			cond += "    ";
 			}
 		bps[0]->SetCondition(cond);
 		}
 
-	for ( unsigned int i = 0; i < bps.size(); ++i )
+	for ( auto& bp : bps )
 		{
-		bps[i]->SetTemporary(false);
-		g_debugger_state.breakpoints[bps[i]->GetID()] = bps[i];
+		bp->SetTemporary(false);
+		g_debugger_state.breakpoints[bp->GetID()] = bp;
 		}
 
 	return 0;
@@ -507,15 +507,13 @@ int dbg_cmd_break_set_state(DebugCmd cmd, const vector<string>& args)
 		}
 	else
 		{
-		for ( unsigned int i = 0; i < args.size(); ++i )
-			if ( int idx = atoi(args[i].c_str()) )
+		for ( const auto& arg : args )
+			if ( int idx = atoi(arg.c_str()) )
 				bps_to_change.push_back(idx);
 		}
 
-	for ( unsigned int i = 0; i < bps_to_change.size(); ++i )
+	for ( auto bp_change : bps_to_change )
 		{
-		int bp_change = bps_to_change[i];
-
 		BPIDMapType::iterator result =
 			g_debugger_state.breakpoints.find(bp_change);
 
@@ -559,10 +557,10 @@ int dbg_cmd_print(DebugCmd cmd, const vector<string>& args)
 
 	// Just concatenate all the 'args' into one expression.
 	string expr;
-	for ( int i = 0; i < int(args.size()); ++i )
+	for ( size_t i = 0; i < args.size(); ++i )
 		{
 		expr += args[i];
-		if ( i < int(args.size()) - 1 )
+		if ( i < args.size() - 1 )
 			expr += " ";
 		}
 

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -366,7 +366,7 @@ int dbg_cmd_break(DebugCmd cmd, const vector<string>& args)
 
 	int cond_index = -1; // at which argument pos. does bp condition start?
 
-	if ( args.size() == 0 || args[0] == "if" )
+	if ( args.empty() || args[0] == "if" )
 		{ // break on next stmt
 		int user_frame_number =
 			g_frame_stack.size() - 1 -
@@ -431,7 +431,7 @@ int dbg_cmd_break(DebugCmd cmd, const vector<string>& args)
 		}
 
 	// Is there a condition specified?
-	if ( cond_index >= 0 && bps.size() )
+	if ( cond_index >= 0 && ! bps.empty() )
 		{
 		// ### Implement conditions
 		string cond;
@@ -490,7 +490,7 @@ int dbg_cmd_break_set_state(DebugCmd cmd, const vector<string>& args)
 		return 0;
 		}
 
-	if ( g_debugger_state.breakpoints.size() == 0 )
+	if ( g_debugger_state.breakpoints.empty() )
 		{
 		debug_msg ("No breakpoints currently set.\n");
 		return -1;
@@ -498,7 +498,7 @@ int dbg_cmd_break_set_state(DebugCmd cmd, const vector<string>& args)
 
 	vector<int> bps_to_change;
 
-	if ( args.size() == 0 )
+	if ( args.empty() )
 		{
 		BPIDMapType::iterator iter;
 		for ( iter = g_debugger_state.breakpoints.begin();
@@ -587,7 +587,7 @@ int dbg_cmd_info(DebugCmd cmd, const vector<string>& args)
 	{
 	assert(cmd == dcInfo);
 
-	if ( ! args.size() )
+	if ( args.empty() )
 		{
 		debug_msg("Syntax: info info-command\n");
 		debug_msg("List of info-commands:\n");
@@ -635,7 +635,7 @@ int dbg_cmd_list(DebugCmd cmd, const vector<string>& args)
 		return 0;
 		}
 
-	if ( args.size() == 0 )
+	if ( args.empty() )
 		{
 		// Special case: if we just hit a breakpoint, then show
 		// that line without advancing first.
@@ -700,7 +700,7 @@ int dbg_cmd_trace(DebugCmd cmd, const vector<string>& args)
 	{
 	assert(cmd == dcTrace);
 
-	if ( args.size() == 0 )
+	if ( args.empty() )
 		{
 		debug_msg("Execution tracing is %s.\n",
 		g_trace_state.DoTrace() ? "on" : "off" );

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -2699,7 +2699,7 @@ ValPtr IndexExpr::Fold(Val* v1, Val* v2) const
 				{
 				result->Resize(sub_length);
 
-				for ( int idx = first; idx < last; idx++ )
+				for ( bro_int_t idx = first; idx < last; idx++ )
 					result->Assign(idx - first, vect->At(idx));
 				}
 

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -208,9 +208,9 @@ TraversalCode Func::Traverse(TraversalCallback* cb) const
 		tc = scope->Traverse(cb);
 		HANDLE_TC_STMT_PRE(tc);
 
-		for ( unsigned int i = 0; i < bodies.size(); ++i )
+		for ( const auto& body : bodies )
 			{
-			tc = bodies[i].stmts->Traverse(cb);
+			tc = body.stmts->Traverse(cb);
 			HANDLE_TC_STMT_PRE(tc);
 			}
 		}
@@ -587,10 +587,10 @@ void ScriptFunc::Describe(ODesc* d) const
 
 	d->NL();
 	d->AddCount(frame_size);
-	for ( unsigned int i = 0; i < bodies.size(); ++i )
+	for ( const auto& body : bodies )
 		{
-		bodies[i].stmts->AccessStats(d);
-		bodies[i].stmts->Describe(d);
+		body.stmts->AccessStats(d);
+		body.stmts->Describe(d);
 		}
 	}
 

--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -965,7 +965,7 @@ VectorValPtr ParaglobVal::Get(StringVal* &pattern)
 	std::string string_pattern (reinterpret_cast<const char*>(pattern->Bytes()), pattern->Len());
 
 	std::vector<std::string> matches = this->internal_paraglob->get(string_pattern);
-	for (unsigned int i = 0; i < matches.size(); i++)
+	for ( size_t i = 0; i < matches.size(); i++ )
 		rval->Assign(i, zeek::make_intrusive<StringVal>(matches.at(i)));
 
 	return rval;

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -250,7 +250,7 @@ zeek::Options zeek::parse_cmdline(int argc, char** argv)
 	// getopt may permute the array, so need yet another array
 	auto zargs = std::make_unique<char*[]>(zeek_args.size());
 
-	for ( size_t i = 0u; i < zeek_args.size(); ++i )
+	for ( size_t i = 0; i < zeek_args.size(); ++i )
 		zargs[i] = zeek_args[i].data();
 
 	while ( (op = getopt_long(zeek_args.size(), zargs.get(), opts, long_opts, &long_optsind)) != EOF )

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -179,7 +179,7 @@ zeek::Options zeek::parse_cmdline(int argc, char** argv)
 
 		rval.run_unit_tests = true;
 
-		for ( auto i = 0; i < std::distance(first, separator); ++i )
+		for ( size_t i = 0; i < std::distance(first, separator); ++i )
 			rval.doctest_args.emplace_back(argv[i]);
 		}
 	else
@@ -250,7 +250,7 @@ zeek::Options zeek::parse_cmdline(int argc, char** argv)
 	// getopt may permute the array, so need yet another array
 	auto zargs = std::make_unique<char*[]>(zeek_args.size());
 
-	for ( auto i = 0u; i < zeek_args.size(); ++i )
+	for ( size_t i = 0u; i < zeek_args.size(); ++i )
 		zargs[i] = zeek_args[i].data();
 
 	while ( (op = getopt_long(zeek_args.size(), zargs.get(), opts, long_opts, &long_optsind)) != EOF )

--- a/src/SmithWaterman.cc
+++ b/src/SmithWaterman.cc
@@ -67,7 +67,7 @@ zeek::VectorVal* BroSubstring::VecToPolicy(Vec* vec)
 
 	if ( vec )
 		{
-		for ( unsigned int i = 0; i < vec->size(); ++i )
+		for ( size_t i = 0; i < vec->size(); ++i )
 			{
 			BroSubstring* bst = (*vec)[i];
 

--- a/src/ZeekString.cc
+++ b/src/ZeekString.cc
@@ -301,7 +301,7 @@ int String::FindSubstring(const String* s) const
 
 String::Vec* String::Split(const String::IdxVec& indices) const
 	{
-	unsigned int i;
+	size_t i;
 
 	if ( indices.empty() )
 		return nullptr;
@@ -482,8 +482,8 @@ String* concatenate(String::Vec& v)
 
 void delete_strings(std::vector<const String*>& v)
 	{
-	for ( unsigned int i = 0; i < v.size(); ++i )
-		delete v[i];
+	for ( auto& elem : v )
+		delete elem;
 	v.clear();
 	}
 

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -126,7 +126,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			pos = myline.length();
 
 		command = myline.substr(0, pos);
-		for ( unsigned int i = 0; i < command.size(); ++i )
+		for ( size_t i = 0; i < command.size(); ++i )
 			command[i] = toupper(command[i]);
 
 		// Adjust for the no-parameter case
@@ -225,7 +225,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			int services = 0;
 			int servers = 0;
 
-			for ( unsigned int i = 1; i < parts.size(); ++i )
+			for ( size_t i = 1; i < parts.size(); ++i )
 				{
 				if ( parts[i] == "users" )
 					users = atoi(parts[i-1].c_str());
@@ -274,11 +274,11 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			auto set = zeek::make_intrusive<zeek::TableVal>(zeek::id::string_set);
 
-			for ( unsigned int i = 0; i < parts.size(); ++i )
+			for ( auto& part : parts )
 				{
-				if ( parts[i][0] == '@' )
-					parts[i] = parts[i].substr(1);
-				auto idx = zeek::make_intrusive<zeek::StringVal>(parts[i].c_str());
+				if ( part[0] == '@' )
+					part = part.substr(1);
+				auto idx = zeek::make_intrusive<zeek::StringVal>(part);
 				set->Assign(std::move(idx), nullptr);
 				}
 
@@ -302,7 +302,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			int services = 0;
 			int servers = 0;
 
-			for ( unsigned int i = 1; i < parts.size(); ++i )
+			for ( size_t i = 1; i < parts.size(); ++i )
 				{
 				if ( parts[i] == "users," )
 					users = atoi(parts[i-1].c_str());
@@ -332,7 +332,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			{
 			vector<string> parts = SplitWords(params, ' ');
 			int channels = 0;
-			for ( unsigned int i = 1; i < parts.size(); ++i )
+			for ( size_t i = 1; i < parts.size(); ++i )
 				if ( parts[i] == ":channels" )
 					channels = atoi(parts[i - 1].c_str());
 
@@ -402,7 +402,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			parts.erase(parts.begin(), parts.begin() + 4);
 
 			string real_name = parts[0];
-			for ( unsigned int i = 1; i < parts.size(); ++i )
+			for ( size_t i = 1; i < parts.size(); ++i )
 				real_name = real_name + " " + parts[i];
 
 			if ( real_name[0] == ':' )
@@ -462,9 +462,9 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			auto set = zeek::make_intrusive<zeek::TableVal>(zeek::id::string_set);
 
-			for ( unsigned int i = 0; i < parts.size(); ++i )
+			for ( const auto& part : parts )
 				{
-				auto idx = zeek::make_intrusive<zeek::StringVal>(parts[i].c_str());
+				auto idx = zeek::make_intrusive<zeek::StringVal>(part);
 				set->Assign(std::move(idx), nullptr);
 				}
 
@@ -637,7 +637,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 
 			// Calculate IP address.
 			uint32_t raw_ip = 0;
-			for ( unsigned int i = 0; i < parts[3].size(); ++i )
+			for ( size_t i = 0; i < parts[3].size(); ++i )
 				{
 				string s = parts[3].substr(i, 1);
 				raw_ip = (10 * raw_ip) + atoi(s.c_str());
@@ -741,7 +741,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		else vl.emplace_back(zeek::val_mgr->EmptyString());
 
 		string realname;
-		for ( unsigned int i = 3; i < parts.size(); i++ )
+		for ( size_t i = 3; i < parts.size(); i++ )
 			{
 			realname += parts[i];
 			if ( i > 3 )
@@ -791,7 +791,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		if ( parts.size() > 2 )
 			{
 			string comment = parts[2];
-			for ( unsigned int i = 3; i < parts.size(); ++i )
+			for ( size_t i = 3; i < parts.size(); ++i )
 				comment += " " + parts[i];
 
 			if ( comment[0] == ':' )
@@ -835,7 +835,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 			passwords = SplitWords(parts[1], ',');
 
 		string empty_string = "";
-		for ( unsigned int i = 0; i < channels.size(); ++i )
+		for ( size_t i = 0; i < channels.size(); ++i )
 			{
 			auto info = zeek::make_intrusive<zeek::RecordVal>(irc_join_info);
 			info->Assign(0, zeek::make_intrusive<zeek::StringVal>(nickname.c_str()));
@@ -942,9 +942,9 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig)
 		vector<string> channelList = SplitWords(channels, ',');
 		auto set = zeek::make_intrusive<zeek::TableVal>(zeek::id::string_set);
 
-		for ( unsigned int i = 0; i < channelList.size(); ++i )
+		for ( const auto& channel : channelList )
 			{
-			auto idx = zeek::make_intrusive<zeek::StringVal>(channelList[i].c_str());
+			auto idx = zeek::make_intrusive<zeek::StringVal>(channel);
 			set->Assign(std::move(idx), nullptr);
 			}
 

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -593,8 +593,8 @@ MIME_Entity::~MIME_Entity()
 	delete content_encoding_str;
 	delete multipart_boundary;
 
-	for ( unsigned int i = 0; i < headers.size(); ++i )
-		delete headers[i];
+	for ( auto& header : headers )
+		delete header;
 	headers.clear();
 
 	delete base64_decoder;
@@ -1286,10 +1286,8 @@ void MIME_Entity::IllegalEncoding(const char* explanation)
 void MIME_Entity::DebugPrintHeaders()
 	{
 #ifdef DEBUG_BRO
-	for ( unsigned int i = 0; i < headers.size(); ++i )
+	for ( MIME_Header* h : headers )
 		{
-		MIME_Header* h = headers[i];
-
 		DEBUG_fputs(h->get_name(), stderr);
 		DEBUG_MSG(":\"");
 		DEBUG_fputs(h->get_value(), stderr);
@@ -1321,7 +1319,7 @@ zeek::TableValPtr MIME_Message::ToHeaderTable(MIME_HeaderList& hlist)
 	static auto mime_header_list = zeek::id::find_type<zeek::TableType>("mime_header_list");
 	auto t = zeek::make_intrusive<zeek::TableVal>(mime_header_list);
 
-	for ( unsigned int i = 0; i < hlist.size(); ++i )
+	for ( size_t i = 0; i < hlist.size(); ++i )
 		{
 		auto index = zeek::val_mgr->Count(i + 1);	// index starting from 1
 		MIME_Header* h = hlist[i];

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -870,7 +870,7 @@ int POP3_Analyzer::ParseCmd(std::string cmd)
 		if ( c == '+' || c == '-' )
 			cmd = cmd.substr(1);
 
-		for ( unsigned int i = 0; i < cmd.size(); ++i )
+		for ( size_t i = 0; i < cmd.size(); ++i )
 			cmd[i] = toupper(cmd[i]);
 
 		if ( ! cmd.compare(pop3_cmd_word[code]) )

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -85,7 +85,7 @@ RPC_CallInfo::RPC_CallInfo(uint32_t arg_xid, const u_char*& buf, int& n, double 
 			return;
 			}
 
-		for ( size_t i = 0u; i < number_of_gids; ++i )
+		for ( size_t i = 0; i < number_of_gids; ++i )
 			auxgids.push_back(extract_XDR_uint32(cred_opaque, cred_opaque_n));
 		}
 

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -85,7 +85,7 @@ RPC_CallInfo::RPC_CallInfo(uint32_t arg_xid, const u_char*& buf, int& n, double 
 			return;
 			}
 
-		for ( auto i = 0u; i < number_of_gids; ++i )
+		for ( size_t i = 0u; i < number_of_gids; ++i )
 			auxgids.push_back(extract_XDR_uint32(cred_opaque, cred_opaque_n));
 		}
 

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -239,7 +239,7 @@ struct val_converter {
 
 			auto list_val = zeek::make_intrusive<zeek::ListVal>(zeek::TYPE_ANY);
 
-			for ( size_t i = 0u; i < indices->size(); ++i )
+			for ( size_t i = 0; i < indices->size(); ++i )
 				{
 				auto index_val = bro_broker::data_to_val(move((*indices)[i]),
 				                                         expected_index_types[i].get());
@@ -298,7 +298,7 @@ struct val_converter {
 
 			auto list_val = zeek::make_intrusive<zeek::ListVal>(zeek::TYPE_ANY);
 
-			for ( size_t i = 0u; i < indices->size(); ++i )
+			for ( size_t i = 0; i < indices->size(); ++i )
 				{
 				auto index_val = bro_broker::data_to_val(move((*indices)[i]),
 				                                         expected_index_types[i].get());
@@ -386,7 +386,7 @@ struct val_converter {
 			auto rval = zeek::make_intrusive<zeek::RecordVal>(zeek::IntrusivePtr{zeek::NewRef{}, rt});
 			auto idx = 0u;
 
-			for ( size_t i = 0u; i < static_cast<size_t>(rt->NumFields()); ++i )
+			for ( size_t i = 0; i < static_cast<size_t>(rt->NumFields()); ++i )
 				{
 				if ( idx >= a.size() )
 					return nullptr;
@@ -574,7 +574,7 @@ struct type_checker {
 						{
 						indices_to_check.reserve(indices->size());
 
-						for ( size_t i = 0u; i < indices->size(); ++i )
+						for ( size_t i = 0; i < indices->size(); ++i )
 							indices_to_check.emplace_back(&(*indices)[i]);
 						}
 					}
@@ -582,7 +582,7 @@ struct type_checker {
 					{
 					indices_to_check.reserve(indices->size());
 
-					for ( size_t i = 0u; i < indices->size(); ++i )
+					for ( size_t i = 0; i < indices->size(); ++i )
 						indices_to_check.emplace_back(&(*indices)[i]);
 					}
 				}
@@ -592,7 +592,7 @@ struct type_checker {
 			if ( expected_index_types.size() != indices_to_check.size() )
 				return false;
 
-			for ( size_t i = 0u; i < indices_to_check.size(); ++i )
+			for ( size_t i = 0; i < indices_to_check.size(); ++i )
 				{
 				auto expect = expected_index_types[i].get();
 				auto& index_to_check = *(indices_to_check)[i];
@@ -633,7 +633,7 @@ struct type_checker {
 						{
 						indices_to_check.reserve(indices->size());
 
-						for ( size_t i = 0u; i < indices->size(); ++i )
+						for ( size_t i = 0; i < indices->size(); ++i )
 							indices_to_check.emplace_back(&(*indices)[i]);
 						}
 					}
@@ -641,7 +641,7 @@ struct type_checker {
 					{
 					indices_to_check.reserve(indices->size());
 
-					for ( size_t i = 0u; i < indices->size(); ++i )
+					for ( size_t i = 0; i < indices->size(); ++i )
 						indices_to_check.emplace_back(&(*indices)[i]);
 					}
 				}
@@ -654,7 +654,7 @@ struct type_checker {
 				return false;
 				}
 
-			for ( size_t i = 0u; i < indices_to_check.size(); ++i )
+			for ( size_t i = 0; i < indices_to_check.size(); ++i )
 				{
 				auto expect = expected_index_types[i].get();
 				auto& index_to_check = *(indices_to_check)[i];
@@ -715,7 +715,7 @@ struct type_checker {
 			auto rt = type->AsRecordType();
 			auto idx = 0u;
 
-			for ( size_t i = 0u; i < static_cast<size_t>(rt->NumFields()); ++i )
+			for ( size_t i = 0; i < static_cast<size_t>(rt->NumFields()); ++i )
 				{
 				if ( idx >= a.size() )
 					return false;
@@ -964,7 +964,7 @@ broker::expected<broker::data> bro_broker::val_to_data(const zeek::Val* v)
 		size_t num_fields = v->GetType()->AsRecordType()->NumFields();
 		rval.reserve(num_fields);
 
-		for ( size_t i = 0u; i < num_fields; ++i )
+		for ( size_t i = 0; i < num_fields; ++i )
 			{
 			auto item_val = rec->GetFieldOrDefault(i);
 

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -239,7 +239,7 @@ struct val_converter {
 
 			auto list_val = zeek::make_intrusive<zeek::ListVal>(zeek::TYPE_ANY);
 
-			for ( auto i = 0u; i < indices->size(); ++i )
+			for ( size_t i = 0u; i < indices->size(); ++i )
 				{
 				auto index_val = bro_broker::data_to_val(move((*indices)[i]),
 				                                         expected_index_types[i].get());
@@ -298,7 +298,7 @@ struct val_converter {
 
 			auto list_val = zeek::make_intrusive<zeek::ListVal>(zeek::TYPE_ANY);
 
-			for ( auto i = 0u; i < indices->size(); ++i )
+			for ( size_t i = 0u; i < indices->size(); ++i )
 				{
 				auto index_val = bro_broker::data_to_val(move((*indices)[i]),
 				                                         expected_index_types[i].get());
@@ -386,7 +386,7 @@ struct val_converter {
 			auto rval = zeek::make_intrusive<zeek::RecordVal>(zeek::IntrusivePtr{zeek::NewRef{}, rt});
 			auto idx = 0u;
 
-			for ( auto i = 0u; i < static_cast<size_t>(rt->NumFields()); ++i )
+			for ( size_t i = 0u; i < static_cast<size_t>(rt->NumFields()); ++i )
 				{
 				if ( idx >= a.size() )
 					return nullptr;
@@ -574,7 +574,7 @@ struct type_checker {
 						{
 						indices_to_check.reserve(indices->size());
 
-						for ( auto i = 0u; i < indices->size(); ++i )
+						for ( size_t i = 0u; i < indices->size(); ++i )
 							indices_to_check.emplace_back(&(*indices)[i]);
 						}
 					}
@@ -582,7 +582,7 @@ struct type_checker {
 					{
 					indices_to_check.reserve(indices->size());
 
-					for ( auto i = 0u; i < indices->size(); ++i )
+					for ( size_t i = 0u; i < indices->size(); ++i )
 						indices_to_check.emplace_back(&(*indices)[i]);
 					}
 				}
@@ -592,7 +592,7 @@ struct type_checker {
 			if ( expected_index_types.size() != indices_to_check.size() )
 				return false;
 
-			for ( auto i = 0u; i < indices_to_check.size(); ++i )
+			for ( size_t i = 0u; i < indices_to_check.size(); ++i )
 				{
 				auto expect = expected_index_types[i].get();
 				auto& index_to_check = *(indices_to_check)[i];
@@ -633,7 +633,7 @@ struct type_checker {
 						{
 						indices_to_check.reserve(indices->size());
 
-						for ( auto i = 0u; i < indices->size(); ++i )
+						for ( size_t i = 0u; i < indices->size(); ++i )
 							indices_to_check.emplace_back(&(*indices)[i]);
 						}
 					}
@@ -641,7 +641,7 @@ struct type_checker {
 					{
 					indices_to_check.reserve(indices->size());
 
-					for ( auto i = 0u; i < indices->size(); ++i )
+					for ( size_t i = 0u; i < indices->size(); ++i )
 						indices_to_check.emplace_back(&(*indices)[i]);
 					}
 				}
@@ -654,7 +654,7 @@ struct type_checker {
 				return false;
 				}
 
-			for ( auto i = 0u; i < indices_to_check.size(); ++i )
+			for ( size_t i = 0u; i < indices_to_check.size(); ++i )
 				{
 				auto expect = expected_index_types[i].get();
 				auto& index_to_check = *(indices_to_check)[i];
@@ -715,7 +715,7 @@ struct type_checker {
 			auto rt = type->AsRecordType();
 			auto idx = 0u;
 
-			for ( auto i = 0u; i < static_cast<size_t>(rt->NumFields()); ++i )
+			for ( size_t i = 0u; i < static_cast<size_t>(rt->NumFields()); ++i )
 				{
 				if ( idx >= a.size() )
 					return false;
@@ -964,7 +964,7 @@ broker::expected<broker::data> bro_broker::val_to_data(const zeek::Val* v)
 		size_t num_fields = v->GetType()->AsRecordType()->NumFields();
 		rval.reserve(num_fields);
 
-		for ( auto i = 0u; i < num_fields; ++i )
+		for ( size_t i = 0u; i < num_fields; ++i )
 			{
 			auto item_val = rec->GetFieldOrDefault(i);
 

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -855,7 +855,7 @@ bool Manager::Forward(string topic_prefix)
 
 bool Manager::Unsubscribe(const string& topic_prefix)
 	{
-	for ( size_t i = 0u; i < forwarded_prefixes.size(); ++i )
+	for ( size_t i = 0; i < forwarded_prefixes.size(); ++i )
 		if ( forwarded_prefixes[i] == topic_prefix )
 			{
 			DBG_LOG(DBG_BROKER, "Unforwading topic prefix %s", topic_prefix.c_str());
@@ -1180,7 +1180,7 @@ void Manager::ProcessEvent(const broker::topic& topic, broker::zeek::Event ev)
 	zeek::Args vl;
 	vl.reserve(args.size());
 
-	for ( size_t i = 0u; i < args.size(); ++i )
+	for ( size_t i = 0; i < args.size(); ++i )
 		{
 		auto got_type = args[i].get_type_name();
 		const auto& expected_type = arg_types[i];
@@ -1255,7 +1255,7 @@ bool bro_broker::Manager::ProcessLogCreate(broker::zeek::LogCreate lc)
 	auto num_fields = fields_data->size();
 	auto fields = new threading::Field* [num_fields];
 
-	for ( size_t i = 0u; i < num_fields; ++i )
+	for ( size_t i = 0; i < num_fields; ++i )
 		{
 		if ( auto field = data_to_threading_field(std::move((*fields_data)[i])) )
 			fields[i] = field;

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -843,8 +843,8 @@ bool Manager::Subscribe(const string& topic_prefix)
 
 bool Manager::Forward(string topic_prefix)
 	{
-	for ( auto i = 0u; i < forwarded_prefixes.size(); ++i )
-		if ( forwarded_prefixes[i] == topic_prefix )
+	for ( const auto& prefix : forwarded_prefixes )
+		if ( prefix == topic_prefix )
 			return false;
 
 	DBG_LOG(DBG_BROKER, "Forwarding topic prefix %s", topic_prefix.c_str());
@@ -855,7 +855,7 @@ bool Manager::Forward(string topic_prefix)
 
 bool Manager::Unsubscribe(const string& topic_prefix)
 	{
-	for ( auto i = 0u; i < forwarded_prefixes.size(); ++i )
+	for ( size_t i = 0u; i < forwarded_prefixes.size(); ++i )
 		if ( forwarded_prefixes[i] == topic_prefix )
 			{
 			DBG_LOG(DBG_BROKER, "Unforwading topic prefix %s", topic_prefix.c_str());
@@ -1154,10 +1154,8 @@ void Manager::ProcessEvent(const broker::topic& topic, broker::zeek::Event ev)
 
 	auto& topic_string = topic.string();
 
-	for ( auto i = 0u; i < forwarded_prefixes.size(); ++i )
+	for ( const auto& p : forwarded_prefixes )
 		{
-		auto& p = forwarded_prefixes[i];
-
 		if ( p.size() > topic_string.size() )
 			continue;
 
@@ -1182,7 +1180,7 @@ void Manager::ProcessEvent(const broker::topic& topic, broker::zeek::Event ev)
 	zeek::Args vl;
 	vl.reserve(args.size());
 
-	for ( auto i = 0u; i < args.size(); ++i )
+	for ( size_t i = 0u; i < args.size(); ++i )
 		{
 		auto got_type = args[i].get_type_name();
 		const auto& expected_type = arg_types[i];
@@ -1194,7 +1192,7 @@ void Manager::ProcessEvent(const broker::topic& topic, broker::zeek::Event ev)
 			{
 			auto expected_name = zeek::type_name(expected_type->Tag());
 
-			reporter->Warning("failed to convert remote event '%s' arg #%d,"
+			reporter->Warning("failed to convert remote event '%s' arg #%lu,"
 					  " got %s, expected %s",
 					  name.data(), i, got_type,
 					  expected_name);
@@ -1257,13 +1255,13 @@ bool bro_broker::Manager::ProcessLogCreate(broker::zeek::LogCreate lc)
 	auto num_fields = fields_data->size();
 	auto fields = new threading::Field* [num_fields];
 
-	for ( auto i = 0u; i < num_fields; ++i )
+	for ( size_t i = 0u; i < num_fields; ++i )
 		{
 		if ( auto field = data_to_threading_field(std::move((*fields_data)[i])) )
 			fields[i] = field;
 		else
 			{
-			reporter->Warning("failed to convert remote log field # %d", i);
+			reporter->Warning("failed to convert remote log field # %lu", i);
 			delete [] fields;
 			return false;
 			}

--- a/src/file_analysis/analyzer/pe/pe-analyzer.pac
+++ b/src/file_analysis/analyzer/pe/pe-analyzer.pac
@@ -14,7 +14,7 @@ zeek::VectorValPtr process_rvas(const RVAS* rva_table)
 	{
 	auto rvas = zeek::make_intrusive<zeek::VectorVal>(zeek::id::index_vec);
 
-	for ( uint16 i=0; i < rva_table->rvas()->size(); ++i )
+	for ( size_t i=0; i < rva_table->rvas()->size(); ++i )
 		rvas->Assign(i, zeek::val_mgr->Count((*rva_table->rvas())[i]->size()));
 
 	return rvas;

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -436,7 +436,7 @@ bool Manager::CreateEventStream(zeek::RecordVal* fval)
 		}
 
 	Field** logf = new Field*[fieldsV.size()];
-	for ( unsigned int i = 0; i < fieldsV.size(); i++ )
+	for ( size_t i = 0; i < fieldsV.size(); i++ )
 		logf[i] = fieldsV[i];
 
 	stream->num_fields = fieldsV.size();
@@ -663,7 +663,7 @@ bool Manager::CreateTableStream(zeek::RecordVal* fval)
 		}
 
 	Field** fields = new Field*[fieldsV.size()];
-	for ( unsigned int i = 0; i < fieldsV.size(); i++ )
+	for ( size_t i = 0; i < fieldsV.size(); i++ )
 		fields[i] = fieldsV[i];
 
 	stream->pred = pred ? pred->AsFunc() : nullptr;

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -1021,7 +1021,7 @@ threading::Value* Manager::ValToLogVal(zeek::Val* val, zeek::Type* ty)
 		lval->val.set_val.size = set->Length();
 		lval->val.set_val.vals = new threading::Value* [lval->val.set_val.size];
 
-		for ( int i = 0; i < lval->val.set_val.size; i++ )
+		for ( bro_int_t i = 0; i < lval->val.set_val.size; i++ )
 			lval->val.set_val.vals[i] = ValToLogVal(set->Idx(i).get());
 
 		break;
@@ -1034,7 +1034,7 @@ threading::Value* Manager::ValToLogVal(zeek::Val* val, zeek::Type* ty)
 		lval->val.vector_val.vals =
 			new threading::Value* [lval->val.vector_val.size];
 
-		for ( int i = 0; i < lval->val.vector_val.size; i++ )
+		for ( bro_int_t i = 0; i < lval->val.vector_val.size; i++ )
 			{
 			lval->val.vector_val.vals[i] =
 				ValToLogVal(vec->At(i).get(),

--- a/src/logging/writers/sqlite/SQLite.cc
+++ b/src/logging/writers/sqlite/SQLite.cc
@@ -294,7 +294,7 @@ int SQLite::AddParams(Value* val, int pos)
 		if ( ! val->val.set_val.size )
 			desc.Add(empty_field);
 		else
-			for ( int j = 0; j < val->val.set_val.size; j++ )
+			for ( bro_int_t j = 0; j < val->val.set_val.size; j++ )
 				{
 				if ( j > 0 )
 					desc.AddRaw(set_separator);
@@ -316,7 +316,7 @@ int SQLite::AddParams(Value* val, int pos)
 		if ( ! val->val.vector_val.size )
 			desc.Add(empty_field);
 		else
-			for ( int j = 0; j < val->val.vector_val.size; j++ )
+			for ( bro_int_t j = 0; j < val->val.vector_val.size; j++ )
 				{
 				if ( j > 0 )
 					desc.AddRaw(set_separator);

--- a/src/probabilistic/CardinalityCounter.cc
+++ b/src/probabilistic/CardinalityCounter.cc
@@ -177,7 +177,7 @@ bool CardinalityCounter::Merge(CardinalityCounter* c)
 
 	V = 0;
 
-	for ( unsigned int i = 0; i < m; i++ )
+	for ( size_t i = 0; i < m; i++ )
 		{
 		if ( temp[i] > buckets[i] )
 			buckets[i] = temp[i];

--- a/src/threading/SerialTypes.cc
+++ b/src/threading/SerialTypes.cc
@@ -107,7 +107,7 @@ Value::~Value()
 
 	else if ( type == zeek::TYPE_TABLE )
 		{
-		for ( int i = 0; i < val.set_val.size; i++ )
+		for ( bro_int_t i = 0; i < val.set_val.size; i++ )
 			delete val.set_val.vals[i];
 
 		delete [] val.set_val.vals;
@@ -115,7 +115,7 @@ Value::~Value()
 
 	else if ( type == zeek::TYPE_VECTOR )
 		{
-		for ( int i = 0; i < val.vector_val.size; i++ )
+		for ( bro_int_t i = 0; i < val.vector_val.size; i++ )
 			delete val.vector_val.vals[i];
 
 		delete [] val.vector_val.vals;
@@ -286,7 +286,7 @@ bool Value::Read(SerializationFormat* fmt)
 
 		val.set_val.vals = new Value* [val.set_val.size];
 
-		for ( int i = 0; i < val.set_val.size; ++i )
+		for ( bro_int_t i = 0; i < val.set_val.size; ++i )
 			{
 			val.set_val.vals[i] = new Value;
 
@@ -304,7 +304,7 @@ bool Value::Read(SerializationFormat* fmt)
 
 		val.vector_val.vals = new Value* [val.vector_val.size];
 
-		for ( int i = 0; i < val.vector_val.size; ++i )
+		for ( bro_int_t i = 0; i < val.vector_val.size; ++i )
 			{
 			val.vector_val.vals[i] = new Value;
 

--- a/src/threading/formatters/Ascii.cc
+++ b/src/threading/formatters/Ascii.cc
@@ -155,7 +155,7 @@ bool Ascii::Describe(ODesc* desc, threading::Value* val, const string& name) con
 
 		desc->AddEscapeSequence(separators.set_separator);
 
-		for ( int j = 0; j < val->val.set_val.size; j++ )
+		for ( bro_int_t j = 0; j < val->val.set_val.size; j++ )
 			{
 			if ( j > 0 )
 				desc->AddRaw(separators.set_separator);
@@ -182,7 +182,7 @@ bool Ascii::Describe(ODesc* desc, threading::Value* val, const string& name) con
 
 		desc->AddEscapeSequence(separators.set_separator);
 
-		for ( int j = 0; j < val->val.vector_val.size; j++ )
+		for ( bro_int_t j = 0; j < val->val.vector_val.size; j++ )
 			{
 			if ( j > 0 )
 				desc->AddRaw(separators.set_separator);
@@ -360,9 +360,9 @@ threading::Value* Ascii::ParseValue(const string& s, const string& name, zeek::T
 		{
 		// how many entries do we have...
 		unsigned int length = 1;
-		for ( unsigned int i = 0; i < s.size(); i++ )
+		for ( const auto& c : s )
 			{
-			if ( s[i] == separators.set_separator[0] )
+			if ( c == separators.set_separator[0] )
 				length++;
 			}
 

--- a/src/threading/formatters/JSON.cc
+++ b/src/threading/formatters/JSON.cc
@@ -182,7 +182,7 @@ void JSON::BuildJSON(NullDoubleWriter& writer, Value* val, const std::string& na
 			{
 			writer.StartArray();
 
-			for ( int idx = 0; idx < val->val.set_val.size; idx++ )
+			for ( bro_int_t idx = 0; idx < val->val.set_val.size; idx++ )
 				BuildJSON(writer, val->val.set_val.vals[idx]);
 
 			writer.EndArray();
@@ -193,7 +193,7 @@ void JSON::BuildJSON(NullDoubleWriter& writer, Value* val, const std::string& na
 			{
 			writer.StartArray();
 
-			for ( int idx = 0; idx < val->val.vector_val.size; idx++ )
+			for ( bro_int_t idx = 0; idx < val->val.vector_val.size; idx++ )
 				BuildJSON(writer, val->val.vector_val.vals[idx]);
 
 			writer.EndArray();


### PR DESCRIPTION
I've had these fixes in a branch for a while. These are fixes for `readability-container-size-empty` and `bugprone-too-small-loop-variable`. For the latter, some of the fixes involved switching over to ranged-for loops instead.