### PR TITLE
Fix potential heap-use-after-free access

### DIFF
--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -964,7 +964,13 @@ void Manager::Process()
 
 		try
 			{
-			DispatchMessage(topic, broker::move_data(message));
+			// Once we call a broker::move_* function, we force Broker to
+			// unshare the content of the message, i.e., copy the content to a
+			// different memory region if other threads keep references to the
+			// message. Since `topic` still points into the original memory
+			// region, we may no longer access it after this point.
+			auto unshared_topic = broker::move_topic(message);
+			DispatchMessage(unshared_topic, broker::move_data(message));
 			}
 		catch ( std::runtime_error& e )
 			{


### PR DESCRIPTION
Fixes a bug found by Cirrus/ASAN (see https://api.cirrus-ci.com/v1/task/5565719163174912/logs/test.log). The bug manifests if `DispatchMessage` gets called while other threads still hold a reference to `message` (forcing Broker to unshare the COW tuple) that are released while `DispatchMessage` still runs (thus invalidating where `topic` points to).