### PR TITLE
Fix config reader regular expression for MUSL.

### DIFF
--- a/src/input/readers/config/Config.cc
+++ b/src/input/readers/config/Config.cc
@@ -182,7 +182,7 @@ bool Config::DoUpdate()
 		}
 
 	regex_t re;
-	if ( regcomp(&re, "^([^[:blank:]]+)[[:blank:]]+(.*[^[:blank:]])?[[:blank:]]*$", REG_EXTENDED) )
+	if ( regcomp(&re, "^([^[:blank:]]+)[[:blank:]]+([^[:blank:]](.*[^[:blank:]])?)?[[:blank:]]*$", REG_EXTENDED) )
 		{
 		Error(Fmt("Failed to compile regex."));
 		return true;

--- a/testing/btest/Baseline/scripts.base.frameworks.input.config.basic/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.config.basic/out
@@ -26,3 +26,4 @@ test_set, {
 test_set, {
 -
 }
+teststring, abc

--- a/testing/btest/scripts/base/frameworks/input/config/basic.zeek
+++ b/testing/btest/scripts/base/frameworks/input/config/basic.zeek
@@ -24,6 +24,7 @@ test_vector 1	2	3	4	5	6
 test_set (empty)
 test_set EMPTY
 test_set -
+teststring      abc   
 @TEST-END-FILE
 
 @load base/protocols/ssh


### PR DESCRIPTION
It was not dealing with multiple spaces between the key and the value
with MUSL correctly. This change ensures that if a value exists, that it
begins and ends with a non-blank character.