### PR TITLE
add port 445 to likely DCE/RPC port

### DIFF
--- a/scripts/base/protocols/dce-rpc/main.zeek
+++ b/scripts/base/protocols/dce-rpc/main.zeek
@@ -56,7 +56,7 @@ redef record connection += {
 	dce_rpc_backing: table[count] of BackingState &optional;
 };
 
-const ports = { 135/tcp };
+const ports = { 135/tcp, 445/tcp };
 redef likely_server_ports += { ports };
 
 event zeek_init() &priority=5


### PR DESCRIPTION
Adds port 445/tcp to an additional likely DCE/RPC port.