### PR TITLE
Added new acld verbs of filter and nofilter.

### DIFF
--- a/scripts/base/frameworks/netcontrol/plugins/acld.zeek
+++ b/scripts/base/frameworks/netcontrol/plugins/acld.zeek
@@ -83,7 +83,8 @@ const acld_add_to_remove: table[string] of string = {
 	["dropudpdsthostport"] ="restoreudpdsthostport",
 	["permittcpdsthostport"] ="unpermittcpdsthostport",
 	["permitudpdsthostport"] ="unpermitudpdsthostport",
-	["nullzero"] ="nonullzero"
+	["nullzero"] ="nonullzero", 
+	["filter"]="nofilter", 
 };
 
 event NetControl::acld_rule_added(id: count, r: Rule, msg: string)


### PR DESCRIPTION
@0xxon  - These are to support actions taken on corsa and keep filter actions distinct from ACLD drops/restore or BGP nullzero/nonullzero.

This does not negatively impacts anything - only adds new verbs for handling zeek-netcontrol actions.
