### PR TITLE
Moved verb ACTION_DROP from policy/frameworks/netcontrol/catch-and-re…

### DIFF
--- a/scripts/base/frameworks/notice/main.zeek
+++ b/scripts/base/frameworks/notice/main.zeek
@@ -44,6 +44,10 @@ export {
 		## ASCII version of the alarm log is emailed in bulk to the
 		## address(es) configured in :zeek:id:`Notice::mail_dest`.
 		ACTION_ALARM,
+		## Indicates that the notice results in a drop action. A drop 
+		## action can be nullzero, acld drop or a filter as per 
+		## configured in :zeek:see:`NetControl::acld_rule_policy`. 
+		ACTION_DROP, 
 	};
 
 	## Type that represents a set of actions.

--- a/scripts/policy/frameworks/notice/actions/drop.zeek
+++ b/scripts/policy/frameworks/notice/actions/drop.zeek
@@ -8,11 +8,6 @@
 module Notice;
 
 export {
-	redef enum Action += {
-		## Drops the address via :zeek:see:`NetControl::drop_address_catch_release`.
-		ACTION_DROP
-	};
-
 	redef record Info += {
 		## Indicate if the $src IP address was dropped and denied
 		## network access.


### PR DESCRIPTION
@0xxon - Moved ACTION_DROP from policy/frameworks/netcontrol/catch-and-release.zeek to base/frameworks/notice/main.zeek 

ACTION_DROP isn't necessarily only a catch-and-release subsystem verb and also it makes more sense to bundle it with other zeek actions such has ACTION_LOG, ACTION_EMAIL etc. 

It *really helps* if this commit is accepted 