### PR TITLE
Use constexpr for IPAddr::v4_mapped_prefix declaration

### DIFF
--- a/src/IPAddr.cc
+++ b/src/IPAddr.cc
@@ -12,10 +12,6 @@
 
 #include "analyzer/Manager.h"
 
-constexpr uint8_t zeek::IPAddr::v4_mapped_prefix[12] = { 0, 0, 0, 0,
-                                                         0, 0, 0, 0,
-                                                         0, 0, 0xff, 0xff };
-
 const zeek::IPAddr zeek::IPAddr::v4_unspecified = zeek::IPAddr(in4_addr{});
 
 const zeek::IPAddr zeek::IPAddr::v6_unspecified = zeek::IPAddr();

--- a/src/IPAddr.h
+++ b/src/IPAddr.h
@@ -459,7 +459,10 @@ private:
 
 	in6_addr in6; // IPv6 or v4-to-v6-mapped address
 
-	static const uint8_t v4_mapped_prefix[12]; // top 96 bits of v4-mapped-addr
+	// Top 96 bits of a v4-mapped-addr.
+	static constexpr uint8_t v4_mapped_prefix[12] = { 0, 0, 0, 0,
+	                                                  0, 0, 0, 0,
+	                                                  0, 0, 0xff, 0xff };
 };
 
 inline IPAddr::IPAddr(Family family, const uint32_t* bytes, ByteOrder order)


### PR DESCRIPTION
The inconsistent use of constexpr in the definition but not declaration
causes an unrecoverable error for Coverity as seen in issue 1431151