### PR TITLE
Misc strings.bif adjustments

### DIFF
--- a/src/strings.bif
+++ b/src/strings.bif
@@ -1181,7 +1181,7 @@ function count_substr%(str: string, sub: string%) : count
 
 %%{
 
-int64_t do_find_str(zeek::StringVal* str, zeek::StringVal* sub, uint64_t start, int64_t end, bool rfind)
+static int64_t do_find_str(zeek::StringVal* str, zeek::StringVal* sub, int64_t start, int64_t end, bool rfind)
 	{
 	// Don't bother if the start is after the end of the string.
 	if ( start > str->Len() )
@@ -1194,7 +1194,7 @@ int64_t do_find_str(zeek::StringVal* str, zeek::StringVal* sub, uint64_t start, 
 		return -1;
 		}
 
-	size_t end_pos = str->Len();
+	int64_t end_pos = str->Len();
 	if ( end >= 0 && end < str->Len() )
 		end_pos = end;
 
@@ -1247,7 +1247,7 @@ function find_str%(str: string, sub: string, start: count &default=0, end: int &
 ## Returns: The position of the substring. Returns -1 if the string wasn't found. Prints an error if the
 ## starting position is after the ending position.
 ##
-function rfind_str%(str: string, sub: string, start: count &default=0, end: int &default=-1%) : count
+function rfind_str%(str: string, sub: string, start: count &default=0, end: int &default=-1%) : int
 	%{
 	return zeek::val_mgr->Int(do_find_str(str, sub, start, end, true));
 	%}
@@ -1340,7 +1340,7 @@ function ljust%(str: string, width: count, fill: string &default=" "%) : string
 
 %%{
 
-static zeek::StringValPtr do_rjust(zeek::StringVal* str, int width, char fill)
+static zeek::StringValPtr do_rjust(zeek::StringVal* str, uint64_t width, char fill)
 	{
 	string new_s = str->ToStdString();
 


### PR DESCRIPTION
* Declare rfind_str() with correct return type
* Fix compiler warnings for signed/unsigned comparisons

`zeek-docs` will need generation on merging.

Original warnings from GCC 9.3.0:

```
strings.bif: In function ‘int64_t do_find_str(zeek::StringVal*, zeek::StringVal*, uint64_t, int64_t, bool)’:
strings.bif:1186:13: warning: comparison of integer expressions of different signedness: ‘uint64_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
strings.bif:1190:27: warning: comparison of integer expressions of different signedness: ‘int64_t’ {aka ‘long int’} and ‘uint64_t’ {aka ‘long unsigned int’} [-Wsign-compare]
strings.bif:1202:29: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
In file included from ../src/Func.cc:68:
strings.bif: In function ‘zeek::StringValPtr do_rjust(zeek::StringVal*, int, char)’:
strings.bif:1346:13: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::__cxx11::basic_string<char>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
```