### PR TITLE
Catch if &add_func/&delete_func is applied to IDs that don't have val…

### DIFF
--- a/src/ID.cc
+++ b/src/ID.cc
@@ -220,6 +220,13 @@ void ID::SetVal(ExprPtr ev, InitClass c)
 	if ( ! a )
 		Internal("no add/delete function in ID::SetVal");
 
+	if ( ! val )
+		{
+		Error(fmt("%s initializer applied to ID without value",
+		      (c == INIT_EXTRA ? "+=" : "-="), this);
+		return;
+		}
+
 	EvalFunc(a->GetExpr(), std::move(ev));
 	}
 

--- a/testing/btest/Baseline/language.global-unset-addto/output
+++ b/testing/btest/Baseline/language.global-unset-addto/output
@@ -1,0 +1,2 @@
+error in /Users/robin/bro/master/testing/btest/.tmp/language.global-unset-addto/global-unset-addto.zeek, line 4: += initializer applied to ID without value (a)
+error in /Users/robin/bro/master/testing/btest/.tmp/language.global-unset-addto/global-unset-addto.zeek, line 5: -= initializer applied to ID without value (b)

--- a/testing/btest/language/global-unset-addto.zeek
+++ b/testing/btest/language/global-unset-addto.zeek
@@ -1,0 +1,15 @@
+# @TEST-EXEC-FAIL: zeek -b %INPUT  >output 2>&1
+# @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff output
+
+global a: count &add_func = function(old: count, new: count): count { return 3; };
+global b: count &delete_func = function(old: count, new: count): count { return 3; };
+
+redef a += 13;
+redef b -= 13;
+
+# The following is ok.
+global c: count &redef &add_func = function(old: count, new: count): count { return 3; };
+redef c = 0;
+redef c += 13;
+
+


### PR DESCRIPTION
…ues.

We do to allow adding &add_func to a global that's not immediately
initialized, as a later redef may fix that.

Closes #467.