### PR TITLE
Fix a case where PktSrc gets processed twice in one runloop iteration

### DIFF
--- a/src/iosource/Manager.cc
+++ b/src/iosource/Manager.cc
@@ -166,7 +166,7 @@ void Manager::FindReadySources(std::vector<IOSource*>* ready)
 					}
 				else
 					{
-					if ( ! zeek::run_state::pseudo_realtime )
+					if ( ! zeek::run_state::pseudo_realtime && ! time_to_poll )
 						// A pcap file is always ready to process unless it's suspended
 						ready->push_back(pkt_src);
 					}


### PR DESCRIPTION
For a non-live PktSrc, it had a special-case to be considered "ready"
every iteration, but additionally every 1 in 100 iterations (the polling
frequency), if there were no other "ready" IOSources, it would get added
to the "ready" set a 2nd time.

This commit completely excludes PktSrc from being processed during the
1/100 runloop iteration where a Poll() happens.  That exclusion is
desirable for a second reason: if reading a pcap happens to do its final
Process() during that 1/100 polling-iteration and there's other
IOSources ready to process like EventMgr/TimerMgr, those sources have
logic to advance network-time to current-time if a PktSrc is no longer
open.  So in such a case, PktSrc::Process() closes, then
EventMgr::Process() sees there's no longer an active PktSrc and advances
to current-time, then EventMgr::Drain() happens and may dispatch
various events that were previous scheduled, with those events now
unexpectedly seeing a network_time() returning current-time.

The issue can be observed rarely in the form of an unstable `capture_loss.log` in the external tests.  Here's a couple times CI encountered it:

- https://cirrus-ci.com/task/4780171301486592
- https://cirrus-ci.com/task/6542765750222848

Here's a relevant excerpt from near the end of a `debug.log`

```
1258617573.914422/1597975689.130473 [main-loop] timeout: 0.000000   ready size: 1   time_to_poll: 1

1258617573.914422/1597975689.130488 [main-loop] realtime=1597975689.130488 ready_count=17
1258617573.914422/1597975689.130494 [main-loop] processing source PktSrc
1258617573.914422/1597975689.130507 [pktio] Closed source /home/jon/Desktop/2009-M57-day11-18.trace
1258617573.914422/1597975689.130511 [main-loop] processing source packet_filter/Log::WRITER_ASCII
1258617573.914422/1597975689.130525 [main-loop] processing source weird/Log::WRITER_ASCII
1258617573.914422/1597975689.130538 [main-loop] processing source dns/Log::WRITER_ASCII
1258617573.914422/1597975689.130554 [main-loop] processing source conn/Log::WRITER_ASCII
1258617573.914422/1597975689.130559 [main-loop] processing source dhcp/Log::WRITER_ASCII
1258617573.914422/1597975689.130572 [main-loop] processing source http/Log::WRITER_ASCII
1258617573.914422/1597975689.130577 [main-loop] processing source capture_loss/Log::WRITER_ASCII
1258617573.914422/1597975689.130589 [main-loop] processing source x509/Log::WRITER_ASCII
1258617573.914422/1597975689.130602 [main-loop] processing source files/Log::WRITER_ASCII
1258617573.914422/1597975689.130607 [main-loop] processing source ntp/Log::WRITER_ASCII
1258617573.914422/1597975689.130619 [main-loop] processing source EventManager
1597975689.130624/1597975689.130625 [main-loop] processing source smtp/Log::WRITER_ASCII
```

See how `time_to_poll` is set, the `PktSrc` closes, and then this logic in `EventMgr` advances to current-time:

https://github.com/zeek/zeek/blob/c322bc249d154013620ae8f46d5442013ffe2f84/src/Event.cc#L229-L230

The last line in that `debug.log` shows that sudden jump from network-time to current-time which corresponds to the 10-year time delta that sometimes causes the `capture_loss.log` baseline to fail.

Another `debug.log` excerpt showing that the double-processing of `PktSrc` sometimes occurs when `time_to_poll` is set:

```
1258563753.565807/1597975655.627143 [main-loop] timeout: 0.000000   ready size: 1   time_to_poll: 1

1258563753.565807/1597975655.627151 [main-loop] realtime=1597975655.627151 ready_count=2
1258563753.565807/1597975655.627156 [main-loop] processing source PktSrc
1258563753.565816/1597975655.627172 [main-loop] processing source PktSrc
```

Side note/exploration: it's notable that the observed test failure happens
rarely since that means there's unexpected nondeterminism in the runloop that
causes the total loop-iteration count to vary from run to run.  That may have
been the result of thread scheduling vagaries in combination with
`pkt_src` being added to the `ready` set multiple times in the case we called
`Poll()` and no other `IOSource` was ready (particularly, when no thread had
produced any new output).  Excluding `pkt_src` from being processed when a
`Poll()` happens should also help prevent that type of nondeterministic
interference, but didn't do any further/exhaustive checks -- I only observe that
I can't reproduce the original `capture_loss.log` failure anymore (within "reasonable"
amount of attempts/time).