### PR TITLE
Fix issue with canonical names not printing for file analyzers

### DIFF
--- a/src/file_analysis/Component.cc
+++ b/src/file_analysis/Component.cc
@@ -36,7 +36,7 @@ Component::~Component()
 
 void Component::DoDescribe(zeek::ODesc* d) const
 	{
-	if ( factory )
+	if ( factory || factory_func )
 		{
 		d->Add("ANALYZER_");
 		d->Add(CanonicalName());


### PR DESCRIPTION
Simple fix for an issue from the IntrusivePtr changes. From `zeek -NN`:

Without the patch

```
Zeek::X509 - X509 and OCSP analyzer (built-in)
    [File Analyzer] OCSP_REPLY ()
    [File Analyzer] OCSP_REQUEST ()
    [File Analyzer] X509 ()
```

With the patch

```
Zeek::X509 - X509 and OCSP analyzer (built-in)
    [File Analyzer] OCSP_REPLY (ANALYZER_OCSP_REPLY)
    [File Analyzer] OCSP_REQUEST (ANALYZER_OCSP_REQUEST)
    [File Analyzer] X509 (ANALYZER_X509)
```
