### PR TITLE
Remove SmithWaterman iterator types and one other cleanup

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -52,7 +52,8 @@ Removed Functionality
 Deprecated Functionality
 ------------------------
 
-TODO: nothing notable yet
+- Marked the Continuation.h and PacketDumper.h files as deprecated. The code
+  contained within them is unused by Zeek.
 
 Zeek 3.2.0
 ==========

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,7 +296,6 @@ set(MAIN_SRCS
     bro_inet_ntop.c
     patricia.c
     setsignal.c
-    PacketDumper.cc
     strsep.c
     modp_numtoa.c
 

--- a/src/Continuation.h
+++ b/src/Continuation.h
@@ -1,3 +1,5 @@
+#warning "This file will be removed in v4.1. The code here is unused by Zeek. Notify a Zeek team member if your plugins are using this code."
+
 // Helper class to implement continuation-like mechanisms for
 // suspending/resuming tasks for incremental operation.
 //

--- a/src/PacketDumper.h
+++ b/src/PacketDumper.h
@@ -1,3 +1,5 @@
+#warning "This file will be removed in v4.1. The code here is unused by Zeek. Notify a Zeek team member if your plugins are using this code."
+
 // See the file "COPYING" in the main distribution directory for copyright.
 
 #pragma once

--- a/src/SmithWaterman.h
+++ b/src/SmithWaterman.h
@@ -2,8 +2,10 @@
 
 #pragma once
 
-#include "ZeekString.h"
 #include <map>
+#include <vector>
+
+#include "ZeekString.h"
 
 namespace zeek::detail {
 
@@ -16,9 +18,7 @@ namespace zeek::detail {
 class Substring : public zeek::String {
 
 public:
-	typedef std::vector<Substring*> Vec;
-	typedef Vec::iterator VecIt;
-	typedef Vec::const_iterator VecCIt;
+	using Vec = std::vector<Substring*>;
 
 	// An alignment to another string.
 	//
@@ -37,9 +37,7 @@ public:
 		int index;
 	};
 
-	typedef std::vector<BSSAlign> BSSAlignVec;
-	typedef BSSAlignVec::iterator BSSAlignVecIt;
-	typedef BSSAlignVec::const_iterator BSSAlignVecCIt;
+	using BSSAlignVec = std::vector<BSSAlign>;
 
 	explicit Substring(const std::string& string)
 		: zeek::String(string), _num(), _new(false) { }
@@ -74,11 +72,10 @@ public:
 	static Vec* VecFromPolicy(zeek::VectorVal* vec);
 	static char* VecToString(Vec* vec);
 	static zeek::String::IdxVec* GetOffsetsVec(const Vec* vec,
-	                                              unsigned int index);
+	                                           unsigned int index);
 
 private:
-	typedef std::map<std::string, void*> DataMap;
-	typedef DataMap::iterator DataMapIt;
+	using DataMap = std::map<std::string, void*>;
 
 	Substring();
 


### PR DESCRIPTION
This PR removes the type aliases from the SmithWaterman code in favor of just using ranged-for loops in the implementation.

It also marks a couple of completely-used files as deprecated.