### PR TITLE
GH-174: Add warning for duplicate attributes

### DIFF
--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -193,7 +193,7 @@ Attributes::Attributes(std::vector<AttrPtr> a,
 		AddAttr(std::move(attr));
 	}
 
-void Attributes::AddAttr(AttrPtr attr)
+void Attributes::AddAttr(AttrPtr attr, bool is_redef)
 	{
 	auto acceptable_duplicate_tag = [&](const AttrPtr& attr, const AttrPtr& existing) -> bool
 		{
@@ -216,9 +216,12 @@ void Attributes::AddAttr(AttrPtr attr)
 	// Display a warning for duplicated tags on a type. &log tags are intentionally
 	// ignored here because duplicate log tags on record types are valid, and don't
 	// cause any significant breakage for other types.
-	auto existing = Find(attr->Tag());
-	if ( existing && ! acceptable_duplicate_tag(attr, existing) )
-		reporter->Error("Duplicate %s tag is ambiguous", attr_name(attr->Tag()));
+	if ( ! is_redef )
+		{
+		auto existing = Find(attr->Tag());
+		if ( existing && ! acceptable_duplicate_tag(attr, existing) )
+			reporter->Error("Duplicate %s tag is ambiguous", attr_name(attr->Tag()));
+		}
 
 	// We overwrite old attributes by deleting them first.
 	RemoveAttr(attr->Tag());
@@ -249,16 +252,16 @@ void Attributes::AddAttr(AttrPtr attr)
 		}
 	}
 
-void Attributes::AddAttrs(const AttributesPtr& a)
+void Attributes::AddAttrs(const AttributesPtr& a, bool is_redef)
 	{
 	for ( const auto& attr : a->GetAttrs() )
-		AddAttr(attr);
+		AddAttr(attr, is_redef);
 	}
 
-void Attributes::AddAttrs(Attributes* a)
+void Attributes::AddAttrs(Attributes* a, bool is_redef)
 	{
 	for ( const auto& attr : a->GetAttrs() )
-		AddAttr(attr);
+		AddAttr(attr, is_redef);
 
 	Unref(a);
 	}

--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -195,17 +195,14 @@ Attributes::Attributes(std::vector<AttrPtr> a,
 
 void Attributes::AddAttr(AttrPtr attr)
 	{
-	auto acceptable_duplicate_tag = [&](AttrPtr attr) -> bool
+	auto acceptable_duplicate_tag = [&](const AttrPtr& attr, const AttrPtr& existing) -> bool
 		{
 		AttrTag new_tag = attr->Tag();
 
 		if ( new_tag == ATTR_DEPRECATED )
 			{
-			if ( ! attr->DeprecationMessage().empty() )
-				return false;
-
-			auto existing = Find(new_tag);
-			if ( existing && ! existing->DeprecationMessage().empty() )
+			if ( ! attr->DeprecationMessage().empty() ||
+			     ( existing && ! existing->DeprecationMessage().empty() ) )
 				return false;
 
 			return true;
@@ -219,7 +216,8 @@ void Attributes::AddAttr(AttrPtr attr)
 	// Display a warning for duplicated tags on a type. &log tags are intentionally
 	// ignored here because duplicate log tags on record types are valid, and don't
 	// cause any significant breakage for other types.
-	if ( ! acceptable_duplicate_tag(attr) && Find(attr->Tag()) )
+	auto existing = Find(attr->Tag());
+	if ( existing && ! acceptable_duplicate_tag(attr, existing) )
 		reporter->Error("Duplicate %s tag is ambiguous", attr_name(attr->Tag()));
 
 	// We overwrite old attributes by deleting them first.

--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -195,6 +195,12 @@ Attributes::Attributes(std::vector<AttrPtr> a,
 
 void Attributes::AddAttr(AttrPtr attr)
 	{
+	// Display a warning for duplicated tags on a type. &log tags are intentionally
+	// ignored here because duplicate log tags on record types are valid, and don't
+	// cause any significant breakage for other types.
+	if ( attr->Tag() != ATTR_LOG && Find(attr->Tag()) )
+		reporter->Warning("Found duplicate tag %s", attr_name(attr->Tag()));
+
 	// We overwrite old attributes by deleting them first.
 	RemoveAttr(attr->Tag());
 	attrs_list.push_back(attr.get());

--- a/src/Attr.h
+++ b/src/Attr.h
@@ -115,12 +115,12 @@ public:
 
 	~Attributes() override = default;
 
-	void AddAttr(AttrPtr a);
+	void AddAttr(AttrPtr a, bool is_redef = false);
 
-	void AddAttrs(const AttributesPtr& a);
+	void AddAttrs(const AttributesPtr& a, bool is_redef = false);
 
 	[[deprecated("Remove in v4.1. Pass IntrusivePtr instead.")]]
-	void AddAttrs(Attributes* a);	// Unref's 'a' when done
+	void AddAttrs(Attributes* a, bool is_redef = false);	// Unref's 'a' when done
 
 	[[deprecated("Remove in v4.1. Use Find().")]]
 	Attr* FindAttr(AttrTag t) const;

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -314,10 +314,10 @@ std::string ID::GetDeprecationWarning() const
 		return zeek::util::fmt("deprecated (%s): %s", Name(), result.c_str());
 	}
 
-void ID::AddAttrs(AttributesPtr a)
+void ID::AddAttrs(AttributesPtr a, bool is_redef)
 	{
 	if ( attrs )
-		attrs->AddAttrs(a);
+		attrs->AddAttrs(a, is_redef);
 	else
 		attrs = std::move(a);
 

--- a/src/ID.h
+++ b/src/ID.h
@@ -121,7 +121,7 @@ public:
 	bool IsRedefinable() const;
 
 	void SetAttrs(AttributesPtr attr);
-	void AddAttrs(AttributesPtr attr);
+	void AddAttrs(AttributesPtr attr, bool is_redef = false);
 	void RemoveAttr(AttrTag a);
 	void UpdateValAttrs();
 

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -213,7 +213,7 @@ static void make_var(const zeek::detail::IDPtr& id, zeek::TypePtr t,
 	id->SetType(t);
 
 	if ( attr )
-		id->AddAttrs(zeek::make_intrusive<zeek::detail::Attributes>(std::move(*attr), t, false, id->IsGlobal()));
+		id->AddAttrs(zeek::make_intrusive<zeek::detail::Attributes>(std::move(*attr), t, false, id->IsGlobal()), dt == VAR_REDEF);
 
 	if ( init )
 		{

--- a/testing/btest/Baseline/language.attr-default-global-set-error/out
+++ b/testing/btest/Baseline/language.attr-default-global-set-error/out
@@ -1,6 +1,6 @@
-error in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 4: &default is not valid for global variables except for tables (&default=0)
-error in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &default is not valid for global variables except for tables (&default=10)
-warning in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: Found duplicate tag &default
-error in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &default is not valid for global variables except for tables (&default=9)
-error in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &optional is not valid for global variables (&default=9, &optional)
-error in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 10: &default is not valid for global variables except for tables (&default=set())
+error in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 4: &default is not valid for global variables except for tables (&default=0)
+error in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &default is not valid for global variables except for tables (&default=10)
+error in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: Duplicate &default tag is ambiguous
+error in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &default is not valid for global variables except for tables (&default=9)
+error in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &optional is not valid for global variables (&default=9, &optional)
+error in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 10: &default is not valid for global variables except for tables (&default=set())

--- a/testing/btest/Baseline/language.attr-default-global-set-error/out
+++ b/testing/btest/Baseline/language.attr-default-global-set-error/out
@@ -1,5 +1,6 @@
-error in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 4: &default is not valid for global variables except for tables (&default=0)
-error in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &default is not valid for global variables except for tables (&default=10)
-error in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &default is not valid for global variables except for tables (&default=9)
-error in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &optional is not valid for global variables (&default=9, &optional)
-error in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 10: &default is not valid for global variables except for tables (&default=set())
+error in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 4: &default is not valid for global variables except for tables (&default=0)
+error in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &default is not valid for global variables except for tables (&default=10)
+warning in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: Found duplicate tag &default
+error in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &default is not valid for global variables except for tables (&default=9)
+error in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 9: &optional is not valid for global variables (&default=9, &optional)
+error in /mnt/data/tim/zeek/testing/btest/.tmp/language.attr-default-global-set-error/attr-default-global-set-error.zeek, line 10: &default is not valid for global variables except for tables (&default=set())

--- a/testing/btest/Baseline/language.duplicate-attributes/out
+++ b/testing/btest/Baseline/language.duplicate-attributes/out
@@ -1,2 +1,3 @@
-warning in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.duplicate-attributes/duplicate-attributes.zeek, line 6: Found duplicate tag &default
-warning in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.duplicate-attributes/duplicate-attributes.zeek, line 6: Found duplicate tag &read_expire
+error in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.duplicate-attributes/duplicate-attributes.zeek, line 4: Duplicate &default tag is ambiguous
+error in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.duplicate-attributes/duplicate-attributes.zeek, line 6: Duplicate &deprecated tag is ambiguous
+error in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.duplicate-attributes/duplicate-attributes.zeek, line 7: Duplicate &deprecated tag is ambiguous

--- a/testing/btest/Baseline/language.duplicate-attributes/out
+++ b/testing/btest/Baseline/language.duplicate-attributes/out
@@ -1,0 +1,2 @@
+warning in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.duplicate-attributes/duplicate-attributes.zeek, line 6: Found duplicate tag &default
+warning in /Users/tim/Desktop/projects/zeek/testing/btest/.tmp/language.duplicate-attributes/duplicate-attributes.zeek, line 6: Found duplicate tag &read_expire

--- a/testing/btest/language/duplicate-attributes.zeek
+++ b/testing/btest/language/duplicate-attributes.zeek
@@ -1,6 +1,8 @@
-# @TEST-EXEC: zeek -b %INPUT >out 2>&1
+# @TEST-EXEC-FAIL: zeek -b %INPUT >out 2>&1
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff out
 
-global a: table[count] of count
-        &default = 10 &default = 9
-        &read_expire = 5 sec &read_expire = 1 min;
+global a: table[count] of count &default = 10 &default = 9;
+global b: table[count] of count &deprecated &deprecated;
+global c: table[count] of count &deprecated="a" &deprecated;
+global d: table[count] of count &deprecated &deprecated="a";
+global e: table[count] of count &redef &redef;

--- a/testing/btest/language/duplicate-attributes.zeek
+++ b/testing/btest/language/duplicate-attributes.zeek
@@ -1,0 +1,6 @@
+# @TEST-EXEC: zeek -b %INPUT >out 2>&1
+# @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff out
+
+global a: table[count] of count
+        &default = 10 &default = 9
+        &read_expire = 5 sec &read_expire = 1 min;


### PR DESCRIPTION
Fixes #174 

Adds a reporter warning when a duplicate attribute is found in a type definition. `&log` attributes are ignored, for reasons explained in the linked issue.