### PR TITLE
Prohibit `fallthrough` in typecasting `switch` cases

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -1638,13 +1638,13 @@ case_list:
 
 case:
 		TOK_CASE expr_list ':' stmt_list
-			{ $$ = new zeek::detail::Case({zeek::AdoptRef{}, $2}, 0, {zeek::AdoptRef{}, $4}); }
+			{ $$ = new zeek::detail::Case({zeek::AdoptRef{}, $2}, nullptr, {zeek::AdoptRef{}, $4}); }
 	|
 		TOK_CASE case_type_list ':' stmt_list
 			{ $$ = new zeek::detail::Case(nullptr, $2, {zeek::AdoptRef{}, $4}); }
 	|
 		TOK_DEFAULT ':' stmt_list
-			{ $$ = new zeek::detail::Case(nullptr, 0, {zeek::AdoptRef{}, $3}); }
+			{ $$ = new zeek::detail::Case(nullptr, nullptr, {zeek::AdoptRef{}, $3}); }
 	;
 
 case_type_list:

--- a/testing/btest/Baseline/language.switch-type-cast-fallthrough-error/out
+++ b/testing/btest/Baseline/language.switch-type-cast-fallthrough-error/out
@@ -1,0 +1,3 @@
+error in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.switch-type-cast-fallthrough-error/switch-type-cast-fallthrough-error.zeek, line 9: invalid 'fallthrough' in type-casting 'case' block
+error in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.switch-type-cast-fallthrough-error/switch-type-cast-fallthrough-error.zeek, line 20: invalid 'fallthrough' in type-casting 'case' block
+error in /home/jon/pro/zeek/zeek/testing/btest/.tmp/language.switch-type-cast-fallthrough-error/switch-type-cast-fallthrough-error.zeek, line 22: invalid 'fallthrough' in type-casting 'case' block

--- a/testing/btest/language/switch-type-cast-fallthrough-error.zeek
+++ b/testing/btest/language/switch-type-cast-fallthrough-error.zeek
@@ -1,0 +1,64 @@
+# @TEST-EXEC-FAIL: zeek -b %INPUT >out 2>&1
+# @TEST-EXEC:      TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff out
+
+local x: any = 0;
+
+switch ( x ) {
+case type count as i:
+	print "count", i;
+	fallthrough;  # This is invalid
+case type double as d:
+	print "double", d;
+	break;
+}
+
+switch ( x ) {
+case type count as i:
+	print "count", i;
+
+	if ( i == 0 )
+		fallthrough;  # This is invalid
+	else
+		fallthrough;  # This is invalid
+
+	break;
+case type double as d:
+	print "double", d;
+	break;
+}
+
+switch ( x ) {
+case type count as i:
+	print "count", i;
+
+	switch ( x as count ) {
+	case 0:
+		fallthrough;  # This is valid (inside nested switch statement)
+	case 1:
+		print "1";
+		break;
+	}
+
+	break;
+case type double as d:
+	print "double", d;
+	break;
+}
+
+switch ( x as count ) {
+case 0:
+	print "0";
+	fallthrough;
+case 1:
+	print "1";
+	break;
+}
+
+switch ( x ) {
+case type count:
+	print "count";
+	fallthrough;
+case type double:
+	print "double";
+	break;
+}


### PR DESCRIPTION
Fixes #955