### PR TITLE
Exclude installing "zeek -> ." include dir symlink

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -467,6 +467,8 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
         PATTERN "*.h"
         PATTERN "*.pac"
         PATTERN "3rdparty/*" EXCLUDE
+        # The "zeek -> ." symlink isn't needed in the install-tree
+        REGEX "^${CMAKE_CURRENT_SOURCE_DIR}/zeek$" EXCLUDE
 )
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/


### PR DESCRIPTION
The symlink only exists for use within the source-tree and isn't needed
for the install-tree.

(@grigorescu FYI)