### PR TITLE
Improve Reporter weird-sampling-whitelist getters/setters

### DIFF
--- a/src/Reporter.h
+++ b/src/Reporter.h
@@ -175,7 +175,7 @@ public:
 	/**
 	 * Gets the weird sampling whitelist.
 	 */
-	WeirdSet GetWeirdSamplingWhitelist() const
+	const WeirdSet& GetWeirdSamplingWhitelist() const
 		{
 		return weird_sampling_whitelist;
 		}
@@ -185,15 +185,15 @@ public:
 	 *
 	 * @param weird_sampling_whitelist New weird sampling whitelist.
 	 */
-	void SetWeirdSamplingWhitelist(const WeirdSet& weird_sampling_whitelist)
+	void SetWeirdSamplingWhitelist(WeirdSet weird_sampling_whitelist)
 		{
-		this->weird_sampling_whitelist = weird_sampling_whitelist;
+		this->weird_sampling_whitelist = std::move(weird_sampling_whitelist);
 		}
 
 	/**
 	 * Gets the weird sampling global list.
 	 */
-	WeirdSet GetWeirdSamplingGlobalList() const
+	const WeirdSet& GetWeirdSamplingGlobalList() const
 		{
 		return weird_sampling_global_list;
 		}
@@ -203,9 +203,9 @@ public:
 	 *
 	 * @param weird_sampling_global list New weird sampling global list.
 	 */
-	void SetWeirdSamplingGlobalList(const WeirdSet& weird_sampling_global_list)
+	void SetWeirdSamplingGlobalList(WeirdSet weird_sampling_global_list)
 		{
-		this->weird_sampling_global_list = weird_sampling_global_list;
+		this->weird_sampling_global_list = std::move(weird_sampling_global_list);
 		}
 
 	/**

--- a/src/reporter.bif
+++ b/src/reporter.bif
@@ -164,7 +164,7 @@ function Reporter::file_weird%(name: string, f: fa_file, addl: string &default="
 function Reporter::get_weird_sampling_whitelist%(%): string_set
 	%{
 	auto set = zeek::make_intrusive<zeek::TableVal>(zeek::id::string_set);
-	for ( auto el : reporter->GetWeirdSamplingWhitelist() )
+	for ( const auto& el : reporter->GetWeirdSamplingWhitelist() )
 		{
 		auto idx = zeek::make_intrusive<zeek::StringVal>(el);
 		set->Assign(std::move(idx), nullptr);
@@ -194,7 +194,7 @@ function Reporter::set_weird_sampling_whitelist%(weird_sampling_whitelist: strin
 		whitelist_set.emplace(move(key));
 		delete k;
 		}
-	reporter->SetWeirdSamplingWhitelist(whitelist_set);
+	reporter->SetWeirdSamplingWhitelist(std::move(whitelist_set));
 	return zeek::val_mgr->True();
 	%}
 
@@ -204,7 +204,7 @@ function Reporter::set_weird_sampling_whitelist%(weird_sampling_whitelist: strin
 function Reporter::get_weird_sampling_global_list%(%): string_set
 	%{
 	auto set = zeek::make_intrusive<zeek::TableVal>(zeek::id::string_set);
-	for ( auto el : reporter->GetWeirdSamplingGlobalList() )
+	for ( const auto& el : reporter->GetWeirdSamplingGlobalList() )
 		{
 		auto idx = zeek::make_intrusive<zeek::StringVal>(el);
 		set->Assign(std::move(idx), nullptr);
@@ -234,7 +234,7 @@ function Reporter::set_weird_sampling_global_list%(weird_sampling_global_list: s
 		global_list_set.emplace(move(key));
 		delete k;
 		}
-	reporter->SetWeirdSamplingGlobalList(global_list_set);
+	reporter->SetWeirdSamplingGlobalList(std::move(global_list_set));
 	return zeek::val_mgr->True();
 	%}
 


### PR DESCRIPTION
- getter methods return const-ref
- setter methods pass by value and std::move()
- ranged-for loops over the whitelists access by const-ref