### PR TITLE
Fix vector-of-interval multiplication/division arithmetic

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -1414,7 +1414,12 @@ TimesExpr::TimesExpr(ExprPtr arg_op1, ExprPtr arg_op2)
 	if ( bt1 == TYPE_INTERVAL || bt2 == TYPE_INTERVAL )
 		{
 		if ( IsArithmetic(bt1) || IsArithmetic(bt2) )
-			PromoteType(TYPE_INTERVAL, is_vector(op1) || is_vector(op2) );
+			{
+			if ( is_vector(op1) && is_vector(op2) )
+				SetType(make_intrusive<VectorType>(base_type(TYPE_INTERVAL)));
+			else
+				PromoteType(TYPE_INTERVAL, is_vector(op1) || is_vector(op2) );
+			}
 		else
 			ExprError("multiplication with interval requires arithmetic operand");
 		}
@@ -1450,7 +1455,12 @@ DivideExpr::DivideExpr(ExprPtr arg_op1, ExprPtr arg_op2)
 	if ( bt1 == TYPE_INTERVAL || bt2 == TYPE_INTERVAL )
 		{
 		if ( IsArithmetic(bt1) || IsArithmetic(bt2) )
-			PromoteType(TYPE_INTERVAL, is_vector(op1) || is_vector(op2));
+			{
+			if ( is_vector(op1) && is_vector(op2) )
+				SetType(make_intrusive<VectorType>(base_type(TYPE_INTERVAL)));
+			else
+				PromoteType(TYPE_INTERVAL, is_vector(op1) || is_vector(op2));
+			}
 		else if ( bt1 == TYPE_INTERVAL && bt2 == TYPE_INTERVAL )
 			{
 			if ( is_vector(op1) || is_vector(op2) )

--- a/testing/btest/Baseline/language.vector-of-interval-arithmetic/out
+++ b/testing/btest/Baseline/language.vector-of-interval-arithmetic/out
@@ -1,0 +1,4 @@
+[4.0 secs 500.0 msecs, 3.0 mins, 4.0 hrs 30.0 mins]
+[4.0 secs 500.0 msecs, 3.0 mins, 4.0 hrs 30.0 mins]
+[500.0 msecs, 50.0 msecs, 1.0 msec 250.0 usecs]
+[2.0 secs, 20.0 secs, 13.0 mins 20.0 secs]

--- a/testing/btest/language/vector-of-interval-arithmetic.zeek
+++ b/testing/btest/language/vector-of-interval-arithmetic.zeek
@@ -1,0 +1,10 @@
+# @TEST-EXEC: zeek -b %INPUT >out
+# @TEST-EXEC: btest-diff out
+
+global v1 = vector(1.5, 3.0, 4.5);
+global v2 = vector(3 sec, 1 min, 1 hr);
+
+print v1 * v2;
+print v2 * v1;
+print v1 / v2;
+print v2 / v1;


### PR DESCRIPTION
Those operations done between a vector-of-interval and a
vector-of-arithmetic-type previously threw a runtime expression error
due to an incorrect coercion being used internally.

Fixes #1159