### PR TITLE
CI: Move to Fedora 32

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,10 +70,10 @@ env:
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
-fedora30_task:
+fedora32_task:
   container:
-    # Fedora 30 EOL: Around June 2020
-    dockerfile: ci/fedora-30/Dockerfile
+    # Fedora 32 EOL: Around May 2021
+    dockerfile: ci/fedora-32/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 

--- a/ci/fedora-32/Dockerfile
+++ b/ci/fedora-32/Dockerfile
@@ -1,24 +1,25 @@
-FROM fedora:30
+FROM fedora:32
 
 RUN yum -y install \
-    git \
+    bison \
     cmake \
-    make \
+    diffutils \
+    findutils \
+    flex \
+    git \
     gcc \
     gcc-c++ \
-    flex \
-    bison \
-    swig \
+    libpcap-devel \
+    make \
     openssl \
     openssl-devel \
-    libpcap-devel \
     python3 \
     python3-devel \
     python3-pip\
-    zlib-devel \
     sqlite \
-    findutils \
+    swig \
     which \
+    zlib-devel \
   && yum clean all && rm -rf /var/cache/yum
 
 # Many distros adhere to PEP 394's recommendation for `python` = `python2` so


### PR DESCRIPTION
Fedora 30 is EOL. For Fedora 32, we need to add the diffutils RPM to
the installation list, since cmp and diff aren't automatically
available in the base image. (Also, sort the RPMs alphabetically.)