### PR TITLE
Add stub payload to dce_rpc_request and dce_rpc_response

### DIFF
--- a/src/analyzer/protocol/dce-rpc/dce_rpc-analyzer.pac
+++ b/src/analyzer/protocol/dce-rpc/dce_rpc-analyzer.pac
@@ -121,6 +121,12 @@ refine connection DCE_RPC_Conn += {
 			                                  ${req.context_id},
 			                                  ${req.opnum},
 			                                  ${req.stub}.length());
+			zeek::BifEvent::enqueue_dce_rpc_request_stub(zeek_analyzer(),
+			                                  zeek_analyzer()->Conn(),
+			                                  fid,
+			                                  ${req.context_id},
+			                                  ${req.opnum},
+			                                  binpac::to_stringval(${req.stub}));
 			}
 
 		set_cont_id_opnum_map(${req.context_id},
@@ -138,6 +144,12 @@ refine connection DCE_RPC_Conn += {
 			                                   ${resp.context_id},
 			                                   get_cont_id_opnum_map(${resp.context_id}),
 			                                   ${resp.stub}.length());
+			zeek::BifEvent::enqueue_dce_rpc_response_stub(zeek_analyzer(),
+			                                   zeek_analyzer()->Conn(),
+			                                   fid,
+			                                   ${resp.context_id},
+			                                   get_cont_id_opnum_map(${resp.context_id}),
+			                                   binpac::to_stringval(${resp.stub}));
 			}
 
 		return true;

--- a/src/analyzer/protocol/dce-rpc/events.bif
+++ b/src/analyzer/protocol/dce-rpc/events.bif
@@ -95,7 +95,7 @@ event dce_rpc_alter_context_resp%(c: connection, fid: count%);
 ##
 ## stub_len: Length of the data for the request.
 ##
-## .. zeek:see:: dce_rpc_message dce_rpc_bind dce_rpc_bind_ack dce_rpc_response
+## .. zeek:see:: dce_rpc_message dce_rpc_bind dce_rpc_bind_ack dce_rpc_response dce_rpc_request_stub
 event dce_rpc_request%(c: connection, fid: count, ctx_id: count, opnum: count, stub_len: count%);
 
 ## Generated for every :abbr:`DCE-RPC (Distributed Computing Environment/Remote Procedure Calls)` response message.
@@ -112,5 +112,39 @@ event dce_rpc_request%(c: connection, fid: count, ctx_id: count, opnum: count, s
 ##
 ## stub_len: Length of the data for the response.
 ##
-## .. zeek:see:: dce_rpc_message dce_rpc_bind dce_rpc_bind_ack dce_rpc_request
+## .. zeek:see:: dce_rpc_message dce_rpc_bind dce_rpc_bind_ack dce_rpc_request dce_rpc_response_stub
 event dce_rpc_response%(c: connection, fid: count, ctx_id: count, opnum: count, stub_len: count%);
+
+## Generated for every :abbr:`DCE-RPC (Distributed Computing Environment/Remote Procedure Calls)` request message.
+##
+## c: The connection.
+##
+## fid: File ID of the PIPE that carried the :abbr:`DCE-RPC (Distributed Computing Environment/Remote Procedure Calls)`
+##      message. Zero will be used if the :abbr:`DCE-RPC (Distributed Computing Environment/Remote Procedure Calls)` was
+##      not transported over a pipe.
+##
+## ctx_id: The context identifier of the data representation.
+##
+## opnum: Number of the RPC operation.
+##
+## stub: The data for the request.
+##
+## .. zeek:see:: dce_rpc_message dce_rpc_bind dce_rpc_bind_ack dce_rpc_response_stub dce_rpc_request
+event dce_rpc_request_stub%(c: connection, fid: count, ctx_id: count, opnum: count, stub: string%);
+
+## Generated for every :abbr:`DCE-RPC (Distributed Computing Environment/Remote Procedure Calls)` response message.
+##
+## c: The connection.
+##
+## fid: File ID of the PIPE that carried the :abbr:`DCE-RPC (Distributed Computing Environment/Remote Procedure Calls)`
+##      message. Zero will be used if the :abbr:`DCE-RPC (Distributed Computing Environment/Remote Procedure Calls)` was
+##      not transported over a pipe.
+##
+## ctx_id: The context identifier of the data representation.
+###
+## opnum: Number of the RPC operation.
+##
+## stub: The data for the response.
+##
+## .. zeek:see:: dce_rpc_message dce_rpc_bind dce_rpc_bind_ack dce_rpc_request_stub dce_rpc_response
+event dce_rpc_response_stub%(c: connection, fid: count, ctx_id: count, opnum: count, stub: string%);


### PR DESCRIPTION
This small change adds the `stub` payload to `dce_rpc_request` and `dce_rpc_response`. The motivation is to provide richer context when building detections around DCE RPC exploits. As an example, the [Zerologon](https://www.secura.com/blog/zero-logon) vulnerability relies on this protocol and being able to analyze the payloads would yield a less error prone detector. 

While writing a [less sophisticated version](https://github.com/corelight/zerologon) of a detector, @sethhall mentioned it would be easy to bubble this payload up, which lead to this PR. Even though the change is small, I have a few questions for how to make this better:

1. @sethhall mentioned the payload wasn't included due to fear of bringing in "bulk" data into script land. Is there a standard way to deal with that, like only surfacing the first N bytes or something? I fear with something like this, however, we're just kicking the can down the road.
1. How should I handle backwards compatibility? To ensure it works, I just added the `stub`, but I'm sure there's a better way. I've seen with [ICMP events](https://docs.zeek.org/en/current/scripts/base/bif/plugins/Zeek_ICMP.events.bif.zeek.html#id-icmp_echo_request) the older event signature is deprecated, and two are added: one with just the new signature and one with both. Is this the preferred style?
1. Related to the above, I imagine we don't need to surface `stub_len` if we are surfacing `stub`.

Thanks!