### PR TITLE
Switch one's complement checksum implementation

### DIFF
--- a/COPYING.3rdparty
+++ b/COPYING.3rdparty
@@ -250,6 +250,39 @@ PROJECT (https://github.com/zeek) UNDER BSD LICENCE.
 
 ==============================================================================
 
+%%% in_cksum.cc
+
+==============================================================================
+
+Copyright (c) 1988, 1992, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+==============================================================================
+
 %%% Patricia.c
 
 ==============================================================================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,6 +296,7 @@ set(MAIN_SRCS
     legacy-netvar-init.cc
     bsd-getopt-long.c
     bro_inet_ntop.c
+    in_cksum.cc
     patricia.c
     setsignal.c
     strsep.c

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -269,7 +269,7 @@ void NetSessions::DoNextPacket(double t, const Packet* pkt, const IP_Hdr* ip_hdr
 		 return;
 
 	if ( ! pkt->l2_checksummed && ! zeek::detail::ignore_checksums && ip4 &&
-	     ones_complement_checksum((void*) ip4, ip_hdr_len, 0) != 0xffff )
+	     detail::in_cksum(reinterpret_cast<const uint8_t*>(ip4), ip_hdr_len) != 0xffff )
 		{
 		Weird("bad_IP_checksum", pkt, encapsulation);
 		return;

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -346,7 +346,8 @@ RecordValPtr ICMP_Analyzer::ExtractICMP4Context(int len, const u_char*& data)
 		bad_hdr_len = 0;
 		ip_len = ip_hdr->TotalLen();
 		bad_checksum = ! run_state::current_pkt->l3_checksummed &&
-			(ones_complement_checksum((void*) ip_hdr->IP4_Hdr(), ip_hdr_len, 0) != 0xffff);
+		  (detail::in_cksum(reinterpret_cast<const uint8_t*>(ip_hdr->IP4_Hdr()),
+		                    ip_hdr_len) != 0xffff);
 
 		src_addr = ip_hdr->SrcAddr();
 		dst_addr = ip_hdr->DstAddr();

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -273,10 +273,10 @@ const struct tcphdr* TCP_Analyzer::ExtractTCP_Header(const u_char*& data,
 	}
 
 bool TCP_Analyzer::ValidateChecksum(const struct tcphdr* tp,
-				TCP_Endpoint* endpoint, int len, int caplen)
+				TCP_Endpoint* endpoint, int len, int caplen, bool ipv4)
 	{
 	if ( ! run_state::current_pkt->l3_checksummed && ! detail::ignore_checksums && caplen >= len &&
-	     ! endpoint->ValidChecksum(tp, len) )
+	     ! endpoint->ValidChecksum(tp, len, ipv4) )
 		{
 		Weird("bad_TCP_checksum");
 		endpoint->ChecksumError();
@@ -1060,7 +1060,7 @@ void TCP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 	TCP_Endpoint* endpoint = is_orig ? orig : resp;
 	TCP_Endpoint* peer = endpoint->peer;
 
-	if ( ! ValidateChecksum(tp, endpoint, len, caplen) )
+	if ( ! ValidateChecksum(tp, endpoint, len, caplen, ip->IP4_Hdr()) )
 		return;
 
 	uint32_t tcp_hdr_len = data - (const u_char*) tp;

--- a/src/analyzer/protocol/tcp/TCP.h
+++ b/src/analyzer/protocol/tcp/TCP.h
@@ -95,7 +95,7 @@ protected:
 	// Returns true if the checksum is valid, false if not (and in which
 	// case also updates the status history of the endpoint).
 	bool ValidateChecksum(const struct tcphdr* tp, TCP_Endpoint* endpoint,
-				int len, int caplen);
+				int len, int caplen, bool ipv4);
 
 	void SetPartialStatus(TCP_Flags flags, bool is_orig);
 

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.h
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.h
@@ -165,7 +165,7 @@ public:
 	// WARNING: this is an O(n) operation and potentially very slow.
 	void SizeBufferedData(uint64_t& waiting_on_hole, uint64_t& waiting_on_ack);
 
-	bool ValidChecksum(const struct tcphdr* tp, int len) const;
+	bool ValidChecksum(const struct tcphdr* tp, int len, bool ipv4) const;
 
 	// Called to inform endpoint that it has generated a checksum error.
 	void ChecksumError();
@@ -211,7 +211,6 @@ public:
 	TCP_Reassembler* contents_processor;
 	TCP_Analyzer* tcp_analyzer;
 	FilePtr contents_file;
-	uint32_t checksum_base;
 
 	double start_time, last_time;
 	IPAddr src_addr; // the other endpoint

--- a/src/in_cksum.cc
+++ b/src/in_cksum.cc
@@ -1,0 +1,141 @@
+// Modified from tcpdump v4.9.3's in_cksum.c (which itself was a modified
+// version of FreeBSD's in_cksum.c).
+
+/* in_cksum.c
+ * 4.4-Lite-2 Internet checksum routine, modified to take a vector of
+ * pointers/lengths giving the pieces to be checksummed.  Also using
+ * Tahoe/CGI version of ADDCARRY(x) macro instead of from portable version.
+ */
+
+/*
+ * Copyright (c) 1988, 1992, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)in_cksum.c	8.1 (Berkeley) 6/10/93
+ */
+
+#include "net_util.h"
+
+namespace zeek::detail {
+
+#define ADDCARRY(x)  {if ((x) > 65535) (x) -= 65535;}
+#define REDUCE {l_util.l = sum; sum = l_util.s[0] + l_util.s[1]; ADDCARRY(sum);}
+
+uint16_t in_cksum(const struct checksum_block *vec, int veclen)
+{
+	const uint16_t *w;
+	int sum = 0;
+	int mlen = 0;
+	int byte_swapped = 0;
+
+	union {
+		uint8_t		c[2];
+		uint16_t	s;
+	} s_util;
+	union {
+		uint16_t	s[2];
+		uint32_t	l;
+	} l_util;
+
+	for (; veclen != 0; vec++, veclen--) {
+		if (vec->len == 0)
+			continue;
+		w = (const uint16_t *)(const void *)vec->block;
+		if (mlen == -1) {
+			/*
+			 * The first byte of this chunk is the continuation
+			 * of a word spanning between this chunk and the
+			 * last chunk.
+			 *
+			 * s_util.c[0] is already saved when scanning previous
+			 * chunk.
+			 */
+			s_util.c[1] = *(const uint8_t *)w;
+			sum += s_util.s;
+			w = (const uint16_t *)(const void *)((const uint8_t *)w + 1);
+			mlen = vec->len - 1;
+		} else
+			mlen = vec->len;
+		/*
+		 * Force to even boundary.
+		 */
+		if ((1 & (uintptr_t) w) && (mlen > 0)) {
+			REDUCE;
+			sum <<= 8;
+			s_util.c[0] = *(const uint8_t *)w;
+			w = (const uint16_t *)(const void *)((const uint8_t *)w + 1);
+			mlen--;
+			byte_swapped = 1;
+		}
+		/*
+		 * Unroll the loop to make overhead from
+		 * branches &c small.
+		 */
+		while ((mlen -= 32) >= 0) {
+			sum += w[0]; sum += w[1]; sum += w[2]; sum += w[3];
+			sum += w[4]; sum += w[5]; sum += w[6]; sum += w[7];
+			sum += w[8]; sum += w[9]; sum += w[10]; sum += w[11];
+			sum += w[12]; sum += w[13]; sum += w[14]; sum += w[15];
+			w += 16;
+		}
+		mlen += 32;
+		while ((mlen -= 8) >= 0) {
+			sum += w[0]; sum += w[1]; sum += w[2]; sum += w[3];
+			w += 4;
+		}
+		mlen += 8;
+		if (mlen == 0 && byte_swapped == 0)
+			continue;
+		REDUCE;
+		while ((mlen -= 2) >= 0) {
+			sum += *w++;
+		}
+		if (byte_swapped) {
+			REDUCE;
+			sum <<= 8;
+			byte_swapped = 0;
+			if (mlen == -1) {
+				s_util.c[1] = *(const uint8_t *)w;
+				sum += s_util.s;
+				mlen = 0;
+			} else
+				mlen = -1;
+		} else if (mlen == -1)
+			s_util.c[0] = *(const uint8_t *)w;
+	}
+	if (mlen == -1) {
+		/* The last mbuf has odd # of bytes. Follow the
+		   standard (the odd byte may be shifted left by 8 bits
+		   or not as determined by endian-ness of the machine) */
+		s_util.c[1] = 0;
+		sum += s_util.s;
+	}
+	REDUCE;
+	return sum;
+}
+
+} // namespace zeek


### PR DESCRIPTION
Borrows the `in_cksum` code from tcpdump, which borrowed from FreeBSD.
It handles unaligned data better and also unrolls the inner loop to
process 16 two-byte values at a time versus 2 one-byte values at a time
in the previous version.  Generally measured as ~1.5x faster in a
release build.  The new API should generally be more amenable to any
future optimization explorations since all relevant data blocks are
available within a single call rather than spread across multiple.