### PR TITLE
logging/ascii: Support shadow logs in non-supervisor setups

### DIFF
--- a/scripts/base/frameworks/cluster/nodes/logger.zeek
+++ b/scripts/base/frameworks/cluster/nodes/logger.zeek
@@ -37,6 +37,8 @@ function supervisor_rotation_format_func(ri: Log::RotationFmtInfo): Log::Rotatio
 
 redef Log::rotation_format_func = supervisor_rotation_format_func;
 
+redef LogAscii::enable_leftover_log_rotation = T;
+
 @else
 
 ## Use the cluster's archive logging script.

--- a/scripts/base/frameworks/logging/writers/ascii.zeek
+++ b/scripts/base/frameworks/logging/writers/ascii.zeek
@@ -26,6 +26,12 @@ export {
 	## This option is also available as a per-filter ``$config`` option.
 	const use_json = F &redef;
 
+	## If true, enable leftover log rotation using .shadow files.
+	##
+	## This requires a positive rotation_interval to be configued
+	## to have an effect.
+	const enable_leftover_log_rotation = F &redef;
+
 	## If true, valid UTF-8 sequences will pass through unescaped and be
 	## written into logs.
 	##

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -16,7 +16,6 @@
 
 #include "Func.h"
 #include "RunState.h"
-#include "supervisor/Supervisor.h"
 #include "logging/Manager.h"
 #include "threading/SerialTypes.h"
 
@@ -450,7 +449,7 @@ bool Ascii::DoInit(const WriterInfo& info, int num_fields, const threading::Fiel
 
 		fname += ext;
 
-		bool use_shadow = Supervisor::ThisNode() && info.rotation_interval > 0;
+		bool use_shadow = BifConst::LogAscii::enable_leftover_log_rotation && Info().rotation_interval > 0;
 
 		if ( use_shadow )
 			{
@@ -667,7 +666,7 @@ bool Ascii::DoRotate(const char* rotated_path, double open, double close, bool t
 		return false;
 		}
 
-	bool use_shadow = Supervisor::ThisNode() && Info().rotation_interval > 0;
+	bool use_shadow = BifConst::LogAscii::enable_leftover_log_rotation && Info().rotation_interval > 0;
 
 	if ( use_shadow )
 		{
@@ -744,7 +743,7 @@ static std::vector<LeftoverLog> find_leftover_logs()
 
 void Ascii::RotateLeftoverLogs()
 	{
-	if ( ! Supervisor::ThisNode() )
+	if ( ! BifConst::LogAscii::enable_leftover_log_rotation )
 		return;
 
 	// Log file crash recovery: if there's still leftover shadow files from the

--- a/src/logging/writers/ascii/ascii.bif
+++ b/src/logging/writers/ascii/ascii.bif
@@ -11,6 +11,7 @@ const set_separator: string;
 const empty_field: string;
 const unset_field: string;
 const use_json: bool;
+const enable_leftover_log_rotation: bool;
 const enable_utf_8: bool;
 const json_timestamps: JSON::TimestampFormat;
 const gzip_level: count;


### PR DESCRIPTION
We have a use case to rotate left-over log files in a non-supervisor
setup. There doesn't seem to be a strict requirement on any supervisor
functionality per-se. Allow enabling shadow logs through
LogAscii::enable_shadow_logs and redef this for the logger node in
a supervisor setup individually.

This is mostly an RFC to see if that could make sense to have available?