### PR TITLE
Fix DebugLogger::Log() format attributes

### DIFF
--- a/src/DebugLogger.h
+++ b/src/DebugLogger.h
@@ -61,8 +61,8 @@ public:
 
 	void OpenDebugLog(const char* filename = 0);
 
-	void Log(DebugStream stream, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
-	void Log(const plugin::Plugin& plugin, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
+	void Log(DebugStream stream, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
+	void Log(const plugin::Plugin& plugin, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 
 	void PushIndent(DebugStream stream)
 		{ ++streams[int(stream)].indent; }


### PR DESCRIPTION
Originally reported in https://github.com/zeek/zeek/issues/913#issuecomment-688078310