### PR TITLE
Capture Loss: Add initial_watch_interval option and Too_Little_Traffic notice

### DIFF
--- a/scripts/policy/misc/capture-loss.zeek
+++ b/scripts/policy/misc/capture-loss.zeek
@@ -18,7 +18,7 @@ export {
 
 	redef enum Notice::Type += {
 		## Report if the detected capture loss exceeds the percentage
-		## threshold.
+		## threshold defined in :zeek:id:`CaptureLoss::too_much_loss`.
 		Too_Much_Loss
 	};
 

--- a/scripts/policy/misc/capture-loss.zeek
+++ b/scripts/policy/misc/capture-loss.zeek
@@ -66,7 +66,7 @@ event CaptureLoss::take_measurement(last_ts: time, last_acks: count, last_gaps: 
 	{
 	if ( last_ts == 0 )
 		{
-		schedule watch_interval { CaptureLoss::take_measurement(network_time(), 0, 0) };
+		schedule initial_watch_interval { CaptureLoss::take_measurement(network_time(), 0, 0) };
 		return;
 		}
 

--- a/scripts/policy/misc/capture-loss.zeek
+++ b/scripts/policy/misc/capture-loss.zeek
@@ -39,8 +39,13 @@ export {
 		percent_lost: double   &log;
 	};
 
-	## The interval at which capture loss reports are created.
+	## The interval at which capture loss reports are created in a
+	## running cluster (that is, after the first report).
 	option watch_interval = 15mins;
+
+	## For faster feedback on cluster health, the first capture loss
+	## report is generated this many minutes after startup.
+	option initial_watch_interval = 1mins;
 
 	## The percentage of missed data that is considered "too much"
 	## when the :zeek:enum:`CaptureLoss::Too_Much_Loss` notice should be
@@ -82,5 +87,5 @@ event zeek_init() &priority=5
 
 	# We only schedule the event if we are capturing packets.
 	if ( reading_live_traffic() || reading_traces() )
-		schedule watch_interval { CaptureLoss::take_measurement(network_time(), 0, 0) };
+		schedule initial_watch_interval { CaptureLoss::take_measurement(network_time(), 0, 0) };
 	}

--- a/testing/btest/Baseline/scripts.policy.misc.capture-loss/capture_loss.log
+++ b/testing/btest/Baseline/scripts.policy.misc.capture-loss/capture_loss.log
@@ -1,0 +1,10 @@
+#separator \x09
+#set_separator	,
+#empty_field	(empty)
+#unset_field	-
+#path	capture_loss
+#open	2020-10-08-16-33-05
+#fields	ts	ts_delta	peer	gaps	acks	percent_lost
+#types	time	interval	string	count	count	double
+964953086.310131	0.000000	zeek	0	0	0.0
+#close	2020-10-08-16-33-05

--- a/testing/btest/Baseline/scripts.policy.misc.capture-loss/notice.log
+++ b/testing/btest/Baseline/scripts.policy.misc.capture-loss/notice.log
@@ -1,0 +1,10 @@
+#separator \x09
+#set_separator	,
+#empty_field	(empty)
+#unset_field	-
+#path	notice
+#open	2020-10-08-16-33-05
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	fuid	file_mime_type	file_desc	proto	note	msg	sub	src	dst	p	n	peer_descr	actions	suppress_for	remote_location.country_code	remote_location.region	remote_location.city	remote_location.latitude	remote_location.longitude
+#types	time	string	addr	port	addr	port	string	string	string	enum	enum	string	string	addr	addr	port	count	string	set[enum]	interval	string	string	string	double	double
+964953086.310131	-	-	-	-	-	-	-	-	-	CaptureLoss::Too_Little_Traffic	The worker only observed 0 ACKs and was expecting at least 1.	-	-	-	-	-	-	Notice::ACTION_LOG	3600.000000	-	-	-	-	-
+#close	2020-10-08-16-33-05

--- a/testing/btest/scripts/policy/misc/capture-loss.zeek
+++ b/testing/btest/scripts/policy/misc/capture-loss.zeek
@@ -1,0 +1,12 @@
+# @TEST-EXEC: zeek -b -r $TRACES/dns53.pcap %INPUT
+# @TEST-EXEC: btest-diff capture_loss.log
+# @TEST-EXEC: btest-diff notice.log
+
+@load misc/capture-loss
+
+module CaptureLoss;
+
+event zeek_init()
+	{
+	event take_measurement(network_time(), 0, 0);
+	}


### PR DESCRIPTION
This branch adds two features to capture loss:

1. A new option, named initial_watch_interval. Oftentimes when restarting a Zeek cluster, you want to get some immediate feedback as to the health of the monitoring via capture loss. However, you need to wait a full watch_interval, which defaults to 15 minutes. This option will provide stats after 1 minute (by default), and then will use the usual 15 minute cadence.
2. A new notice type, Too_Little_Traffic. If a worker sees less than minimum_acks ACKs in a given interval, this notice gets raised. We occasionally see workers that, for whatever reason, stop seeing traffic, but capture loss happily reports that 0 gaps out of 0 is 0% loss.