### PR TITLE
Silence Clang's warning about ignoring GCC's maybe-uninitialized warning

### DIFF
--- a/src/Val.cc
+++ b/src/Val.cc
@@ -2192,10 +2192,14 @@ void TableVal::SendToStore(const Val* index, const TableEntryVal* new_entry_val,
 			case ELEMENT_NEW:
 			case ELEMENT_CHANGED:
 				{
+				#ifndef __clang__
 				#pragma GCC diagnostic push
 				#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+				#endif
 				broker::optional<broker::timespan> expiry;
+				#ifndef __clang__
 				#pragma GCC diagnostic pop
+				#endif
 
 				auto expire_time = GetExpireTime();
 				if ( expire_time == 0 )


### PR DESCRIPTION
Clang supports `#pragma GCC diagnostic` for "compatibility", but not
`-Wmaybe-uninitialized`, so was emitting `warning: unknown warning group
'-Wmaybe-uninitialized'`