### PR TITLE
New bif to wrap pcap_findalldevs

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -4989,12 +4989,10 @@ export {
 		## of ``127.0.0.1`` or ``[::1]`` are used by loopback interfaces.
 		is_loopback: bool;
 		
-		extended_flags: bool &default=F;
-		# If the "extended_flags" field is set to T, then these next two 
-		# flags will have valid settings.  Otherwise, the following
-		# two fields are explicitly false.
-		is_up: bool &default=F;
-		is_running: bool &default=F;
+		## Whether the device is up.  Not set when that info is unavailable.
+		is_up: bool &optional;
+		## Whether the device is running.  Not set when that info is unavailable.
+		is_running: bool &optional;
 	};
 
 	type Interfaces: set[Pcap::Interface];

--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -4979,9 +4979,14 @@ export {
 
 	## The definition of a "pcap interface".
 	type Interface: record {
+		## The interface/device name.
 		name: string;
+		## A human-readable description of the device.
 		description: string &optional;
+		## The network addresses associated with the device.
 		addrs: set[addr];
+		## Whether the device is a loopback interface.  E.g. addresses
+		## of ``127.0.0.1`` or ``[::1]`` are used by loopback interfaces.
 		is_loopback: bool;
 		
 		extended_flags: bool &default=F;

--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -4976,6 +4976,23 @@ export {
 	## Number of Mbytes to provide as buffer space when capturing from live
 	## interfaces.
 	const bufsize = 128 &redef;
+
+	## The definition of a "pcap interface".
+	type Interface: record {
+		name: string;
+		description: string &optional;
+		addrs: set[addr];
+		is_loopback: bool;
+		
+		extended_flags: bool &default=F;
+		# If the "extended_flags" field is set to T, then these next two 
+		# flags will have valid settings.  Otherwise, the following
+		# two fields are explicitly false.
+		is_up: bool &default=F;
+		is_running: bool &default=F;
+	};
+
+	type Interfaces: set[Pcap::Interface];
 } # end export
 
 module DCE_RPC;

--- a/src/iosource/pcap/pcap.bif
+++ b/src/iosource/pcap/pcap.bif
@@ -111,10 +111,16 @@ function findalldevs%(%): Pcap::Interfaces
 	pcap_if_t *alldevs, *d;
 	char errbuf[PCAP_ERRBUF_SIZE];
 
-	int ret = pcap_findalldevs(&alldevs, errbuf);
-
 	static auto ifaces_type = id::find_type<TableType>("Pcap::Interfaces");
 	auto pcap_interfaces = make_intrusive<TableVal>(ifaces_type);
+
+	int ret = pcap_findalldevs(&alldevs, errbuf);
+	if ( ret == PCAP_ERROR )
+		{
+		emit_builtin_error(util::fmt("Error calling pcap_findalldevs: %s", errbuf));
+		// Return an empty set in case of failure.
+		return pcap_interfaces;
+		}
 
 	static auto iface_type = id::find_type<RecordType>("Pcap::Interface");
 	for ( d=alldevs; d; d=d->next )
@@ -142,9 +148,9 @@ function findalldevs%(%): Pcap::Interfaces
 		r->Assign(2, addrs->ToSetVal());
 		r->Assign(3, val_mgr->Bool(d->flags & PCAP_IF_LOOPBACK));
 #ifdef PCAP_IF_UP
-		r->Assign(4, val_mgr->True()); // <-- "extended" vals set.
-		r->Assign(5, val_mgr->Bool(d->flags & PCAP_IF_UP));
-		r->Assign(6, val_mgr->Bool(d->flags & PCAP_IF_RUNNING));
+		// These didn't become available until libpcap 1.6.1
+		r->Assign(4, val_mgr->Bool(d->flags & PCAP_IF_UP));
+		r->Assign(5, val_mgr->Bool(d->flags & PCAP_IF_RUNNING));
 #endif
 		
 		pcap_interfaces->Assign(std::move(r), nullptr);

--- a/src/iosource/pcap/pcap.bif
+++ b/src/iosource/pcap/pcap.bif
@@ -149,7 +149,7 @@ function findalldevs%(%): Pcap::Interfaces
 		r->Assign(6, val_mgr->Bool(d->flags & PCAP_IF_RUNNING));
 #endif
 		
-		pcap_interfaces->Assign(std::move(r), 0);
+		pcap_interfaces->Assign(std::move(r), nullptr);
 		}
 
 	pcap_freealldevs(alldevs);

--- a/src/iosource/pcap/pcap.bif
+++ b/src/iosource/pcap/pcap.bif
@@ -1,7 +1,6 @@
 
 module Pcap;
 
-type Interface: record;
 
 const snaplen: count;
 const bufsize: count;
@@ -156,4 +155,3 @@ function findalldevs%(%): Pcap::Interfaces
 	pcap_freealldevs(alldevs);
 	return pcap_interfaces;
 	%}
-

--- a/src/iosource/pcap/pcap.bif
+++ b/src/iosource/pcap/pcap.bif
@@ -116,8 +116,6 @@ function findalldevs%(%): Pcap::Interfaces
 	static auto ifaces_type = id::find_type<TableType>("Pcap::Interfaces");
 	auto pcap_interfaces = make_intrusive<TableVal>(ifaces_type);
 
-	int i=0;
-	RecordVal *r;
 	static auto iface_type = id::find_type<RecordType>("Pcap::Interface");
 	for ( d=alldevs; d; d=d->next )
 		{

--- a/src/iosource/pcap/pcap.bif
+++ b/src/iosource/pcap/pcap.bif
@@ -145,7 +145,7 @@ function findalldevs%(%): Pcap::Interfaces
 		r->Assign(2, addrs->ToSetVal());
 		r->Assign(3, val_mgr->Bool(d->flags & PCAP_IF_LOOPBACK));
 #ifdef PCAP_IF_UP
-		r->Assign(4, val_mgr->True(); // <-- "extended" vals set.
+		r->Assign(4, val_mgr->True()); // <-- "extended" vals set.
 		r->Assign(5, val_mgr->Bool(d->flags & PCAP_IF_UP));
 		r->Assign(6, val_mgr->Bool(d->flags & PCAP_IF_RUNNING));
 #endif

--- a/src/iosource/pcap/pcap.bif
+++ b/src/iosource/pcap/pcap.bif
@@ -1,10 +1,14 @@
 
 module Pcap;
 
+type Interface: record;
+
 const snaplen: count;
 const bufsize: count;
 
 %%{
+#include "pcap.h"
+
 #include "iosource/Manager.h"
 %%}
 
@@ -102,3 +106,54 @@ function error%(%): string
 
 	return zeek::make_intrusive<zeek::StringVal>("no error");
 	%}
+
+function findalldevs%(%): Pcap::Interfaces
+	%{
+	pcap_if_t *alldevs, *d;
+	char errbuf[PCAP_ERRBUF_SIZE];
+
+	int ret = pcap_findalldevs(&alldevs, errbuf);
+
+	static auto ifaces_type = id::find_type<TableType>("Pcap::Interfaces");
+	auto pcap_interfaces = make_intrusive<TableVal>(ifaces_type);
+
+	int i=0;
+	RecordVal *r;
+	static auto iface_type = id::find_type<RecordType>("Pcap::Interface");
+	for ( d=alldevs; d; d=d->next )
+		{
+		auto r = make_intrusive<RecordVal>(iface_type);
+
+		r->Assign(0, make_intrusive<StringVal>(d->name));
+		if ( d->description )
+			r->Assign(1, make_intrusive<StringVal>(d->description));
+
+		auto addrs = make_intrusive<ListVal>(TYPE_ADDR);
+		for ( auto addr = d->addresses; addr != NULL; addr = addr->next ) 
+			{
+			if ( addr->addr->sa_family == AF_INET ) 
+				{
+				IPAddr a(reinterpret_cast<struct sockaddr_in *>(addr->addr)->sin_addr);
+				addrs->Append(make_intrusive<AddrVal>(a));
+				}
+			else if ( addr->addr->sa_family == AF_INET6 )
+				{
+				IPAddr a(reinterpret_cast<struct sockaddr_in6 *>(addr->addr)->sin6_addr);
+				addrs->Append(make_intrusive<AddrVal>(a));
+				}
+			}
+		r->Assign(2, addrs->ToSetVal());
+		r->Assign(3, val_mgr->Bool(d->flags & PCAP_IF_LOOPBACK));
+#ifdef PCAP_IF_UP
+		r->Assign(4, val_mgr->True(); // <-- "extended" vals set.
+		r->Assign(5, val_mgr->Bool(d->flags & PCAP_IF_UP));
+		r->Assign(6, val_mgr->Bool(d->flags & PCAP_IF_RUNNING));
+#endif
+		
+		pcap_interfaces->Assign(std::move(r), 0);
+		}
+
+	pcap_freealldevs(alldevs);
+	return pcap_interfaces;
+	%}
+


### PR DESCRIPTION
I didn't create a test for this Bif because I'm not exactly sure how I'd do so.  Keep in mind that if the user you are running Zeek as doesn't have access to enumerate interfaces then you will get an empty set back from this function (probably need to run as root to get anything back).