### PR TITLE
Use Dictionary validity assertions only during CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -161,6 +161,7 @@ sanitizer_task:
   << : *CI_TEMPLATE
   test_fuzzers_script: ./ci/test-fuzzers.sh
   env:
+    CXXFLAGS: -DZEEK_DICT_DEBUG
     ZEEK_CI_CONFIGURE_FLAGS: *SANITIZER_CONFIG
     ZEEK_TAILORED_UB_CHECKS: 1
     UBSAN_OPTIONS: print_stacktrace=1

--- a/src/Dict.cc
+++ b/src/Dict.cc
@@ -17,7 +17,7 @@
 
 #include "3rdparty/doctest.h"
 
-#ifdef DEBUG
+#if defined(DEBUG) && defined(ZEEK_DICT_DEBUG)
 #define ASSERT_VALID(o)	o->AssertValid()
 #else
 #define ASSERT_VALID(o)


### PR DESCRIPTION
Fixes #1208

Don't think there's too much concern about stability of the new Dictionary code by now to warrant making everyone pay the overhead of all the validity checks just because they do a debug build, but do think it's nice to at least leave CI doing those checks to help catch mistakes in any future maintenance/transformations in Dict.cc.