### PR TITLE
Implement standard-library-compatible iterators for Dictionary

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -343,6 +343,11 @@ Deprecated Functionality
   *e* and *p*, were named in misleading way (*e* is the modulus)
   and now deprecated in favor of the new *modulus* and *exponent* parameters.
 
+- The ``IterCookie`` version of iteration over ``Dictionary`` and ``PDict``
+  objects wars marked as deprecated. It was replaced by standard-library
+  compatible iterators. This enables the use of standard constructs such
+  as ranged-for loops to iterate over those objects.
+
 Zeek 3.2.0
 ==========
 

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -77,16 +77,12 @@ void Reporter::InitOptions()
 		auto wl_val = id::find_val(name)->AsTableVal();
 		auto wl_table = wl_val->AsTable();
 
-		detail::HashKey* k;
-		IterCookie* c = wl_table->InitForIteration();
-		TableEntryVal* v;
-
-		while ( (v = wl_table->NextEntry(k, c)) )
+		for ( const auto& wle : *wl_table )
 			{
+			auto k = wle.GetHashKey();
 			auto index = wl_val->RecreateIndex(*k);
 			std::string key = index->Idx(0)->AsString()->CheckString();
 			set->emplace(move(key));
-			delete k;
 			}
 		};
 

--- a/src/Val.h
+++ b/src/Val.h
@@ -14,6 +14,7 @@
 #include "zeek/Notifier.h"
 #include "zeek/Reporter.h"
 #include "zeek/net_util.h"
+#include "zeek/Dict.h"
 
 // We have four different port name spaces: TCP, UDP, ICMP, and UNKNOWN.
 // We distinguish between them based on the bits specified in the *_PORT_MASK
@@ -26,13 +27,10 @@
 #define ICMP_PORT_MASK	0x30000
 
 namespace zeek {
-template<typename T> class PDict;
 class String;
 }
-template<typename T> using PDict [[deprecated("Remove in v4.1. Use zeek::PDict instead.")]] = zeek::PDict<T>;
 using BroString [[deprecated("Remove in v4.1. Use zeek::String instead.")]] = zeek::String;
 
-ZEEK_FORWARD_DECLARE_NAMESPACED(IterCookie, zeek);
 ZEEK_FORWARD_DECLARE_NAMESPACED(Frame, zeek::detail);
 ZEEK_FORWARD_DECLARE_NAMESPACED(Func, zeek);
 ZEEK_FORWARD_DECLARE_NAMESPACED(IPAddr, zeek);
@@ -1107,7 +1105,7 @@ protected:
 	detail::ExprPtr expire_time;
 	detail::ExprPtr expire_func;
 	TableValTimer* timer;
-	IterCookie* expire_cookie;
+	RobustDictIterator* expire_iterator;
 	detail::PrefixTable* subnets;
 	ValPtr def_val;
 	detail::ExprPtr change_func;

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -927,14 +927,12 @@ broker::expected<broker::data> val_to_data(const Val* v)
 		else
 			rval = broker::table();
 
-		zeek::detail::HashKey* hk;
-		TableEntryVal* entry;
-		auto c = table->InitForIteration();
-
-		while ( (entry = table->NextEntry(hk, c)) )
+		for ( const auto& te : *table )
 			{
+			auto hk = te.GetHashKey();
+			auto* entry = te.GetValue<TableEntryVal*>();
+
 			auto vl = table_val->RecreateIndex(*hk);
-			delete hk;
 
 			broker::vector composite_key;
 			composite_key.reserve(vl->Length());

--- a/src/broker/messaging.bif
+++ b/src/broker/messaging.bif
@@ -34,14 +34,13 @@ std::set<std::string> val_to_topic_set(zeek::Val* val)
 		if ( tbl->Length() == 0 )
 			return rval;
 
-		zeek::IterCookie* c = tbl->InitForIteration();
-		zeek::detail::HashKey* k;
-
-		while ( tbl->NextEntry(k, c) )
+		for ( const auto& te : *tbl )
 			{
+			auto k = te.GetHashKey();
+			auto* v = te.GetValue<zeek::TableEntryVal*>();
+
 			auto index = val->AsTableVal()->RecreateIndex(*k);
 			rval.emplace(index->Idx(0)->AsString()->CheckString());
-			delete k;
 			}
 		}
 

--- a/src/file_analysis/AnalyzerSet.h
+++ b/src/file_analysis/AnalyzerSet.h
@@ -92,8 +92,14 @@ public:
 	 * @see Dictionary#InitForIteration
 	 * @return an iterator that may be used to loop over analyzers in the set.
 	 */
+	[[deprecated("Remove in v5.1. Use standard-library compatible iteration.")]]
 	IterCookie* InitForIteration() const
-		{ return analyzer_map.InitForIteration(); }
+		{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+		return analyzer_map.InitForIteration();
+#pragma GCC diagnostic pop
+		}
 
 	/**
 	 * Get next entry in the analyzer set.
@@ -102,8 +108,27 @@ public:
 	 * @return the next analyzer in the set or a null pointer if there is no
 	 *         more left (in that case the cookie is also deleted).
 	 */
+	[[deprecated("Remove in v5.1. Use standard-library compatible iteration.")]]
 	file_analysis::Analyzer* NextEntry(IterCookie* c)
-		{ return analyzer_map.NextEntry(c); }
+		{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+		return analyzer_map.NextEntry(c);
+#pragma GCC diagnostic pop
+		}
+
+	// Iterator support
+	using iterator = zeek::DictIterator;
+	using const_iterator = const iterator;
+	using reverse_iterator = std::reverse_iterator<iterator>;
+	using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+	iterator begin() { return analyzer_map.begin(); }
+	iterator end() { return analyzer_map.end(); }
+	const_iterator begin() const { return analyzer_map.begin(); }
+	const_iterator end() const { return analyzer_map.end(); }
+	const_iterator cbegin() { return analyzer_map.cbegin(); }
+	const_iterator cend() { return analyzer_map.cend(); }
 
 protected:
 

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -393,11 +393,10 @@ void File::DeliverStream(const u_char* data, uint64_t len)
 	        util::fmt_bytes((const char*) data, std::min((uint64_t)40, len)),
 	        len > 40 ? "..." : "");
 
-	file_analysis::Analyzer* a = nullptr;
-	IterCookie* c = analyzers.InitForIteration();
-
-	while ( (a = analyzers.NextEntry(c)) )
+	for ( const auto& entry : analyzers )
 		{
+		auto* a = entry.GetValue<file_analysis::Analyzer*>();
+
 		DBG_LOG(DBG_FILE_ANALYSIS, "stream delivery to analyzer %s", file_mgr->GetComponentName(a->Tag()).c_str());
 		if ( ! a->GotStreamDelivery() )
 			{
@@ -497,11 +496,10 @@ void File::DeliverChunk(const u_char* data, uint64_t len, uint64_t offset)
 	        util::fmt_bytes((const char*) data, std::min((uint64_t)40, len)),
 	        len > 40 ? "..." : "");
 
-	file_analysis::Analyzer* a = nullptr;
-	IterCookie* c = analyzers.InitForIteration();
-
-	while ( (a = analyzers.NextEntry(c)) )
+	for ( const auto& entry : analyzers )
 		{
+		auto* a = entry.GetValue<file_analysis::Analyzer*>();
+
 		DBG_LOG(DBG_FILE_ANALYSIS, "chunk delivery to analyzer %s", file_mgr->GetComponentName(a->Tag()).c_str());
 		if ( ! a->Skipping() )
 			{
@@ -561,11 +559,10 @@ void File::EndOfFile()
 
 	done = true;
 
-	file_analysis::Analyzer* a = nullptr;
-	IterCookie* c = analyzers.InitForIteration();
-
-	while ( (a = analyzers.NextEntry(c)) )
+	for ( const auto& entry : analyzers )
 		{
+		auto* a = entry.GetValue<file_analysis::Analyzer*>();
+
 		if ( ! a->EndOfFile() )
 			analyzers.QueueRemove(a->Tag(), a->GetArgs());
 		}
@@ -594,11 +591,10 @@ void File::Gap(uint64_t offset, uint64_t len)
 		DeliverStream((const u_char*) "", 0);
 		}
 
-	file_analysis::Analyzer* a = nullptr;
-	IterCookie* c = analyzers.InitForIteration();
-
-	while ( (a = analyzers.NextEntry(c)) )
+	for ( const auto& entry : analyzers )
 		{
+		auto* a = entry.GetValue<file_analysis::Analyzer*>();
+
 		if ( ! a->Undelivered(offset, len) )
 			analyzers.QueueRemove(a->Tag(), a->GetArgs());
 		}

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -889,17 +889,16 @@ bool Manager::Write(EnumVal* id, RecordVal* columns_arg)
 			info->path = util::copy_string(path.c_str());
 			info->network_time = run_state::network_time;
 
-			zeek::detail::HashKey* k;
-			IterCookie* c = filter->config->AsTable()->InitForIteration();
-
-			TableEntryVal* v;
-			while ( (v = filter->config->AsTable()->NextEntry(k, c)) )
+			auto* filter_config_table = filter->config->AsTable();
+			for ( const auto& fcte : *filter_config_table )
 				{
+				auto k = fcte.GetHashKey();
+				auto* v = fcte.GetValue<TableEntryVal*>();
+
 				auto index = filter->config->RecreateIndex(*k);
 				string key = index->Idx(0)->AsString()->CheckString();
 				string value = v->GetVal()->AsString()->CheckString();
 				info->config.insert(std::make_pair(util::copy_string(key.c_str()), util::copy_string(value.c_str())));
-				delete k;
 				}
 
 			// CreateWriter() will set the other fields in info.

--- a/src/reporter.bif
+++ b/src/reporter.bif
@@ -183,16 +183,14 @@ function Reporter::set_weird_sampling_whitelist%(weird_sampling_whitelist: strin
 	auto wl_table = wl_val->AsTable();
 	std::unordered_set<std::string> whitelist_set;
 
-	zeek::detail::HashKey* k;
-	IterCookie* c = wl_table->InitForIteration();
-	TableEntryVal* v;
-
-	while ( (v = wl_table->NextEntry(k, c)) )
+	for ( const auto& tble : *wl_table )
 		{
+		auto k = tble.GetHashKey();
+		auto* v = tble.GetValue<TableEntryVal*>();
+
 		auto index = wl_val->RecreateIndex(*k);
 		string key = index->Idx(0)->AsString()->CheckString();
 		whitelist_set.emplace(move(key));
-		delete k;
 		}
 	reporter->SetWeirdSamplingWhitelist(std::move(whitelist_set));
 	return zeek::val_mgr->True();
@@ -223,16 +221,12 @@ function Reporter::set_weird_sampling_global_list%(weird_sampling_global_list: s
 	auto wl_table = wl_val->AsTable();
 	std::unordered_set<std::string> global_list_set;
 
-	zeek::detail::HashKey* k;
-	IterCookie* c = wl_table->InitForIteration();
-	TableEntryVal* v;
-
-	while ( (v = wl_table->NextEntry(k, c)) )
+	for ( const auto& tble : *wl_table )
 		{
+		auto k = tble.GetHashKey();
 		auto index = wl_val->RecreateIndex(*k);
 		string key = index->Idx(0)->AsString()->CheckString();
 		global_list_set.emplace(move(key));
-		delete k;
 		}
 	reporter->SetWeirdSamplingGlobalList(std::move(global_list_set));
 	return zeek::val_mgr->True();

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -1261,14 +1261,13 @@ Supervisor::NodeConfig Supervisor::NodeConfig::FromRecord(const RecordVal* node)
 
 	auto cluster_table_val = node->GetField("cluster")->AsTableVal();
 	auto cluster_table = cluster_table_val->AsTable();
-	auto c = cluster_table->InitForIteration();
-	detail::HashKey* k;
-	TableEntryVal* v;
 
-	while ( (v = cluster_table->NextEntry(k, c)) )
+	for ( const auto& cte : *cluster_table )
 		{
+		auto k = cte.GetHashKey();
+		auto* v = cte.GetValue<TableEntryVal*>();
+
 		auto key = cluster_table_val->RecreateIndex(*k);
-		delete k;
 		auto name = key->Idx(0)->AsStringVal()->ToStdString();
 		auto rv = v->GetVal()->AsRecordVal();
 


### PR DESCRIPTION
This PR implements new iterators for the Dictionary and PDict types that allow them to be used in constructs like ranged-for loops and the various STL algorithms. The old IterCookie iterators are marked deprecated and can be removed in v4.1. Support for "robust" iterators remains in the form of a second iterator type called a RobustDictIterator, but it's usage is a little more restricted. Performance between the existing iterators and these new iterators is nearly identical.

Other improvements to Dictionary coming later:

- Support for structured bindings in the iterator types
- Templated Dictionary and DictEntry objects, removing the need to store void pointers.