### PR TITLE
Improve how Zeekygen generated record/enum redefinition docs

### DIFF
--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1271,7 +1271,7 @@ EnumType::~EnumType() = default;
 // location in the error message, rather than the one where the type was
 // originally defined.
 void EnumType::AddName(const string& module_name, const char* name, bool is_export,
-                       detail::Expr* deprecation)
+                       detail::Expr* deprecation, bool from_redef)
 	{
 	/* implicit, auto-increment */
 	if ( counter < 0)
@@ -1280,12 +1280,12 @@ void EnumType::AddName(const string& module_name, const char* name, bool is_expo
 		SetError();
 		return;
 		}
-	CheckAndAddName(module_name, name, counter, is_export, deprecation);
+	CheckAndAddName(module_name, name, counter, is_export, deprecation, from_redef);
 	counter++;
 	}
 
 void EnumType::AddName(const string& module_name, const char* name, bro_int_t val,
-                       bool is_export, detail::Expr* deprecation)
+                       bool is_export, detail::Expr* deprecation, bool from_redef)
 	{
 	/* explicit value specified */
 	if ( counter > 0 )
@@ -1295,11 +1295,12 @@ void EnumType::AddName(const string& module_name, const char* name, bro_int_t va
 		return;
 		}
 	counter = -1;
-	CheckAndAddName(module_name, name, val, is_export, deprecation);
+	CheckAndAddName(module_name, name, val, is_export, deprecation, from_redef);
 	}
 
 void EnumType::CheckAndAddName(const string& module_name, const char* name,
-                               bro_int_t val, bool is_export, detail::Expr* deprecation)
+                               bro_int_t val, bool is_export, detail::Expr* deprecation,
+                               bool from_redef)
 	{
 	if ( Lookup(val) )
 		{
@@ -1320,7 +1321,7 @@ void EnumType::CheckAndAddName(const string& module_name, const char* name,
 		if ( deprecation )
 			id->MakeDeprecated({NewRef{}, deprecation});
 
-		detail::zeekygen_mgr->Identifier(std::move(id));
+		detail::zeekygen_mgr->Identifier(std::move(id), from_redef);
 		}
 	else
 		{

--- a/src/Type.h
+++ b/src/Type.h
@@ -693,12 +693,12 @@ public:
 
 	// The value of this name is next internal counter value, starting
 	// with zero. The internal counter is incremented.
-	void AddName(const std::string& module_name, const char* name, bool is_export, detail::Expr* deprecation = nullptr);
+	void AddName(const std::string& module_name, const char* name, bool is_export, detail::Expr* deprecation = nullptr, bool from_redef = false);
 
 	// The value of this name is set to val. Once a value has been
 	// explicitly assigned using this method, no further names can be
 	// added that aren't likewise explicitly initalized.
-	void AddName(const std::string& module_name, const char* name, bro_int_t val, bool is_export, detail::Expr* deprecation = nullptr);
+	void AddName(const std::string& module_name, const char* name, bro_int_t val, bool is_export, detail::Expr* deprecation = nullptr, bool from_redef = false);
 
 	// -1 indicates not found.
 	bro_int_t Lookup(const std::string& module_name, const char* name) const;
@@ -721,7 +721,8 @@ protected:
 
 	void CheckAndAddName(const std::string& module_name,
 	                     const char* name, bro_int_t val, bool is_export,
-	                     detail::Expr* deprecation = nullptr);
+	                     detail::Expr* deprecation = nullptr,
+	                     bool from_redef = false);
 
 	typedef std::map<std::string, bro_int_t> NameMap;
 	NameMap names;

--- a/src/zeekygen/IdentifierInfo.h
+++ b/src/zeekygen/IdentifierInfo.h
@@ -31,8 +31,11 @@ public:
 	 * @param id The script-level identifier.
 	 * @param script The info object associated with the script in which \a id
 	 * is declared.
+	 * @param from_redef  Whether the identifier was create as part of a
+	 * redefinition (e.g. an enum).
 	 */
-	IdentifierInfo(zeek::detail::IDPtr id, ScriptInfo* script);
+	IdentifierInfo(zeek::detail::IDPtr id, ScriptInfo* script,
+	               bool from_redef = false);
 
 	/**
 	 * Dtor.  Releases any references to script-level objects.
@@ -81,9 +84,10 @@ public:
 	 * @param script The script in which the field was declared.  This may
 	 * differ from the script in which a record type is declared due to redefs.
 	 * @param comments Comments associated with the record field.
+	 * @param from_redef  The field is from a record redefinition.
 	 */
 	void AddRecordField(const TypeDecl* field, const std::string& script,
-	                    std::vector<std::string>& comments);
+	                    std::vector<std::string>& comments, bool from_redef);
 
 	/**
 	 * Signals that a record type has been completely parsed.  This resets
@@ -110,6 +114,19 @@ public:
 	 * @return The script which declared the record field name.
 	 */
 	std::string GetDeclaringScriptForField(const std::string& field) const;
+
+	/**
+	 * @return True if the identifier was created as part of a redefinition
+	 * (e.g. an enum).
+	 */
+	bool IsFromRedef() const
+		{ return from_redef; }
+
+	/**
+	 * @param field A record field name.
+	 * @return True if the field name was added to a record as part of a redef.
+	 */
+	bool FieldIsFromRedef(const std::string& field) const;
 
 	/**
 	 * @return All Zeekygen comments associated with the identifier.
@@ -168,6 +185,7 @@ private:
 		TypeDecl* field;
 		std::string from_script;
 		std::vector<std::string> comments;
+		bool from_redef;
 	};
 
 	typedef std::list<Redefinition*> redef_list;
@@ -180,6 +198,7 @@ private:
 	record_field_map fields;
 	RecordField* last_field_seen;
 	ScriptInfo* declaring_script;
+	bool from_redef = false;
 };
 
 } // namespace zeek::zeekygen::detail

--- a/src/zeekygen/Manager.cc
+++ b/src/zeekygen/Manager.cc
@@ -219,11 +219,12 @@ void Manager::ModuleUsage(const string& path, const string& module)
 	        module.c_str(), name.c_str());
 	}
 
-IdentifierInfo* Manager::CreateIdentifierInfo(zeek::detail::IDPtr id, ScriptInfo* script)
+IdentifierInfo* Manager::CreateIdentifierInfo(zeek::detail::IDPtr id, ScriptInfo* script, bool from_redef)
 	{
 	const auto& id_name = id->Name();
 	auto prev = identifiers.GetInfo(id_name);
-	IdentifierInfo* rval = prev ? prev : new IdentifierInfo(std::move(id), script);
+	IdentifierInfo* rval = prev ? prev : new IdentifierInfo(std::move(id), script,
+	                                                        from_redef);
 
 	rval->AddComments(comment_buffer);
 	comment_buffer.clear();
@@ -281,7 +282,7 @@ static bool IsEnumType(zeek::detail::ID* id)
 	return id->IsType() ? id->GetType()->Tag() == TYPE_ENUM : false;
 	}
 
-void Manager::Identifier(zeek::detail::IDPtr id)
+void Manager::Identifier(zeek::detail::IDPtr id, bool from_redef)
 	{
 	if ( disabled )
 		return;
@@ -322,7 +323,7 @@ void Manager::Identifier(zeek::detail::IDPtr id)
 		// Handled specially since they don't have a script location.
 		DBG_LOG(DBG_ZEEKYGEN, "Made internal IdentifierInfo %s",
 		        id->Name());
-		CreateIdentifierInfo(id, nullptr);
+		CreateIdentifierInfo(id, nullptr, from_redef);
 		return;
 		}
 
@@ -337,11 +338,11 @@ void Manager::Identifier(zeek::detail::IDPtr id)
 
 	DBG_LOG(DBG_ZEEKYGEN, "Making IdentifierInfo %s, in script %s",
 	        id->Name(), script.c_str());
-	CreateIdentifierInfo(std::move(id), script_info);
+	CreateIdentifierInfo(std::move(id), script_info, from_redef);
 	}
 
 void Manager::RecordField(const zeek::detail::ID* id, const TypeDecl* field,
-                          const string& path)
+                          const string& path, bool from_redef)
 	{
 	if ( disabled )
 		return;
@@ -357,7 +358,7 @@ void Manager::RecordField(const zeek::detail::ID* id, const TypeDecl* field,
 		}
 
 	string script = NormalizeScriptPath(path);
-	idd->AddRecordField(field, script, comment_buffer);
+	idd->AddRecordField(field, script, comment_buffer, from_redef);
 	comment_buffer.clear();
 	DBG_LOG(DBG_ZEEKYGEN, "Document record field %s, identifier %s, script %s",
 	        field->id, id->Name(), script.c_str());

--- a/src/zeekygen/Manager.h
+++ b/src/zeekygen/Manager.h
@@ -115,8 +115,9 @@ public:
 	 * Register a script-level identifier for which information/documentation
 	 * will be gathered.
 	 * @param id The script-level identifier.
+	 * @param from_redef  The identifier was created from a redef (e.g. an enum).
 	 */
-	void Identifier(zeek::detail::IDPtr id);
+	void Identifier(zeek::detail::IDPtr id, bool from_redef = false);
 
 	/**
 	 * Register a record-field for which information/documentation will be
@@ -126,9 +127,10 @@ public:
 	 * @param path Absolute path to a Bro script in which this field is
 	 * declared.  This can be different from the place where the record type
 	 * is declared due to redefs.
+	 * @param from_redef  The field is from a record redefinition.
 	 */
 	void RecordField(const zeek::detail::ID* id, const TypeDecl* field,
-	                 const std::string& path);
+	                 const std::string& path, bool from_redef);
 
 	/**
 	 * Register a redefinition of a particular identifier.
@@ -216,7 +218,8 @@ private:
 	typedef std::vector<std::string> comment_buffer_t;
 	typedef std::map<std::string, comment_buffer_t> comment_buffer_map_t;
 
-	IdentifierInfo* CreateIdentifierInfo(zeek::detail::IDPtr id, ScriptInfo* script);
+	IdentifierInfo* CreateIdentifierInfo(zeek::detail::IDPtr id, ScriptInfo* script,
+	                                     bool from_redef = false);
 
 	bool disabled;
 	comment_buffer_t comment_buffer; // For whatever next identifier comes in.

--- a/testing/btest/Baseline/doc.zeekygen.example/example.rst
+++ b/testing/btest/Baseline/doc.zeekygen.example/example.rst
@@ -57,13 +57,40 @@ Types
 
 Redefinitions
 #############
-=============================================================== ====================================================================
+=============================================================== =====================================================================
 :zeek:type:`Log::ID`: :zeek:type:`enum`                         
+                                                                
+                                                                * :zeek:enum:`ZeekygenExample::LOG`
 :zeek:type:`Notice::Type`: :zeek:type:`enum`                    
+                                                                
+                                                                * :zeek:enum:`ZeekygenExample::Zeekygen_Four`:
+                                                                  Omitting comments is fine, and so is mixing ``##`` and ``##<``, but
+                                                                  it's probably best to use only one style consistently.
+                                                                
+                                                                * :zeek:enum:`ZeekygenExample::Zeekygen_One`:
+                                                                  Any number of this type of comment
+                                                                  will document "Zeekygen_One".
+                                                                
+                                                                * :zeek:enum:`ZeekygenExample::Zeekygen_Three`
+                                                                
+                                                                * :zeek:enum:`ZeekygenExample::Zeekygen_Two`:
+                                                                  Any number of this type of comment
+                                                                  will document "ZEEKYGEN_TWO".
 :zeek:type:`ZeekygenExample::SimpleEnum`: :zeek:type:`enum`     Document the "SimpleEnum" redef here with any special info regarding
                                                                 the *redef* itself.
+                                                                
+                                                                * :zeek:enum:`ZeekygenExample::FIVE`:
+                                                                  Also "FIVE".
+                                                                
+                                                                * :zeek:enum:`ZeekygenExample::FOUR`:
+                                                                  And some documentation for "FOUR".
 :zeek:type:`ZeekygenExample::SimpleRecord`: :zeek:type:`record` Document the record extension *redef* itself here.
-=============================================================== ====================================================================
+                                                                
+                                                                :New Fields: :zeek:type:`ZeekygenExample::SimpleRecord`
+                                                                
+                                                                  field_ext: :zeek:type:`string` :zeek:attr:`&optional`
+                                                                    Document the extending field like this.
+=============================================================== =====================================================================
 
 Events
 ######


### PR DESCRIPTION
It now provides a summary of the new fields/enums added by any given
redefinition along with associated commentary.

Here's what some docs looked like before:

![Screen Shot 2020-10-19 at 6 37 19 PM](https://user-images.githubusercontent.com/422685/96529595-711c1100-123a-11eb-884d-186d954e30b5.png)

After this patch:

![Screen Shot 2020-10-19 at 6 39 06 PM](https://user-images.githubusercontent.com/422685/96529604-77aa8880-123a-11eb-91e8-fdea52e4523d.png)
