### PR TITLE
Update pubkey-hashes.zeek

### DIFF
--- a/scripts/policy/frameworks/intel/seen/pubkey-hashes.zeek
+++ b/scripts/policy/frameworks/intel/seen/pubkey-hashes.zeek
@@ -10,3 +10,12 @@ event ssh_server_host_key(c: connection, hash: string)
 				 $where=SSH::IN_SERVER_HOST_KEY);
 	Intel::seen(seen);
 	}
+
+event ssh2_server_host_key(c: connection, key: string)
+        {
+        local seen = Intel::Seen($indicator=md5_hash(key),
+                                 $indicator_type=Intel::PUBKEY_HASH,
+                                 $conn=c,
+                                 $where=SSH::IN_SERVER_HOST_KEY);
+        Intel::seen(seen);
+        }


### PR DESCRIPTION
Add intel framework support for SSH2 host keys.