### PR TITLE
Improved regex for SMTP parsing

### DIFF
--- a/scripts/base/utils/email.zeek
+++ b/scripts/base/utils/email.zeek
@@ -59,7 +59,7 @@ function split_mime_email_addresses(line: string): set[string]
 	{
 	local output = string_set();
 
-	local addrs = find_all(line, /(\"[^"]*\")?[^,]+/);
+	local addrs = find_all(line, /(\"[^"]*\")?[^,]+@[^,]+/);
 	for ( part in addrs )
 		{
 		add output[strip(part)];

--- a/testing/btest/Baseline/scripts.base.utils.email/output
+++ b/testing/btest/Baseline/scripts.base.utils.email/output
@@ -19,3 +19,9 @@ three@example.com,
 one@example.com,
 two@example.com
 }
+john.smith@email.com
+[john.smith@email.com, jane.doe@email.com]
+{
+john.smith@email.com
+jane.doe@email.com
+}

--- a/testing/btest/scripts/base/utils/email.zeek
+++ b/testing/btest/scripts/base/utils/email.zeek
@@ -15,3 +15,7 @@ s = "ieje one@example.com, eifj two@example.com, asdf three@example.com, one@exa
 print extract_first_email_addr(s);
 print extract_email_addrs_vec(s);
 print extract_email_addrs_set(s);
+s = "\"Smith, John\" <john.smith@email.com>, \"Doe, Jane\" <jane.doe@email.com>";
+print extract_first_email_addr(s);
+print extract_email_addrs_vec(s);
+print extract_email_addrs_set(s);


### PR DESCRIPTION
Hi, We are requesting this change in an effort to improve the SMTP (i.e., email) parsing for the function split_mime_email_addresses in zeek/scripts/base/utils/email.zeek. Although the regex isn't RFC compliant, this is a simple improvement for a very common case for email parsing, compared to the existing regex.

A quick example of what our regex improvement does differently:
**Current State:**
{
Jane” <jone.doe@blah.com>,
“ Doe,
}
{
“Smith, John” <john.smith@blah.com>
}
 
**Post-Change:**
{
“Smith, John” <john.smith@blah.com>,
“Doe, Jane” <jone.doe@blah.com>
}

Please let us know if you have any questions. We have also summed up everything here for added reference: 
[Zeek Regex SMTP Improvement.pdf](https://github.com/zeek/zeek/files/5466744/Zeek.Regex.SMTP.Improvement.pdf)