### PR TITLE
Add CI support for Fedora 31 & 33, FreeBSD 11, Ubuntu 20.04

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,6 +73,13 @@ env:
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
+fedora33_task:
+  container:
+    # Fedora 33 EOL: Around November 2022
+    dockerfile: ci/fedora-33/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
 fedora32_task:
   container:
     # Fedora 32 EOL: Around May 2021
@@ -80,10 +87,10 @@ fedora32_task:
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
-centos7_task:
+fedora31_task:
   container:
-    # CentOS 7 EOL: June 30, 2024
-    dockerfile: ci/centos-7/Dockerfile
+    # Fedora 31 EOL: Nov 24 2021
+    dockerfile: ci/fedora-31/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
@@ -99,6 +106,20 @@ centos8_task:
     path: build.tgz
   benchmark_script: ./ci/benchmark.sh
 
+centos7_task:
+  container:
+    # CentOS 7 EOL: June 30, 2024
+    dockerfile: ci/centos-7/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
+debian10_task:
+  container:
+    # Debian 10 EOL: June 2024
+    dockerfile: ci/debian-10/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
 debian9_task:
   container:
     # Debian 9 EOL: June 2022
@@ -110,6 +131,13 @@ debian9_32bit_task:
   container:
     # Debian 9 EOL: June 2022
     dockerfile: ci/debian-9-32bit/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
+ubuntu20_task:
+  container:
+    # Ubuntu 20.04 EOL: April 2025
+    dockerfile: ci/ubuntu-20.04/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
@@ -144,10 +172,20 @@ macos_task:
     CIRRUS_WORKING_DIR: /tmp/zeek
 
 # FreeBSD EOL timelines: https://www.freebsd.org/security/security.html#sup
-freebsd_task:
+freebsd12_task:
   freebsd_instance:
     # FreeBSD 12 EOL: June 30, 2024
-    image_family: freebsd-12-1
+    image_family: freebsd-12-2
+    cpu: 8
+    # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
+    memory: 8GB
+  prepare_script: ./ci/freebsd/prepare.sh
+  << : *CI_TEMPLATE
+
+freebsd11_task:
+  freebsd_instance:
+    # FreeBSD 11 EOL: September 30, 2021
+    image_family: freebsd-11-4
     cpu: 8
     # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
     memory: 8GB

--- a/ci/debian-10/Dockerfile
+++ b/ci/debian-10/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM debian:10
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
@@ -23,13 +23,13 @@ RUN apt-get update && apt-get -y install \
     curl \
     wget \
     xz-utils \
+    clang \
+    libc++-7-dev \
+    libc++abi-7-dev \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget -q https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-RUN mkdir /clang-9
-RUN tar --strip-components=1 -C /clang-9 -xvf clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-RUN update-alternatives --install /usr/bin/cc cc /clang-9/bin/clang 100
-RUN update-alternatives --install /usr/bin/c++ c++ /clang-9/bin/clang++ 100
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 
 # Many distros adhere to PEP 394's recommendation for `python` = `python2` so
 # this is a simple workaround until we drop Python 2 support and explicitly
@@ -40,4 +40,3 @@ RUN ln -sf /usr/bin/pip3 /usr/local/bin/pip
 RUN pip install junit2html
 
 ENV CXXFLAGS=-stdlib=libc++
-ENV LD_LIBRARY_PATH=/clang-9/lib

--- a/ci/debian-9-32bit/Dockerfile
+++ b/ci/debian-9-32bit/Dockerfile
@@ -1,5 +1,7 @@
 FROM i386/debian:9
 
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
 RUN apt-get update && apt-get -y install \
     git \
     cmake \

--- a/ci/debian-9/Dockerfile
+++ b/ci/debian-9/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:9
 
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
 RUN apt-get update && apt-get -y install \
     git \
     cmake \

--- a/ci/fedora-31/Dockerfile
+++ b/ci/fedora-31/Dockerfile
@@ -1,0 +1,31 @@
+FROM fedora:31
+
+RUN yum -y install \
+    bison \
+    cmake \
+    diffutils \
+    findutils \
+    flex \
+    git \
+    gcc \
+    gcc-c++ \
+    libpcap-devel \
+    make \
+    openssl \
+    openssl-devel \
+    python3 \
+    python3-devel \
+    python3-pip\
+    sqlite \
+    swig \
+    which \
+    zlib-devel \
+  && yum clean all && rm -rf /var/cache/yum
+
+# Many distros adhere to PEP 394's recommendation for `python` = `python2` so
+# this is a simple workaround until we drop Python 2 support and explicitly
+# use `python3` for all invocations (e.g. in shebangs).
+RUN ln -sf /usr/bin/python3 /usr/local/bin/python
+RUN ln -sf /usr/bin/pip3 /usr/local/bin/pip
+
+RUN pip install junit2html

--- a/ci/fedora-33/Dockerfile
+++ b/ci/fedora-33/Dockerfile
@@ -1,0 +1,31 @@
+FROM fedora:33
+
+RUN yum -y install \
+    bison \
+    cmake \
+    diffutils \
+    findutils \
+    flex \
+    git \
+    gcc \
+    gcc-c++ \
+    libpcap-devel \
+    make \
+    openssl \
+    openssl-devel \
+    python3 \
+    python3-devel \
+    python3-pip\
+    sqlite \
+    swig \
+    which \
+    zlib-devel \
+  && yum clean all && rm -rf /var/cache/yum
+
+# Many distros adhere to PEP 394's recommendation for `python` = `python2` so
+# this is a simple workaround until we drop Python 2 support and explicitly
+# use `python3` for all invocations (e.g. in shebangs).
+RUN ln -sf /usr/bin/python3 /usr/local/bin/python
+RUN ln -sf /usr/bin/pip3 /usr/local/bin/pip
+
+RUN pip install junit2html

--- a/ci/ubuntu-18.04/Dockerfile
+++ b/ci/ubuntu-18.04/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
 RUN apt-get update && apt-get -y install \
     git \
     cmake \

--- a/ci/ubuntu-20.04/Dockerfile
+++ b/ci/ubuntu-20.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
@@ -17,19 +17,17 @@ RUN apt-get update && apt-get -y install \
     python3-pip\
     swig \
     zlib1g-dev \
+    libmaxminddb-dev \
     libkrb5-dev \
     bsdmainutils \
     sqlite3 \
     curl \
     wget \
-    xz-utils \
+    unzip \
+    ruby \
+    bc \
+    lcov \
   && rm -rf /var/lib/apt/lists/*
-
-RUN wget -q https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-RUN mkdir /clang-9
-RUN tar --strip-components=1 -C /clang-9 -xvf clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-RUN update-alternatives --install /usr/bin/cc cc /clang-9/bin/clang 100
-RUN update-alternatives --install /usr/bin/c++ c++ /clang-9/bin/clang++ 100
 
 # Many distros adhere to PEP 394's recommendation for `python` = `python2` so
 # this is a simple workaround until we drop Python 2 support and explicitly
@@ -38,6 +36,4 @@ RUN ln -sf /usr/bin/python3 /usr/local/bin/python
 RUN ln -sf /usr/bin/pip3 /usr/local/bin/pip
 
 RUN pip install junit2html
-
-ENV CXXFLAGS=-stdlib=libc++
-ENV LD_LIBRARY_PATH=/clang-9/lib
+RUN gem install coveralls-lcov


### PR DESCRIPTION
The context for this PR is our [platform support policy](https://github.com/zeek/zeek/wiki/Platform-Support-Policy) discussion. It brings the current CI setups in line with what's mentioned on that page.