### PR TITLE
Fix LogAscii::enable_leftover_log_rotation crash in bad dirs

### DIFF
--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -710,6 +710,21 @@ static std::vector<LeftoverLog> find_leftover_logs()
 	auto d = opendir(".");
 	struct dirent* dp;
 
+	if ( ! d )
+		{
+		char cwd[PATH_MAX];
+
+		if ( ! getcwd(cwd, sizeof(cwd)) )
+			{
+			cwd[0] = '.';
+			cwd[1] = '\0';
+			}
+
+		reporter->Error("failed to open directory '%s' in search of leftover logs: %s",
+		                cwd, strerror(errno));
+		return rval;
+		}
+
 	while ( (dp = readdir(d)) )
 		{
 		if ( strncmp(dp->d_name, shadow_file_prefix, prefix_len) != 0 )


### PR DESCRIPTION
Running with that option enabled inside a bad directory (e.g. lack of
permissions) crashed due to not checking for failure of opendir().

Fixes GH-1269