### PR TITLE
proof-of-principle shift of double_val out of BroValUnion

### DIFF
--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -101,7 +101,7 @@ char* CompositeHash::SingleValHash(bool type_check, char* kp0,
 	case TYPE_INTERNAL_INT:
 		{
 		bro_int_t* kp = AlignAndPadType<bro_int_t>(kp0);
-		*kp = v->ForceAsInt();
+		*kp = v->AsInt();
 		kp1 = reinterpret_cast<char*>(kp+1);
 		}
 		break;
@@ -109,7 +109,7 @@ char* CompositeHash::SingleValHash(bool type_check, char* kp0,
 	case TYPE_INTERNAL_UNSIGNED:
 		{
 		bro_uint_t* kp = AlignAndPadType<bro_uint_t>(kp0);
-		*kp = v->ForceAsUInt();
+		*kp = v->AsCount();
 		kp1 = reinterpret_cast<char*>(kp+1);
 		}
 		break;
@@ -407,8 +407,10 @@ std::unique_ptr<HashKey> CompositeHash::ComputeSingletonHash(const Val* v, bool 
 
 	switch ( singleton_tag ) {
 	case TYPE_INTERNAL_INT:
+		return std::make_unique<HashKey>(v->AsInt());
+
 	case TYPE_INTERNAL_UNSIGNED:
-		return std::make_unique<HashKey>(v->ForceAsInt());
+		return std::make_unique<HashKey>(v->AsCount());
 
 	case TYPE_INTERNAL_ADDR:
 		return v->AsAddr().MakeHashKey();

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -855,7 +855,7 @@ const char* CompositeHash::RecoverOneVal(
 			if ( ! f )
 				reporter->InternalError("failed to look up unique function id %" PRIu32 " in CompositeHash::RecoverOneVal()", *kp);
 
-			*pval = make_intrusive<Val>(f);
+			*pval = make_intrusive<FuncVal>(f);
 			const auto& pvt = (*pval)->GetType();
 
 			if ( ! pvt )

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -432,7 +432,7 @@ void Connection::AppendAddl(const char* str)
 	{
 	const auto& cv = ConnVal();
 
-	const char* old = cv->GetField(6)->AsString()->CheckString();
+	const char* old = cv->GetStringField(6)->CheckString();
 	const char* format = *old ? "%s %s" : "%s%s";
 
 	cv->Assign(6, make_intrusive<StringVal>(util::fmt(format, old, str)));

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -1815,7 +1815,7 @@ ValPtr EqExpr::Fold(Val* v1, Val* v2) const
 	{
 	if ( op1->GetType()->Tag() == TYPE_PATTERN )
 		{
-		RE_Matcher* re = v1->AsPattern();
+		auto re = dynamic_cast<PatternVal*>(v1);
 		const String* s = v2->AsString();
 		if ( tag == EXPR_EQ )
 			return val_mgr->Bool(re->MatchExactly(s));
@@ -4074,7 +4074,7 @@ ValPtr InExpr::Fold(Val* v1, Val* v2) const
 	{
 	if ( v1->GetType()->Tag() == TYPE_PATTERN )
 		{
-		RE_Matcher* re = v1->AsPattern();
+		auto re = dynamic_cast<PatternVal*>(v1);
 		const String* s = v2->AsString();
 		return val_mgr->Bool(re->MatchAnywhere(s) != 0);
 		}

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -4333,7 +4333,7 @@ LambdaExpr::LambdaExpr(std::unique_ptr<function_ingredients> arg_ing,
 	// Update lamb's name
 	dummy_func->SetName(my_name.c_str());
 
-	auto v = make_intrusive<Val>(std::move(dummy_func));
+	auto v = make_intrusive<FuncVal>(std::move(dummy_func));
 	id->SetVal(std::move(v));
 	id->SetType(ingredients->id->GetType());
 	id->SetConst();
@@ -4359,7 +4359,7 @@ ValPtr LambdaExpr::Eval(Frame* f) const
 	// Allows for lookups by the receiver.
 	lamb->SetName(my_name.c_str());
 
-	return make_intrusive<Val>(std::move(lamb));
+	return make_intrusive<FuncVal>(std::move(lamb));
 	}
 
 void LambdaExpr::ExprDescribe(ODesc* d) const

--- a/src/File.cc
+++ b/src/File.cc
@@ -331,7 +331,7 @@ void File::RaiseOpenEvent()
 		return;
 
 	FilePtr bf{NewRef{}, this};
-	auto* event = new Event(::file_opened, {make_intrusive<Val>(std::move(bf))});
+	auto* event = new Event(::file_opened, {make_intrusive<FileVal>(std::move(bf))});
 	event_mgr.Dispatch(event, true);
 	}
 

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -626,7 +626,7 @@ BuiltinFunc::BuiltinFunc(built_in_func arg_func, const char* arg_name,
 		reporter->InternalError("built-in function %s multiply defined", Name());
 
 	type = id->GetType<FuncType>();
-	id->SetVal(make_intrusive<Val>(IntrusivePtr{NewRef{}, this}));
+	id->SetVal(make_intrusive<FuncVal>(IntrusivePtr{NewRef{}, this}));
 	}
 
 BuiltinFunc::~BuiltinFunc()

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -87,7 +87,7 @@ FuncPtr id::find_func(std::string_view name)
 		reporter->InternalError("Expected variable '%s' to be a function",
 		                              std::string(name).data());
 
-	return v->AsFuncPtr();
+	return dynamic_cast<FuncVal*>(v.get())->AsFuncPtr();
 	}
 
 void id::detail::init_types()
@@ -162,17 +162,18 @@ void ID::SetVal(ValPtr v)
 	     type->AsFuncType()->Flavor() == FUNC_FLAVOR_EVENT )
 		{
 		EventHandler* handler = event_registry->Lookup(name);
+		auto func = dynamic_cast<FuncVal*>(val.get())->AsFuncPtr();
 		if ( ! handler )
 			{
 			handler = new EventHandler(name);
-			handler->SetFunc(val->AsFuncPtr());
+			handler->SetFunc(func);
 			event_registry->Register(handler);
 			}
 		else
 			{
 			// Otherwise, internally defined events cannot
 			// have local handler.
-			handler->SetFunc(val->AsFuncPtr());
+			handler->SetFunc(func);
 			}
 		}
 	}

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -369,11 +369,11 @@ bool Reporter::PermitFlowWeird(const char* name,
 
 bool Reporter::PermitExpiredConnWeird(const char* name, const RecordVal& conn_id)
 	{
-	auto conn_tuple = std::make_tuple(conn_id.GetField("orig_h")->AsAddr(),
-	                                  conn_id.GetField("resp_h")->AsAddr(),
-	                                  conn_id.GetField("orig_p")->AsPortVal()->Port(),
-	                                  conn_id.GetField("resp_p")->AsPortVal()->Port(),
-	                                  conn_id.GetField("resp_p")->AsPortVal()->PortType());
+	auto conn_tuple = std::make_tuple(conn_id.GetAddrField("orig_h"),
+	                                  conn_id.GetAddrField("resp_h"),
+	                                  conn_id.GetPortValField("orig_p")->Port(),
+	                                  conn_id.GetPortValField("resp_p")->Port(),
+	                                  conn_id.GetPortValField("resp_p")->PortType());
 
 	auto& map = expired_conn_weird_state[conn_tuple];
 

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -328,7 +328,7 @@ Connection* NetSessions::FindConnection(Val* v)
 		return nullptr;
 
 	RecordType* vr = vt->AsRecordType();
-	auto vl = v->AsRecord();
+	auto vl = dynamic_cast<RecordVal*>(v);
 
 	int orig_h, orig_p;	// indices into record's value list
 	int resp_h, resp_p;
@@ -356,11 +356,11 @@ Connection* NetSessions::FindConnection(Val* v)
 		// types, too.
 		}
 
-	const IPAddr& orig_addr = (*vl)[orig_h]->AsAddr();
-	const IPAddr& resp_addr = (*vl)[resp_h]->AsAddr();
+	const IPAddr& orig_addr = vl->GetField(orig_h)->AsAddr();
+	const IPAddr& resp_addr = vl->GetField(resp_h)->AsAddr();
 
-	PortVal* orig_portv = (*vl)[orig_p]->AsPortVal();
-	PortVal* resp_portv = (*vl)[resp_p]->AsPortVal();
+	PortVal* orig_portv = vl->GetField(orig_p)->AsPortVal();
+	PortVal* resp_portv = vl->GetField(resp_p)->AsPortVal();
 
 	ConnID id;
 

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -356,11 +356,11 @@ Connection* NetSessions::FindConnection(Val* v)
 		// types, too.
 		}
 
-	const IPAddr& orig_addr = vl->GetField(orig_h)->AsAddr();
-	const IPAddr& resp_addr = vl->GetField(resp_h)->AsAddr();
+	const IPAddr& orig_addr = vl->GetAddrField(orig_h);
+	const IPAddr& resp_addr = vl->GetAddrField(resp_h);
 
-	PortVal* orig_portv = vl->GetField(orig_p)->AsPortVal();
-	PortVal* resp_portv = vl->GetField(resp_p)->AsPortVal();
+	const PortVal* orig_portv = vl->GetPortValField(orig_p);
+	const PortVal* resp_portv = vl->GetPortValField(resp_p);
 
 	ConnID id;
 

--- a/src/SmithWaterman.cc
+++ b/src/SmithWaterman.cc
@@ -109,19 +109,19 @@ Substring::Vec* Substring::VecFromPolicy(VectorVal* vec)
 		if ( ! v )
 			continue;
 
-		const String* str = v->AsRecordVal()->GetField(0)->AsString();
+		const String* str = v->AsRecordVal()->GetStringField(0);
 		auto* substr = new Substring(*str);
 
 		const VectorVal* aligns = v->AsRecordVal()->GetField(1)->AsVectorVal();
 		for ( unsigned int j = 1; j <= aligns->Size(); ++j )
 			{
 			const RecordVal* align = aligns->AsVectorVal()->At(j)->AsRecordVal();
-			const String* str = align->GetField(0)->AsString();
-			int index = align->GetField(1)->AsCount();
+			const String* str = align->GetStringField(0);
+			int index = align->GetCountField(1);
 			substr->AddAlignment(str, index);
 			}
 
-		bool new_alignment = v->AsRecordVal()->GetField(2)->AsBool();
+		bool new_alignment = v->AsRecordVal()->GetBoolField(2);
 		substr->MarkNewAlignment(new_alignment);
 
 		result->push_back(substr);

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -323,7 +323,7 @@ void ProfileLogger::Log()
 	if ( profiling_update )
 		{
 		event_mgr.Dispatch(new Event(profiling_update, {
-					make_intrusive<Val>(IntrusivePtr{NewRef{}, file}),
+					make_intrusive<FileVal>(IntrusivePtr{NewRef{}, file}),
 					val_mgr->Bool(expensive),
 					}));
 		}

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1128,7 +1128,7 @@ ValPtr StringVal::DoClone(CloneState* state)
 	                   string_val->Len(), true)));
 	}
 
-FuncVal::FuncVal(FuncPtr f) : Val(base_type(TYPE_FUNC))
+FuncVal::FuncVal(FuncPtr f) : Val(f->GetType())
 	{
 	func_val = std::move(f);
 	}

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -198,7 +198,7 @@ bool Val::IsZero() const
 	switch ( type->InternalType() ) {
 	case TYPE_INTERNAL_INT:		return val.int_val == 0;
 	case TYPE_INTERNAL_UNSIGNED:	return val.uint_val == 0;
-	case TYPE_INTERNAL_DOUBLE:	return val.double_val == 0.0;
+	case TYPE_INTERNAL_DOUBLE:	return AsDouble() == 0.0;
 
 	default:			return false;
 	}
@@ -209,7 +209,7 @@ bool Val::IsOne() const
 	switch ( type->InternalType() ) {
 	case TYPE_INTERNAL_INT:		return val.int_val == 1;
 	case TYPE_INTERNAL_UNSIGNED:	return val.uint_val == 1;
-	case TYPE_INTERNAL_DOUBLE:	return val.double_val == 1.0;
+	case TYPE_INTERNAL_DOUBLE:	return AsDouble() == 1.0;
 
 	default:			return false;
 	}
@@ -241,7 +241,7 @@ bro_uint_t Val::InternalUnsigned() const
 double Val::InternalDouble() const
 	{
 	if ( type->InternalType() == TYPE_INTERNAL_DOUBLE )
-		return val.double_val;
+		return AsDouble();
 	else
 		InternalWarning("bad request for InternalDouble");
 
@@ -255,7 +255,7 @@ bro_int_t Val::CoerceToInt() const
 	else if ( type->InternalType() == TYPE_INTERNAL_UNSIGNED )
 		return static_cast<bro_int_t>(val.uint_val);
 	else if ( type->InternalType() == TYPE_INTERNAL_DOUBLE )
-		return static_cast<bro_int_t>(val.double_val);
+		return static_cast<bro_int_t>(AsDouble());
 	else
 		InternalWarning("bad request for CoerceToInt");
 
@@ -269,7 +269,7 @@ bro_uint_t Val::CoerceToUnsigned() const
 	else if ( type->InternalType() == TYPE_INTERNAL_INT )
 		return static_cast<bro_uint_t>(val.int_val);
 	else if ( type->InternalType() == TYPE_INTERNAL_DOUBLE )
-		return static_cast<bro_uint_t>(val.double_val);
+		return static_cast<bro_uint_t>(AsDouble());
 	else
 		InternalWarning("bad request for CoerceToUnsigned");
 
@@ -279,7 +279,7 @@ bro_uint_t Val::CoerceToUnsigned() const
 double Val::CoerceToDouble() const
 	{
 	if ( type->InternalType() == TYPE_INTERNAL_DOUBLE )
-		return val.double_val;
+		return AsDouble();
 	else if ( type->InternalType() == TYPE_INTERNAL_INT )
 		return static_cast<double>(val.int_val);
 	else if ( type->InternalType() == TYPE_INTERNAL_UNSIGNED )
@@ -305,7 +305,7 @@ ValPtr Val::SizeVal() const
 		return val_mgr->Count(val.uint_val);
 
 	case TYPE_INTERNAL_DOUBLE:
-		return make_intrusive<DoubleVal>(fabs(val.double_val));
+		return make_intrusive<DoubleVal>(fabs(AsDouble()));
 
 	case TYPE_INTERNAL_OTHER:
 		if ( type->Tag() == TYPE_FUNC )
@@ -366,7 +366,7 @@ void Val::ValDescribe(ODesc* d) const
 	switch ( type->InternalType() ) {
 	case TYPE_INTERNAL_INT:		d->Add(val.int_val); break;
 	case TYPE_INTERNAL_UNSIGNED:	d->Add(val.uint_val); break;
-	case TYPE_INTERNAL_DOUBLE:	d->Add(val.double_val); break;
+	case TYPE_INTERNAL_DOUBLE:	d->Add(AsDouble()); break;
 	case TYPE_INTERNAL_STRING:	d->AddBytes(val.string_val); break;
 	case TYPE_INTERNAL_ADDR:	d->Add(val.addr_val->AsString().c_str()); break;
 
@@ -710,7 +710,7 @@ void IntervalVal::ValDescribe(ODesc* d) const
 		unit_word{ Microseconds, "usec" },
 	};
 
-	double v = val.double_val;
+	double v = AsDouble();
 
 	if ( v == 0.0 )
 		{

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -46,24 +46,6 @@ using namespace std;
 
 namespace zeek {
 
-#ifdef DEPRECATED
-Val::Val(Func* f) : Val({NewRef{}, f})
-	{}
-
-Val::Val(FuncPtr f)
-	: val(f.release()), type(val.func_val->GetType())
-	{}
-
-Val::Val(File* f) : Val({AdoptRef{}, f})
-	{}
-
-Val::Val(FilePtr f)
-	: val(f.release()), type(GetStringFileType())
-	{
-	assert(val.file_val->GetType()->Tag() == TYPE_STRING);
-	}
-#endif
-
 Val::~Val()
 	{
 #ifdef DEBUG

--- a/src/Val.h
+++ b/src/Val.h
@@ -109,10 +109,7 @@ union BroValUnion {
 	String* string_val;
 	RE_Matcher* re_val;
 	Func* func_val;
-#endif
 	File* file_val;
-
-#ifdef DEPRECATED
 	PDict<TableEntryVal>* table_val;
 	std::vector<ValPtr>* record_val;
 	std::vector<ValPtr>* vector_val;
@@ -144,12 +141,10 @@ union BroValUnion {
 
 	constexpr BroValUnion(Func* value) noexcept
 		: func_val(value) {}
-#endif
 
 	constexpr BroValUnion(File* value) noexcept
 		: file_val(value) {}
 
-#ifdef DEPRECATED
 	constexpr BroValUnion(PDict<TableEntryVal>* value) noexcept
 		: table_val(value) {}
 #endif
@@ -168,13 +163,13 @@ public:
 	[[deprecated("Remove in v4.1.  Construct from IntrusivePtr instead.")]]
 	explicit Val(Func* f);
 	explicit Val(FuncPtr f);
-#endif
 
 	[[deprecated("Remove in v4.1.  Construct from IntrusivePtr instead.")]]
 	explicit Val(File* f);
 	// Note, the file will be closed after this Val is destructed if there's
 	// no other remaining references.
 	explicit Val(FilePtr f);
+#endif
 
 	// Extra arg to differentiate from protected version.
 	Val(TypePtr t, bool type_type)
@@ -252,7 +247,6 @@ public:
 	CONST_ACCESSOR2(TYPE_INT, bro_int_t, int_val, AsInt)
 	CONST_ACCESSOR2(TYPE_COUNT, bro_uint_t, uint_val, AsCount)
 	CONST_ACCESSOR2(TYPE_ENUM, int, int_val, AsEnum)
-	CONST_ACCESSOR(TYPE_FILE, File*, file_val, AsFile)
 
 #define UNDERLYING_ACCESSOR_DECL(ztype, ctype, name) \
 	ctype name() const;
@@ -264,7 +258,7 @@ UNDERLYING_ACCESSOR_DECL(AddrVal, const IPAddr&, AsAddr)
 UNDERLYING_ACCESSOR_DECL(SubNetVal, const IPPrefix&, AsSubNet)
 UNDERLYING_ACCESSOR_DECL(StringVal, const String*, AsString)
 UNDERLYING_ACCESSOR_DECL(FuncVal, Func*, AsFunc)
-// UNDERLYING_ACCESSOR_DECL(FileVal, File*, AsFile)
+UNDERLYING_ACCESSOR_DECL(FileVal, File*, AsFile)
 UNDERLYING_ACCESSOR_DECL(PatternVal, const RE_Matcher*, AsPattern)
 UNDERLYING_ACCESSOR_DECL(TableVal, const PDict<TableEntryVal>*, AsTable)
 
@@ -280,10 +274,6 @@ UNDERLYING_ACCESSOR_DECL(TableVal, const PDict<TableEntryVal>*, AsTable)
 		CHECK_TAG(type->Tag(), tag, "Val::ACCESSOR", type_name) \
 		return val.accessor; \
 		}
-
-	// Accessors for mutable values are called AsNonConst* and
-	// are protected to avoid external state changes.
-	ACCESSOR(TYPE_FILE, File*, file_val, AsFile)
 
 	// Gives fast access to the bits of something that is one of
 	// bool, int, count, or counter.
@@ -663,7 +653,6 @@ private:
 class FuncVal final : public Val {
 public:
 	explicit FuncVal(FuncPtr f);
-	~FuncVal() override;
 
 	FuncPtr AsFuncPtr() const;
 
@@ -677,6 +666,22 @@ protected:
 
 private:
 	FuncPtr func_val;
+};
+
+class FileVal final : public Val {
+public:
+	explicit FileVal(FilePtr f);
+
+	ValPtr SizeVal() const override;
+
+	File* UnderlyingVal() const	{ return file_val.get(); }
+
+protected:
+	void ValDescribe(ODesc* d) const override;
+	ValPtr DoClone(CloneState* state) override;
+
+private:
+	FilePtr file_val;
 };
 
 class PatternVal final : public Val {
@@ -1533,7 +1538,7 @@ UNDERLYING_ACCESSOR_DEF(SubNetVal, const IPPrefix&, AsSubNet)
 UNDERLYING_ACCESSOR_DEF(AddrVal, const IPAddr&, AsAddr)
 UNDERLYING_ACCESSOR_DEF(StringVal, const String*, AsString)
 UNDERLYING_ACCESSOR_DEF(FuncVal, Func*, AsFunc)
-// UNDERLYING_ACCESSOR_DEF(FileVal, File*, AsFile)
+UNDERLYING_ACCESSOR_DEF(FileVal, File*, AsFile)
 UNDERLYING_ACCESSOR_DEF(PatternVal, const RE_Matcher*, AsPattern)
 UNDERLYING_ACCESSOR_DEF(TableVal, const PDict<TableEntryVal>*, AsTable)
 

--- a/src/Val.h
+++ b/src/Val.h
@@ -266,7 +266,6 @@ UNDERLYING_ACCESSOR_DECL(SubNetVal, const IPPrefix&, AsSubNet)
 UNDERLYING_ACCESSOR_DECL(StringVal, const String*, AsString)
 UNDERLYING_ACCESSOR_DECL(PatternVal, const RE_Matcher*, AsPattern)
 UNDERLYING_ACCESSOR_DECL(TableVal, const PDict<TableEntryVal>*, AsTable)
-UNDERLYING_ACCESSOR_DECL(RecordVal, const std::vector<ValPtr>*, AsRecord)
 UNDERLYING_ACCESSOR_DECL(VectorVal, const std::vector<ValPtr>*, AsVector)
 
 	zeek::Type* AsType() const
@@ -350,6 +349,7 @@ UNDERLYING_ACCESSOR_DECL(VectorVal, const std::vector<ValPtr>*, AsVector)
 
 protected:
 
+	// Friends with access to Clone().
 	friend class EnumType;
 	friend class ListVal;
 	friend class RecordVal;
@@ -1189,10 +1189,17 @@ public:
 	/**
 	 * Ensures that the record has enough internal storage for the
 	 * given number of fields.
-	 * param n  The number of fields.
+	 * @param n  The number of fields.
 	 */
 	void Reserve(unsigned int n)
 		{ record_val->reserve(n); }
+
+	/**
+	 * Returns the number of fields in the record.
+	 * @return  The number of fields in the record.
+	 */
+	unsigned int NumFields()
+		{ return record_val->size(); }
 
 	/**
 	 * Returns the value of a given field index.
@@ -1200,7 +1207,7 @@ public:
 	 * @return  The value at the given field index.
 	 */
 	const ValPtr& GetField(int field) const
-		{ return (*AsRecord())[field]; }
+		{ return (*record_val)[field]; }
 
 	/**
 	 * Returns the value of a given field index as cast to type @c T.
@@ -1305,9 +1312,6 @@ public:
 	                      bool allow_orphaning = false) const;
 	RecordValPtr CoerceTo(RecordTypePtr other,
 	                      bool allow_orphaning = false);
-
-	const std::vector<ValPtr>* UnderlyingVal() const
-		{ return record_val; }
 
 	unsigned int MemoryAllocation() const override;
 	void DescribeReST(ODesc* d) const override;
@@ -1483,7 +1487,6 @@ UNDERLYING_ACCESSOR_DEF(AddrVal, const IPAddr&, AsAddr)
 UNDERLYING_ACCESSOR_DEF(StringVal, const String*, AsString)
 UNDERLYING_ACCESSOR_DEF(PatternVal, const RE_Matcher*, AsPattern)
 UNDERLYING_ACCESSOR_DEF(TableVal, const PDict<TableEntryVal>*, AsTable)
-UNDERLYING_ACCESSOR_DEF(RecordVal, const std::vector<ValPtr>*, AsRecord)
 UNDERLYING_ACCESSOR_DEF(VectorVal, const std::vector<ValPtr>*, AsVector)
 
 

--- a/src/Val.h
+++ b/src/Val.h
@@ -1272,6 +1272,27 @@ public:
 	IntrusivePtr<T> GetFieldOrDefault(const char* field) const
 		{ return cast_intrusive<T>(GetField(field)); }
 
+	// The following return the given field converted to a particular
+	// underlying value.  We provide these to enable efficient
+	// access to record fields (without requiring an intermediary Val)
+	// if we change the underlying representation of records.
+#define GET_FIELD_AS(ctype, name ) \
+	ctype Get ## name ## Field(int field) const \
+		{ return GetField(field)->As ## name(); } \
+	ctype Get ## name ## Field(const char* field) const \
+		{ return GetField(field)->As ## name(); }
+
+	GET_FIELD_AS(bool, Bool)
+	GET_FIELD_AS(int, Enum)
+	GET_FIELD_AS(bro_int_t, Int)
+	GET_FIELD_AS(bro_uint_t, Count)
+	GET_FIELD_AS(double, Double)
+	GET_FIELD_AS(double, Time)
+	GET_FIELD_AS(double, Interval)
+	GET_FIELD_AS(const PortVal*, PortVal)
+	GET_FIELD_AS(const IPAddr&, Addr)
+	GET_FIELD_AS(const String*, String)
+
 	/**
 	 * Looks up the value of a field by field name.  If the field doesn't
 	 * exist in the record type, it's an internal error: abort.

--- a/src/Val.h
+++ b/src/Val.h
@@ -108,8 +108,8 @@ union BroValUnion {
 
 	String* string_val;
 	RE_Matcher* re_val;
-#endif
 	Func* func_val;
+#endif
 	File* file_val;
 
 #ifdef DEPRECATED
@@ -141,10 +141,10 @@ union BroValUnion {
 
 	constexpr BroValUnion(RE_Matcher* value) noexcept
 		: re_val(value) {}
-#endif
 
 	constexpr BroValUnion(Func* value) noexcept
 		: func_val(value) {}
+#endif
 
 	constexpr BroValUnion(File* value) noexcept
 		: file_val(value) {}
@@ -164,11 +164,11 @@ public:
 	Val(double d, TypeTag t)
 		: val(d), type(base_type(t))
 		{}
-#endif
 
 	[[deprecated("Remove in v4.1.  Construct from IntrusivePtr instead.")]]
 	explicit Val(Func* f);
 	explicit Val(FuncPtr f);
+#endif
 
 	[[deprecated("Remove in v4.1.  Construct from IntrusivePtr instead.")]]
 	explicit Val(File* f);
@@ -252,7 +252,6 @@ public:
 	CONST_ACCESSOR2(TYPE_INT, bro_int_t, int_val, AsInt)
 	CONST_ACCESSOR2(TYPE_COUNT, bro_uint_t, uint_val, AsCount)
 	CONST_ACCESSOR2(TYPE_ENUM, int, int_val, AsEnum)
-	CONST_ACCESSOR(TYPE_FUNC, Func*, func_val, AsFunc)
 	CONST_ACCESSOR(TYPE_FILE, File*, file_val, AsFile)
 
 #define UNDERLYING_ACCESSOR_DECL(ztype, ctype, name) \
@@ -264,6 +263,8 @@ UNDERLYING_ACCESSOR_DECL(IntervalVal, double, AsInterval)
 UNDERLYING_ACCESSOR_DECL(AddrVal, const IPAddr&, AsAddr)
 UNDERLYING_ACCESSOR_DECL(SubNetVal, const IPPrefix&, AsSubNet)
 UNDERLYING_ACCESSOR_DECL(StringVal, const String*, AsString)
+UNDERLYING_ACCESSOR_DECL(FuncVal, Func*, AsFunc)
+// UNDERLYING_ACCESSOR_DECL(FileVal, File*, AsFile)
 UNDERLYING_ACCESSOR_DECL(PatternVal, const RE_Matcher*, AsPattern)
 UNDERLYING_ACCESSOR_DECL(TableVal, const PDict<TableEntryVal>*, AsTable)
 
@@ -282,10 +283,7 @@ UNDERLYING_ACCESSOR_DECL(TableVal, const PDict<TableEntryVal>*, AsTable)
 
 	// Accessors for mutable values are called AsNonConst* and
 	// are protected to avoid external state changes.
-	ACCESSOR(TYPE_FUNC, Func*, func_val, AsFunc)
 	ACCESSOR(TYPE_FILE, File*, file_val, AsFile)
-
-	FuncPtr AsFuncPtr() const;
 
 	// Gives fast access to the bits of something that is one of
 	// bool, int, count, or counter.
@@ -660,6 +658,25 @@ protected:
 
 private:
 	String* string_val;
+};
+
+class FuncVal final : public Val {
+public:
+	explicit FuncVal(FuncPtr f);
+	~FuncVal() override;
+
+	FuncPtr AsFuncPtr() const;
+
+	ValPtr SizeVal() const override;
+
+	Func* UnderlyingVal() const	{ return func_val.get(); }
+
+protected:
+	void ValDescribe(ODesc* d) const override;
+	ValPtr DoClone(CloneState* state) override;
+
+private:
+	FuncPtr func_val;
 };
 
 class PatternVal final : public Val {
@@ -1515,6 +1532,8 @@ UNDERLYING_ACCESSOR_DEF(IntervalVal, double, AsInterval)
 UNDERLYING_ACCESSOR_DEF(SubNetVal, const IPPrefix&, AsSubNet)
 UNDERLYING_ACCESSOR_DEF(AddrVal, const IPAddr&, AsAddr)
 UNDERLYING_ACCESSOR_DEF(StringVal, const String*, AsString)
+UNDERLYING_ACCESSOR_DEF(FuncVal, Func*, AsFunc)
+// UNDERLYING_ACCESSOR_DEF(FileVal, File*, AsFile)
 UNDERLYING_ACCESSOR_DEF(PatternVal, const RE_Matcher*, AsPattern)
 UNDERLYING_ACCESSOR_DEF(TableVal, const PDict<TableEntryVal>*, AsTable)
 

--- a/src/Val.h
+++ b/src/Val.h
@@ -266,7 +266,6 @@ UNDERLYING_ACCESSOR_DECL(SubNetVal, const IPPrefix&, AsSubNet)
 UNDERLYING_ACCESSOR_DECL(StringVal, const String*, AsString)
 UNDERLYING_ACCESSOR_DECL(PatternVal, const RE_Matcher*, AsPattern)
 UNDERLYING_ACCESSOR_DECL(TableVal, const PDict<TableEntryVal>*, AsTable)
-UNDERLYING_ACCESSOR_DECL(VectorVal, const std::vector<ValPtr>*, AsVector)
 
 	zeek::Type* AsType() const
 		{
@@ -1437,6 +1436,16 @@ public:
 	 */
 	const ValPtr& At(unsigned int index) const;
 
+	/**
+	 * Returns the given element treated as a Count type, to efficiently
+	 * support a common type of vector access if we change the underlying
+	 * vector representation.
+	 * @param index  The position in the vector of the element to return.
+	 * @return  The element's value, as a Count underlying representation.
+	 */
+	bro_uint_t CountAt(unsigned int index) const
+		{ return At(index)->AsCount(); }
+
 	[[deprecated("Remove in v4.1.  Use At().")]]
 	Val* Lookup(unsigned int index) const
 		{ return At(index).get(); }
@@ -1508,7 +1517,6 @@ UNDERLYING_ACCESSOR_DEF(AddrVal, const IPAddr&, AsAddr)
 UNDERLYING_ACCESSOR_DEF(StringVal, const String*, AsString)
 UNDERLYING_ACCESSOR_DEF(PatternVal, const RE_Matcher*, AsPattern)
 UNDERLYING_ACCESSOR_DEF(TableVal, const PDict<TableEntryVal>*, AsTable)
-UNDERLYING_ACCESSOR_DEF(VectorVal, const std::vector<ValPtr>*, AsVector)
 
 
 // Checks the given value for consistency with the given type.  If an

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -320,7 +320,7 @@ static void make_var(const IDPtr& id, TypePtr t, InitClass c, ExprPtr init,
 		// defined.
 		std::vector<IDPtr> inits;
 		auto f = make_intrusive<ScriptFunc>(id, nullptr, inits, 0, 0);
-		id->SetVal(make_intrusive<Val>(std::move(f)));
+		id->SetVal(make_intrusive<FuncVal>(std::move(f)));
 		}
 	}
 
@@ -720,7 +720,7 @@ void end_func(StmtPtr body)
 			ingredients->frame_size,
 			ingredients->priority);
 
-		ingredients->id->SetVal(make_intrusive<Val>(std::move(f)));
+		ingredients->id->SetVal(make_intrusive<FuncVal>(std::move(f)));
 		ingredients->id->SetConst();
 		}
 

--- a/src/analyzer/protocol/krb/krb-analyzer.pac
+++ b/src/analyzer/protocol/krb/krb-analyzer.pac
@@ -263,7 +263,7 @@ refine connection KRB_Conn += {
 			rv->Assign(1, zeek::val_mgr->Bool(${msg.ap_options.mutual_required}));
 
 			auto rvticket = proc_ticket(${msg.ticket});
-			auto authenticationinfo = zeek_analyzer()->GetAuthenticationInfo(rvticket->GetField(2)->AsString(), rvticket->GetField(4)->AsString(), rvticket->GetField(3)->AsCount());
+			auto authenticationinfo = zeek_analyzer()->GetAuthenticationInfo(rvticket->GetStringField(2), rvticket->GetStringField(4), rvticket->GetCountField(3));
 
 			if ( authenticationinfo )
 				rvticket->Assign(5, authenticationinfo);

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -176,7 +176,7 @@ bool NFS_Interp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status rpc_status,
 
 	case BifEnum::NFS3::PROC_READ:
 		bro_uint_t offset;
-		offset = c->RequestVal()->AsRecordVal()->GetField(1)->AsCount();
+		offset = c->RequestVal()->AsRecordVal()->GetCountField(1);
 		reply = nfs3_read_reply(buf, n, nfs_status, offset);
 		event = nfs_proc_read;
 		break;

--- a/src/analyzer/protocol/tcp/functions.bif
+++ b/src/analyzer/protocol/tcp/functions.bif
@@ -127,7 +127,7 @@ function get_contents_file%(cid: conn_id, direction: count%): file
 		auto cf = c->GetRootAnalyzer()->GetContentsFile(direction);
 
 		if ( cf )
-			return zeek::make_intrusive<zeek::Val>(std::move(cf));
+			return zeek::make_intrusive<zeek::FileVal>(std::move(cf));
 		}
 
 	// Return some sort of error value.
@@ -136,5 +136,5 @@ function get_contents_file%(cid: conn_id, direction: count%): file
 	else
 		zeek::emit_builtin_error("no contents file for given direction");
 
-	return zeek::make_intrusive<zeek::Val>(zeek::make_intrusive<zeek::File>(stderr, "-", "w"));
+	return zeek::make_intrusive<zeek::FileVal>(zeek::make_intrusive<zeek::File>(stderr, "-", "w"));
 	%}

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -126,7 +126,7 @@ struct val_converter {
 			auto file = File::Get(a.data());
 
 			if ( file )
-				return make_intrusive<Val>(std::move(file));
+				return make_intrusive<FileVal>(std::move(file));
 
 			return nullptr;
 			}

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -439,7 +439,7 @@ bool Manager::PublishEvent(string topic, RecordVal* args)
 	if ( ! args->GetField(0) )
 		return false;
 
-	auto event_name = args->GetField(0)->AsString()->CheckString();
+	auto event_name = args->GetStringField(0)->CheckString();
 	auto vv = args->GetField(1)->AsVectorVal();
 	broker::vector xs;
 	xs.reserve(vv->Size());

--- a/src/broker/Store.cc
+++ b/src/broker/Store.cc
@@ -106,14 +106,14 @@ broker::backend_options to_backend_options(broker::backend backend,
 	case broker::backend::sqlite:
 		{
 		auto path = options->GetField(0)->AsRecordVal()
-			->GetField(0)->AsStringVal()->CheckString();
+			->GetStringField(0)->CheckString();
 		return {{"path", path}};
 		}
 
 	case broker::backend::rocksdb:
 		{
 		auto path = options->GetField(1)->AsRecordVal()
-			->GetField(0)->AsStringVal()->CheckString();
+			->GetStringField(0)->CheckString();
 		return {{"path", path}};
 		}
 

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -120,7 +120,7 @@ void File::UpdateLastActivityTime()
 
 double File::GetLastActivityTime() const
 	{
-	return val->GetField(last_active_idx)->AsTime();
+	return val->GetTimeField(last_active_idx);
 	}
 
 bool File::UpdateConnectionFields(Connection* conn, bool is_orig)

--- a/src/iosource/pcap/pcap.bif
+++ b/src/iosource/pcap/pcap.bif
@@ -44,7 +44,7 @@ function precompile_pcap_filter%(id: PcapFilterID, s: string%): bool
 	bool success = true;
 
 	zeek::iosource::PktSrc* ps = zeek::iosource_mgr->GetPktSrc();
-	if ( ps && ! ps->PrecompileFilter(id->ForceAsInt(), s->CheckString()) )
+	if ( ps && ! ps->PrecompileFilter(id->AsInt(), s->CheckString()) )
 		success = false;
 
 	return zeek::val_mgr->Bool(success);
@@ -73,7 +73,7 @@ function Pcap::install_pcap_filter%(id: PcapFilterID%): bool
 	bool success = true;
 
 	zeek::iosource::PktSrc* ps = zeek::iosource_mgr->GetPktSrc();
-	if ( ps && ! ps->SetFilter(id->ForceAsInt()) )
+	if ( ps && ! ps->SetFilter(id->AsInt()) )
 		success = false;
 
 	return zeek::val_mgr->Bool(success);

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -1531,7 +1531,7 @@ std::string Manager::FormatRotationPath(EnumValPtr writer,
 	ri->Assign<TimeVal>(2, open);
 	ri->Assign<TimeVal>(3, close);
 	ri->Assign(4, val_mgr->Bool(terminating));
-	ri->Assign<Val>(5, std::move(postprocessor));
+	ri->Assign<FuncVal>(5, std::move(postprocessor));
 
 	std::string rval;
 

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -1540,7 +1540,7 @@ std::string Manager::FormatRotationPath(EnumValPtr writer,
 		auto res = rotation_format_func->Invoke(ri);
 		auto rp_val = res->AsRecordVal();
 		auto dir_val = rp_val->GetFieldOrDefault(0);
-		auto prefix = rp_val->GetField(1)->AsString()->CheckString();
+		auto prefix = rp_val->GetStringField(1)->CheckString();
 		auto dir = dir_val->AsString()->CheckString();
 
 		if ( ! util::streq(dir, "") && ! util::detail::ensure_intermediate_dirs(dir) )

--- a/src/option.bif
+++ b/src/option.bif
@@ -209,6 +209,7 @@ function Option::set_change_handler%(ID: string, on_change: any, priority: int &
 		return zeek::val_mgr->False();
 		}
 
-	i->AddOptionHandler(on_change->AsFuncPtr(), -priority);
+	auto func = dynamic_cast<FuncVal*>(on_change)->AsFuncPtr();
+	i->AddOptionHandler(func, -priority);
 	return zeek::val_mgr->True();
 	%}

--- a/src/reporter.bif
+++ b/src/reporter.bif
@@ -148,7 +148,7 @@ function Reporter::conn_weird%(name: string, c: connection, addl: string &defaul
 ## Returns: true if the file was still valid, else false.
 function Reporter::file_weird%(name: string, f: fa_file, addl: string &default=""%): bool
 	%{
-	auto fuid = f->AsRecordVal()->GetField(0)->AsStringVal();
+	auto fuid = f->AsRecordVal()->GetStringField(0);
 	auto file = zeek::file_mgr->LookupFile(fuid->CheckString());
 
 	if ( ! file )

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -683,8 +683,8 @@ function string_to_ascii_hex%(s: string%): string
 function str_smith_waterman%(s1: string, s2: string, params: sw_params%) : sw_substring_vec
 	%{
 	zeek::detail::SWParams sw_params(
-            params->AsRecordVal()->GetField(0)->AsCount(),
-	    zeek::detail::SWVariant(params->AsRecordVal()->GetField(1)->AsCount()));
+            params->AsRecordVal()->GetCountField(0),
+	    zeek::detail::SWVariant(params->AsRecordVal()->GetCountField(1)));
 
 	auto* subseq = zeek::detail::smith_waterman(s1->AsString(), s2->AsString(), sw_params);
 	auto result = zeek::VectorValPtr{zeek::AdoptRef{}, zeek::detail::Substring::VecToPolicy(subseq)};

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -706,12 +706,13 @@ function str_smith_waterman%(s1: string, s2: string, params: sw_params%) : sw_su
 ## .. zeek:see:: split_string split_string1 split_string_all split_string_n
 function str_split%(s: string, idx: index_vec%): string_vec &deprecated="Remove in v4.1. Use str_split_indices."
 	%{
-	auto idx_v = idx->AsVector();
-	zeek::String::IdxVec indices(idx_v->size());
+	auto idx_v = dynamic_cast<VectorVal*>(idx);
+	auto n = idx_v->Size();
+	zeek::String::IdxVec indices(n);
 	unsigned int i;
 
-	for ( i = 0; i < idx_v->size(); i++ )
-		indices[i] = (*idx_v)[i]->AsCount();
+	for ( i = 0; i < n; i++ )
+		indices[i] = idx_v->CountAt(i);
 
 	zeek::String::Vec* result = s->AsString()->Split(indices);
 	auto result_v = zeek::make_intrusive<zeek::VectorVal>(zeek::id::string_vec);
@@ -744,12 +745,13 @@ function str_split%(s: string, idx: index_vec%): string_vec &deprecated="Remove 
 ## .. zeek:see:: split_string split_string1 split_string_all split_string_n
 function str_split_indices%(s: string, idx: index_vec%): string_vec
 	%{
-	auto idx_v = idx->AsVector();
-	zeek::String::IdxVec indices(idx_v->size());
+	auto idx_v = dynamic_cast<VectorVal*>(idx);
+	auto n = idx_v->Size();
+	zeek::String::IdxVec indices(n);
 	unsigned int i;
 
-	for ( i = 0; i < idx_v->size(); i++ )
-		indices[i] = (*idx_v)[i]->AsCount();
+	for ( i = 0; i < n; i++ )
+		indices[i] = idx_v->CountAt(i);
 
 	zeek::String::Vec* result = s->AsString()->Split(indices);
 	auto result_v = zeek::make_intrusive<zeek::VectorVal>(zeek::id::string_vec);

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -1225,7 +1225,7 @@ static BifEnum::Supervisor::ClusterRole role_str_to_enum(std::string_view r)
 Supervisor::NodeConfig Supervisor::NodeConfig::FromRecord(const RecordVal* node)
 	{
 	Supervisor::NodeConfig rval;
-	rval.name = node->GetField("name")->AsString()->CheckString();
+	rval.name = node->GetStringField("name")->CheckString();
 	const auto& iface_val = node->GetField("interface");
 
 	if ( iface_val )
@@ -1273,9 +1273,9 @@ Supervisor::NodeConfig Supervisor::NodeConfig::FromRecord(const RecordVal* node)
 		auto rv = v->GetVal()->AsRecordVal();
 
 		Supervisor::ClusterEndpoint ep;
-		ep.role = static_cast<BifEnum::Supervisor::ClusterRole>(rv->GetField("role")->AsEnum());
-		ep.host = rv->GetField("host")->AsAddr().AsString();
-		ep.port = rv->GetField("p")->AsPortVal()->Port();
+		ep.role = static_cast<BifEnum::Supervisor::ClusterRole>(rv->GetEnumField("role"));
+		ep.host = rv->GetAddrField("host").AsString();
+		ep.port = rv->GetPortValField("p")->Port();
 
 		const auto& iface = rv->GetField("interface");
 

--- a/src/threading/SerialTypes.h
+++ b/src/threading/SerialTypes.h
@@ -111,8 +111,8 @@ struct Value {
 	struct subnet_t { addr_t prefix; uint8_t length; };
 
 	/**
-	 * This union is a subset of BroValUnion, including only the types we
-	 * can log directly. See IsCompatibleType().
+	 * This union is a subset of the "underlying" values in Val subclasses,
+	 * including only the types we can log directly. See IsCompatibleType().
 	 */
 	union _val {
 		bro_int_t int_val;

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -3376,13 +3376,13 @@ function lookup_connection%(cid: conn_id%): connection
 %%{
 const char* conn_id_string(zeek::Val* c)
 	{
-	const auto& id = (*(c->AsRecord()))[0];
-	auto vl = id->AsRecord();
+	auto id = dynamic_cast<const zeek::RecordVal*>(c)->GetField(0);
+	auto id_r = dynamic_cast<const zeek::RecordVal*>(id.get());
 
-	const zeek::IPAddr& orig_h = (*vl)[0]->AsAddr();
-	uint32_t orig_p = (*vl)[1]->AsPortVal()->Port();
-	const zeek::IPAddr& resp_h = (*vl)[2]->AsAddr();
-	uint32_t resp_p = (*vl)[3]->AsPortVal()->Port();
+	const zeek::IPAddr& orig_h = id_r->GetField(0)->AsAddr();
+	uint32_t orig_p = id_r->GetField(1)->AsPortVal()->Port();
+	const zeek::IPAddr& resp_h = id_r->GetField(2)->AsAddr();
+	uint32_t resp_p = id_r->GetField(3)->AsPortVal()->Port();
 
 	return zeek::util::fmt("%s/%u -> %s/%u\n", orig_h.AsString().c_str(), orig_p,
 	                       resp_h.AsString().c_str(), resp_p);
@@ -3502,14 +3502,14 @@ function dump_packet%(pkt: pcap_packet, file_name: string%) : bool
 		uint32_t caplen, len, link_type;
 		u_char *data;
 
-		auto pkt_vl = pkt->AsRecord();
+		auto pkt_r = dynamic_cast<RecordVal*>(pkt);
 
-		ts.tv_sec = (*pkt_vl)[0]->AsCount();
-		ts.tv_usec = (*pkt_vl)[1]->AsCount();
-		caplen = (*pkt_vl)[2]->AsCount();
-		len = (*pkt_vl)[3]->AsCount();
-		data = (*pkt_vl)[4]->AsString()->Bytes();
-		link_type = (*pkt_vl)[5]->AsEnum();
+		ts.tv_sec = pkt_r->GetField(0)->AsCount();
+		ts.tv_usec = pkt_r->GetField(1)->AsCount();
+		caplen = pkt_r->GetField(2)->AsCount();
+		len = pkt_r->GetField(3)->AsCount();
+		data = pkt_r->GetField(4)->AsString()->Bytes();
+		link_type = pkt_r->GetField(5)->AsEnum();
 		Packet p(link_type, &ts, caplen, len, data, true);
 
 		addl_pkt_dumper->Dump(&p);

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -1502,8 +1502,8 @@ function order%(v: any, ...%) : index_vec
 	if ( ! comp && ! IsIntegral(elt_type->Tag()) )
 		zeek::emit_builtin_error("comparison function required for order() with non-integral types");
 
-	auto& vv = *v->AsVector();
-	auto n = vv.size();
+	auto vv = dynamic_cast<VectorVal*>(v);
+	auto n = vv->Size();
 
 	// Set up initial mapping of indices directly to corresponding
 	// elements.
@@ -1513,7 +1513,7 @@ function order%(v: any, ...%) : index_vec
 	for ( i = 0; i < n; ++i )
 		{
 		ind_vv[i] = i;
-		index_map.emplace_back(&vv[i]);
+		index_map.emplace_back(&vv->At(i));
 		}
 
 	if ( comp )
@@ -2284,15 +2284,17 @@ function addr_to_counts%(a: addr%): index_vec
 ## .. zeek:see:: addr_to_counts
 function counts_to_addr%(v: index_vec%): addr
 	%{
-	if ( v->AsVector()->size() == 1 )
+	auto vv = dynamic_cast<VectorVal*>(v);
+
+	if ( vv->Size() == 1 )
 		{
-		return zeek::make_intrusive<zeek::AddrVal>(htonl((*v->AsVector())[0]->AsCount()));
+		return zeek::make_intrusive<zeek::AddrVal>(htonl(vv->CountAt(0)));
 		}
-	else if ( v->AsVector()->size() == 4 )
+	else if ( vv->Size() == 4 )
 		{
 		uint32_t bytes[4];
 		for ( int i = 0; i < 4; ++i )
-			bytes[i] = htonl((*v->AsVector())[i]->AsCount());
+			bytes[i] = htonl(vv->CountAt(i));
 		return zeek::make_intrusive<zeek::AddrVal>(bytes);
 		}
 	else

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -4444,9 +4444,9 @@ function open%(f: string%): file
 	const char* file = f->CheckString();
 
 	if ( zeek::util::streq(file, "-") )
-		return zeek::make_intrusive<zeek::Val>(zeek::make_intrusive<zeek::File>(stdout, "-", "w"));
+		return zeek::make_intrusive<zeek::FileVal>(zeek::make_intrusive<zeek::File>(stdout, "-", "w"));
 	else
-		return zeek::make_intrusive<zeek::Val>(zeek::make_intrusive<zeek::File>(file, "w"));
+		return zeek::make_intrusive<zeek::FileVal>(zeek::make_intrusive<zeek::File>(file, "w"));
 	%}
 
 ## Opens a file for writing or appending. If a file with the same name already
@@ -4461,7 +4461,7 @@ function open%(f: string%): file
 ##              rmdir unlink rename
 function open_for_append%(f: string%): file
 	%{
-	return zeek::make_intrusive<zeek::Val>(zeek::make_intrusive<zeek::File>(f->CheckString(), "a"));
+	return zeek::make_intrusive<zeek::FileVal>(zeek::make_intrusive<zeek::File>(f->CheckString(), "a"));
 	%}
 
 ## Closes an open file and flushes any buffered content.

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -1432,7 +1432,7 @@ function sort%(v: any, ...%) : any
 	if ( ! comp && ! IsIntegral(elt_type->Tag()) )
 		zeek::emit_builtin_error("comparison function required for sort() with non-integral types");
 
-	auto& vv = *v->AsVector();
+	auto vv = dynamic_cast<VectorVal*>(v);
 
 	if ( comp )
 		{
@@ -1447,14 +1447,14 @@ function sort%(v: any, ...%) : any
 
 		sort_function_comp = comp;
 
-		sort(vv.begin(), vv.end(), sort_function);
+		vv->Sort(sort_function);
 		}
 	else
 		{
 		if ( elt_type->InternalType() == zeek::TYPE_INTERNAL_UNSIGNED )
-			sort(vv.begin(), vv.end(), unsigned_sort_function);
+			vv->Sort(unsigned_sort_function);
 		else
-			sort(vv.begin(), vv.end(), signed_sort_function);
+			vv->Sort(signed_sort_function);
 		}
 
 	return rval;

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -3379,10 +3379,10 @@ const char* conn_id_string(zeek::Val* c)
 	auto id = dynamic_cast<const zeek::RecordVal*>(c)->GetField(0);
 	auto id_r = dynamic_cast<const zeek::RecordVal*>(id.get());
 
-	const zeek::IPAddr& orig_h = id_r->GetField(0)->AsAddr();
-	uint32_t orig_p = id_r->GetField(1)->AsPortVal()->Port();
-	const zeek::IPAddr& resp_h = id_r->GetField(2)->AsAddr();
-	uint32_t resp_p = id_r->GetField(3)->AsPortVal()->Port();
+	const zeek::IPAddr& orig_h = id_r->GetAddrField(0);
+	uint32_t orig_p = id_r->GetPortValField(1)->Port();
+	const zeek::IPAddr& resp_h = id_r->GetAddrField(2);
+	uint32_t resp_p = id_r->GetPortValField(3)->Port();
 
 	return zeek::util::fmt("%s/%u -> %s/%u\n", orig_h.AsString().c_str(), orig_p,
 	                       resp_h.AsString().c_str(), resp_p);
@@ -3504,12 +3504,12 @@ function dump_packet%(pkt: pcap_packet, file_name: string%) : bool
 
 		auto pkt_r = dynamic_cast<RecordVal*>(pkt);
 
-		ts.tv_sec = pkt_r->GetField(0)->AsCount();
-		ts.tv_usec = pkt_r->GetField(1)->AsCount();
-		caplen = pkt_r->GetField(2)->AsCount();
-		len = pkt_r->GetField(3)->AsCount();
-		data = pkt_r->GetField(4)->AsString()->Bytes();
-		link_type = pkt_r->GetField(5)->AsEnum();
+		ts.tv_sec = pkt_r->GetCountField(0);
+		ts.tv_usec = pkt_r->GetCountField(1);
+		caplen = pkt_r->GetCountField(2);
+		len = pkt_r->GetCountField(3);
+		data = pkt_r->GetStringField(4)->Bytes();
+		link_type = pkt_r->GetEnumField(5);
 		Packet p(link_type, &ts, caplen, len, data, true);
 
 		addl_pkt_dumper->Dump(&p);


### PR DESCRIPTION
@rsmmr Here's a cut at hoisting an underlying `Val` representation up into a subclass.  Let me know if this approach looks good and if so I'll build it further out.

(Making this a draft pull request just to get the feedback in a clear/easy fashion, happy to go another route if that works better.)

Oh, and: the stuff marked `#ifdef DEPRECATED` would be left in for now.  I commented it out to make sure things will work without it, since it's only needed for deprecated `Val` constructors.