### PR TITLE
Fixing zeek SMB sessionization Issue

### DIFF
--- a/scripts/base/protocols/smb/main.zeek
+++ b/scripts/base/protocols/smb/main.zeek
@@ -231,7 +231,7 @@ function write_file_log(state: State)
 			log_f$ts = network_time()
 		}
 	
-		Log::write(FILES_LOG, f);
+		Log::write(FILES_LOG, log_f);
 		}
 	}
 

--- a/scripts/base/protocols/smb/main.zeek
+++ b/scripts/base/protocols/smb/main.zeek
@@ -225,7 +225,12 @@ function write_file_log(state: State)
 			else
 				add state$recent_files[file_ident];
 			}
-		
+
+		local log_f = copy(f);
+		if (!log_f?$ts){
+			log_f$ts = network_time()
+		}
+	
 		Log::write(FILES_LOG, f);
 		}
 	}

--- a/scripts/base/protocols/smb/smb1-main.zeek
+++ b/scripts/base/protocols/smb/smb1-main.zeek
@@ -128,6 +128,11 @@ event smb1_tree_connect_andx_response(c: connection, hdr: SMB1::Header, service:
 
 event smb1_tree_connect_andx_response(c: connection, hdr: SMB1::Header, service: string, native_file_system: string) &priority=-5
 	{
+	local log_tree = copy (c$smb_state$current_tree);
+	if (!log_tree?$ts) {
+		log_tree$ts = network_time();
+	}
+	
 	Log::write(SMB::MAPPING_LOG, c$smb_state$current_tree);
 	}
 

--- a/scripts/base/protocols/smb/smb1-main.zeek
+++ b/scripts/base/protocols/smb/smb1-main.zeek
@@ -133,7 +133,7 @@ event smb1_tree_connect_andx_response(c: connection, hdr: SMB1::Header, service:
 		log_tree$ts = network_time();
 	}
 	
-	Log::write(SMB::MAPPING_LOG, c$smb_state$current_tree);
+	Log::write(SMB::MAPPING_LOG, log_tree);
 	}
 
 event smb1_nt_create_andx_request(c: connection, hdr: SMB1::Header, name: string) &priority=5

--- a/scripts/base/protocols/smb/smb2-main.zeek
+++ b/scripts/base/protocols/smb/smb2-main.zeek
@@ -110,6 +110,11 @@ event smb2_tree_connect_response(c: connection, hdr: SMB2::Header, response: SMB
 
 event smb2_tree_connect_response(c: connection, hdr: SMB2::Header, response: SMB2::TreeConnectResponse) &priority=-5
 	{
+	local log_tree = copy(c$smb_state$current_tree);
+	if( !log_tree?$ts ){
+		log_tree$ts = network_time();
+	}
+	
 	Log::write(SMB::MAPPING_LOG, c$smb_state$current_tree);
 	}
 

--- a/scripts/base/protocols/smb/smb2-main.zeek
+++ b/scripts/base/protocols/smb/smb2-main.zeek
@@ -115,7 +115,7 @@ event smb2_tree_connect_response(c: connection, hdr: SMB2::Header, response: SMB
 		log_tree$ts = network_time();
 	}
 	
-	Log::write(SMB::MAPPING_LOG, c$smb_state$current_tree);
+	Log::write(SMB::MAPPING_LOG, log_tree);
 	}
 
 event smb2_tree_disconnect_request(c: connection, hdr: SMB2::Header) &priority=5


### PR DESCRIPTION
Hi, we are requesting this change to highlight the SMB parsing issues when it only sees part of a session that results in the log file (smb_mapping.log file) being sent with no timestamp.

Detailed explanation: 
[Zeek SMB Sessionization Issue.pdf](https://github.com/zeek/zeek/files/5533843/Zeek.SMB.Sessionization.Issue.pdf)

Please let us know if you have any questions.