### PR TITLE
Fix baseline error for the scripts.base.utils.email test

### DIFF
--- a/testing/btest/Baseline/scripts.base.utils.email/output
+++ b/testing/btest/Baseline/scripts.base.utils.email/output
@@ -22,6 +22,6 @@ two@example.com
 john.smith@email.com
 [john.smith@email.com, jane.doe@email.com]
 {
-john.smith@email.com
+john.smith@email.com,
 jane.doe@email.com
 }


### PR DESCRIPTION
I think we had a small baseline error sneak in recently?  This intentionally doesn't yet introduce the new btest baseline header, so we can introduce it consistently in the near future.