### PR TITLE
Update .gitignore to ignore pyenv .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ cmake-build-*
 
 # skip DS Store for MacOS
 .DS_Store
+
+# ignore pyenv local settings
+.python-version


### PR DESCRIPTION
You may have this file if you have multiple versions of python installed, and zeek doesn't build with all of them