### PR TITLE
Find correct zeek namespace in debug logger macros.

### DIFF
--- a/src/DebugLogger.h
+++ b/src/DebugLogger.h
@@ -12,15 +12,15 @@
 #include <set>
 
 #define DBG_LOG(stream, args...) \
-	if ( zeek::detail::debug_logger.IsEnabled(stream) ) \
-		zeek::detail::debug_logger.Log(stream, args)
+	if ( ::zeek::detail::debug_logger.IsEnabled(stream) ) \
+		::zeek::detail::debug_logger.Log(stream, args)
 #define DBG_LOG_VERBOSE(stream, args...) \
-	if ( zeek::detail::debug_logger.IsVerbose() && zeek::detail::debug_logger.IsEnabled(stream) ) \
-		zeek::detail::debug_logger.Log(stream, args)
-#define DBG_PUSH(stream) zeek::detail::debug_logger.PushIndent(stream)
-#define DBG_POP(stream) zeek::detail::debug_logger.PopIndent(stream)
+	if ( ::zeek::detail::debug_logger.IsVerbose() && ::zeek::detail::debug_logger.IsEnabled(stream) ) \
+		::zeek::detail::debug_logger.Log(stream, args)
+#define DBG_PUSH(stream) ::zeek::detail::debug_logger.PushIndent(stream)
+#define DBG_POP(stream) ::zeek::detail::debug_logger.PopIndent(stream)
 
-#define PLUGIN_DBG_LOG(plugin, args...) zeek::detail::debug_logger.Log(plugin, args)
+#define PLUGIN_DBG_LOG(plugin, args...) ::zeek::detail::debug_logger.Log(plugin, args)
 
 ZEEK_FORWARD_DECLARE_NAMESPACED(Plugin, zeek, plugin);
 


### PR DESCRIPTION
These macros forward to functionality in `zeek::detail::debug_logger`
and are not intended for customization. This patch fixes the macros to
always use `::zeek::detail::debug_logger` as without the leading `::`
lookup could happen in any potentially local namespace `zeek` which does
not need to provide this symbol.

This closes zeek/spicy#597.