### PR TITLE
Simplify CI dependencies and setup

### DIFF
--- a/ci/debian-9/Dockerfile
+++ b/ci/debian-9/Dockerfile
@@ -28,9 +28,6 @@ RUN apt-get update && apt-get -y install \
     libc++abi-7-dev \
   && rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100
-RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-7 100
-
 # Many distros adhere to PEP 394's recommendation for `python` = `python2` so
 # this is a simple workaround until we drop Python 2 support and explicitly
 # use `python3` for all invocations (e.g. in shebangs).
@@ -39,4 +36,6 @@ RUN ln -sf /usr/bin/pip3 /usr/local/bin/pip
 
 RUN pip install junit2html
 
+ENV CC=/usr/bin/clang-7
+ENV CXX=/usr/bin/clang++-7
 ENV CXXFLAGS=-stdlib=libc++

--- a/ci/ubuntu-16.04/Dockerfile
+++ b/ci/ubuntu-16.04/Dockerfile
@@ -15,6 +15,9 @@ RUN apt-get update && apt-get -y install \
     python3 \
     python3-dev \
     python3-pip\
+    clang-8 \
+    libc++-8-dev \
+    libc++abi-8-dev \
     swig \
     zlib1g-dev \
     libkrb5-dev \
@@ -25,12 +28,6 @@ RUN apt-get update && apt-get -y install \
     xz-utils \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget -q https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-RUN mkdir /clang-9
-RUN tar --strip-components=1 -C /clang-9 -xvf clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-RUN update-alternatives --install /usr/bin/cc cc /clang-9/bin/clang 100
-RUN update-alternatives --install /usr/bin/c++ c++ /clang-9/bin/clang++ 100
-
 # Many distros adhere to PEP 394's recommendation for `python` = `python2` so
 # this is a simple workaround until we drop Python 2 support and explicitly
 # use `python3` for all invocations (e.g. in shebangs).
@@ -39,5 +36,6 @@ RUN ln -sf /usr/bin/pip3 /usr/local/bin/pip
 
 RUN pip install junit2html
 
+ENV CC=/usr/bin/clang-8
+ENV CXX=/usr/bin/clang++-8
 ENV CXXFLAGS=-stdlib=libc++
-ENV LD_LIBRARY_PATH=/clang-9/lib


### PR DESCRIPTION
Unless there was a specific issue with Clang 8 on Ubuntu 16.04 that I'm not aware of (Zeek works with the older release on Debian 9), I think we can simplify our dependencies for 16.04 by using the default Clang 8 package instead of picking Clang 9 from an external source.

Also, at least CMake picks up the `CC`/`CXX` variable, so we probably can also get rid of the `update-alternatives` setup. That's probably more a matter of taste, but I think just setting the environment variables is more straightforward/simple.