### PR TITLE
Fix misassociation of Zeekygen-style comments within function scopes

### DIFF
--- a/scripts/zeekygen/example.zeek
+++ b/scripts/zeekygen/example.zeek
@@ -175,6 +175,11 @@ export {
 # documentation.  So using ``##``-style comments is pointless here.
 function function_without_proto(tag: string): string
     {
+    # Zeekygen-style comments only apply to entities at global-scope so
+    # Zeekygen doesn't associate the following comments with anything.
+    ##! This comment should be ignored by Zeekygen.
+    ## This comment should be ignored by Zeekygen.
+    ##< This comment should be ignored by Zeekygen.
     return "blah";
     }
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -149,19 +149,24 @@ ESCSEQ	(\\([^\n]|[0-7]+|x[[:xdigit:]]+))
 %%
 
 ##!.* {
-	zeek::detail::zeekygen_mgr->SummaryComment(::filename, yytext + 3);
+	if ( zeek::detail::current_scope() == zeek::detail::global_scope() )
+		zeek::detail::zeekygen_mgr->SummaryComment(::filename, yytext + 3);
 	}
 
 ##<.* {
-	std::string hint(cur_enum_type && last_id_tok ?
-	            zeek::detail::make_full_var_name(zeek::detail::current_module.c_str(), last_id_tok) : "");
+	if ( zeek::detail::current_scope() == zeek::detail::global_scope() )
+		{
+		std::string hint(cur_enum_type && last_id_tok ?
+		            zeek::detail::make_full_var_name(zeek::detail::current_module.c_str(), last_id_tok) : "");
 
-	zeek::detail::zeekygen_mgr->PostComment(yytext + 3, hint);
+		zeek::detail::zeekygen_mgr->PostComment(yytext + 3, hint);
+		}
 }
 
 ##.* {
-	if ( yytext[2] != '#' )
-		zeek::detail::zeekygen_mgr->PreComment(yytext + 2);
+	if ( zeek::detail::current_scope() == zeek::detail::global_scope() )
+		if ( yytext[2] != '#' )
+			zeek::detail::zeekygen_mgr->PreComment(yytext + 2);
 }
 
 #{OWS}@no-test.* return TOK_NO_TEST;


### PR DESCRIPTION
All Zeekygen-style comments relate to entities at global scope, so those
found within functions are now ignored instead of misassociated.