### PR TITLE
Add LGTM config file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,45 @@
+# LGTM config file docs: https://lgtm.com/help/lgtm/lgtm.yml-configuration-file
+
+# Results from files under any classifier will be excluded from LGTM stats.
+path_classifiers:
+  library:
+    - "auxil/broker/caf/"
+    - "auxil/libkqueue/"
+    - "auxil/highwayhash/"
+    - "auxil/rapidjson/"
+    - "src/3rdparty/"
+
+# Filter out alerts that aren't concerning.
+queries:
+  - exclude: cpp/use-of-goto
+  - exclude: cpp/short-global-name
+  - exclude: cpp/fixme-comment
+  - exclude: cpp/function-in-block
+
+extraction:
+  cpp:
+    prepare:
+      # Ubuntu packages to install.
+      packages:
+        - cmake
+        - make
+        - ninja-build
+        - gcc
+        - g++
+        - flex
+        - bison
+        - libpcap-dev
+        - libssl-dev
+        - python3
+        - python3-dev
+        - swig
+        - zlib1g-dev
+        - libkrb5-dev
+
+    configure:
+      command:
+        - ./configure --build-type=debug --generator=Ninja
+
+    index:
+      build_command:
+        - ( cd build && ninja )


### PR DESCRIPTION
LGTM has already been analyzing and finding possible issues without any configuration:

https://lgtm.com/projects/g/zeek/zeek/alerts/?mode=list

This config file just helps it get done quicker (2 hour build -> 1 hour) and also filters out a few unconcerning alerts.

If others agree about the utility of it, can decide to enable automated analysis of PRs to see if it helps catch issues before merging them.