### PR TITLE
Call Zeek's cleanup function from standalone fuzzer driver

### DIFF
--- a/src/fuzzers/standalone-driver.cc
+++ b/src/fuzzers/standalone-driver.cc
@@ -6,6 +6,8 @@
 #include <memory>
 #include <chrono>
 
+#include "zeek/zeek-setup.h"
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
 extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv);
 
@@ -64,4 +66,5 @@ int main(int argc, char** argv)
 	auto fuzz_dt = duration<double>(agg_stop - fuzz_start).count();
 	printf("Processed %d inputs in %fs (%fs w/ initialization), avg = %fs\n",
 	       num_inputs, fuzz_dt, agg_dt, fuzz_dt / num_inputs);
+	return zeek::detail::cleanup(false);
 	}

--- a/src/main.cc
+++ b/src/main.cc
@@ -16,11 +16,11 @@ int main(int argc, char** argv)
 		return setup_result.code;
 
 	auto& options = setup_result.options;
-	auto do_net_run = zeek::iosource_mgr->Size() > 0 ||
-	                  zeek::run_state::detail::have_pending_timers ||
-	                  zeek::BifConst::exit_only_after_terminate;
+	auto do_run_loop = zeek::iosource_mgr->Size() > 0 ||
+	                   zeek::run_state::detail::have_pending_timers ||
+	                   zeek::BifConst::exit_only_after_terminate;
 
-	if ( do_net_run )
+	if ( do_run_loop )
 		{
 		if ( zeek::detail::profiling_logger )
 			zeek::detail::profiling_logger->Log();
@@ -78,5 +78,5 @@ int main(int argc, char** argv)
 			}
 		}
 
-	return zeek::detail::cleanup(do_net_run);
+	return zeek::detail::cleanup(do_run_loop);
 	}

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -908,9 +908,9 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 	return {0, std::move(options)};
 	}
 
-int cleanup(bool did_net_run)
+int cleanup(bool did_run_loop )
 	{
-	if ( did_net_run )
+	if ( did_run_loop )
 		done_with_network();
 
 	run_state::detail::delete_run();

--- a/src/zeek-setup.h
+++ b/src/zeek-setup.h
@@ -24,8 +24,8 @@ SetupResult setup(int argc, char** argv, Options* options = nullptr);
 
 /**
  * Cleans up Zeek's global state.
- * @param did_net_run  whether the net_run() was called.
+ * @param did_run_loop  whether the run_loop() function was called.
  */
-int cleanup(bool did_net_run);
+int cleanup(bool did_run_loop);
 
 } // namespace zeek::detail


### PR DESCRIPTION
Otherwise, the global Broker manager object containing CAF/threading
logic is never destructed and can result in a heap-use-after-free if it
tries to access other global objects after they're cleaned up from
__cxa_finalize().

Fixes #1329