### PR TITLE
Fix segfault in config framework for unsupported set types

### DIFF
--- a/scripts/base/frameworks/config/main.zeek
+++ b/scripts/base/frameworks/config/main.zeek
@@ -124,8 +124,13 @@ function format_value(value: any) : string
 	{
 	local tn = type_name(value);
 	local part: string_vec = vector();
-	if ( /^set/ in tn )
+
+	if ( /^set/ in tn && strstr(tn, ",") == 0 )
 		{
+		# The conversion to set here is tricky and assumes
+		# that the set isn't indexed via a tuple of types.
+		# The above check for commas in the type name
+		# ensures this.
 		local it: set[bool] = value;
 		for ( sv in it )
 			part += cat(sv);

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -833,7 +833,12 @@ bool Manager::IsCompatibleType(Type* t, bool atomic_only)
 		if ( ! t->IsSet() )
 			return false;
 
-		return IsCompatibleType(t->AsSetType()->GetIndices()->GetPureType().get(), true);
+		const auto& indices = t->AsSetType()->GetIndices();
+
+		if ( indices->GetTypes().size() != 1 )
+			return false;
+
+		return IsCompatibleType(indices->GetPureType().get(), true);
 		}
 
 	case TYPE_VECTOR:

--- a/src/input/readers/config/Config.h
+++ b/src/input/readers/config/Config.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <unordered_map>
 
+#include "zeek/ID.h"
 #include "zeek/input/ReaderBackend.h"
 #include "zeek/threading/formatters/Ascii.h"
 
@@ -50,7 +51,7 @@ private:
 	std::string empty_field;
 
 	std::unique_ptr<threading::Formatter> formatter;
-	std::unordered_map<std::string, std::tuple<TypeTag, TypeTag>> option_types;
+	std::unordered_map<std::string, std::tuple<TypeTag, TypeTag, zeek::detail::IDPtr>> option_types;
 	std::unordered_map<std::string, std::string> option_values;
 };
 

--- a/testing/btest/Baseline/scripts.base.frameworks.input.config.errors/errout
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.config.errors/errout
@@ -10,6 +10,6 @@ warning: Value 'unknown' for source 'thread ../configfile/Input::READER_CONFIG' 
 error: SendEvent for event InputConfig::new_value failed
 warning: ../configfile/Input::READER_CONFIG: Option 'testbooool' does not exist. Ignoring line.
 warning: ../configfile/Input::READER_CONFIG: Option 'test_any' has type 'any', which is not supported for file input. Ignoring line.
-warning: ../configfile/Input::READER_CONFIG: Option 'test_table' has type 'table', which is not supported for file input. Ignoring line.
+warning: ../configfile/Input::READER_CONFIG: Option 'test_table' has type 'table[string] of string', which is not supported for file input. Ignoring line.
 received termination signal
 >>>


### PR DESCRIPTION
This currently crashes Zeek:
```
option tuples_set: set[addr, addr] = {[127.0.0.1, 127.0.0.2]};

event zeek_init() {
        local s: set[addr, addr] = {[10.0.0.1, 10.0.0.2]};
        Option::set("tuples_set", s);
}
```
```
$ zeek ./test.zeek
Segmentation fault (core dumped)
```
The reason for this is that the framework code assumes that change events for sets happen only for sets with a single index type. This PR hardens that assumption by checking that a set actually really only does have a single index type. It also plugs a corresponding hole in the input framework's manager, whose `IsCompatible()` method already rejected sets with non-pure index tuples. It now rejects any sets that have more than a single index type.

Note that this is quite the corner case — you need a set with a pure type tuple as index, and with an option that initializes the set with a value or that explicitly sets it via `Option::set()`, since the config reader cannot actually parse such types. We do not have any options in our codebase that will trigger this (but we do have ones that cannot actually be provided via a config file).

Backtrace, if you're curious:
```
Thread 1 "zeek" received signal SIGSEGV, Segmentation fault.
zeek::detail::Frame::SetElement (this=this@entry=0x1f292d0, id=0x0, v=...) at /usr/include/c++/10/bits/move.h:152
152         __exchange(_Tp& __obj, _Up&& __new_val)
(gdb) bt
#0  zeek::detail::Frame::SetElement (this=this@entry=0x1f292d0, id=0x0, v=...) at /usr/include/c++/10/bits/move.h:152
#1  0x0000000000852e29 in zeek::detail::ForStmt::DoExec (this=0x2e3bca0, f=0x1f292d0, v=<optimized out>, flow=@0x7fffffffba5c: zeek::detail::FLOW_NEXT) at /home/christian/devel/zeek/zeek-master/src/Stmt.cc:1281
#2  0x000000000085210c in zeek::detail::ExprStmt::Exec (this=0x2e3bca0, f=0x1f292d0, flow=@0x7fffffffba5c: zeek::detail::FLOW_NEXT) at /home/christian/devel/zeek/zeek-master/src/Stmt.cc:365
#3  0x00000000008522f7 in zeek::detail::StmtList::Exec (this=<optimized out>, f=0x1f292d0, flow=@0x7fffffffba5c: zeek::detail::FLOW_NEXT) at /home/christian/devel/zeek/zeek-master/src/Stmt.cc:1592
#4  0x0000000000852079 in zeek::detail::IfStmt::DoExec (this=<optimized out>, f=0x1f292d0, v=<optimized out>, flow=@0x7fffffffba5c: zeek::detail::FLOW_NEXT) at /home/christian/devel/zeek/zeek-master/src/Stmt.cc:443
#5  0x000000000085210c in zeek::detail::ExprStmt::Exec (this=0x2e43c20, f=0x1f292d0, flow=@0x7fffffffba5c: zeek::detail::FLOW_NEXT) at /home/christian/devel/zeek/zeek-master/src/Stmt.cc:365
```
The for-loop it's in is [here](https://github.com/zeek/zeek/blob/master/scripts/base/frameworks/config/main.zeek#L130).

The PR also includes a small tweak to the error/reporter output that includes more precise type info than the string version of the type tag. So, if you're trying to use a `set[addr,addr]` it now tells you that `set[addr,addr]` isn't supported, not the somewhat misleading`table`.