### PR TITLE
Install BTest with Zeek

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,6 +568,7 @@ add_subdirectory(man)
 
 include(CheckOptionalBuildSources)
 
+CheckOptionalBuildSources(auxil/btest BTest INSTALL_BTEST)
 CheckOptionalBuildSources(auxil/package-manager ZKG INSTALL_ZKG)
 CheckOptionalBuildSources(auxil/zeekctl   ZeekControl INSTALL_ZEEKCTL)
 CheckOptionalBuildSources(auxil/zeek-aux  Zeek-Aux  INSTALL_AUX_TOOLS)
@@ -616,6 +617,7 @@ message(
     "\n"
     "\nZeekControl:       ${INSTALL_ZEEKCTL}"
     "\nAux. Tools:        ${INSTALL_AUX_TOOLS}"
+    "\nBTest:             ${INSTALL_BTEST}"
     "\nzkg:               ${INSTALL_ZKG}"
     "\n"
     "\nlibmaxminddb:      ${USE_GEOIP}"

--- a/configure
+++ b/configure
@@ -65,6 +65,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --disable-zeekctl      don't install ZeekControl
     --disable-auxtools     don't build or install auxiliary tools
     --disable-archiver     don't build or install zeek-archiver tool
+    --disable-btest        don't install BTest
     --disable-python       don't try to build python bindings for Broker
     --disable-broker-tests don't try to build Broker unit tests
     --disable-zkg          don't install zkg
@@ -162,6 +163,7 @@ append_cache_entry ENABLE_PERFTOOLS     BOOL   false
 append_cache_entry ENABLE_JEMALLOC      BOOL   false
 append_cache_entry BUILD_SHARED_LIBS    BOOL   true
 append_cache_entry INSTALL_AUX_TOOLS    BOOL   true
+append_cache_entry INSTALL_BTEST        BOOL   true
 append_cache_entry INSTALL_ZEEK_ARCHIVER BOOL  true
 append_cache_entry INSTALL_ZEEKCTL      BOOL   true
 append_cache_entry INSTALL_ZKG          BOOL   true
@@ -286,6 +288,9 @@ while [ $# -ne 0 ]; do
             ;;
         --disable-archiver)
             append_cache_entry INSTALL_ZEEK_ARCHIVER    BOOL   false
+            ;;
+        --disable-btest)
+            append_cache_entry INSTALL_BTEST BOOL false
             ;;
         --disable-python)
             append_cache_entry DISABLE_PYTHON_BINDINGS     BOOL   true


### PR DESCRIPTION
This adds support for installing btest with Zeek, similar to what we've done for zkg. Configuring with `--disable-btest` skips the installation.

The main reason for doing this is that many Zeek packages come with testsuites that nearly always require btest, so providing btest out of the box makes sense. Note that zkg's recent additions to its PATH environment variable management mean that this btest instance is automatically found also when the Zeek installation's binary folder isn't in the path.

Note that the submodule pointer update for `auxil/btest` pulls in additional work that had landed in btest's master (0.66 vs 0.65). I think that's okay, but wanted to flag.

Resolves #1360.