### PR TITLE
Use xcode 11 on the Catalina CI image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -186,7 +186,7 @@ macos_big_sur_task:
 
 macos_catalina_task:
   osx_instance:
-    image: catalina-base
+    image: catalina-xcode-11.6
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_RESOURCES_TEMPLATE


### PR DESCRIPTION
Cirrus recently upgraded their Catalina image to Xcode 12, which had the side-effect of breaking our builds on that host. The build works fine on local installs of that combination, and Xcode 12 works fine on the Big Sur image that Cirrus uses.

This PR reverts the Catalina task back to an image that still has Xcode 11.6 installed. This image seems to work fine for our builds. If someone in the wild runs into a build failure with 12.x on Catalina, we can investigate more.