### PR TITLE
Remove superfluous nullptr checks in Val/RecordVal methods

### DIFF
--- a/src/Val.h
+++ b/src/Val.h
@@ -215,12 +215,7 @@ UNDERLYING_ACCESSOR_DECL(TypeVal, zeek::Type*, AsType)
 		{
 		// Since we're converting from "this", make sure the type requested is a pointer.
 		static_assert(std::is_pointer<T>());
-
-		auto v = static_cast<T>(this);
-		if ( ! v )
-			reporter->InternalError("Failed dynamic_cast between Val types");
-
-		return v;
+		return static_cast<T>(this);
 		}
 
 protected:
@@ -1264,9 +1259,6 @@ public:
 		{
 		auto& field_ptr = GetField(field);
 		auto field_val_ptr = static_cast<T*>(field_ptr.get());
-		if ( ! field_val_ptr )
-			reporter->InternalError("Typecast failed in TableVal::GetFieldAs");
-
 		return field_val_ptr->Get();
 		}
 
@@ -1275,9 +1267,6 @@ public:
 		{
 		auto& field_ptr = GetField(field);
 		auto field_val_ptr = static_cast<T*>(field_ptr.get());
-		if ( ! field_val_ptr )
-			reporter->InternalError("Typecast failed in TableVal::GetFieldAs");
-
 		return field_val_ptr->Get();
 		}
 


### PR DESCRIPTION
These just seemed leftover from `dynamic_cast` times and `static_cast` can no longer help do any type-checking.