### PR TITLE
Update CI configuration for release/3.0 branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,6 +10,15 @@ resources_template: &RESOURCES_TEMPLATE
   cpu: *CPUS
   memory: *MEMORY
 
+macos_resources_template: &MACOS_RESOURCES_TEMPLATE
+  # https://medium.com/cirruslabs/new-macos-task-execution-architecture-for-cirrus-ci-604250627c94
+  # suggests we can go faster here:
+  env:
+    ZEEK_CI_CPUS: 12
+    ZEEK_CI_BTEST_JOBS: 12
+    # No permission to write to default location of /zeek
+    CIRRUS_WORKING_DIR: /tmp/zeek
+
 ci_template: &CI_TEMPLATE
   only_if: >
     $CIRRUS_PR != '' ||
@@ -59,11 +68,25 @@ env:
 
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
+#
+fedora33_task:
+  container:
+    # Fedora 33 EOL: Around November 2022
+    dockerfile: ci/fedora-33/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
 
 fedora32_task:
   container:
     # Fedora 32 EOL: Around May 2021
     dockerfile: ci/fedora-32/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
+centos8_task:
+  container:
+    # CentOS 8 EOL: May 31, 2029
+    dockerfile: ci/centos-8/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
@@ -74,10 +97,24 @@ centos7_task:
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
+debian10_task:
+  container:
+    # Debian 10 EOL: June 2024
+    dockerfile: ci/debian-10/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
 debian9_task:
   container:
     # Debian 9 EOL: June 2022
     dockerfile: ci/debian-9/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
+ubuntu20_task:
+  container:
+    # Ubuntu 20.04 EOL: April 2025
+    dockerfile: ci/ubuntu-20.04/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
@@ -95,27 +132,37 @@ ubuntu16_task:
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
-# Apple doesn't publish official long-term support timelines, so easiest
-# option is to only support the latest macOS release or whatever latest
-# image is available.
-macos_task:
-  osx_instance:
-    image: catalina-base
-    # cpu/memory setting is implicitly 2 core / 4 thread and 8GB, and
-    # trying to set it explicitly results in an error.
+# Apple doesn't publish official long-term support timelines.
+# We aim to support both the current and previous macOS release.
+macos_big_sur_task:
+  macos_instance:
+    image: big-sur-base
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
-  env:
-    ZEEK_CI_CPUS: 4
-    ZEEK_CI_BTEST_JOBS: 4
-    # No permission to write to default location of /zeek
-    CIRRUS_WORKING_DIR: /tmp/zeek
+  << : *MACOS_RESOURCES_TEMPLATE
+
+macos_catalina_task:
+  macos_instance:
+    image: catalina-xcode-11.6
+  prepare_script: ./ci/macos/prepare.sh
+  << : *CI_TEMPLATE
+  << : *MACOS_RESOURCES_TEMPLATE
 
 # FreeBSD EOL timelines: https://www.freebsd.org/security/security.html#sup
-freebsd_task:
+freebsd12_task:
   freebsd_instance:
     # FreeBSD 12 EOL: June 30, 2024
-    image_family: freebsd-12-1
+    image_family: freebsd-12-2
+    cpu: 8
+    # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
+    memory: 8GB
+  prepare_script: ./ci/freebsd/prepare.sh
+  << : *CI_TEMPLATE
+
+freebsd11_task:
+  freebsd_instance:
+    # FreeBSD 11 EOL: September 30, 2021
+    image_family: freebsd-11-4
     cpu: 8
     # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
     memory: 8GB

--- a/ci/centos-8/Dockerfile
+++ b/ci/centos-8/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 RUN dnf -y install epel-release dnf-plugins-core \
   && dnf clean all && rm -rf /var/cache/dnf
 
-RUN dnf config-manager --set-enabled PowerTools
+RUN dnf config-manager --set-enabled powertools
 
 RUN dnf -y update && dnf -y install \
     git \

--- a/ci/centos-8/Dockerfile
+++ b/ci/centos-8/Dockerfile
@@ -1,0 +1,36 @@
+FROM centos:8
+
+RUN dnf -y install epel-release dnf-plugins-core \
+  && dnf clean all && rm -rf /var/cache/dnf
+
+RUN dnf config-manager --set-enabled PowerTools
+
+RUN dnf -y update && dnf -y install \
+    git \
+    cmake3 \
+    make \
+    gcc \
+    gcc-c++ \
+    flex \
+    bison \
+    swig \
+    openssl \
+    openssl-devel \
+    libpcap-devel \
+    python3 \
+    python3-devel \
+    python3-pip \
+    zlib-devel \
+    libsqlite3x-devel \
+    findutils \
+    diffutils \
+    which \
+  && dnf clean all && rm -rf /var/cache/dnf
+
+# Many distros adhere to PEP 394's recommendation for `python` = `python2` so
+# this is a simple workaround until we drop Python 2 support and explicitly
+# use `python3` for all invocations (e.g. in shebangs).
+RUN ln -sf /usr/bin/python3 /usr/local/bin/python
+RUN ln -sf /usr/bin/pip3 /usr/local/bin/pip
+
+RUN pip install junit2html

--- a/ci/debian-10/Dockerfile
+++ b/ci/debian-10/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:10
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+RUN apt-get update && apt-get -y install \
+    git \
+    cmake \
+    make \
+    gcc \
+    g++ \
+    flex \
+    bison \
+    libpcap-dev \
+    libssl-dev \
+    python3 \
+    python3-dev \
+    python3-pip\
+    swig \
+    zlib1g-dev \
+    libkrb5-dev \
+    bsdmainutils \
+    sqlite3 \
+    curl \
+    wget \
+    xz-utils \
+  && rm -rf /var/lib/apt/lists/*
+
+# Many distros adhere to PEP 394's recommendation for `python` = `python2` so
+# this is a simple workaround until we drop Python 2 support and explicitly
+# use `python3` for all invocations (e.g. in shebangs).
+RUN ln -sf /usr/bin/python3 /usr/local/bin/python
+RUN ln -sf /usr/bin/pip3 /usr/local/bin/pip
+
+RUN pip install junit2html

--- a/ci/fedora-33/Dockerfile
+++ b/ci/fedora-33/Dockerfile
@@ -1,0 +1,31 @@
+FROM fedora:33
+
+RUN yum -y install \
+    bison \
+    cmake \
+    diffutils \
+    findutils \
+    flex \
+    git \
+    gcc \
+    gcc-c++ \
+    libpcap-devel \
+    make \
+    openssl \
+    openssl-devel \
+    python3 \
+    python3-devel \
+    python3-pip\
+    sqlite \
+    swig \
+    which \
+    zlib-devel \
+  && yum clean all && rm -rf /var/cache/yum
+
+# Many distros adhere to PEP 394's recommendation for `python` = `python2` so
+# this is a simple workaround until we drop Python 2 support and explicitly
+# use `python3` for all invocations (e.g. in shebangs).
+RUN ln -sf /usr/bin/python3 /usr/local/bin/python
+RUN ln -sf /usr/bin/pip3 /usr/local/bin/pip
+
+RUN pip install junit2html

--- a/ci/ubuntu-20.04/Dockerfile
+++ b/ci/ubuntu-20.04/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+RUN apt-get update && apt-get -y install \
+    git \
+    cmake \
+    make \
+    gcc \
+    g++ \
+    flex \
+    bison \
+    libpcap-dev \
+    libssl-dev \
+    python3 \
+    python3-dev \
+    python3-pip\
+    swig \
+    zlib1g-dev \
+    libmaxminddb-dev \
+    libkrb5-dev \
+    bsdmainutils \
+    sqlite3 \
+    curl \
+    wget \
+    unzip \
+    ruby \
+    bc \
+    lcov \
+  && rm -rf /var/lib/apt/lists/*
+
+# Many distros adhere to PEP 394's recommendation for `python` = `python2` so
+# this is a simple workaround until we drop Python 2 support and explicitly
+# use `python3` for all invocations (e.g. in shebangs).
+RUN ln -sf /usr/bin/python3 /usr/local/bin/python
+RUN ln -sf /usr/bin/pip3 /usr/local/bin/pip
+
+RUN pip install junit2html


### PR DESCRIPTION
* Add tasks for Fedora 33, CentOS 8, Debian 10, Ubuntu 20.04,
  FreeBSD 11, and macOS Big Sur
* Bump FreeBSD 12-1 task to 12-2
* Switch macOS Catalina image to "catalina-xode-11.6 image"
* Increase CPUs used for macOS tasks