### PR TITLE
Add CentOS Stream to CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -104,6 +104,13 @@ fedora32_task:
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
+centosstream8_task:
+  container:
+    # Stream 8 support should be 5 years, so until 2024. but I cannot find a concrete timeline --cpk
+    dockerfile: ci/centos-stream-8/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
 centos8_task:
   container:
     # CentOS 8 EOL: May 31, 2029

--- a/ci/centos-stream-8/Dockerfile
+++ b/ci/centos-stream-8/Dockerfile
@@ -1,0 +1,23 @@
+FROM quay.io/centos/centos:stream8
+
+RUN dnf config-manager --set-enabled powertools
+
+RUN dnf -y install \
+    bison \
+    cmake \
+    diffutils \
+    flex \
+    git \
+    gcc \
+    gcc-c++ \
+    libpcap-devel \
+    make \
+    openssl-devel \
+    python3-devel \
+    python3-pip\
+    sqlite \
+    swig \
+    zlib-devel \
+  && dnf clean all && rm -rf /var/cache/dnf
+
+RUN pip3 install junit2html

--- a/ci/fedora-32/Dockerfile
+++ b/ci/fedora-32/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:32
 
-RUN yum -y install \
+RUN dnf -y install \
     bison \
     cmake \
     diffutils \
@@ -11,15 +11,13 @@ RUN yum -y install \
     gcc-c++ \
     libpcap-devel \
     make \
-    openssl \
     openssl-devel \
-    python3 \
     python3-devel \
     python3-pip\
     sqlite \
     swig \
     which \
     zlib-devel \
-  && yum clean all && rm -rf /var/cache/yum
+  && dnf clean all && rm -rf /var/cache/dnf
 
 RUN pip3 install junit2html

--- a/ci/fedora-33/Dockerfile
+++ b/ci/fedora-33/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:33
 
-RUN yum -y install \
+RUN dnf -y install \
     bison \
     cmake \
     diffutils \
@@ -11,15 +11,13 @@ RUN yum -y install \
     gcc-c++ \
     libpcap-devel \
     make \
-    openssl \
     openssl-devel \
-    python3 \
     python3-devel \
     python3-pip\
     sqlite \
     swig \
     which \
     zlib-devel \
-  && yum clean all && rm -rf /var/cache/yum
+  && dnf clean all && rm -rf /var/cache/dnf
 
 RUN pip3 install junit2html


### PR DESCRIPTION
I'm thinking we should start running Stream builds in CI, just to get a feel for how that distro behaves even if we don't officially support it yet. Given its positioning between Fedora and RedHat I can't imagine this'll be much of a burden since we support Fedora anyway.

Also includes minor tweaks for Fedora, where the default package manager has been `dnf` for a long time time now.