### PR TITLE
Avoid reporting paths repeatedly in `zeek-config --include_dir`

### DIFF
--- a/zeek-config.in
+++ b/zeek-config.in
@@ -17,11 +17,25 @@ binpac_root=@ZEEK_CONFIG_BINPAC_ROOT_DIR@
 caf_root=@ZEEK_CONFIG_CAF_ROOT_DIR@
 broker_root=@ZEEK_CONFIG_BROKER_ROOT_DIR@
 
-include_dir=${include_dir}:@ZEEK_CONFIG_PCAP_INCLUDE_DIR@
-include_dir=${include_dir}:@ZEEK_CONFIG_ZLIB_INCLUDE_DIR@
-include_dir=${include_dir}:@ZEEK_CONFIG_OPENSSL_INCLUDE_DIR@
-include_dir=${include_dir}:@ZEEK_CONFIG_LibKrb5_INCLUDE_DIR@
-include_dir=${include_dir}:@ZEEK_CONFIG_GooglePerftools_INCLUDE_DIR@
+add_path() {
+    # $1: existing path
+    # $2: path to add
+    if test -z "$2" || test "$1" = "$2" ||
+       echo "$1" | grep -q "^$2:" 2>/dev/null ||
+       echo "$1" | grep -q ":$2:" 2>/dev/null ||
+       echo "$1" | grep -q ":$2$" 2>/dev/null; then
+        echo "$1"
+        return
+    fi
+
+    echo "$1:$2"
+}
+
+include_dir=$(add_path "$include_dir" "@ZEEK_CONFIG_PCAP_INCLUDE_DIR@")
+include_dir=$(add_path "$include_dir" "@ZEEK_CONFIG_ZLIB_INCLUDE_DIR@")
+include_dir=$(add_path "$include_dir" "@ZEEK_CONFIG_OPENSSL_INCLUDE_DIR@")
+include_dir=$(add_path "$include_dir" "@ZEEK_CONFIG_LibKrb5_INCLUDE_DIR@")
+include_dir=$(add_path "$include_dir" "@ZEEK_CONFIG_GooglePerftools_INCLUDE_DIR@")
 
 usage="\
 Usage: zeek-config [--version] [--build_type] [--prefix] [--lib_dir] [--script_dir] [--site_dir] [--plugin_dir] [--config_dir] [--python_dir] [--include_dir] [--cmake_dir] [--zeekpath] [--zeek_dist] [--binpac_root] [--caf_root] [--broker_root]"


### PR DESCRIPTION
On my Linux systems `zeek-config --include_dir` ends up looking like this ...
```
$ ./zeek-config --include_dir
/home/christian/inst/opt/zeek/include:/usr/include:/usr/include:/usr/include:/usr/include:
```
... and on FreeBSD like this:
```
$ ./zeek-config --include_dir
/home/christian/inst/opt/zeek/include:/usr/include:/usr/include:/usr/include::
```
No harm here, but it's a bit cluttered. The patch avoids adding redundant or empty paths. Really plain to be portable ... works for me on Linux and FreeBSD. The result in both cases:
```
./zeek-config --include_dir
/home/christian/inst/opt/zeek/include:/usr/include
```