### PR TITLE
Fix potential mime type detection bug in IRC/FTP file_transferred event

### DIFF
--- a/src/analyzer/protocol/file/File.cc
+++ b/src/analyzer/protocol/file/File.cc
@@ -25,7 +25,7 @@ void File_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 
 	if ( n )
 		{
-		strncpy(buffer + buffer_len, (const char*) data, n);
+		memcpy(buffer + buffer_len, (const char*) data, n);
 		buffer_len += n;
 
 		if ( buffer_len == BUFFER_SIZE )


### PR DESCRIPTION
The files framework uses strncpy to copy data into the buffer that is
used for mime type detection. From all I can tell that means that
currently mime type detection will be messed up if the data being passed
in contains zero bytes.