### PR TITLE
Avoid searching a directory for dynamic plugins multiple times

### DIFF
--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -7,6 +7,8 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <limits.h> // for PATH_MAX
+#include <cstdlib>
 #include <optional>
 #include <sstream>
 #include <fstream>
@@ -69,6 +71,19 @@ void Manager::SearchDynamicPlugins(const std::string& dir)
 		DBG_LOG(DBG_PLUGINS, "Not a valid plugin directory: %s", dir.c_str());
 		return;
 		}
+
+	char canon_path[PATH_MAX];
+	if ( ! realpath(dir.data(), canon_path) )
+		{
+		DBG_LOG(DBG_PLUGINS, "skip dynamic plugin search in %s, realpath failed: %s",
+		        dir.data(), strerror(errno));
+		return;
+		}
+
+	if ( searched_dirs.count(canon_path) )
+		return;
+
+	searched_dirs.emplace(canon_path);
 
 	// Check if it's a plugin dirctory.
 

--- a/src/plugin/Manager.h
+++ b/src/plugin/Manager.h
@@ -416,6 +416,11 @@ private:
 	void MetaHookPre(HookType hook, const HookArgumentList& args) const;
 	void MetaHookPost(HookType hook, const HookArgumentList& args, const HookArgument& result) const;
 
+	// Directories that have already been searched for dynamic plugins.
+	// Used to prevent multiple searches of the same dirs (e.g. via symlinks).
+	// The paths stored in the set are made canonical via realpath().
+	std::set<std::string, std::less<>> searched_dirs;
+
 	// Plugins that were explicitly requested to be activated, but failed to
 	// load at first.
 	std::set<std::string> requested_plugins;


### PR DESCRIPTION
This can improve `zeek` startup time (~2x for me on one system) when running from the build-tree since commit c44cbe1febdde6c4386a5ead8a68be412cc6c712 because that introduced a symlink causing an infinite search loop that's only stopped due to a `stat()` call failing with "too many levels of symbolic links" and silently skipping further recursion. 