### PR TITLE
Use buffered IO for file extraction

### DIFF
--- a/src/file_analysis/analyzer/extract/Extract.h
+++ b/src/file_analysis/analyzer/extract/Extract.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <string>
+#include <cstdio>
 
 #include "zeek/Val.h"
 #include "zeek/file_analysis/File.h"
@@ -72,7 +73,7 @@ protected:
 
 private:
 	std::string filename;
-	int fd;
+	FILE* file_stream;
 	uint64_t limit;
 	uint64_t depth;
 };


### PR DESCRIPTION
This can improve performance significantly: ~3.5x faster when tested on
a large file passing data to the file analysis framework in small chunks
of 20 bytes.

Fixes GH-1432

@JustinAzoff can you check if your test case improves with this?