### PR TITLE
Install btest tooling with the distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,6 +531,9 @@ if ( GooglePerftools_INCLUDE_DIR )
     set(ZEEK_CONFIG_GooglePerftools_INCLUDE_DIR ${GooglePerftools_INCLUDE_DIR})
 endif ()
 
+set(ZEEK_CONFIG_BTEST_TOOLS_DIR ${ZEEK_ROOT_DIR}/share/btest)
+install(DIRECTORY DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR})
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zeek-config.in
                ${CMAKE_CURRENT_BINARY_DIR}/zeek-config @ONLY)
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/zeek-config DESTINATION bin)
@@ -568,6 +571,7 @@ endif ()
 add_subdirectory(src)
 add_subdirectory(scripts)
 add_subdirectory(man)
+add_subdirectory(testing)
 
 include(CheckOptionalBuildSources)
 
@@ -600,6 +604,12 @@ if (CMAKE_BUILD_TYPE)
     string(TOUPPER ${CMAKE_BUILD_TYPE} BuildType)
 endif ()
 
+if ( INSTALL_BTEST_PCAPS )
+    set(_install_btest_tools_msg "all")
+else ()
+    set(_install_btest_tools_msg "no pcaps")
+endif ()
+
 message(
     "\n====================|  Zeek Build Summary  |===================="
     "\n"
@@ -621,6 +631,7 @@ message(
     "\nZeekControl:       ${INSTALL_ZEEKCTL}"
     "\nAux. Tools:        ${INSTALL_AUX_TOOLS}"
     "\nBTest:             ${INSTALL_BTEST}"
+    "\nBTest tooling:     ${_install_btest_tools_msg}"
     "\nzkg:               ${INSTALL_ZKG}"
     "\n"
     "\nlibmaxminddb:      ${USE_GEOIP}"

--- a/configure
+++ b/configure
@@ -65,6 +65,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --disable-auxtools     don't build or install auxiliary tools
     --disable-archiver     don't build or install zeek-archiver tool
     --disable-btest        don't install BTest
+    --disable-btest-pcaps  don't install Zeek's BTest input pcaps
     --disable-python       don't try to build python bindings for Broker
     --disable-broker-tests don't try to build Broker unit tests
     --disable-zkg          don't install zkg
@@ -161,6 +162,7 @@ append_cache_entry ENABLE_JEMALLOC      BOOL   false
 append_cache_entry BUILD_SHARED_LIBS    BOOL   true
 append_cache_entry INSTALL_AUX_TOOLS    BOOL   true
 append_cache_entry INSTALL_BTEST        BOOL   true
+append_cache_entry INSTALL_BTEST_PCAPS  BOOL   true
 append_cache_entry INSTALL_ZEEK_ARCHIVER BOOL  true
 append_cache_entry INSTALL_ZEEKCTL      BOOL   true
 append_cache_entry INSTALL_ZKG          BOOL   true
@@ -288,6 +290,9 @@ while [ $# -ne 0 ]; do
             ;;
         --disable-btest)
             append_cache_entry INSTALL_BTEST BOOL false
+            ;;
+        --disable-btest-pcaps)
+            append_cache_entry INSTALL_BTEST_PCAPS BOOL false
             ;;
         --disable-python)
             append_cache_entry DISABLE_PYTHON_BINDINGS     BOOL   true

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,0 +1,8 @@
+install(DIRECTORY scripts/ DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/scripts
+    USE_SOURCE_PERMISSIONS
+    FILES_MATCHING PATTERN "diff-*")
+install(FILES btest/random.seed DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/data)
+
+if ( INSTALL_BTEST_PCAPS )
+    install(DIRECTORY btest/Traces/ DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/data/pcaps)
+endif ()

--- a/zeek-config.in
+++ b/zeek-config.in
@@ -16,6 +16,7 @@ zeek_dist=@ZEEK_DIST@
 binpac_root=@ZEEK_CONFIG_BINPAC_ROOT_DIR@
 caf_root=@ZEEK_CONFIG_CAF_ROOT_DIR@
 broker_root=@ZEEK_CONFIG_BROKER_ROOT_DIR@
+btest_tools_dir=@ZEEK_CONFIG_BTEST_TOOLS_DIR@
 
 add_path() {
     # $1: existing path
@@ -38,7 +39,7 @@ include_dir=$(add_path "$include_dir" "@ZEEK_CONFIG_LibKrb5_INCLUDE_DIR@")
 include_dir=$(add_path "$include_dir" "@ZEEK_CONFIG_GooglePerftools_INCLUDE_DIR@")
 
 usage="\
-Usage: zeek-config [--version] [--build_type] [--prefix] [--lib_dir] [--script_dir] [--site_dir] [--plugin_dir] [--config_dir] [--python_dir] [--include_dir] [--cmake_dir] [--zeekpath] [--zeek_dist] [--binpac_root] [--caf_root] [--broker_root]"
+Usage: zeek-config [--version] [--build_type] [--prefix] [--btest_tools_dir] [--lib_dir] [--script_dir] [--site_dir] [--plugin_dir] [--config_dir] [--python_dir] [--include_dir] [--cmake_dir] [--zeekpath] [--zeek_dist] [--binpac_root] [--caf_root] [--broker_root]"
 
 if [ $# -eq 0 ] ; then
       echo "${usage}" 1>&2
@@ -63,6 +64,9 @@ while [ $# -ne 0 ]; do
       ;;
     --bropath)   # For compatibility with legacy Bro plugins.
       echo $zeekpath
+      ;;
+    --btest_tools_dir)
+      echo $btest_tools_dir
       ;;
     --build_type)
       echo $build_type

--- a/zeek-config.in
+++ b/zeek-config.in
@@ -38,11 +38,39 @@ include_dir=$(add_path "$include_dir" "@ZEEK_CONFIG_OPENSSL_INCLUDE_DIR@")
 include_dir=$(add_path "$include_dir" "@ZEEK_CONFIG_LibKrb5_INCLUDE_DIR@")
 include_dir=$(add_path "$include_dir" "@ZEEK_CONFIG_GooglePerftools_INCLUDE_DIR@")
 
-usage="\
-Usage: zeek-config [--version] [--build_type] [--prefix] [--btest_tools_dir] [--lib_dir] [--script_dir] [--site_dir] [--plugin_dir] [--config_dir] [--python_dir] [--include_dir] [--cmake_dir] [--zeekpath] [--zeek_dist] [--binpac_root] [--caf_root] [--broker_root]"
+usage() {
+    echo "Usage: zeek-config [OPTIONS]
+
+Basic options:
+
+  --build_type          Zeek build type as per cmake, lower case (e.g. 'relwithdebinfo')
+  --prefix              Toplevel Zeek distribution installation directory
+  --version             Zeek version number
+  --zeek_dist           Toplevel directory of source tree the distribution built from
+  --zeekpath            ZEEKPATH environment variable paths for this distribution
+
+Specific directories in the Zeek distribution:
+
+  --btest_tools_dir     Zeek-related BTest tooling
+  --cmake_dir           Zeek's cmake modules
+  --config_dir          Configuration files for cluster topology, zkg, etc
+  --include_dir         C/C++ header folders for Zeek and related components, colon-separated
+  --lib_dir             Toplevel folder for shared libraries, Python packages, etc
+  --plugin_dir          Native-code Zeek plugins
+  --python_dir          Python packages (Broker, ZeekControl, zkg, etc)
+  --script_dir          Toplevel folder for Zeek scripts
+  --site_dir            Site-specific Zeek scripts
+
+Toplevel installation directories for third-party components:
+
+  --binpac_root         BinPAC compiler
+  --broker_root         Broker communication framework
+  --caf_root            C++ Actor Framework
+"
+}
 
 if [ $# -eq 0 ] ; then
-      echo "${usage}" 1>&2
+      usage 1>&2
       exit 1
 fi
 
@@ -111,7 +139,7 @@ while [ $# -ne 0 ]; do
       echo $zeekpath
       ;;
     *)
-      echo "${usage}" 1>&2
+      usage 1>&2
       exit 1
       ;;
   esac

--- a/zeek-config.in
+++ b/zeek-config.in
@@ -1,22 +1,22 @@
 #!/bin/sh
 
-version=@VERSION@
-build_type=@CMAKE_BUILD_TYPE_LOWER@
-prefix=@CMAKE_INSTALL_PREFIX@
-script_dir=@ZEEK_SCRIPT_INSTALL_PATH@
-site_dir=@ZEEK_SCRIPT_INSTALL_PATH@/site
-lib_dir=@CMAKE_INSTALL_FULL_LIBDIR@
-plugin_dir=@BRO_PLUGIN_INSTALL_PATH@
-config_dir=@ZEEK_ETC_INSTALL_DIR@
-python_dir=@PY_MOD_INSTALL_DIR@
-cmake_dir=@CMAKE_INSTALL_PREFIX@/share/zeek/cmake
-include_dir=@CMAKE_INSTALL_PREFIX@/include
-zeekpath=@DEFAULT_ZEEKPATH@
-zeek_dist=@ZEEK_DIST@
 binpac_root=@ZEEK_CONFIG_BINPAC_ROOT_DIR@
-caf_root=@ZEEK_CONFIG_CAF_ROOT_DIR@
 broker_root=@ZEEK_CONFIG_BROKER_ROOT_DIR@
 btest_tools_dir=@ZEEK_CONFIG_BTEST_TOOLS_DIR@
+build_type=@CMAKE_BUILD_TYPE_LOWER@
+caf_root=@ZEEK_CONFIG_CAF_ROOT_DIR@
+cmake_dir=@CMAKE_INSTALL_PREFIX@/share/zeek/cmake
+config_dir=@ZEEK_ETC_INSTALL_DIR@
+include_dir=@CMAKE_INSTALL_PREFIX@/include
+lib_dir=@CMAKE_INSTALL_FULL_LIBDIR@
+plugin_dir=@BRO_PLUGIN_INSTALL_PATH@
+prefix=@CMAKE_INSTALL_PREFIX@
+python_dir=@PY_MOD_INSTALL_DIR@
+script_dir=@ZEEK_SCRIPT_INSTALL_PATH@
+site_dir=@ZEEK_SCRIPT_INSTALL_PATH@/site
+version=@VERSION@
+zeek_dist=@ZEEK_DIST@
+zeekpath=@DEFAULT_ZEEKPATH@
 
 add_path() {
     # $1: existing path


### PR DESCRIPTION
This adds $PREFIX/share/btest to the installation and puts Zeek's btest canonifiers, random.seed, and pcaps in there. For example, in order to use the `diff-canonifier` you'd say `$(zeek-config --btest_tools_dir)/scripts/diff-canonifier` from your package's btest.

Pcaps can be skipped via `configure --disable-btest-pcaps`. I don't feel strongly here and could also see opt-in — just let me know, or feel free to change upon merge.

Also adds help output to `zeek-config`, since it has a lot of options these days.

Resolves #1431.