### PR TITLE
Expose a configure-time option to set the plugin path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,14 @@ get_filename_component(ZEEK_SCRIPT_INSTALL_PATH ${ZEEK_SCRIPT_INSTALL_PATH}
 # A folder for library-like Zeek-specific things: Python modules, Zeek
 # plugins, etc.
 set(ZEEK_LIBDIR_PATH ${CMAKE_INSTALL_FULL_LIBDIR}/zeek)
-set(BRO_PLUGIN_INSTALL_PATH ${ZEEK_LIBDIR_PATH}/plugins
-    CACHE STRING "Installation path for plugins" FORCE)
+
+if (ZEEK_PLUGIN_DIR)
+    set(BRO_PLUGIN_INSTALL_PATH ${ZEEK_PLUGIN_DIR}
+        CACHE STRING "Installation path for plugins" FORCE)
+else ()
+    set(BRO_PLUGIN_INSTALL_PATH ${ZEEK_LIBDIR_PATH}/plugins
+        CACHE STRING "Installation path for plugins" FORCE)
+endif ()
 
 configure_file(zeek-path-dev.in ${CMAKE_CURRENT_BINARY_DIR}/zeek-path-dev)
 execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink

--- a/configure
+++ b/configure
@@ -41,6 +41,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --logdir=PATH          when using ZeekControl, path to store log file
                            [PREFIX/logs]
     --libdir=PATH          installation directory for library files [PREFIX/lib]
+    --plugindir=PATH       installation directory for plugins [LIBDIR/zeek/plugin]
     --conf-files-dir=PATH  config files installation directory [PREFIX/etc]
     --mandir=PATH          installation path for man pages [PREFIX/share/man]
     --python-dir=PATH      explicit installation directory for Python modules
@@ -212,6 +213,9 @@ while [ $# -ne 0 ]; do
             ;;
         --libdir=*)
             append_cache_entry CMAKE_INSTALL_LIBDIR PATH   $optarg
+            ;;
+        --plugindir=*)
+            append_cache_entry ZEEK_PLUGIN_DIR PATH   $optarg
             ;;
         --python-dir=*)
             append_cache_entry ZEEK_PYTHON_DIR PATH   $optarg


### PR DESCRIPTION
Adds a new `--plugindir` option to the configure script. I ran into a use-case where I needed to set this, but couldn't.

I believe that this is the last option presented during the build summary which wasn't available to be set by the user.