### PR TITLE
Clean up iterator usage in Analyzer

### DIFF
--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -38,7 +38,7 @@ class AnalyzerTimer;
 class SupportAnalyzer;
 class OutputHandler;
 
-using analyzer_list = std::list<Analyzer*>;
+using analyzer_list = std::vector<Analyzer*>;
 typedef uint32_t ID;
 typedef void (Analyzer::*analyzer_timer_func)(double t);
 
@@ -685,8 +685,9 @@ protected:
 
 private:
 	// Internal method to eventually delete a child analyzer that's
-	// already Done().
-	void DeleteChild(analyzer_list::iterator i);
+	// already Done(). Returns an iterator to the next element, following
+	// std::list::erase()'s semantics.
+	analyzer_list::iterator DeleteChild(analyzer_list::iterator i);
 
 	// Helper for the ctors.
 	void CtorInit(const Tag& tag, Connection* conn);
@@ -727,31 +728,27 @@ private:
  * Internal convenience macro to iterate over the list of child analyzers.
  */
 #define LOOP_OVER_CHILDREN(var) \
-	for ( zeek::analyzer::analyzer_list::iterator var = children.begin(); \
-	      var != children.end(); var++ )
+	for ( auto var = children.begin(); var != children.end(); ++var )
 
 /**
  * Internal convenience macro to iterate over the constant list of child
  * analyzers.
  */
 #define LOOP_OVER_CONST_CHILDREN(var) \
-	for ( zeek::analyzer::analyzer_list::const_iterator var = children.begin(); \
-	      var != children.end(); var++ )
+	for ( auto var = children.cbegin(); var != children.cend(); ++var )
 
 /**
  * Convenience macro to iterate over a given list of child analyzers.
  */
 #define LOOP_OVER_GIVEN_CHILDREN(var, the_kids) \
-	for ( zeek::analyzer::analyzer_list::iterator var = the_kids.begin(); \
-	      var != the_kids.end(); var++ )
+	for ( auto var = the_kids.begin(); var != the_kids.end(); ++var )
 
 /**
  * Convenience macro to iterate over a given constant list of child
  * analyzers.
  */
 #define LOOP_OVER_GIVEN_CONST_CHILDREN(var, the_kids) \
-	for ( zeek::analyzer::analyzer_list::const_iterator var = the_kids.begin(); \
-	      var != the_kids.end(); var++ )
+	for ( auto var = the_kids.cbegin(); var != the_kids.cend(); ++var )
 
 /**
  * Support analyzer preprocess input before it reaches an analyzer's main

--- a/src/analyzer/protocol/tcp/TCP.h
+++ b/src/analyzer/protocol/tcp/TCP.h
@@ -174,7 +174,6 @@ private:
 	TCP_Endpoint* orig;
 	TCP_Endpoint* resp;
 
-	using analyzer_list = std::list<analyzer::Analyzer*>;
 	analyzer_list packet_children;
 
 	unsigned int first_packet_seen: 2;


### PR DESCRIPTION
These changes result in a 1.5-2% performance increase reading the 2009-M57-day11-18.trace file. Changing over to use `std::vector` also helps debugging this code a little bit since it's easier to look at the members of a vector vs a list.