### PR TITLE
Prep work for Script Compilation: simple changes

### DIFF
--- a/scripts/base/frameworks/logging/main.zeek
+++ b/scripts/base/frameworks/logging/main.zeek
@@ -713,6 +713,8 @@ function enable_stream(id: ID) : bool
 
 	if ( id in all_streams )
 		active_streams[id] = all_streams[id];
+
+	return T;
 	}
 
 # convenience function to add a filter name to stream_filters

--- a/scripts/base/frameworks/openflow/plugins/broker.zeek
+++ b/scripts/base/frameworks/openflow/plugins/broker.zeek
@@ -87,7 +87,7 @@ function broker_new(name: string, host: addr, host_port: port, topic: string, dp
 	register_controller(OpenFlow::BROKER, name, c);
 
 	if ( [host_port, cat(host)] in broker_peers )
-		Reporter::warning(fmt("Peer %s:%s was added to NetControl acld plugin twice.", host, host_port));
+		Reporter::warning(fmt("Peer %s:%s was added to NetControl openflow plugin twice.", host, host_port));
 	else
 		broker_peers[host_port, cat(host)] = c;
 

--- a/scripts/base/protocols/conn/thresholds.zeek
+++ b/scripts/base/protocols/conn/thresholds.zeek
@@ -217,7 +217,7 @@ function set_current_threshold(c: connection, ttype: threshold_type, is_orig: bo
 		return set_current_conn_packets_threshold(c$id, t, T);
 	else if ( ttype == PACKETS && ! is_orig )
 		return set_current_conn_packets_threshold(c$id, t, F);
-	else if ( ttype == DURATION )
+	else # ttype == DURATION
 		return set_current_conn_duration_threshold(c$id, td);
 	}
 

--- a/scripts/base/utils/directions-and-hosts.zeek
+++ b/scripts/base/utils/directions-and-hosts.zeek
@@ -33,7 +33,7 @@ function id_matches_direction(id: conn_id, d: Direction): bool
 		return (o_local && !r_local) || (!o_local && r_local);
 	else if ( d == OUTBOUND )
 		return o_local && !r_local;
-	else if ( d == INBOUND )
+	else # d == INBOUND
 		return !o_local && r_local;
 	}
 

--- a/src/Desc.h
+++ b/src/Desc.h
@@ -122,7 +122,7 @@ public:
 				Add("\n", 0);
 			}
 
-	// Bypasses the escaping enabled via SetEscape().
+	// Bypasses the escaping enabled via EnableEscaping().
 	void AddRaw(const char* s, int len)	{ AddBytesRaw(s, len); }
 	void AddRaw(const std::string &s)		{ AddBytesRaw(s.data(), s.size()); }
 

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -183,7 +183,7 @@ bool Expr::CanDel() const
 
 void Expr::Add(Frame* /* f */)
 	{
-	Internal("Expr::Delete called");
+	Internal("Expr::Add called");
 	}
 
 void Expr::Delete(Frame* /* f */)

--- a/src/Reporter.h
+++ b/src/Reporter.h
@@ -84,19 +84,19 @@ public:
 	// Returns the number of errors reported so far.
 	int Errors()	{ return errors; }
 
-	// Report a fatal error. Bro will terminate after the message has been
+	// Report a fatal error. Zeek will terminate after the message has been
 	// reported.
 	[[noreturn]] void FatalError(const char* fmt, ...) FMT_ATTR;
 
-	// Report a fatal error. Bro will terminate after the message has been
+	// Report a fatal error. Zeek will terminate after the message has been
 	// reported and always generate a core dump.
 	[[noreturn]] void FatalErrorWithCore(const char* fmt, ...) FMT_ATTR;
 
-	// Report a runtime error in evaluating a Bro script expression. This
+	// Report a runtime error in evaluating a Zeek script expression. This
 	// function will not return but raise an InterpreterException.
 	[[noreturn]] void ExprRuntimeError(const detail::Expr* expr, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
 
-	// Report a runtime error in evaluating a Bro script expression. This
+	// Report a runtime error in evaluating a Zeek script expression. This
 	// function will not return but raise an InterpreterException.
 	[[noreturn]] void RuntimeError(const detail::Location* location, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
 
@@ -116,16 +116,16 @@ public:
 	// offline from a trace.
 	void Syslog(const char* fmt, ...) FMT_ATTR;
 
-	// Report about a potential internal problem. Bro will continue
+	// Report about a potential internal problem. Zeek will continue
 	// normally.
 	void InternalWarning(const char* fmt, ...) FMT_ATTR;
 
-	// Report an internal program error. Bro will terminate with a core
+	// Report an internal program error. Zeek will terminate with a core
 	// dump after the message has been reported.
 	[[noreturn]] void InternalError(const char* fmt, ...) FMT_ATTR;
 
 	// Report an analyzer error. That analyzer will be set to not process
-	// any further input, but Bro otherwise continues normally.
+	// any further input, but Zeek otherwise continues normally.
 	void AnalyzerError(analyzer::Analyzer* a, const char* fmt, ...) __attribute__((format(printf, 3, 4)));;
 
 	// Toggle whether non-fatal messages should be reported through the

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -235,7 +235,7 @@ ExprListStmt::ExprListStmt(StmtTag t, ListExprPtr arg_l)
 
 ExprListStmt::~ExprListStmt() = default;
 
-ValPtr ExprListStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr ExprListStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	last_access = run_state::network_time;
 	flow = FLOW_NEXT;
@@ -303,7 +303,7 @@ static void print_log(const std::vector<ValPtr>& vals)
 	}
 
 ValPtr PrintStmt::DoExec(std::vector<ValPtr> vals,
-                         StmtFlowType& /* flow */) const
+                         StmtFlowType& /* flow */)
 	{
 	RegisterAccess();
 
@@ -393,7 +393,7 @@ ExprPtr ExprStmt::StmtExprPtr() const
 	return e;
 	}
 
-ValPtr ExprStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr ExprStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_NEXT;
@@ -406,7 +406,7 @@ ValPtr ExprStmt::Exec(Frame* f, StmtFlowType& flow) const
 		return nullptr;
 	}
 
-ValPtr ExprStmt::DoExec(Frame* /* f */, Val* /* v */, StmtFlowType& /* flow */) const
+ValPtr ExprStmt::DoExec(Frame* /* f */, Val* /* v */, StmtFlowType& /* flow */)
 	{
 	return nullptr;
 	}
@@ -470,7 +470,7 @@ IfStmt::IfStmt(ExprPtr test,
 
 IfStmt::~IfStmt() = default;
 
-ValPtr IfStmt::DoExec(Frame* f, Val* v, StmtFlowType& flow) const
+ValPtr IfStmt::DoExec(Frame* f, Val* v, StmtFlowType& flow)
 	{
 	// Treat 0 as false, but don't require 1 for true.
 	Stmt* do_stmt = v->IsZero() ? s2.get() : s1.get();
@@ -917,7 +917,7 @@ std::pair<int, ID*> SwitchStmt::FindCaseLabelMatch(const Val* v) const
 		return std::make_pair(label_idx, label_id);
 	}
 
-ValPtr SwitchStmt::DoExec(Frame* f, Val* v, StmtFlowType& flow) const
+ValPtr SwitchStmt::DoExec(Frame* f, Val* v, StmtFlowType& flow)
 	{
 	ValPtr rval;
 
@@ -930,7 +930,7 @@ ValPtr SwitchStmt::DoExec(Frame* f, Val* v, StmtFlowType& flow) const
 
 	for ( int i = matching_label_idx; i < cases->length(); ++i )
 		{
-		const Case* c = (*cases)[i];
+		auto c = (*cases)[i];
 
 		if ( matching_id )
 			{
@@ -1033,7 +1033,7 @@ AddStmt::AddStmt(ExprPtr arg_e) : AddDelStmt(STMT_ADD, std::move(arg_e))
 		Error("illegal add statement");
 	}
 
-ValPtr AddStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr AddStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_NEXT;
@@ -1051,7 +1051,7 @@ DelStmt::DelStmt(ExprPtr arg_e) : AddDelStmt(STMT_DELETE, std::move(arg_e))
 		Error("illegal delete statement");
 	}
 
-ValPtr DelStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr DelStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_NEXT;
@@ -1065,7 +1065,7 @@ EventStmt::EventStmt(EventExprPtr arg_e)
 	{
 	}
 
-ValPtr EventStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr EventStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	auto args = eval_list(f, event_expr->Args());
@@ -1142,7 +1142,7 @@ TraversalCode WhileStmt::Traverse(TraversalCallback* cb) const
 	HANDLE_TC_STMT_POST(tc);
 	}
 
-ValPtr WhileStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr WhileStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_NEXT;
@@ -1288,7 +1288,7 @@ ForStmt::~ForStmt()
 	delete loop_vars;
 	}
 
-ValPtr ForStmt::DoExec(Frame* f, Val* v, StmtFlowType& flow) const
+ValPtr ForStmt::DoExec(Frame* f, Val* v, StmtFlowType& flow)
 	{
 	ValPtr ret;
 
@@ -1430,7 +1430,7 @@ TraversalCode ForStmt::Traverse(TraversalCallback* cb) const
 	HANDLE_TC_STMT_POST(tc);
 	}
 
-ValPtr NextStmt::Exec(Frame* /* f */, StmtFlowType& flow) const
+ValPtr NextStmt::Exec(Frame* /* f */, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_LOOP;
@@ -1457,7 +1457,7 @@ TraversalCode NextStmt::Traverse(TraversalCallback* cb) const
 	HANDLE_TC_STMT_POST(tc);
 	}
 
-ValPtr BreakStmt::Exec(Frame* /* f */, StmtFlowType& flow) const
+ValPtr BreakStmt::Exec(Frame* /* f */, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_BREAK;
@@ -1484,7 +1484,7 @@ TraversalCode BreakStmt::Traverse(TraversalCallback* cb) const
 	HANDLE_TC_STMT_POST(tc);
 	}
 
-ValPtr FallthroughStmt::Exec(Frame* /* f */, StmtFlowType& flow) const
+ValPtr FallthroughStmt::Exec(Frame* /* f */, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_FALLTHROUGH;
@@ -1555,7 +1555,7 @@ ReturnStmt::ReturnStmt(ExprPtr arg_e)
 		}
 	}
 
-ValPtr ReturnStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr ReturnStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_RETURN;
@@ -1597,7 +1597,7 @@ StmtList::~StmtList()
 	delete stmts;
 	}
 
-ValPtr StmtList::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr StmtList::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_NEXT;
@@ -1684,7 +1684,7 @@ InitStmt::InitStmt(std::vector<IDPtr> arg_inits) : Stmt(STMT_INIT)
 		SetLocationInfo(inits[0]->GetLocationInfo());
 	}
 
-ValPtr InitStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr InitStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_NEXT;
@@ -1749,7 +1749,7 @@ TraversalCode InitStmt::Traverse(TraversalCallback* cb) const
 	HANDLE_TC_STMT_POST(tc);
 	}
 
-ValPtr NullStmt::Exec(Frame* /* f */, StmtFlowType& flow) const
+ValPtr NullStmt::Exec(Frame* /* f */, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_NEXT;
@@ -1804,7 +1804,7 @@ WhenStmt::WhenStmt(ExprPtr arg_cond,
 
 WhenStmt::~WhenStmt() = default;
 
-ValPtr WhenStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr WhenStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_NEXT;

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -33,9 +33,8 @@ protected:
 
 	~ExprListStmt() override;
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
-	virtual ValPtr DoExec(std::vector<ValPtr> vals,
-	                      StmtFlowType& flow) const = 0;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
+	virtual ValPtr DoExec(std::vector<ValPtr> vals, StmtFlowType& flow) = 0;
 
 	void StmtDescribe(ODesc* d) const override;
 
@@ -57,8 +56,7 @@ public:
 	StmtPtr Duplicate() override;
 
 protected:
-	ValPtr DoExec(std::vector<ValPtr> vals,
-	              StmtFlowType& flow) const override;
+	ValPtr DoExec(std::vector<ValPtr> vals, StmtFlowType& flow) override;
 
 	// Optimization-related:
 	StmtPtr DoSubclassReduce(ListExprPtr singletons, Reducer* c) override;
@@ -74,7 +72,7 @@ public:
 	// not allowing us to use "friend" for protected access.
 	ExprStmt(StmtTag t, ExprPtr e);
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
 	const Expr* StmtExpr() const	{ return e.get(); }
 	ExprPtr StmtExprPtr() const;
@@ -91,7 +89,7 @@ public:
 	StmtPtr DoReduce(Reducer* c) override;
 
 protected:
-	virtual ValPtr DoExec(Frame* f, Val* v, StmtFlowType& flow) const;
+	virtual ValPtr DoExec(Frame* f, Val* v, StmtFlowType& flow);
 
 	bool IsPure() const override;
 
@@ -120,7 +118,7 @@ public:
 	bool NoFlowAfter(bool ignore_break) const override;
 
 protected:
-	ValPtr DoExec(Frame* f, Val* v, StmtFlowType& flow) const override;
+	ValPtr DoExec(Frame* f, Val* v, StmtFlowType& flow) override;
 	bool IsPure() const override;
 
 	StmtPtr s1;
@@ -180,7 +178,7 @@ public:
 	bool NoFlowAfter(bool ignore_break) const override;
 
 protected:
-	ValPtr DoExec(Frame* f, Val* v, StmtFlowType& flow) const override;
+	ValPtr DoExec(Frame* f, Val* v, StmtFlowType& flow) override;
 	bool IsPure() const override;
 
 	// Initialize composite hash and case label map.
@@ -229,7 +227,7 @@ class AddStmt final : public AddDelStmt {
 public:
 	explicit AddStmt(ExprPtr e);
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
 	// Optimization-related:
 	StmtPtr Duplicate() override;
@@ -239,7 +237,7 @@ class DelStmt final : public AddDelStmt {
 public:
 	explicit DelStmt(ExprPtr e);
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
 	// Optimization-related:
 	StmtPtr Duplicate() override;
@@ -249,7 +247,7 @@ class EventStmt final : public ExprStmt {
 public:
 	explicit EventStmt(EventExprPtr e);
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
 	TraversalCode Traverse(TraversalCallback* cb) const override;
 
@@ -290,7 +288,7 @@ public:
 	// execute zero times, so it's always the default of "false".
 
 protected:
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
 	ExprPtr loop_condition;
 	StmtPtr body;
@@ -339,7 +337,7 @@ public:
 	// execute zero times, so it's always the default of "false".
 
 protected:
-	ValPtr DoExec(Frame* f, Val* v, StmtFlowType& flow) const override;
+	ValPtr DoExec(Frame* f, Val* v, StmtFlowType& flow) override;
 
 	IDPList* loop_vars;
 	StmtPtr body;
@@ -352,7 +350,7 @@ class NextStmt final : public Stmt {
 public:
 	NextStmt() : Stmt(STMT_NEXT)	{ }
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 	bool IsPure() const override;
 
 	void StmtDescribe(ODesc* d) const override;
@@ -371,7 +369,7 @@ class BreakStmt final : public Stmt {
 public:
 	BreakStmt() : Stmt(STMT_BREAK)	{ }
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 	bool IsPure() const override;
 
 	void StmtDescribe(ODesc* d) const override;
@@ -391,7 +389,7 @@ class FallthroughStmt final : public Stmt {
 public:
 	FallthroughStmt() : Stmt(STMT_FALLTHROUGH)	{ }
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 	bool IsPure() const override;
 
 	void StmtDescribe(ODesc* d) const override;
@@ -409,7 +407,7 @@ class ReturnStmt final : public ExprStmt {
 public:
 	explicit ReturnStmt(ExprPtr e);
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
 	void StmtDescribe(ODesc* d) const override;
 
@@ -432,7 +430,7 @@ public:
 	StmtList();
 	~StmtList() override;
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
 	const StmtPList& Stmts() const	{ return *stmts; }
 	StmtPList& Stmts()		{ return *stmts; }
@@ -474,7 +472,7 @@ class InitStmt final : public Stmt {
 public:
 	explicit InitStmt(std::vector<IDPtr> arg_inits);
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
 	const std::vector<IDPtr>& Inits() const
 		{ return inits; }
@@ -497,7 +495,7 @@ class NullStmt final : public Stmt {
 public:
 	NullStmt() : Stmt(STMT_NULL)	{ }
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 	bool IsPure() const override;
 
 	void StmtDescribe(ODesc* d) const override;
@@ -516,7 +514,7 @@ public:
 	         ExprPtr timeout, bool is_return);
 	~WhenStmt() override;
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 	bool IsPure() const override;
 
 	const Expr* Cond() const	{ return cond.get(); }
@@ -560,7 +558,7 @@ public:
 	// or nil if it hasn't (the common case).
 	StmtPtr AssignStmt() const	{ return assign_stmt; }
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
 	bool IsPure() const override;
 
@@ -597,7 +595,7 @@ class CheckAnyLenStmt : public ExprStmt {
 public:
 	explicit CheckAnyLenStmt(ExprPtr e, int expected_len);
 
-	ValPtr Exec(Frame* f, StmtFlowType& flow) const override;
+	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
 	StmtPtr Duplicate() override;
 

--- a/src/StmtBase.h
+++ b/src/StmtBase.h
@@ -54,7 +54,7 @@ public:
 
 	~Stmt() override;
 
-	virtual ValPtr Exec(Frame* f, StmtFlowType& flow) const = 0;
+	virtual ValPtr Exec(Frame* f, StmtFlowType& flow) = 0;
 
 	Stmt* Ref()			{ zeek::Ref(this); return this; }
 	StmtPtr ThisPtr()		{ return {NewRef{}, this}; }

--- a/src/Val.h
+++ b/src/Val.h
@@ -362,9 +362,6 @@ public:
 	BoolVal(bro_int_t v)
 		: detail::IntValImplementation(base_type(TYPE_BOOL), v)
 		{}
-	BoolVal(bool b)
-		: BoolVal(bro_int_t(b))
-		{}
 
 	bool Get() const	{ return static_cast<bool>(int_val); }
 };

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -681,7 +681,7 @@ public:
 	TraversalCode PostExpr(const Expr*) override;
 
 	std::vector<Scope*> scopes;
-	std::unordered_set<const NameExpr*> outer_id_references;
+	std::unordered_set<ID*> outer_id_references;
 };
 
 TraversalCode OuterIDBindingFinder::PreExpr(const Expr* expr)
@@ -707,7 +707,7 @@ TraversalCode OuterIDBindingFinder::PreExpr(const Expr* expr)
 			// not something we have to worry about also being at outer scope.
 			return TC_CONTINUE;
 
-	outer_id_references.insert(e);
+	outer_id_references.insert(e->Id());
 	return TC_CONTINUE;
 	}
 
@@ -773,8 +773,8 @@ IDPList gather_outer_ids(Scope* scope, Stmt* body)
 
 	IDPList idl;
 
-	for ( auto ne : cb.outer_id_references )
-		idl.append(ne->Id());
+	for ( auto id : cb.outer_id_references )
+		idl.append(id);
 
 	return idl;
 	}

--- a/src/script_opt/Inline.h
+++ b/src/script_opt/Inline.h
@@ -29,7 +29,7 @@ public:
 	ExprPtr CheckForInlining(CallExprPtr c);
 
 	// True if the given function has been inlined.
-	bool WasInlined(Func* f)	{ return inline_ables.count(f) > 0; }
+	bool WasInlined(const Func* f)	{ return inline_ables.count(f) > 0; }
 
 protected:
 	// Driver routine that analyzes all of the script functions and
@@ -44,7 +44,7 @@ protected:
 	std::vector<FuncInfo>& funcs;
 
 	// Functions that we've determined to be suitable for inlining.
-	std::unordered_set<Func*> inline_ables;
+	std::unordered_set<const Func*> inline_ables;
 
 	// As we do inlining for a given function, this tracks the
 	// largest frame size of any inlined function.

--- a/src/script_opt/ScriptOpt.h
+++ b/src/script_opt/ScriptOpt.h
@@ -64,12 +64,12 @@ class FuncInfo {
 public:
 	FuncInfo(ScriptFuncPtr _func, ScopePtr _scope, StmtPtr _body);
 
-	ScriptFunc* Func()	{ return func.get(); }
-	ScriptFuncPtr FuncPtr()	{ return func; }
-	ScopePtr Scope()	{ return scope; }
-	StmtPtr Body()		{ return body; }
-	std::shared_ptr<ProfileFunc> Profile()	{ return pf; }
-	const std::string& SaveFile()	{ return save_file; }
+	ScriptFunc* Func() const	{ return func.get(); }
+	ScriptFuncPtr FuncPtr() const	{ return func; }
+	ScopePtr Scope() const		{ return scope; }
+	StmtPtr Body() const		{ return body; }
+	std::shared_ptr<ProfileFunc> Profile() const	{ return pf; }
+	const std::string& SaveFile() const	{ return save_file; }
 
 	void SetBody(StmtPtr new_body)	{ body = std::move(new_body); }
 	void SetProfile(std::shared_ptr<ProfileFunc> _pf);

--- a/src/script_opt/Stmt.cc
+++ b/src/script_opt/Stmt.cc
@@ -960,7 +960,7 @@ CatchReturnStmt::CatchReturnStmt(StmtPtr _block, NameExprPtr _ret_var)
 	ret_var = _ret_var;
 	}
 
-ValPtr CatchReturnStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr CatchReturnStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 
@@ -1047,7 +1047,7 @@ CheckAnyLenStmt::CheckAnyLenStmt(ExprPtr arg_e, int _expected_len)
 	expected_len = _expected_len;
 	}
 
-ValPtr CheckAnyLenStmt::Exec(Frame* f, StmtFlowType& flow) const
+ValPtr CheckAnyLenStmt::Exec(Frame* f, StmtFlowType& flow)
 	{
 	RegisterAccess();
 	flow = FLOW_NEXT;

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -68,6 +68,10 @@ static int check_fmt_type(zeek::TypeTag t, zeek::TypeTag ok[])
 
 static void do_fmt(const char*& fmt, zeek::Val* v, zeek::ODesc* d)
 	{
+	if ( ! v )
+		// Help with error propagation in compiled code.
+		return;
+
 	zeek::TypeTag t = v->GetType()->Tag();
 	zeek::InternalTypeTag it = v->GetType()->InternalType();
 

--- a/testing/btest/language/closure-sending-naming.zeek
+++ b/testing/btest/language/closure-sending-naming.zeek
@@ -29,7 +29,7 @@ function send_event()
     {
     local event_count = 1;
     # log fails to be looked up because of a missing print statment
-    # functions must have the sama name on both ends of broker.
+    # functions must have the same name on both ends of broker.
     local log : myfunctype = function(c: count) : function(d: count) : count
         {
         # print fmt("inside: %s | outside: %s | global: %s", c, event_count, global_with_same_name);


### PR DESCRIPTION
This PR is the first of a set of changes to existing files associated with a larger upcoming PR on script compilation.  The commits in this PR are all conceptually simple tweaks: typos, lint adjustments, removing a latent ambiguity, enabling statements to manage side-information during execution (such as lambdas updating their captures), and introducing some const/streamlining tidiness.