### PR TITLE
Prep work for Script Compilation: fixes for some iffy/broken behavior

### DIFF
--- a/scripts/base/frameworks/config/main.zeek
+++ b/scripts/base/frameworks/config/main.zeek
@@ -127,13 +127,9 @@ function format_value(value: any) : string
 
 	if ( /^set/ in tn && strstr(tn, ",") == 0 )
 		{
-		# The conversion to set here is tricky and assumes
-		# that the set isn't indexed via a tuple of types.
-		# The above check for commas in the type name
-		# ensures this.
-		local it: set[bool] = value;
-		for ( sv in it )
-			part += cat(sv);
+		local vec = Option::any_set_to_any_vec(value);
+		for ( sv in vec )
+			part += cat(vec[sv]);
 		return join_string_vec(part, ",");
 		}
 	else if ( /^vector/ in tn )

--- a/src/option.bif
+++ b/src/option.bif
@@ -213,3 +213,30 @@ function Option::set_change_handler%(ID: string, on_change: any, priority: int &
 	i->AddOptionHandler(func, -priority);
 	return zeek::val_mgr->True();
 	%}
+
+## Helper function that converts a set (of arbitrary index type) to
+## a "vector of any".
+##
+## v: an "any" type corresponding to a set.
+##
+## Returns: a vector-of-any with one element for each member of v.
+function Option::any_set_to_any_vec%(v: any%): any_vec
+	%{
+	auto ret_type = make_intrusive<VectorType>(base_type(TYPE_ANY));
+	auto ret = make_intrusive<VectorVal>(ret_type);
+	const auto& t = v->GetType();
+
+	if ( ! t->IsSet() )
+		{
+		zeek::emit_builtin_error("argument is not a set");
+		return ret;
+		}
+
+	auto lv = v->AsTableVal()->ToListVal();
+	auto n = lv->Length();
+
+	for ( int i = 0; i < n; ++i )
+		ret->Assign(i, lv->Idx(i));
+
+	return ret;
+	%}

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -146,6 +146,10 @@ void FuncInfo::SetProfile(std::shared_ptr<ProfileFunc> _pf)
 
 void analyze_func(ScriptFuncPtr f)
 	{
+	if ( analysis_options.only_func &&
+	     *analysis_options.only_func != f->Name() )
+		return;
+
 	funcs.emplace_back(f, ScopePtr{NewRef{}, f->GetScope()}, f->CurrentBody());
 	}
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -394,6 +394,10 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 
 	auto options = zopts ? *zopts : parse_cmdline(argc, argv);
 
+	// Set up the global that facilitates access to analysis/optimization
+	// options from deep within some modules.
+	analysis_options = options.analysis_options;
+
 	if ( options.print_usage )
 		usage(argv[0], 0);
 
@@ -747,10 +751,6 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 			delete [] interfaces_str;
 			}
 		}
-
-	// Set up the global that facilitates access to analysis/optimization
-	// options from deep within some modules.
-	analysis_options = options.analysis_options;
 
 	analyze_scripts();
 


### PR DESCRIPTION
This set of commits addresses some bugs in various components.  The most serious is modifying `same_type()` to work on recursive types (which takes a fair amount of surgery).