### PR TITLE
Sometimes user_agent is missing

### DIFF
--- a/scripts/policy/protocols/smtp/software.zeek
+++ b/scripts/policy/protocols/smtp/software.zeek
@@ -48,7 +48,7 @@ export {
 
 event mime_one_header(c: connection, h: mime_header_rec) &priority=4
 	{
-	if ( ! c?$smtp ) return;
+	if ( ! c?$smtp || ! c$smtp?$user_agent ) return;
 	if ( h$name == "USER-AGENT" && webmail_user_agents in c$smtp$user_agent )
 		c$smtp$is_webmail = T;
 	}


### PR DESCRIPTION
Example:
Mar 23 20:40:41 zeek-test2.es.net zeek_w5[1112439]: 1616532041.338921 expression error in /usr/local/zeek/share/zeek/policy/protocols/smtp/software.zeek, line 52: field value missing (SMTP::c$smtp$user_agent)

Ran across this by accident.