### PR TITLE
Prep work for Script Compilation: Encapsulating Global Statements in a Quasi-Function

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -266,7 +266,7 @@ static bool expr_is_table_type_name(const zeek::detail::Expr* expr)
 
 %%
 
-bro:
+zeek:
 		decl_list stmt_list
 			{
 			if ( zeek::detail::stmts )

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -3,6 +3,7 @@
 #include "zeek/Options.h"
 #include "zeek/Reporter.h"
 #include "zeek/Desc.h"
+#include "zeek/module_util.h"
 #include "zeek/script_opt/ScriptOpt.h"
 #include "zeek/script_opt/ProfileFunc.h"
 #include "zeek/script_opt/Inline.h"
@@ -151,6 +152,28 @@ void analyze_func(ScriptFuncPtr f)
 		return;
 
 	funcs.emplace_back(f, ScopePtr{NewRef{}, f->GetScope()}, f->CurrentBody());
+	}
+
+const FuncInfo* analyze_global_stmts(Stmt* stmts)
+	{
+	// We ignore analysis_options.only_func - if it's in use, later
+	// logic will keep this function from being compiled, but it's handy
+	// now to enter it into "funcs" so we have a FuncInfo to return.
+
+	auto id = install_ID("<global-stmts>", GLOBAL_MODULE_NAME, true, false);
+	auto empty_args_t = make_intrusive<RecordType>(nullptr);
+	auto func_t = make_intrusive<FuncType>(empty_args_t, nullptr, FUNC_FLAVOR_FUNCTION);
+	id->SetType(func_t);
+
+	auto sc = current_scope();
+	std::vector<IDPtr> empty_inits;
+	StmtPtr stmts_p{NewRef{}, stmts};
+	auto sf = make_intrusive<ScriptFunc>(id, stmts_p, empty_inits,
+						sc->Length(), 0);
+
+	funcs.emplace_back(sf, ScopePtr{NewRef{}, sc}, stmts_p);
+
+	return &funcs.back();
 	}
 
 static void check_env_opt(const char* opt, bool& opt_flag)

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -168,8 +168,7 @@ const FuncInfo* analyze_global_stmts(Stmt* stmts)
 	auto sc = current_scope();
 	std::vector<IDPtr> empty_inits;
 	StmtPtr stmts_p{NewRef{}, stmts};
-	auto sf = make_intrusive<ScriptFunc>(id, stmts_p, empty_inits,
-						sc->Length(), 0);
+	auto sf = make_intrusive<ScriptFunc>(id, stmts_p, empty_inits, sc->Length(), 0);
 
 	funcs.emplace_back(sf, ScopePtr{NewRef{}, sc}, stmts_p);
 

--- a/src/script_opt/ScriptOpt.h
+++ b/src/script_opt/ScriptOpt.h
@@ -96,6 +96,11 @@ extern std::unordered_set<const Func*> non_recursive_funcs;
 // Analyze a given function for optimization.
 extern void analyze_func(ScriptFuncPtr f);
 
+// Analyze the given top-level statement(s) for optimization.  Returns
+// a pointer to a FuncInfo for an argument-less quasi-function that can
+// be Invoked, or its body executed directly, to execute the statements.
+extern const FuncInfo* analyze_global_stmts(Stmt* stmts);
+
 // Analyze all of the parsed scripts collectively for optimization.
 extern void analyze_scripts();
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -752,6 +752,8 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 			}
 		}
 
+	auto init_stmts = stmts ? analyze_global_stmts(stmts) : nullptr;
+
 	analyze_scripts();
 
 	if ( analysis_options.report_recursive )
@@ -838,15 +840,15 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 	// cause more severe problems.
 	ZEEK_LSAN_ENABLE();
 
-	if ( stmts )
+	if ( init_stmts )
 		{
 		StmtFlowType flow;
-		Frame f(current_scope()->Length(), nullptr, nullptr);
+		Frame f(init_stmts->Scope()->Length(), nullptr, nullptr);
 		g_frame_stack.push_back(&f);
 
 		try
 			{
-			stmts->Exec(&f, flow);
+			init_stmts->Body()->Exec(&f, flow);
 			}
 		catch ( InterpreterException& )
 			{

--- a/testing/btest/scripts/base/frameworks/netcontrol/acld-hook.zeek
+++ b/testing/btest/scripts/base/frameworks/netcontrol/acld-hook.zeek
@@ -9,6 +9,7 @@
 @TEST-START-FILE send.zeek
 
 @load base/frameworks/netcontrol
+@load base/frameworks/broker
 
 redef exit_only_after_terminate = T;
 global have_peer = F;

--- a/testing/btest/scripts/base/frameworks/openflow/broker-basic.zeek
+++ b/testing/btest/scripts/base/frameworks/openflow/broker-basic.zeek
@@ -82,6 +82,7 @@ event OpenFlow::flow_mod_failure(name: string, match: OpenFlow::ofp_match, flow_
 
 @TEST-START-FILE recv.zeek
 
+@load base/protocols/conn
 @load base/frameworks/openflow
 
 redef exit_only_after_terminate = T;


### PR DESCRIPTION
This PR reflects the discussion in https://github.com/zeek/zeek/pull/1452 about putting global script statements into their own (quasi-)function, to make them amenable to script optimization.  The main use is in support of running the test suite against script optimizers, since a number of those tests express their functionality in global-level statements rather than `zeek_init()` event handlers.  Thus, this PR supersedes the bulk of https://github.com/zeek/zeek/pull/1452 (but also incorporates the minor "balancing" change from that PR, so we don't lose sight of it).