### PR TITLE
Heartbleed: fix substraction order

### DIFF
--- a/scripts/policy/protocols/ssl/heartbleed.zeek
+++ b/scripts/policy/protocols/ssl/heartbleed.zeek
@@ -154,7 +154,7 @@ event ssl_encrypted_heartbeat(c: connection, is_orig: bool, length: count)
 			NOTICE([$note=SSL_Heartbeat_Many_Requests,
 				$msg=fmt("Server sending more heartbeat responses than requests seen. Possible attack. Client count: %d, server count: %d", c$ssl$originator_heartbeats, c$ssl$responder_heartbeats),
 				$conn=c,
-				$n=(c$ssl$originator_heartbeats-c$ssl$responder_heartbeats),
+				$n=(c$ssl$responder_heartbeats-c$ssl$originator_heartbeats),
 				$identifier=fmt("%s%d", c$uid, c$ssl$responder_heartbeats/1000) # re-throw every 1000 heartbeats
 				]);
 


### PR DESCRIPTION
The larger number was substracted from the smaller one leading to an
integer overflow. However, no information was lost due to everything
also being present in the notice message.

Fixes GH-1454.

I don't have test traffic for this that we can include - however I verified that this fixes the problem. It is also very unlikely that we will ever have anything that will hit (or change) this codepath again - so not having a test for this specific case seems ok.