### PR TITLE
Fix incomplete-type for struct timeval

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -5,17 +5,6 @@
 
 #include "zeek/util.h"
 
-#ifdef TIME_WITH_SYS_TIME
-# include <sys/time.h>
-# include <time.h>
-#else
-# ifdef HAVE_SYS_TIME_H
-#  include <sys/time.h>
-# else
-#  include <time.h>
-# endif
-#endif
-
 #ifdef HAVE_DARWIN
 #include <mach/task.h>
 #include <mach/mach_init.h>

--- a/src/util.h
+++ b/src/util.h
@@ -29,6 +29,17 @@
 #include <vector>
 #include <memory> // std::unique_ptr
 
+#ifdef TIME_WITH_SYS_TIME
+# include <sys/time.h>
+# include <time.h>
+#else
+# ifdef HAVE_SYS_TIME_H
+#  include <sys/time.h>
+# else
+#  include <time.h>
+# endif
+#endif
+
 #ifdef DEBUG
 
 #include <assert.h>


### PR DESCRIPTION
`time.h` should be included before using types like `struct timeval`.  For example, on Void LInux (`x86_64-musl`):

```
../src/util.cc:2061:42: error: return type 'struct zeek::util::timeval' is incomplete
 2061 | struct timeval double_to_timeval(double t)
      |                                          ^
../src/util.cc:2061:16: error: ambiguating new declaration of 'void zeek::util::double_to_timeval(double)'
 2061 | struct timeval double_to_timeval(double t)
      |                ^~~~~~~~~~~~~~~~~
In file included from ../src/util.cc:6:
../src/zeek/util.h:479:23: note: old declaration 'zeek::util::timeval zeek::util::double_to_timeval(double)'
  479 | extern struct timeval double_to_timeval(double t);
      |                       ^~~~~~~~~~~~~~~~~
```

