### PR TITLE
CI: Add OpenSUSE Leap 15.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -161,6 +161,13 @@ debian9_32bit_task:
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
+opensuse_leap_15_2_task:
+  container:
+    # Opensuse Leap 15.2 EOL: Dec 2021
+    dockerfile: ci/opensuse-leap-15.2/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
 ubuntu20_task:
   container:
     # Ubuntu 20.04 EOL: April 2025

--- a/ci/opensuse-leap-15.2/Dockerfile
+++ b/ci/opensuse-leap-15.2/Dockerfile
@@ -1,0 +1,25 @@
+FROM opensuse/leap:15.2
+
+RUN zypper in -y \
+  cmake \
+  make \
+  gcc \
+  gcc-c++ \
+  python3 \
+  python3-devel \
+  flex \
+  bison \
+  libpcap-devel \
+  libopenssl-devel \
+  zlib-devel \
+  swig \
+  git \
+  curl \
+  python3-pip \
+  which \
+  gzip \
+  tar \
+  && rm -rf /var/cache/zypp
+
+
+RUN pip3 install junit2html


### PR DESCRIPTION
This PR adds OpenSUSE Leap to CI.

OpenSUSE Leap is not currently listed in our [platform support policy](https://github.com/zeek/zeek/wiki/Platform-Support-Policy). However, I would like to add it to it - since it implicitly has actually been supported for a long time due to the fact that we have been running and publishing nightly builds for it for years.

Hence adding it both to CI and to our Platform Support Policy seems adequate.