### PR TITLE
Add a check for null packet data in pcap IOSource

### DIFF
--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -220,6 +220,14 @@ bool PcapSource::ExtractNextPacket(Packet* pkt)
 		return false;
 	case 1:
 		// Read a packet without problem.
+		// Although, some libpcaps may claim to have read a packet, but either did
+		// not really read a packet or at least provide no way to access its
+		// contents, so the following check for null-data helps handle those cases.
+		if ( ! data )
+			{
+			reporter->Weird("pcap_null_data_packet");
+			return false;
+			}
 		break;
 	default:
 		reporter->InternalError("unhandled pcap_next_ex return value: %d", res);


### PR DESCRIPTION
Some libpcaps (observed in Myricom's) may claim to have read a packet,
but either did not really read a packet or at least provide no way
to access its contents, so this adds a check for null-data to
handle those cases.

In my testing (release build, `zeek -r 2009-M57-day11-18.trace`), I found the additional check to have sub 1% performance impact, so think it's not too annoying to just go with this accommodation even though the state it guards against isn't cogent with the pcap API documentation.

For testing how much impact the weird has, I artificially null'd half the packets and found it could increase overhead up to ~3% and I take that to be fine given it's not an expected/common path and maybe the weird helps someone at least discover the inefficient/broken API results, whether it's caused by broken pcap implemention, broken traffic, or whatever.