### PR TITLE
Reference the manual's explanation of originator and responder from conn_id

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -168,6 +168,10 @@ type transport_proto: enum {
 ## .. note:: It's actually a 5-tuple: the transport-layer protocol is stored as
 ##    part of the port values, `orig_p` and `resp_p`, and can be extracted from
 ##    them with :zeek:id:`get_port_transport_proto`.
+##
+## .. note:: For explanation of Zeek's "originator" and "responder" terminology,
+##    see :ref:`the manual's description of the connection record
+##    <writing-scripts-connection-record>`.
 type conn_id: record {
 	orig_h: addr;	##< The originator's IP address.
 	orig_p: port;	##< The originator's port number.


### PR DESCRIPTION
This is a companion PR to zeek/zeek-docs#59.

We don't normally refer to the manual from the in-code documentation, but it seems like a natural fit to me here. I first tried using the `:doc:` construct, but it seems it doesn't let you travel outside of the source code hierarchy. So I'm using `:ref:` instead.

Resolves #1485 