### PR TITLE
GH-1528: Remove broken Queue/PQueue class, replace with std::deque

### DIFF
--- a/src/DbgBreakpoint.cc
+++ b/src/DbgBreakpoint.cc
@@ -8,7 +8,6 @@
 
 #include "zeek/Desc.h"
 #include "zeek/ID.h"
-#include "zeek/Queue.h"
 #include "zeek/Debug.h"
 #include "zeek/Scope.h"
 #include "zeek/Frame.h"

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -5,9 +5,9 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <deque>
 
 #include "zeek/Obj.h"
-#include "zeek/Queue.h"
 #include "zeek/StmtEnums.h"
 #include "zeek/util.h"
 
@@ -38,7 +38,7 @@ public:
 };
 
 class StmtLocMapping;
-using Filemap = PQueue<StmtLocMapping>; // mapping for a single file
+using Filemap = std::deque<StmtLocMapping*>; // mapping for a single file
 
 using BPIDMapType = std::map<int, DbgBreakpoint*>;
 using BPMapType = std::multimap<const Stmt*, DbgBreakpoint*>;

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -26,10 +26,9 @@
 
 using namespace std;
 
-zeek::PQueue<zeek::detail::DebugCmdInfo> zeek::detail::g_DebugCmdInfos;
-zeek::PQueue<zeek::detail::DebugCmdInfo>& g_DebugCmdInfos = zeek::detail::g_DebugCmdInfos;
-
 namespace zeek::detail {
+
+DebugCmdInfoQueue g_DebugCmdInfos;
 
 //
 // Helper routines
@@ -154,7 +153,7 @@ DebugCmdInfo::DebugCmdInfo(DebugCmd arg_cmd, const char* const* arg_names,
 
 const DebugCmdInfo* get_debug_cmd_info(DebugCmd cmd)
 	{
-	if ( (int) cmd < g_DebugCmdInfos.length() )
+	if ( (int) cmd < g_DebugCmdInfos.size() )
 		return g_DebugCmdInfos[(int) cmd];
 	else
 		return nullptr;

--- a/src/DebugCmds.h
+++ b/src/DebugCmds.h
@@ -6,8 +6,7 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
-
-#include "zeek/Queue.h"
+#include <deque>
 
 // This file is generated during the build.
 #include "DebugCmdConstants.h"
@@ -45,11 +44,12 @@ protected:
 	bool repeatable;
 };
 
-extern PQueue<DebugCmdInfo> g_DebugCmdInfos;
+using DebugCmdInfoQueue = std::deque<DebugCmdInfo*>;
+extern DebugCmdInfoQueue g_DebugCmdInfos;
 
 void init_global_dbg_constants ();
 
-#define num_debug_cmds() (g_DebugCmdInfos.length())
+#define num_debug_cmds() (g_DebugCmdInfos.size())
 
 // Looks up the info record and returns it; if cmd is not found returns 0.
 const DebugCmdInfo* get_debug_cmd_info(DebugCmd cmd);

--- a/src/Queue.h
+++ b/src/Queue.h
@@ -26,11 +26,11 @@
 namespace zeek {
 
 template<typename T>
-class Queue {
+class [[deprecated("Remove in v5.1. This class is deprecated (and is likely broken, see #1528). Use std::vector<T>.")]] Queue {
 public:
 	explicit Queue(int size = 0)
 		{
-		const int DEFAULT_CHUNK_SIZE = 10;
+		constexpr int DEFAULT_CHUNK_SIZE = 10;
 		chunk_size = DEFAULT_CHUNK_SIZE;
 
 		head = tail = num_entries = 0;
@@ -55,6 +55,7 @@ public:
 	~Queue()		{ delete[] entries; }
 
 	int length() const	{ return num_entries; }
+	int capacity() const	{ return max_entries; }
 	int resize(int new_size = 0)	// 0 => size to fit current number of entries
 		{
 		if ( new_size < num_entries )
@@ -197,6 +198,6 @@ protected:
 
 
 template<typename T>
-using PQueue = Queue<T*>;
+using PQueue [[deprecated("Remove in v5.1. This class is deprecated (and is likely broken, see #1528). Use std::vector<T*>.")]] = Queue<T*>;
 
 } // namespace zeek

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -150,7 +150,7 @@ bool Stmt::SetLocationInfo(const Location* start, const Location* end)
 	// Optimistically just put it at the end.
 	map.push_back(new_mapping);
 
-	int curr_idx = map.length() - 1;
+	size_t curr_idx = map.size() - 1;
 	if ( curr_idx == 0 )
 		return true;
 

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -73,7 +73,7 @@ bool SteppingStoneEndpoint::DataSent(double t, uint64_t seq, int len, int caplen
 
 	double tmin = t - zeek::detail::stp_delta;
 
-	while ( stp_manager->OrderedEndpoints().length() > 0 )
+	while ( ! stp_manager->OrderedEndpoints().empty() )
 		{
 	    auto e = stp_manager->OrderedEndpoints().front();
 

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.h
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.h
@@ -2,7 +2,8 @@
 
 #pragma once
 
-#include "zeek/Queue.h"
+#include <deque>
+
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 
 namespace zeek {
@@ -72,14 +73,15 @@ protected:
 class SteppingStoneManager {
 public:
 
-	PQueue<SteppingStoneEndpoint>& OrderedEndpoints()
-		{ return ordered_endps; }
+	using EndpointQueue = std::deque<SteppingStoneEndpoint*>;
+
+	EndpointQueue& OrderedEndpoints()	{ return ordered_endps; }
 
 	// Use postfix ++, since the first ID needs to be even.
-	int NextID()			{ return endp_cnt++; }
+	int NextID()	{ return endp_cnt++; }
 
 protected:
-	PQueue<SteppingStoneEndpoint> ordered_endps;
+	EndpointQueue ordered_endps;
 	int endp_cnt = 0;
 };
 


### PR DESCRIPTION
Fixes #1528

I opted for `deque` here because of the one use of `pop_front` in stepping stone. Alternatively, `vector` would work in the places `pop_front` isn't used since it's slightly faster, but those uses are all in the debugger code, and performance doesn't matter a whole lot there.