### PR TITLE
Fix excessive coredump for duplicate enum definitions

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -769,6 +769,13 @@ expr:
 
 				else if ( id->IsEnumConst() )
 					{
+					if ( IsErrorType(id->GetType()->Tag()) )
+						{
+						// The most-relevant error message should already be reported, so
+						// just bail out.
+						YYERROR;
+						}
+
 					EnumType* t = id->GetType()->AsEnumType();
 					auto intval = t->Lookup(id->ModuleName(), id->Name());
 					if ( intval < 0 )

--- a/testing/btest/Baseline/language.enum-name-conflict/output
+++ b/testing/btest/Baseline/language.enum-name-conflict/output
@@ -4,3 +4,4 @@ error in <...>/enum-name-conflict.zeek, line 15 and <...>/enum-name-conflict.zee
 error in <...>/enum-name-conflict.zeek, line 27 and <...>/enum-name-conflict.zeek, line 23: conflicting definition of enum value 'Foo::TWO' in type 'Foo::bf'
 error in <...>/enum-name-conflict.zeek, line 32 and <...>/enum-name-conflict.zeek, line 22: conflicting definition of enum value 'Foo::ONE' in type 'Foo::bf'
 error in <...>/enum-name-conflict.zeek, line 41 and <...>/enum-name-conflict.zeek, line 38: conflicting definition of enum value 'NOPE' in type 'a'
+error in <...>/enum-name-conflict.zeek, line 46 and <...>/enum-name-conflict.zeek, line 45: conflicting definition of enum value 'Pink' in type 'E'

--- a/testing/btest/language/enum-name-conflict.zeek
+++ b/testing/btest/language/enum-name-conflict.zeek
@@ -40,3 +40,10 @@ global NOPE = 37;
 redef enum a += {
 	NOPE,
 };
+
+type E: enum { Red, Green, Blue };
+redef enum E += { Pink };
+redef enum E += { Pink };
+
+print Pink;
+print Pink;


### PR DESCRIPTION
An adequate error message was previously reported for duplicate enum
definitions, this just now prevents trying to access it as a constant in
subsequent parsing and further generating a coredump.

Fixes GH-1534