### PR TITLE
Switch RecordVal's to use std::optional for tracking whether a field is present

### DIFF
--- a/src/ZVal.h
+++ b/src/ZVal.h
@@ -8,19 +8,31 @@
 
 namespace zeek {
 
-class StringVal;
 class AddrVal;
-class SubNetVal;
 class File;
 class Func;
 class ListVal;
 class OpaqueVal;
 class PatternVal;
-class TableVal;
 class RecordVal;
-class VectorVal;
+class StringVal;
+class SubNetVal;
+class TableVal;
 class Type;
 class Val;
+class VectorVal;
+
+using AddrValPtr = IntrusivePtr<AddrVal>;
+using EnumValPtr = IntrusivePtr<EnumVal>;
+using ListValPtr = IntrusivePtr<ListVal>;
+using OpaqueValPtr = IntrusivePtr<OpaqueVal>;
+using PatternValPtr = IntrusivePtr<PatternVal>;
+using RecordValPtr = IntrusivePtr<RecordVal>;
+using StringValPtr = IntrusivePtr<StringVal>;
+using SubNetValPtr = IntrusivePtr<SubNetVal>;
+using TableValPtr = IntrusivePtr<TableVal>;
+using ValPtr = IntrusivePtr<Val>;
+using VectorValPtr = IntrusivePtr<VectorVal>;
 
 // Note that a ZVal by itself is ambiguous: it doesn't track its type.
 // This makes them consume less memory and cheaper to copy.  It does
@@ -42,6 +54,35 @@ union ZVal {
 
 	// Construct an empty value compatible with the given type.
 	ZVal(const TypePtr& t);
+
+	// Construct directly.
+	ZVal(bro_int_t v)	{ int_val = v; }
+	ZVal(bro_uint_t v)	{ uint_val = v; }
+	ZVal(double v)		{ double_val = v; }
+
+	ZVal(StringVal* v)	{ string_val = v; }
+	ZVal(AddrVal* v)	{ addr_val = v; }
+	ZVal(SubNetVal* v)	{ subnet_val = v; }
+	ZVal(File* v)		{ file_val = v; }
+	ZVal(Func* v)		{ func_val = v; }
+	ZVal(ListVal* v)	{ list_val = v; }
+	ZVal(OpaqueVal* v)	{ opaque_val = v; }
+	ZVal(PatternVal* v)	{ re_val = v; }
+	ZVal(TableVal* v)	{ table_val = v; }
+	ZVal(RecordVal* v)	{ record_val = v; }
+	ZVal(VectorVal* v)	{ vector_val = v; }
+	ZVal(Type* v)		{ type_val = v; }
+
+	ZVal(StringValPtr v)	{ string_val = v.release(); }
+	ZVal(AddrValPtr v)	{ addr_val = v.release(); }
+	ZVal(SubNetValPtr v)	{ subnet_val = v.release(); }
+	ZVal(ListValPtr v)	{ list_val = v.release(); }
+	ZVal(OpaqueValPtr v)	{ opaque_val = v.release(); }
+	ZVal(PatternValPtr v)	{ re_val = v.release(); }
+	ZVal(TableValPtr v)	{ table_val = v.release(); }
+	ZVal(RecordValPtr v)	{ record_val = v.release(); }
+	ZVal(VectorValPtr v)	{ vector_val = v.release(); }
+	ZVal(TypePtr v)		{ type_val = v.release(); }
 
 	// Convert to a higher-level script value.  The caller needs to
 	// ensure that they're providing the correct type.


### PR DESCRIPTION
This PR is a companion to that in https://github.com/zeek/zeek/pull/1512.  It simplifies the `RecordVal` implementation by removing the separate `vector<bool>` previously used to track whether a given field is present in the record.

In addition, this PR adds a bunch of `ZVal` constructors for building `ZVal` objects directly from an underlying type, rather than always needing a `ValPtr`.  This change is both necessary to efficiently support the `RecordVal` change, and, later, for the upcoming `ZAM`-based script optimization.