### PR TITLE
Fix Coverity issues from SessionManager work

### DIFF
--- a/src/IPAddr.cc
+++ b/src/IPAddr.cc
@@ -44,10 +44,24 @@ ConnKey::ConnKey(const IPAddr& src, const IPAddr& dst, uint16_t src_port,
 		}
 	}
 
-detail::ConnKey::ConnKey(const ConnTuple& id)
+ConnKey::ConnKey(const ConnTuple& id)
 	: ConnKey(id.src_addr, id.dst_addr, id.src_port, id.dst_port,
 	          id.proto, id.is_one_way)
 	{
+	}
+
+ConnKey& ConnKey::operator=(const ConnKey& rhs)
+	{
+	if ( this == &rhs )
+		return *this;
+
+	memcpy(&ip1, &rhs.ip1, sizeof(in6_addr));
+	memcpy(&ip2, &rhs.ip2, sizeof(in6_addr));
+	port1 = rhs.port1;
+	port2 = rhs.port2;
+	transport = rhs.transport;
+
+	return *this;
 	}
 
 } // namespace detail

--- a/src/IPAddr.h
+++ b/src/IPAddr.h
@@ -10,7 +10,7 @@
 
 #include "zeek/threading/SerialTypes.h"
 
-typedef in_addr in4_addr;
+using in4_addr = in_addr;
 
 namespace zeek {
 
@@ -29,12 +29,9 @@ struct ConnKey {
 	TransportProto transport;
 
 	ConnKey(const IPAddr& src, const IPAddr& dst, uint16_t src_port,
-	          uint16_t dst_port, TransportProto t, bool one_way);
+	        uint16_t dst_port, TransportProto t, bool one_way);
 	ConnKey(const ConnTuple& conn);
-	ConnKey(const ConnKey& rhs)
-		{
-		*this = rhs;
-		}
+	ConnKey(const ConnKey& rhs)	{ *this = rhs; }
 
 	bool operator<(const ConnKey& rhs) const { return memcmp(this, &rhs, sizeof(ConnKey)) < 0; }
 	bool operator<=(const ConnKey& rhs) const { return memcmp(this, &rhs, sizeof(ConnKey)) <= 0; }
@@ -58,7 +55,7 @@ public:
 	/**
 	 * Address family.
 	 */
-	typedef IPFamily Family;
+	using Family = IPFamily;
 
 	/**
 	 * Byte order.
@@ -381,9 +378,10 @@ public:
 		return ! ( addr1 <= addr2 );
 		}
 
-	/** Converts the address into the type used internally by the
-	  * inter-thread communication.
-	  */
+	/**
+	 * Converts the address into the type used internally by the
+	 * inter-thread communication.
+	 */
 	void ConvertToThreadingValue(threading::Value::addr_t* v) const;
 
 	unsigned int MemoryAllocation() const { return padded_sizeof(*this); }
@@ -601,7 +599,8 @@ public:
 	 */
 	uint8_t LengthIPv6() const { return length; }
 
-	/** Returns true if the given address is part of the prefix.
+	/**
+	 * Returns true if the given address is part of the prefix.
 	 *
 	 * @param addr The address to test.
 	 */
@@ -637,9 +636,10 @@ public:
 	 */
 	std::unique_ptr<detail::HashKey> MakeHashKey() const;
 
-	/** Converts the prefix into the type used internally by the
-	  * inter-thread communication.
-	  */
+	/**
+	 * Converts the prefix into the type used internally by the
+	 * inter-thread communication.
+	 */
 	void ConvertToThreadingValue(threading::Value::subnet_t* v) const
 		{
 		v->length = length;

--- a/src/IPAddr.h
+++ b/src/IPAddr.h
@@ -4,7 +4,7 @@
 
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <string.h>
+#include <cstring>
 #include <string>
 #include <memory>
 
@@ -43,13 +43,7 @@ struct ConnKey {
 	bool operator>=(const ConnKey& rhs) const { return memcmp(this, &rhs, sizeof(ConnKey)) >= 0; }
 	bool operator>(const ConnKey& rhs) const { return memcmp(this, &rhs, sizeof(ConnKey)) > 0; }
 
-	ConnKey& operator=(const ConnKey& rhs)
-		{
-		if ( this != &rhs )
-			memcpy(this, &rhs, sizeof(ConnKey));
-
-		return *this;
-		}
+	ConnKey& operator=(const ConnKey& rhs);
 };
 
 using ConnIDKey [[deprecated("Remove in v5.1. Use zeek::detail::ConnKey.")]] = ConnKey;

--- a/src/session/Key.cc
+++ b/src/session/Key.cc
@@ -7,8 +7,11 @@ namespace zeek::session::detail {
 Key::Key(const void* session, size_t size, bool copy) : size(size)
 	{
 	data = reinterpret_cast<const uint8_t*>(session);
+
 	if ( copy )
 		CopyData();
+
+	copied = copy;
 	}
 
 Key::Key(Key&& rhs)


### PR DESCRIPTION
This PR fixes one Coverity issue and makes the code around two more a bit more explicit about what it's doing. The Coverity scanner gets the two unfixed issues wrong, so I'll mark them as False Positive. See the image below for explanation about what it gets wrong (issue 1452759):

![Screen Shot 2021-05-03 at 11 04 24 AM](https://user-images.githubusercontent.com/2653616/116914468-9fbe6f80-abff-11eb-9f8f-7a9e1a05b583.png)

We're passing `false` to the constructor here in the `copy` argument and storing it in `copied`. Coverity for some reason is taking the `true` branch on the `if` statement in the constructor, caches that, and then screws up the deletion of the data in the destructor.