### PR TITLE
Add missing "zeek/" to header includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,6 +495,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zeek-config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/zeek-config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zeek-config.h DESTINATION include/zeek)
+execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink
+                "."
+                "${CMAKE_CURRENT_BINARY_DIR}/zeek")
 
 if ( CAF_ROOT )
   set(ZEEK_CONFIG_CAF_ROOT_DIR ${CAF_ROOT})

--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Attr.h"
 #include "zeek/Expr.h"

--- a/src/Base64.cc
+++ b/src/Base64.cc
@@ -1,4 +1,4 @@
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <math.h>
 

--- a/src/Base64.h
+++ b/src/Base64.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include <string>
 
 namespace zeek { class String; }

--- a/src/BifReturnVal.h
+++ b/src/BifReturnVal.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/IntrusivePtr.h"
 
 ZEEK_FORWARD_DECLARE_NAMESPACED(Val, zeek);

--- a/src/CCL.cc
+++ b/src/CCL.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/CCL.h"
 
 #include <algorithm>

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/CompHash.h"
 
 #include <cstring>

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Conn.h"
 
 #include <ctype.h>

--- a/src/DFA.cc
+++ b/src/DFA.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/DFA.h"
 #include "zeek/EquivClass.h"

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/DNS_Mgr.h"
 
 #include <sys/types.h>

--- a/src/DbgBreakpoint.cc
+++ b/src/DbgBreakpoint.cc
@@ -1,6 +1,6 @@
 // Implementation of breakpoints.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/DbgBreakpoint.h"
 

--- a/src/DbgHelp.cc
+++ b/src/DbgHelp.cc
@@ -1,5 +1,5 @@
 // Bro Debugger Help
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Debug.h"

--- a/src/DbgWatch.cc
+++ b/src/DbgWatch.cc
@@ -1,6 +1,6 @@
 // Implementation of watches
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/DbgWatch.h"
 
 #include "zeek/Debug.h"

--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -1,6 +1,6 @@
 // Debugging support for Bro policy files.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Debug.h"
 

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -1,7 +1,7 @@
 // Support routines to help deal with Bro debugging commands and
 // implementation of most commands.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/DebugCmds.h"
 
 #include <sys/types.h>

--- a/src/DebugLogger.h
+++ b/src/DebugLogger.h
@@ -5,7 +5,7 @@
 
 #ifdef DEBUG
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <stdio.h>
 #include <string>

--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Desc.h"
 
 #include <stdlib.h>

--- a/src/Dict.cc
+++ b/src/Dict.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Dict.h"
 
 #ifdef HAVE_MEMORY_H

--- a/src/Discard.cc
+++ b/src/Discard.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Discard.h"
 

--- a/src/EquivClass.cc
+++ b/src/EquivClass.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/EquivClass.h"
 #include "zeek/CCL.h"

--- a/src/Event.cc
+++ b/src/Event.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Event.h"
 #include "zeek/Desc.h"

--- a/src/EventRegistry.h
+++ b/src/EventRegistry.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <map>
 #include <memory>

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Expr.h"
 #include "zeek/Event.h"

--- a/src/File.cc
+++ b/src/File.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/File.h"
 
 #include <sys/types.h>

--- a/src/Frag.cc
+++ b/src/Frag.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Frag.h"
 #include "zeek/Hash.h"

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -1,7 +1,7 @@
 
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Func.h"
 
 #include <sys/types.h>

--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Hash.h"
 
 #include <highwayhash/sip_hash.h>

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -1,7 +1,7 @@
 
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/ID.h"
 
 #include "zeek/Attr.h"

--- a/src/IP.h
+++ b/src/IP.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <sys/types.h> // for u_char
 #include <netinet/in.h>

--- a/src/IntSet.cc
+++ b/src/IntSet.cc
@@ -1,4 +1,4 @@
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/IntSet.h"
 
 #ifdef HAVE_MEMORY_H

--- a/src/NFA.cc
+++ b/src/NFA.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/NFA.h"
 
 #include <algorithm>

--- a/src/NetVar.cc
+++ b/src/NetVar.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/NetVar.h"
 #include "zeek/Var.h"

--- a/src/Obj.cc
+++ b/src/Obj.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Obj.h"
 
 #include <stdlib.h>

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <limits.h>
 

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Options.h"
 

--- a/src/PolicyFile.cc
+++ b/src/PolicyFile.cc
@@ -1,4 +1,4 @@
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/PolicyFile.h"
 
 #include <sys/types.h>

--- a/src/PriorityQueue.cc
+++ b/src/PriorityQueue.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/PriorityQueue.h"
 
 #include <stdio.h>

--- a/src/PriorityQueue.h
+++ b/src/PriorityQueue.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <math.h>
 #include <stdint.h>

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/RE.h"
 
 #include <stdlib.h>

--- a/src/RandTest.h
+++ b/src/RandTest.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include <stdint.h>
 
 #define RT_MONTEN 6  /* Bytes used as Monte Carlo

--- a/src/Reassem.cc
+++ b/src/Reassem.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Reassem.h"
 
 #include <algorithm>

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -2,7 +2,7 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 //
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Reporter.h"
 
 #include <unistd.h>

--- a/src/Rule.cc
+++ b/src/Rule.cc
@@ -1,4 +1,4 @@
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Rule.h"
 #include "zeek/RuleAction.h"

--- a/src/RuleAction.cc
+++ b/src/RuleAction.cc
@@ -1,4 +1,4 @@
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/RuleAction.h"
 
 #include <string>

--- a/src/RuleCondition.cc
+++ b/src/RuleCondition.cc
@@ -1,4 +1,4 @@
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/RuleCondition.h"
 #include "zeek/RuleMatcher.h"

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -1,5 +1,5 @@
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/RuleMatcher.h"
 
 #include <algorithm>

--- a/src/RunState.cc
+++ b/src/RunState.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/RunState.h"
 
 #include <sys/types.h>

--- a/src/RunState.h
+++ b/src/RunState.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <string>
 #include <optional>

--- a/src/Scope.cc
+++ b/src/Scope.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Scope.h"
 #include "zeek/Desc.h"

--- a/src/SerializationFormat.h
+++ b/src/SerializationFormat.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <stdint.h>
 #include <string>

--- a/src/Sessions.cc
+++ b/src/Sessions.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Sessions.h"
 
 #include <netinet/in.h>

--- a/src/SmithWaterman.cc
+++ b/src/SmithWaterman.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <ctype.h>
 #include <algorithm>

--- a/src/Stats.h
+++ b/src/Stats.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <sys/types.h>
 #include <sys/time.h>

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/Stmt.h"
 

--- a/src/Tag.h
+++ b/src/Tag.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <stdint.h>
 #include <string>

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Timer.h"
 
 #include "zeek/util.h"

--- a/src/TraverseTypes.h
+++ b/src/TraverseTypes.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 ZEEK_FORWARD_DECLARE_NAMESPACED(TraversalCallback, zeek::detail);
 

--- a/src/TunnelEncapsulation.h
+++ b/src/TunnelEncapsulation.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <vector>
 

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Type.h"
 
 #include <string>

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Val.h"
 
 #include <sys/types.h>

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Var.h"
 
 #include <memory>

--- a/src/ZeekString.cc
+++ b/src/ZeekString.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/ZeekString.h"
 
 #include <ctype.h>

--- a/src/ZeekString.h
+++ b/src/ZeekString.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <sys/types.h>
 

--- a/src/analyzer/Component.h
+++ b/src/analyzer/Component.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/analyzer/Tag.h"
 #include "zeek/plugin/Component.h"

--- a/src/analyzer/Tag.h
+++ b/src/analyzer/Tag.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Tag.h"
 
 ZEEK_FORWARD_DECLARE_NAMESPACED(EnumVal, zeek);

--- a/src/analyzer/protocol/dce-rpc/DCE_RPC.cc
+++ b/src/analyzer/protocol/dce-rpc/DCE_RPC.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/dce-rpc/DCE_RPC.h"
 
 #include <stdlib.h>

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/dns/DNS.h"
 
 #include <ctype.h>

--- a/src/analyzer/protocol/finger/Finger.cc
+++ b/src/analyzer/protocol/finger/Finger.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/finger/Finger.h"
 
 #include <ctype.h>

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/ftp/FTP.h"
 
 #include <stdlib.h>

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/gnutella/Gnutella.h"
 
 #include <ctype.h>

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/http/HTTP.h"
 
 #include <ctype.h>

--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/icmp/ICMP.h"
 
 #include <netinet/icmp6.h>

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/ident/Ident.h"
 
 #include <ctype.h>

--- a/src/analyzer/protocol/imap/imap.pac
+++ b/src/analyzer/protocol/imap/imap.pac
@@ -12,7 +12,7 @@ namespace zeek::analyzer::imap { class IMAP_Analyzer; }
 namespace binpac { namespace IMAP { class IMAP_Conn; } }
 using IMAPAnalyzer = zeek::analyzer::imap::IMAP_Analyzer*;
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/protocol/imap/IMAP.h"
 

--- a/src/analyzer/protocol/krb/KRB.h
+++ b/src/analyzer/protocol/krb/KRB.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include <mutex>
 
 #ifdef USE_KRB5

--- a/src/analyzer/protocol/krb/krb.pac
+++ b/src/analyzer/protocol/krb/krb.pac
@@ -6,7 +6,7 @@ namespace zeek::analyzer::krb { class KRB_Analyzer; }
 namespace binpac { namespace KRB { class KRB_Conn; } }
 using KRBAnalyzer = zeek::analyzer::krb::KRB_Analyzer*;
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/krb/KRB.h"
 
 #include "analyzer/protocol/krb/types.bif.h"

--- a/src/analyzer/protocol/krb/krb_TCP.pac
+++ b/src/analyzer/protocol/krb/krb_TCP.pac
@@ -6,7 +6,7 @@ namespace zeek::analyzer::krb_tcp { class KRB_Analyzer; }
 namespace binpac { namespace KRB_TCP { class KRB_Conn; } }
 using KRBTCPAnalyzer = zeek::analyzer::krb_tcp::KRB_Analyzer*;
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/krb/KRB_TCP.h"
 
 #include "analyzer/protocol/krb/types.bif.h"

--- a/src/analyzer/protocol/login/Login.cc
+++ b/src/analyzer/protocol/login/Login.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/login/Login.h"
 
 #include <ctype.h>

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/login/NVT.h"
 
 #include <stdlib.h>

--- a/src/analyzer/protocol/login/RSH.cc
+++ b/src/analyzer/protocol/login/RSH.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/login/RSH.h"
 
 #include "zeek/NetVar.h"

--- a/src/analyzer/protocol/login/Rlogin.cc
+++ b/src/analyzer/protocol/login/Rlogin.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/login/Rlogin.h"
 
 #include "zeek/NetVar.h"

--- a/src/analyzer/protocol/login/Telnet.cc
+++ b/src/analyzer/protocol/login/Telnet.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/analyzer/protocol/login/Telnet.h"
 #include "zeek/analyzer/protocol/login/NVT.h"

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -1,4 +1,4 @@
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/mime/MIME.h"
 
 #include "zeek/NetVar.h"

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/ncp/NCP.h"
 
 #include <stdlib.h>

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/netbios/NetbiosSSN.h"
 
 #include <ctype.h>

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -1,7 +1,7 @@
 // This code contributed to Bro by Florian Schimandl, Hugh Dollman and
 // Robin Sommer.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/pop3/POP3.h"
 
 #include <vector>

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/rpc/MOUNT.h"
 
 #include <algorithm>

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/rpc/NFS.h"
 
 #include <utility>

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/rpc/Portmap.h"
 
 #include "zeek/NetVar.h"

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/rpc/RPC.h"
 
 #include <stdlib.h>

--- a/src/analyzer/protocol/rpc/XDR.cc
+++ b/src/analyzer/protocol/rpc/XDR.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/rpc/XDR.h"
 
 #include <string.h>

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/smtp/SMTP.h"
 
 #include <stdlib.h>

--- a/src/analyzer/protocol/stepping-stone/SteppingStone.cc
+++ b/src/analyzer/protocol/stepping-stone/SteppingStone.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/stepping-stone/SteppingStone.h"
 
 #include <stdlib.h>

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/analyzer/protocol/udp/UDP.h"
 
 #include <algorithm>

--- a/src/analyzer/protocol/zip/ZIP.h
+++ b/src/analyzer/protocol/zip/ZIP.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <zlib.h>
 

--- a/src/bsd-getopt-long.c
+++ b/src/bsd-getopt-long.c
@@ -54,7 +54,7 @@
 
 #define IN_GETOPT_LONG_C 1
 
-#include <zeek-config.h>
+#include <zeek/zeek-config.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdio.h>

--- a/src/file_analysis/Component.h
+++ b/src/file_analysis/Component.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/file_analysis/Tag.h"
 #include "zeek/plugin/Component.h"

--- a/src/file_analysis/Tag.h
+++ b/src/file_analysis/Tag.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Tag.h"
 
 ZEEK_FORWARD_DECLARE_NAMESPACED(EnumVal, zeek);

--- a/src/input/Tag.h
+++ b/src/input/Tag.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Tag.h"
 
 ZEEK_FORWARD_DECLARE_NAMESPACED(EnumVal, zeek);

--- a/src/input/readers/sqlite/SQLite.cc
+++ b/src/input/readers/sqlite/SQLite.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/input/readers/sqlite/SQLite.h"
 
 #include <sys/types.h>

--- a/src/input/readers/sqlite/SQLite.h
+++ b/src/input/readers/sqlite/SQLite.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <iostream>
 #include <vector>

--- a/src/iosource/BPF_Program.cc
+++ b/src/iosource/BPF_Program.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/iosource/BPF_Program.h"
 
 #include <string.h>

--- a/src/iosource/Manager.h
+++ b/src/iosource/Manager.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <string>
 #include <vector>

--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <stdint.h>
 #include <sys/types.h> // for u_char

--- a/src/iosource/PktDumper.cc
+++ b/src/iosource/PktDumper.cc
@@ -1,7 +1,7 @@
 
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/iosource/PktDumper.h"
 #include "zeek/DebugLogger.h"

--- a/src/iosource/PktDumper.h
+++ b/src/iosource/PktDumper.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include <string>
 
 ZEEK_FORWARD_DECLARE_NAMESPACED(Packet, zeek);

--- a/src/iosource/PktSrc.cc
+++ b/src/iosource/PktSrc.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/iosource/PktSrc.h"
 
 #include <sys/stat.h>

--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -1,6 +1,6 @@
 // See the file  in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/iosource/pcap/Source.h"
 
 #ifdef HAVE_PCAP_INT_H

--- a/src/logging/Tag.h
+++ b/src/logging/Tag.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Tag.h"
 
 ZEEK_FORWARD_DECLARE_NAMESPACED(EnumVal, zeek);

--- a/src/logging/writers/sqlite/SQLite.cc
+++ b/src/logging/writers/sqlite/SQLite.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/logging/writers/sqlite/SQLite.h"
 
 #include <errno.h>

--- a/src/logging/writers/sqlite/SQLite.h
+++ b/src/logging/writers/sqlite/SQLite.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "zeek/logging/WriterBackend.h"
 #include "zeek/threading/formatters/Ascii.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/zeek-setup.h"
 
 #include "zeek/iosource/Manager.h"

--- a/src/nb_dns.c
+++ b/src/nb_dns.c
@@ -11,7 +11,7 @@
  * crack reply buffers is private.
  */
 
-#include "zeek-config.h"			/* must appear before first ifdef */
+#include "zeek/zeek-config.h"			/* must appear before first ifdef */
 #include "zeek/nb_dns.h"
 
 #include <sys/types.h>

--- a/src/net_util.cc
+++ b/src/net_util.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/net_util.h"
 
 #include <sys/types.h>

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 // Define first.
 typedef enum {

--- a/src/packet_analysis/Component.h
+++ b/src/packet_analysis/Component.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <functional>
 

--- a/src/packet_analysis/Tag.h
+++ b/src/packet_analysis/Tag.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/Tag.h"
 
 namespace zeek::plugin {

--- a/src/packet_analysis/protocol/arp/ARP.cc
+++ b/src/packet_analysis/protocol/arp/ARP.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/packet_analysis/protocol/arp/ARP.h"
 
 #ifdef HAVE_NET_ETHERNET_H

--- a/src/plugin/Component.h
+++ b/src/plugin/Component.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include <string>
 
 ZEEK_FORWARD_DECLARE_NAMESPACED(ODesc, zeek);

--- a/src/plugin/Plugin.h
+++ b/src/plugin/Plugin.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <list>
 #include <string>

--- a/src/probabilistic/BloomFilter.h
+++ b/src/probabilistic/BloomFilter.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <memory>
 #include <vector>

--- a/src/probabilistic/CounterVector.h
+++ b/src/probabilistic/CounterVector.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <cstddef>
 #include <cstdint>

--- a/src/rule-parse.y
+++ b/src/rule-parse.y
@@ -1,5 +1,5 @@
 %{
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include <stdio.h>
 #include <netinet/in.h>
 #include <vector>

--- a/src/setsignal.c
+++ b/src/setsignal.c
@@ -2,7 +2,7 @@
  * See the file "COPYING" in the main distribution directory for copyright.
  */
 
-#include "zeek-config.h"			/* must appear before first ifdef */
+#include "zeek/zeek-config.h"			/* must appear before first ifdef */
 
 #include <sys/types.h>
 

--- a/src/strsep.c
+++ b/src/strsep.c
@@ -31,7 +31,7 @@
  * SUCH DAMAGE.
  */
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #ifndef HAVE_STRSEP
 

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/supervisor/Supervisor.h"
 
 #include <sys/types.h>

--- a/src/threading/BasicThread.cc
+++ b/src/threading/BasicThread.cc
@@ -1,4 +1,4 @@
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/threading/BasicThread.h"
 
 #include <signal.h>

--- a/src/threading/BasicThread.h
+++ b/src/threading/BasicThread.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <stdint.h>
 

--- a/src/threading/Formatter.cc
+++ b/src/threading/Formatter.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/threading/Formatter.h"
 
 #include <errno.h>

--- a/src/threading/formatters/Ascii.cc
+++ b/src/threading/formatters/Ascii.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "threading/formatters/Ascii.h"
 
 #include <errno.h>

--- a/src/threading/formatters/JSON.cc
+++ b/src/threading/formatters/JSON.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/threading/formatters/JSON.h"
 
 #ifndef __STDC_LIMIT_MACROS

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "util-config.h"
 
 #include "zeek/util.h"

--- a/src/util.h
+++ b/src/util.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 // Expose C99 functionality from inttypes.h, which would otherwise not be
 // available in C++.

--- a/src/version.c.in
+++ b/src/version.c.in
@@ -1,5 +1,5 @@
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 char version[] = "@VERSION@";
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 #include "zeek/zeek-setup.h"
 
 #include <stdio.h>

--- a/src/zeekygen/ScriptInfo.h
+++ b/src/zeekygen/ScriptInfo.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <time.h> // for time_t
 #include <set>

--- a/src/zeekygen/Target.h
+++ b/src/zeekygen/Target.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <map>
 #include <string>

--- a/src/zeekygen/utils.h
+++ b/src/zeekygen/utils.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include <time.h> // for time_t
 #include <string>


### PR DESCRIPTION
This cherry-picks 8a8a983c49518d05a21812284c6e0a49406cdc8a for inclusion into the `release/4.0` branch.

Relates to https://github.com/zeek/bifcl/pull/10, which contains the corresponding fix to `bifcl`. The submodule pointer currently points directly into `bifcl`'s `topic/christian/zeek-include-fix` branch, which will need straightening out post-merge of the nested PR.

Resolves #1547.