### PR TITLE
GH-1546: Make DictIterator() public, add copy/move operators

### DIFF
--- a/src/Dict.cc
+++ b/src/Dict.cc
@@ -265,6 +265,11 @@ TEST_CASE("dict new iteration")
 		count++;
 		}
 
+	PDict<uint32_t>::iterator it;
+	it = dict.begin();
+	it = dict.end();
+	PDict<uint32_t>::iterator it2 = it;
+
 	CHECK(count == 2);
 
 	delete key;
@@ -1558,8 +1563,11 @@ DictIterator::DictIterator(const Dictionary* d, detail::DictEntry* begin, detail
 
 DictIterator::~DictIterator()
 	{
-	assert(dict->num_iterators > 0);
-	dict->num_iterators--;
+	if ( dict )
+		{
+		assert(dict->num_iterators > 0);
+		dict->num_iterators--;
+		}
 	}
 
 DictIterator& DictIterator::operator++()
@@ -1570,6 +1578,80 @@ DictIterator& DictIterator::operator++()
 		++curr;
 		}
 	while ( curr != end && curr->Empty() );
+
+	return *this;
+	}
+
+DictIterator::DictIterator(const DictIterator& that)
+	{
+	if ( this == &that )
+		return;
+
+	if ( dict )
+		{
+		assert(dict->num_iterators > 0);
+		dict->num_iterators--;
+		}
+
+	dict = that.dict;
+	curr = that.curr;
+	end = that.end;
+	dict->num_iterators++;
+	}
+
+DictIterator& DictIterator::operator=(const DictIterator& that)
+	{
+	if ( this == &that )
+		return *this;
+
+	if ( dict )
+		{
+		assert(dict->num_iterators > 0);
+		dict->num_iterators--;
+		}
+
+	dict = that.dict;
+	curr = that.curr;
+	end = that.end;
+	dict->num_iterators++;
+
+	return *this;
+	}
+
+DictIterator::DictIterator(DictIterator&& that)
+	{
+	if ( this == &that )
+		return;
+
+	if ( dict )
+		{
+		assert(dict->num_iterators > 0);
+		dict->num_iterators--;
+		}
+
+	dict = that.dict;
+	curr = that.curr;
+	end = that.end;
+
+	that.dict = nullptr;
+	}
+
+DictIterator& DictIterator::operator=(DictIterator&& that)
+	{
+	if ( this == &that )
+		return *this;
+
+	if ( dict )
+		{
+		assert(dict->num_iterators > 0);
+		dict->num_iterators--;
+		}
+
+	dict = that.dict;
+	curr = that.curr;
+	end = that.end;
+
+	that.dict = nullptr;
 
 	return *this;
 	}

--- a/src/Dict.h
+++ b/src/Dict.h
@@ -159,7 +159,13 @@ public:
 	using difference_type = std::ptrdiff_t;
 	using iterator_category = std::forward_iterator_tag;
 
+	DictIterator() = default;
 	~DictIterator();
+
+	DictIterator(const DictIterator& that);
+	DictIterator& operator=(const DictIterator& that);
+	DictIterator(DictIterator&& that);
+	DictIterator& operator=(DictIterator&& that);
 
 	reference operator*() { return *curr; }
 	pointer operator->() { return curr; }
@@ -173,7 +179,6 @@ public:
 private:
 	friend class Dictionary;
 
-	DictIterator() = default;
 	DictIterator(const Dictionary* d, detail::DictEntry* begin, detail::DictEntry* end);
 
 	Dictionary* dict = nullptr;


### PR DESCRIPTION
Fixes #1546 

This PR adds copy and move constructors and assignment operators for DictEntry, and makes the default DictEntry constructor public. This allows for iterators to be constructed but not immediately initialized by a dictionary's `begin()` method.