### PR TITLE
Just a few ideas for improving the manual page

### DIFF
--- a/man/zeek.8
+++ b/man/zeek.8
@@ -170,6 +170,9 @@ Usually Zeek is started by running \fBzeekctl\fR. To configure Zeek with an init
 configuration, install, and restart:
 .br
     # zeekctl deploy
+
+Note: the default configuration may need to be updated before use. Especially the
+network interface used should be the correct one.
 .SH SEE ALSO
 zeekctl(8) zeek-cut(1)
 .SH AUTHOR

--- a/man/zeek.8
+++ b/man/zeek.8
@@ -16,6 +16,8 @@ tasks, including detecting malware by interfacing to external registries,
 reporting vulnerable versions of software seen on the network, identifying
 popular web applications, detecting SSH brute-forcing, validating SSL
 certificate chains, among others.
+
+You must have read access to the files or interfaces specified.
 .SH OPTIONS
 .TP
 .B <file>
@@ -148,6 +150,28 @@ Output file for script execution statistics
 .TP
 .B ZEEK_DISABLE_ZEEKYGEN
 Disable Zeekygen (Broxygen) documentation support
+.SH OUTPUT FORMAT
+Output is written in multiple files depending on configuration. Default
+location is the current directory. Packets can be written to a tcpdump file.
+
+The output written by Zeek can be formatted in multiple ways using the
+logging framework.
+.PP
+The default are files in human-readable (ASCII) format and data is organized
+into columns (tab-delimited), They can be processed by the \fBzeek-cut\fR tool.
+
+
+.SH EXAMPLES
+Read a capture file:
+.br
+    # zeek -r test-capture.pcap
+.PP
+Usually Zeek is started by running \fBzeekctl\fR. To configure Zeek with an initial
+configuration, install, and restart:
+.br
+    # zeekctl deploy
+.SH SEE ALSO
+zeekctl(8) zeek-cut(1)
 .SH AUTHOR
 .B zeek
 was written by The Zeek Project <info@zeek.org>.

--- a/man/zeek.8
+++ b/man/zeek.8
@@ -152,7 +152,7 @@ Output file for script execution statistics
 Disable Zeekygen (Broxygen) documentation support
 .SH OUTPUT FORMAT
 Output is written in multiple files depending on configuration. Default
-location is the current directory. 
+location is the current directory.
 
 The output written by Zeek can be formatted in multiple ways using the
 logging framework.
@@ -162,7 +162,7 @@ into columns (tab-delimited), They can be processed by the \fBzeek-cut\fR tool.
 
 
 .SH EXAMPLES
-Read a capture file:
+Read a capture file and generate the default logs:
 .br
     # zeek -r test-capture.pcap
 .PP

--- a/man/zeek.8
+++ b/man/zeek.8
@@ -152,7 +152,7 @@ Output file for script execution statistics
 Disable Zeekygen (Broxygen) documentation support
 .SH OUTPUT FORMAT
 Output is written in multiple files depending on configuration. Default
-location is the current directory. Packets can be written to a tcpdump file.
+location is the current directory. 
 
 The output written by Zeek can be formatted in multiple ways using the
 logging framework.


### PR DESCRIPTION
Hi
2nd try, with more clean -  a single commit, I hope, retry for #1553 

I think the manual page for Zeek is a bit short and terse. I have added a few comments about:

* read acces for interfaces at the beginning, inspired by a similar comment in tcpdump man page
* output format, using the words from https://docs.zeek.org/en/current/quickstart.html about logs being human readable etc.
* Example, showing how to read a basic file - most basic use
* Example, reference to zeekctl - which is what most people should use for running I guess
* Also added zeekctl(8) zeek-cut(1) in a "SEE ALSO", I think we should add more to this

Looking forward to your comments.

I would like to add more comments and expand the manuals more, so if you DONT want that, let me know.

Ideas to add:

* Reference to changing the output format to JSON, using the example zeek ... LogAscii::use_json=T , since I think a lot of newcomers would prefer that format ASAP. So making their life easier
* Making sure we have a SEE ALSO in each man page, with ref to other Zeek commands again helping newcomers navigate the commands
* Add comments to the main manual page for zeek about the scripting language with link to the web pages describing it