### PR TITLE
Add Fedora 34 to CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -91,6 +91,13 @@ env:
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
+fedora34_task:
+  container:
+    # Fedora 34 EOL: Around May 2022
+    dockerfile: ci/fedora-34/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
 fedora33_task:
   container:
     # Fedora 33 EOL: Around November 2022

--- a/ci/fedora-34/Dockerfile
+++ b/ci/fedora-34/Dockerfile
@@ -1,0 +1,23 @@
+FROM fedora:34
+
+RUN dnf -y install \
+    bison \
+    cmake \
+    diffutils \
+    findutils \
+    flex \
+    git \
+    gcc \
+    gcc-c++ \
+    libpcap-devel \
+    make \
+    openssl-devel \
+    python3-devel \
+    python3-pip\
+    sqlite \
+    swig \
+    which \
+    zlib-devel \
+  && dnf clean all && rm -rf /var/cache/dnf
+
+RUN pip3 install junit2html


### PR DESCRIPTION
Fedora 34 got released on April 20, so I'm quite behind here — whoops!