### PR TITLE
Add deprecated headers for UDP and ICMP analyzers

### DIFF
--- a/src/analyzer/protocol/icmp/ICMP.h
+++ b/src/analyzer/protocol/icmp/ICMP.h
@@ -1,0 +1,15 @@
+#warning "Remove in v5.1. This analyzer has been moved to packet analysis, use 'zeek/packet_analysis/protocol/icmp/ICMPSessionAdapter.h' and/or 'zeek/packet_analysis/protocol/icmp/ICMP.h'."
+
+#include "zeek/packet_analysis/protocol/icmp/ICMPSessionAdapter.h"
+#include "zeek/packet_analysis/protocol/icmp/ICMP.h"
+
+namespace zeek::analyzer::icmp {
+
+using ICMP_Analyzer [[deprecated("Remove in v5.1. Use zeek::packet_analysis::ICMP::ICMPSessionAdapter.")]] =
+	zeek::packet_analysis::ICMP::ICMPSessionAdapter;
+constexpr auto ICMP4_counterpart [[deprecated("Remove in v5.1. Use zeek::packet_analysis::ICMP::ICMP4_counterpart.")]] =
+	zeek::packet_analysis::ICMP::ICMP4_counterpart;
+constexpr auto ICMP6_counterpart [[deprecated("Remove in v5.1. Use zeek::packet_analysis::ICMP::ICMP6_counterpart.")]] =
+	zeek::packet_analysis::ICMP::ICMP6_counterpart;
+
+} // namespace zeek::analyzer::icmp

--- a/src/analyzer/protocol/tcp/TCP.h
+++ b/src/analyzer/protocol/tcp/TCP.h
@@ -10,7 +10,6 @@
 #include "zeek/Conn.h"
 
 namespace zeek::analyzer::pia { class PIA_TCP; }
-namespace zeek::packet_analysis::TCP { class TCPSessionAdapter; }
 
 namespace zeek::analyzer::tcp {
 

--- a/src/analyzer/protocol/udp/UDP.h
+++ b/src/analyzer/protocol/udp/UDP.h
@@ -1,0 +1,10 @@
+#warning "Remove in v5.1. This analyzer has been moved to packet analysis, use 'zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h'."
+
+#include "zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h"
+
+namespace zeek::analyzer::udp {
+
+using UDP_Analyzer [[deprecated("Remove in v5.1. Use zeek::packet_analysis::UDP::UDPSessionAdapter.")]] =
+	zeek::packet_analysis::UDP::UDPSessionAdapter;
+
+} // namespace zeek::analyzer::udp


### PR DESCRIPTION
This restores the old names for the UDP and ICMP analyzers as well as a couple of ICMP functions that got lost in the work for #1114. The TCP name was already deprecated properly.