### PR TITLE
Improve assignment operators for IntrusivePtr

### DIFF
--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -137,9 +137,26 @@ public:
 		return std::exchange(ptr_, nullptr);
 		}
 
-	IntrusivePtr& operator=(IntrusivePtr other) noexcept
+	IntrusivePtr& operator=(const IntrusivePtr& other) noexcept
+		{
+		IntrusivePtr tmp{other};
+		swap(tmp);
+		return *this;
+		}
+
+	IntrusivePtr& operator=(IntrusivePtr&& other) noexcept
 		{
 		swap(other);
+		return *this;
+		}
+
+	IntrusivePtr& operator=(std::nullptr_t) noexcept
+		{
+		if ( ptr_ )
+			{
+			Unref(ptr_);
+			ptr_ = nullptr;
+			}
 		return *this;
 		}
 


### PR DESCRIPTION
Fixes Coverity finding CID-1367523 (Missing move assignment operator).

I've noticed this warning while looking into the new Coverity findings regarding the Broker telemetry API. Figured it's worth addressing since `IntrusivePtr` is a heavily used class. With the new move assignment operator, we can swap directly with the assigned-from object instead of going through a temporary first. We can also get away without the temporary object when assigning `nullptr`.