### PR TITLE
Fix macOS Big Sur builds on Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -219,7 +219,7 @@ alpine_task:
 # We aim to support both the current and previous macOS release.
 macos_big_sur_task:
   macos_instance:
-    image: big-sur-base
+    image: big-sur-xcode-12.5
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_RESOURCES_TEMPLATE

--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -5,4 +5,5 @@ sysctl hw.model hw.machine hw.ncpu hw.physicalcpu hw.logicalcpu
 set -e
 set -x
 
-brew install cmake swig openssl bison
+brew upgrade cmake openssl
+brew install swig bison


### PR DESCRIPTION
- Upgrade the Big Sur VM to use the Xcode 12.5 version. This has a newer
  version of brew installed on it that fixes an issue with an EOL package host
  that finally shut down for good recently.
- Use `brew upgrade` for openssl and cmake, since those are both present on the
  base VM. This prevents `brew install` from printing an error if the package
  exists but is out of date.