### PR TITLE
Add OpenSUSE Leap 15.3 to testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -176,6 +176,13 @@ opensuse_leap_15_2_task:
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
+opensuse_leap_15_3_task:
+  container:
+    # Opensuse Leap 15.3 EOL: TBD
+    dockerfile: ci/opensuse-leap-15.3/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
 ubuntu20_task:
   container:
     # Ubuntu 20.04 EOL: April 2025

--- a/ci/opensuse-leap-15.3/Dockerfile
+++ b/ci/opensuse-leap-15.3/Dockerfile
@@ -1,0 +1,25 @@
+FROM opensuse/leap:15.3
+
+RUN zypper in -y \
+  cmake \
+  make \
+  gcc \
+  gcc-c++ \
+  python3 \
+  python3-devel \
+  flex \
+  bison \
+  libpcap-devel \
+  libopenssl-devel \
+  zlib-devel \
+  swig \
+  git \
+  curl \
+  python3-pip \
+  which \
+  gzip \
+  tar \
+  && rm -rf /var/cache/zypp
+
+
+RUN pip3 install junit2html


### PR DESCRIPTION
OpenSUSE Leap 15.3 was released a few days ago - and we should test against it :)