### PR TITLE
Logging/cli logdir scripted

### DIFF
--- a/man/zeek.8
+++ b/man/zeek.8
@@ -44,6 +44,9 @@ command line help
 \fB\-i\fR,\ \-\-iface <interface>
 read from given interface
 .TP
+\fB\-l\fR,\ \-\-logdir <directory>
+write log files into directory
+.TP
 \fB\-p\fR,\ \-\-prefix <prefix>
 add given prefix to policy file resolution
 .TP

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -89,6 +89,7 @@ void usage(const char* prog, int code)
 	fprintf(stderr, "    -f|--filter <filter>           | tcpdump filter\n");
 	fprintf(stderr, "    -h|--help                      | command line help\n");
 	fprintf(stderr, "    -i|--iface <interface>         | read from given interface (only one allowed)\n");
+	fprintf(stderr, "    -l|--logdir <dir>              | output log files to directory specified\n");
 	fprintf(stderr, "    -p|--prefix <prefix>           | add given prefix to Zeek script file resolution\n");
 	fprintf(stderr, "    -r|--readfile <readfile>       | read from given tcpdump file (only one allowed, pass '-' as the filename to read from stdin)\n");
 	fprintf(stderr, "    -s|--rulefile <rulefile>       | read rules from given file\n");
@@ -307,6 +308,7 @@ Options parse_cmdline(int argc, char** argv)
 		{"filter",		required_argument,	nullptr,	'f'},
 		{"help",		no_argument,		nullptr,	'h'},
 		{"iface",		required_argument,	nullptr,	'i'},
+		{"logdir", required_argument, nullptr, 'l'},
 		{"zeekygen",		required_argument,		nullptr,	'X'},
 		{"prefix",		required_argument,	nullptr,	'p'},
 		{"readfile",		required_argument,	nullptr,	'r'},
@@ -350,7 +352,7 @@ Options parse_cmdline(int argc, char** argv)
 	};
 
 	char opts[256];
-	util::safe_strncpy(opts, "B:e:f:G:H:I:i:j::n:O:o:p:r:s:T:t:U:w:X:CDFNPQSWabdhuv",
+	util::safe_strncpy(opts, "B:e:f:G:H:I:i:j::l:n:O:o:p:r:s:T:t:U:w:X:CDFNPQSWabdhuv",
 	                         sizeof(opts));
 
 #ifdef USE_PERFTOOLS_DEBUG
@@ -363,6 +365,7 @@ Options parse_cmdline(int argc, char** argv)
 
 	// getopt may permute the array, so need yet another array
 	auto zargs = std::make_unique<char*[]>(zeek_args.size());
+	std::string logdir_plugin;
 
 	for ( size_t i = 0; i < zeek_args.size(); ++i )
 		zargs[i] = zeek_args[i].data();
@@ -410,6 +413,11 @@ Options parse_cmdline(int argc, char** argv)
 				// expected to be number of workers like "-j 4" or possibly a
 				// list of worker/proxy/logger counts like "-j 4,2,1"
 				}
+			break;
+		case 'l':
+			logdir_plugin = "LogAscii::logdir=";
+			logdir_plugin += optarg;
+			rval.script_options_to_set.emplace_back(logdir_plugin);
 			break;
 		case 'p':
 			rval.script_prefixes.emplace_back(optarg);


### PR DESCRIPTION
Hi there
Note: this is a 2nd try in getting this in. First try was in #1530 , this is much more clean!

I was looking at the issue #772 and would like to contribute to this.

I have done,
Analyzed (looked at man pages, and I use Suricata extensively)
Both Snort and Suritcata, two of the most popular IDS engines, use -l for this purpose

Added feature, as suggested by Zeek developer, and accepted as #1551 a script option.

1551 allows the use of:
zeek -r test-capture.cap LogAscii::logdir=logdir
with only changes in the writer 

This patch adds a small change, syntactic sugar you may wish to call it, to allow:
zeek -r test-capture.cap -l logdir

I teach a lot, and since both Suricata and Snort has this, it would be nice if newcomers to Zeek and others can re-use the same option, less to remember.

also, this would block the -l from being used for something completely different in the future - worst case for me.

Tagging a few people, hoping you dont mind, and you had an opinion before. Feel free to shoot it down, if you still think it is a bad idea. Promise I will only bring this up once a year in the future.

@ckreibich @rsmmr @0xxon 

