### PR TITLE
Load the builtin-plugin preload files and fix the dev path.

### DIFF
--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -281,15 +281,6 @@ bool Manager::ActivateDynamicPluginInternal(const std::string& name, bool ok_if_
 		scripts_to_load.push_back(init);
 		}
 
-	// First load {scripts}/__preload__.zeek automatically.
-	init = dir + "builtin-plugins/__preload__.zeek";
-
-	if ( util::is_file(init) )
-		{
-		DBG_LOG(DBG_PLUGINS, "  Loading %s", init.c_str());
-		scripts_to_load.push_back(init);
-		}
-
 	// Load {bif,scripts}/__load__.zeek automatically.
 	init = dir + "lib/bif/__load__.zeek";
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -548,6 +548,7 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 	if ( ! options.bare_mode )
 		add_input_file("base/init-default.zeek");
 
+	add_input_file("builtin-plugins/__preload__.zeek");
 	add_input_file("builtin-plugins/__load__.zeek");
 
 	plugin_mgr->SearchDynamicPlugins(util::zeek_plugin_path());

--- a/testing/btest/Baseline/coverage.bare-load-baseline/canonified_loaded_scripts.log
+++ b/testing/btest/Baseline/coverage.bare-load-baseline/canonified_loaded_scripts.log
@@ -230,6 +230,7 @@ scripts/base/init-frameworks-and-bifs.zeek
     build/scripts/base/bif/plugins/Zeek_AsciiWriter.ascii.bif.zeek
     build/scripts/base/bif/plugins/Zeek_NoneWriter.none.bif.zeek
     build/scripts/base/bif/plugins/Zeek_SQLiteWriter.sqlite.bif.zeek
+build/scripts/builtin-plugins/__preload__.zeek
 build/scripts/builtin-plugins/__load__.zeek
 scripts/policy/misc/loaded-scripts.zeek
   scripts/base/utils/paths.zeek

--- a/testing/btest/Baseline/coverage.default-load-baseline/canonified_loaded_scripts.log
+++ b/testing/btest/Baseline/coverage.default-load-baseline/canonified_loaded_scripts.log
@@ -427,6 +427,7 @@ scripts/base/init-default.zeek
   scripts/base/misc/find-checksum-offloading.zeek
   scripts/base/misc/find-filtered-trace.zeek
   scripts/base/misc/version.zeek
+build/scripts/builtin-plugins/__preload__.zeek
 build/scripts/builtin-plugins/__load__.zeek
 scripts/policy/misc/loaded-scripts.zeek
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/btest/Baseline/plugins.hooks/output
+++ b/testing/btest/Baseline/plugins.hooks/output
@@ -1013,6 +1013,7 @@
 0.000000   MetaHookPost  LoadFile(0, base<...>/xmpp, <...>/xmpp) -> -1
 0.000000   MetaHookPost  LoadFile(0, base<...>/zeek.bif, <...>/zeek.bif.zeek) -> -1
 0.000000   MetaHookPost  LoadFile(0, builtin-plugins/__load__.zeek, <...>/__load__.zeek) -> -1
+0.000000   MetaHookPost  LoadFile(0, builtin-plugins/__preload__.zeek, <...>/__preload__.zeek) -> -1
 0.000000   MetaHookPost  LoadFile(1, ./archive, <...>/archive.sig) -> -1
 0.000000   MetaHookPost  LoadFile(1, ./audio, <...>/audio.sig) -> -1
 0.000000   MetaHookPost  LoadFile(1, ./dpd.sig, <...>/dpd.sig) -> -1
@@ -2044,6 +2045,7 @@
 0.000000   MetaHookPre   LoadFile(0, base<...>/xmpp, <...>/xmpp)
 0.000000   MetaHookPre   LoadFile(0, base<...>/zeek.bif, <...>/zeek.bif.zeek)
 0.000000   MetaHookPre   LoadFile(0, builtin-plugins/__load__.zeek, <...>/__load__.zeek)
+0.000000   MetaHookPre   LoadFile(0, builtin-plugins/__preload__.zeek, <...>/__preload__.zeek)
 0.000000   MetaHookPre   LoadFile(1, ./archive, <...>/archive.sig)
 0.000000   MetaHookPre   LoadFile(1, ./audio, <...>/audio.sig)
 0.000000   MetaHookPre   LoadFile(1, ./dpd.sig, <...>/dpd.sig)
@@ -3086,6 +3088,7 @@
 0.000000 | HookLoadFile  base<...>/xmpp <...>/xmpp
 0.000000 | HookLoadFile  base<...>/zeek.bif <...>/zeek.bif.zeek
 0.000000 | HookLoadFile  builtin-plugins/__load__.zeek <...>/__load__.zeek
+0.000000 | HookLoadFile  builtin-plugins/__preload__.zeek <...>/__preload__.zeek
 0.000000 | HookLogInit   packet_filter 1/1 {ts (time), node (string), filter (string), init (bool), success (bool)}
 0.000000 | HookLogWrite  packet_filter [ts=XXXXXXXXXX.XXXXXX, node=zeek, filter=ip or not ip, init=T, success=T]
 0.000000 | HookQueueEvent NetControl::init()

--- a/zeek-path-dev.in
+++ b/zeek-path-dev.in
@@ -10,4 +10,4 @@
 #     ZEEKPATH=`./zeek-path-dev` ./src/zeek
 #
 
-echo .:${CMAKE_SOURCE_DIR}/scripts:${CMAKE_SOURCE_DIR}/scripts/policy:${CMAKE_SOURCE_DIR}/scripts/site:${CMAKE_BINARY_DIR}/scripts
+echo .:${CMAKE_SOURCE_DIR}/scripts:${CMAKE_SOURCE_DIR}/scripts/policy:${CMAKE_SOURCE_DIR}/scripts/site:${CMAKE_BINARY_DIR}/scripts:${CMAKE_BINARY_DIR}/scripts/builtin-plugins


### PR DESCRIPTION
The builtin plugin preload scripts weren't being loaded.  This merge request makes them load correctly and fixes the development path (Zeek-path-dev) too.