### PR TITLE
Disallow `-B` when not built with debugging support, fix perftools build

### DIFF
--- a/src/Options.cc
+++ b/src/Options.cc
@@ -350,12 +350,8 @@ Options parse_cmdline(int argc, char** argv)
 	};
 
 	char opts[256];
-	util::safe_strncpy(opts, "B:e:f:G:H:I:i:j::n:O:o:p:r:s:T:t:U:w:X:CDFNPQSWabdhuv",
+	util::safe_strncpy(opts, "B:e:f:G:H:I:i:j::n:O:o:p:r:s:T:t:U:w:X:CDFMNPQSWabdhmuv",
 	                         sizeof(opts));
-
-#ifdef USE_PERFTOOLS_DEBUG
-	strncat(opts, "mM", 2);
-#endif
 
 	int op;
 	int long_optsind;
@@ -444,15 +440,19 @@ Options parse_cmdline(int argc, char** argv)
 		case 'w':
 			rval.pcap_output_file = optarg;
 			break;
+
+#ifdef DEBUG
 		case 'B':
 			rval.debug_log_streams = optarg;
 			break;
+#endif
+
 		case 'C':
 			rval.ignore_checksums = true;
 			break;
 		case 'D':
-		    rval.deterministic_mode = true;
-		    break;
+			rval.deterministic_mode = true;
+			break;
 		case 'E':
 			rval.pseudo_realtime = 1.0;
 			if ( optarg )

--- a/src/main.cc
+++ b/src/main.cc
@@ -26,10 +26,10 @@ int main(int argc, char** argv)
 			zeek::detail::profiling_logger->Log();
 
 #ifdef USE_PERFTOOLS_DEBUG
-		if ( perftools_leaks )
+		if ( options.perftools_check_leaks )
 			heap_checker = new HeapLeakChecker("net_run");
 
-		if ( perftools_profile )
+		if ( options.perftools_profile )
 			{
 			HeapProfilerStart("heap");
 			HeapProfilerDump("pre net_run");

--- a/testing/btest/broker/connect-on-retry.zeek
+++ b/testing/btest/broker/connect-on-retry.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/broker/disconnect.zeek
+++ b/testing/btest/broker/disconnect.zeek
@@ -1,11 +1,11 @@
 # @TEST-PORT: BROKER_PORT
 
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek >send.out"
 
 # @TEST-EXEC: $SCRIPTS/wait-for-file send/lost 45 || (btest-bg-wait -k 1 && false)
 
-# @TEST-EXEC: btest-bg-run recv2 "zeek -B broker -b ../recv.zeek >recv2.out"
+# @TEST-EXEC: btest-bg-run recv2 "zeek -b ../recv.zeek >recv2.out"
 # @TEST-EXEC: btest-bg-wait 45
 
 # @TEST-EXEC: btest-diff send/send.out

--- a/testing/btest/broker/error.zeek
+++ b/testing/btest/broker/error.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: zeek -B main-loop,broker -b send.zeek >send.out
+# @TEST-EXEC: zeek -b send.zeek >send.out
 # @TEST-EXEC: btest-diff send.out
 # 
 

--- a/testing/btest/broker/remote_event.zeek
+++ b/testing/btest/broker/remote_event.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/broker/remote_event_any.zeek
+++ b/testing/btest/broker/remote_event_any.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/broker/remote_event_index_types.zeek
+++ b/testing/btest/broker/remote_event_index_types.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/broker/remote_event_ssl_auth.zeek
+++ b/testing/btest/broker/remote_event_ssl_auth.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/broker/remote_event_vector_any.zeek
+++ b/testing/btest/broker/remote_event_vector_any.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/broker/remote_id.zeek
+++ b/testing/btest/broker/remote_id.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek test_var=newval >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek test_var=newval >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/broker/remote_log.zeek
+++ b/testing/btest/broker/remote_log.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek >send.out"
 
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/broker/remote_log_batch.zeek
+++ b/testing/btest/broker/remote_log_batch.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek >send.out"
 
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/broker/ssl_auth_failure.zeek
+++ b/testing/btest/broker/ssl_auth_failure.zeek
@@ -1,13 +1,13 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send-check1 "zeek -B broker -b ../send-check.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send-check1 "zeek -b ../send-check.zeek >send.out"
 # @TEST-EXEC: $SCRIPTS/wait-for-file recv/listen-ready 20 || (btest-bg-wait -k 1 && false)
 #
-# @TEST-EXEC: btest-bg-run send "zeek -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run send "zeek -b ../send.zeek >send.out"
 # @TEST-EXEC: $SCRIPTS/wait-for-file send/failed 20 || (btest-bg-wait -k 1 && false)
 #
-# @TEST-EXEC: btest-bg-run send-check2 "zeek -B broker -b ../send-check.zeek >send.out"
+# @TEST-EXEC: btest-bg-run send-check2 "zeek -b ../send-check.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff send/send.out

--- a/testing/btest/broker/store/brokerstore-attr-clone.zeek
+++ b/testing/btest/broker/store/brokerstore-attr-clone.zeek
@@ -2,9 +2,9 @@
 
 # @TEST-PORT: BROKER_PORT
 
-# @TEST-EXEC: btest-bg-run master "zeek -B broker -b %DIR/sort-stuff.zeek ../common.zeek ../master.zeek >../master.out"
-# @TEST-EXEC: btest-bg-run cloneone "zeek -B broker -b %DIR/sort-stuff.zeek ../common.zeek ../cloneone.zeek >../cloneone.out"
-# @TEST-EXEC: btest-bg-run clonetwo "zeek -B broker -b %DIR/sort-stuff.zeek ../common.zeek ../clonetwo.zeek >../clonetwo.out"
+# @TEST-EXEC: btest-bg-run master "zeek -b %DIR/sort-stuff.zeek ../common.zeek ../master.zeek >../master.out"
+# @TEST-EXEC: btest-bg-run cloneone "zeek -b %DIR/sort-stuff.zeek ../common.zeek ../cloneone.zeek >../cloneone.out"
+# @TEST-EXEC: btest-bg-run clonetwo "zeek -b %DIR/sort-stuff.zeek ../common.zeek ../clonetwo.zeek >../clonetwo.out"
 # @TEST-EXEC: btest-bg-wait 20
 #
 # @TEST-EXEC: btest-diff master.out

--- a/testing/btest/broker/store/brokerstore-attr-expire.zeek
+++ b/testing/btest/broker/store/brokerstore-attr-expire.zeek
@@ -8,8 +8,8 @@
 
 # @TEST-PORT: BROKER_PORT
 
-# @TEST-EXEC: btest-bg-run master "zeek -B broker -b ../common.zeek ../master.zeek >../master.out"
-# @TEST-EXEC: btest-bg-run clone "zeek -B broker -b ../common.zeek ../clone.zeek >../clone.out"
+# @TEST-EXEC: btest-bg-run master "zeek -b ../common.zeek ../master.zeek >../master.out"
+# @TEST-EXEC: btest-bg-run clone "zeek -b ../common.zeek ../clone.zeek >../clone.out"
 # @TEST-EXEC: btest-bg-wait 20
 #
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-sort btest-diff clone.out

--- a/testing/btest/broker/store/brokerstore-attr-persistence-clone.zeek
+++ b/testing/btest/broker/store/brokerstore-attr-persistence-clone.zeek
@@ -1,8 +1,8 @@
 # @TEST-PORT: BROKER_PORT
 
-# @TEST-EXEC: zeek -B broker -b %DIR/sort-stuff.zeek common.zeek one.zeek > output1
-# @TEST-EXEC: btest-bg-run master "cp ../*.sqlite . && zeek -B broker -b %DIR/sort-stuff.zeek ../common.zeek ../two.zeek >../output2"
-# @TEST-EXEC: btest-bg-run clone "zeek -B broker -b %DIR/sort-stuff.zeek ../common.zeek ../three.zeek >../output3"
+# @TEST-EXEC: zeek -b %DIR/sort-stuff.zeek common.zeek one.zeek > output1
+# @TEST-EXEC: btest-bg-run master "cp ../*.sqlite . && zeek -b %DIR/sort-stuff.zeek ../common.zeek ../two.zeek >../output2"
+# @TEST-EXEC: btest-bg-run clone "zeek -b %DIR/sort-stuff.zeek ../common.zeek ../three.zeek >../output3"
 # @TEST-EXEC: btest-bg-wait 20
 
 # @TEST-EXEC: btest-diff output1

--- a/testing/btest/broker/store/brokerstore-attr-persistence.zeek
+++ b/testing/btest/broker/store/brokerstore-attr-persistence.zeek
@@ -1,5 +1,5 @@
-# @TEST-EXEC: zeek -B broker -b %DIR/sort-stuff.zeek common.zeek one.zeek > output1
-# @TEST-EXEC: zeek -B broker -b %DIR/sort-stuff.zeek common.zeek two.zeek > output2
+# @TEST-EXEC: zeek -b %DIR/sort-stuff.zeek common.zeek one.zeek > output1
+# @TEST-EXEC: zeek -b %DIR/sort-stuff.zeek common.zeek two.zeek > output2
 # @TEST-EXEC: btest-diff output1
 # @TEST-EXEC: btest-diff output2
 # @TEST-EXEC: diff output1 output2

--- a/testing/btest/broker/store/brokerstore-attr-simple.zeek
+++ b/testing/btest/broker/store/brokerstore-attr-simple.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 
-# @TEST-EXEC: btest-bg-run master "zeek -b -B broker -b %DIR/sort-stuff.zeek ../common.zeek ../master.zeek >../master.out"
-# @TEST-EXEC: btest-bg-run clone "zeek -b -B broker -b %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone.out"
+# @TEST-EXEC: btest-bg-run master "zeek -b %DIR/sort-stuff.zeek ../common.zeek ../master.zeek >../master.out"
+# @TEST-EXEC: btest-bg-run clone "zeek -b %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone.out"
 # @TEST-EXEC: btest-bg-wait 20
 #
 # @TEST-EXEC: btest-diff clone.out

--- a/testing/btest/broker/store/brokerstore-backend-invalid.zeek
+++ b/testing/btest/broker/store/brokerstore-backend-invalid.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC-FAIL: zeek -b -B broker %INPUT
+# @TEST-EXEC-FAIL: zeek -b %INPUT
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff .stderr
 
 module TestModule;

--- a/testing/btest/broker/store/brokerstore-backend-simple-incompatible.zeek
+++ b/testing/btest/broker/store/brokerstore-backend-simple-incompatible.zeek
@@ -2,9 +2,9 @@
 # @TEST-PORT: BROKER_PORT2
 # @TEST-PORT: BROKER_PORT3
 
-# @TEST-EXEC: btest-bg-run manager-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=manager-1 zeek -b -B broker ../master.zeek >../master.out"
-# @TEST-EXEC: btest-bg-run worker-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b -B broker ../clone.zeek >../clone.out"
-# @TEST-EXEC: btest-bg-run worker-2 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b -B broker ../clone.zeek >../clone2.out"
+# @TEST-EXEC: btest-bg-run manager-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=manager-1 zeek -b ../master.zeek >../master.out"
+# @TEST-EXEC: btest-bg-run worker-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b ../clone.zeek >../clone.out"
+# @TEST-EXEC: btest-bg-run worker-2 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b ../clone.zeek >../clone2.out"
 # @TEST-EXEC: btest-bg-wait 30
 #
 # @TEST-EXEC: TEST_DIFF_CANONIFIER="$SCRIPTS/diff-sort" btest-diff worker-1/err.log

--- a/testing/btest/broker/store/brokerstore-backend-simple-reverse.zeek
+++ b/testing/btest/broker/store/brokerstore-backend-simple-reverse.zeek
@@ -2,9 +2,9 @@
 # @TEST-PORT: BROKER_PORT2
 # @TEST-PORT: BROKER_PORT3
 
-# @TEST-EXEC: btest-bg-run manager-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=manager-1 zeek -b -B broker %DIR/sort-stuff.zeek ../common.zeek ../master.zeek >../master.out"
-# @TEST-EXEC: btest-bg-run worker-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b -B broker %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone.out"
-# @TEST-EXEC: btest-bg-run worker-2 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b -B broker %DIR/sort-stuff.zeek ../common.zeek ../clone2.zeek >../clone2.out"
+# @TEST-EXEC: btest-bg-run manager-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=manager-1 zeek -b %DIR/sort-stuff.zeek ../common.zeek ../master.zeek >../master.out"
+# @TEST-EXEC: btest-bg-run worker-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone.out"
+# @TEST-EXEC: btest-bg-run worker-2 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b %DIR/sort-stuff.zeek ../common.zeek ../clone2.zeek >../clone2.out"
 # @TEST-EXEC: btest-bg-wait 40
 #
 # @TEST-EXEC: btest-diff master.out

--- a/testing/btest/broker/store/brokerstore-backend-simple.zeek
+++ b/testing/btest/broker/store/brokerstore-backend-simple.zeek
@@ -2,9 +2,9 @@
 # @TEST-PORT: BROKER_PORT2
 # @TEST-PORT: BROKER_PORT3
 
-# @TEST-EXEC: btest-bg-run manager-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=manager-1 zeek -b -B broker %DIR/sort-stuff.zeek ../common.zeek ../master.zeek >../master.out"
-# @TEST-EXEC: btest-bg-run worker-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b -B broker %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone.out"
-# @TEST-EXEC: btest-bg-run worker-2 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b -B broker %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone2.out"
+# @TEST-EXEC: btest-bg-run manager-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=manager-1 zeek -b %DIR/sort-stuff.zeek ../common.zeek ../master.zeek >../master.out"
+# @TEST-EXEC: btest-bg-run worker-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone.out"
+# @TEST-EXEC: btest-bg-run worker-2 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone2.out"
 # @TEST-EXEC: btest-bg-wait 30
 #
 # @TEST-EXEC: btest-diff master.out

--- a/testing/btest/broker/store/brokerstore-backend-sqlite-incompatible.zeek
+++ b/testing/btest/broker/store/brokerstore-backend-sqlite-incompatible.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 
-# @TEST-EXEC: zeek -B broker -b one.zeek > output1
-# @TEST-EXEC-FAIL: zeek -B broker -b two.zeek > output2
+# @TEST-EXEC: zeek -b one.zeek > output1
+# @TEST-EXEC-FAIL: zeek -b two.zeek > output2
 # @TEST-EXEC: btest-diff .stderr
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff .stderr
 

--- a/testing/btest/broker/store/brokerstore-backend-sqlite.zeek
+++ b/testing/btest/broker/store/brokerstore-backend-sqlite.zeek
@@ -3,9 +3,9 @@
 # @TEST-PORT: BROKER_PORT3
 
 # @TEST-EXEC: zeek -b %DIR/sort-stuff.zeek common.zeek preseed-sqlite.zeek
-# @TEST-EXEC: btest-bg-run manager-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=manager-1 zeek -b -B broker %DIR/sort-stuff.zeek ../common.zeek ../master.zeek >../master.out"
-# @TEST-EXEC: btest-bg-run worker-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b -B broker %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone.out"
-# @TEST-EXEC: btest-bg-run worker-2 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b -B broker %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone2.out"
+# @TEST-EXEC: btest-bg-run manager-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=manager-1 zeek -b %DIR/sort-stuff.zeek ../common.zeek ../master.zeek >../master.out"
+# @TEST-EXEC: btest-bg-run worker-1 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone.out"
+# @TEST-EXEC: btest-bg-run worker-2 "ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b %DIR/sort-stuff.zeek ../common.zeek ../clone.zeek >../clone2.out"
 # @TEST-EXEC: btest-bg-wait 40
 #
 # @TEST-EXEC: btest-diff master.out

--- a/testing/btest/broker/store/clone.zeek
+++ b/testing/btest/broker/store/clone.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run clone "zeek -B broker -b  ../clone-main.zeek >clone.out"
-# @TEST-EXEC: btest-bg-run master "zeek -B broker -b  ../master-main.zeek >master.out"
+# @TEST-EXEC: btest-bg-run clone "zeek -b  ../clone-main.zeek >clone.out"
+# @TEST-EXEC: btest-bg-run master "zeek -b  ../master-main.zeek >master.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff clone/clone.out

--- a/testing/btest/broker/store/ops.zeek
+++ b/testing/btest/broker/store/ops.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: btest-bg-run master "zeek -B broker -b %INPUT >out"
+# @TEST-EXEC: btest-bg-run master "zeek -b %INPUT >out"
 # @TEST-EXEC: btest-bg-wait 60
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-sort btest-diff master/out
 

--- a/testing/btest/language/closure-sending-deprecated.zeek
+++ b/testing/btest/language/closure-sending-deprecated.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -D -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -D -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -D -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -D -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/language/closure-sending-naming.zeek
+++ b/testing/btest/language/closure-sending-naming.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -D -B broker -b ../recv.zeek >recv.out 2>recv.error"
-# @TEST-EXEC: btest-bg-run send "zeek -D -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -D -b ../recv.zeek >recv.out 2>recv.error"
+# @TEST-EXEC: btest-bg-run send "zeek -D -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 20
 # @TEST-EXEC: btest-diff recv/recv.error

--- a/testing/btest/language/closure-sending2.zeek
+++ b/testing/btest/language/closure-sending2.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -D -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -D -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -D -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -D -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/language/function-sending.zeek
+++ b/testing/btest/language/function-sending.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -D -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -D -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -D -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -D -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 20
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/language/paraglob-serialization.zeek
+++ b/testing/btest/language/paraglob-serialization.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run recv "zeek -D -B broker -b ../recv.zeek >recv.out"
-# @TEST-EXEC: btest-bg-run send "zeek -D -B broker -b ../send.zeek >send.out"
+# @TEST-EXEC: btest-bg-run recv "zeek -D -b ../recv.zeek >recv.out"
+# @TEST-EXEC: btest-bg-run send "zeek -D -b ../send.zeek >send.out"
 #
 # @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff recv/recv.out

--- a/testing/btest/scripts/base/frameworks/control/configuration_update.zeek
+++ b/testing/btest/scripts/base/frameworks/control/configuration_update.zeek
@@ -1,7 +1,7 @@
 # @TEST-PORT: BROKER_PORT
 #
-# @TEST-EXEC: btest-bg-run controllee  ZEEKPATH=$ZEEKPATH:.. zeek -b -Bbroker %INPUT frameworks/control/controllee Broker::default_port=$BROKER_PORT
-# @TEST-EXEC: btest-bg-run controller  ZEEKPATH=$ZEEKPATH:.. zeek -b -Bbroker %INPUT test-redef frameworks/control/controller Control::host=127.0.0.1 Control::host_port=$BROKER_PORT Control::cmd=configuration_update
+# @TEST-EXEC: btest-bg-run controllee  ZEEKPATH=$ZEEKPATH:.. zeek -b %INPUT frameworks/control/controllee Broker::default_port=$BROKER_PORT
+# @TEST-EXEC: btest-bg-run controller  ZEEKPATH=$ZEEKPATH:.. zeek -b %INPUT test-redef frameworks/control/controller Control::host=127.0.0.1 Control::host_port=$BROKER_PORT Control::cmd=configuration_update
 # @TEST-EXEC: btest-bg-wait 30
 # @TEST-EXEC: btest-diff controllee/.stdout
 

--- a/testing/btest/scripts/base/frameworks/logging/remove.zeek
+++ b/testing/btest/scripts/base/frameworks/logging/remove.zeek
@@ -1,5 +1,5 @@
 #
-# @TEST-EXEC: zeek -b -B logging %INPUT
+# @TEST-EXEC: zeek -b %INPUT
 # @TEST-EXEC: btest-diff ssh.log
 # @TEST-EXEC: btest-diff ssh.failure.log
 # @TEST-EXEC: btest-diff .stdout


### PR DESCRIPTION
When configured without `--enable-debug`, Zeek already disallowed the `--debug` command line flag but accepted `-B` silently (if passed an option). We now trigger the usage output and exit with error in that case as well.

For consistency, this keeps the optparse string fixed (as opposed to tucking on available options depending on ifdefs) since for our getopt usage it makes no difference: we always fall back to `usage()` for unhandled options.

While tinkering with the `-m` and `-M` flags I noticed the perftools build was broken:
```
/home/christian/devel/zeek/zeek/src/main.cc: In function ‘int main(int, char**)’:
/home/christian/devel/zeek/zeek/src/main.cc:29:22: error: ‘perftools_leaks’ was not declared in this scope
   29 |                 if ( perftools_leaks )
      |                      ^~~~~~~~~~~~~~~
/home/christian/devel/zeek/zeek/src/main.cc:32:22: error: ‘perftools_profile’ was not declared in this scope
   32 |                 if ( perftools_profile )
      |                      ^~~~~~~~~~~~~~~~~
```
Those variables exist in `zeek-setup.cc` but they look meant for internal use in that module (could make them static?), so I switched the above to using the `Options` struct. (`heap_checker` is available via `util.h`.)

Resolves #1600