### PR TITLE
GH-572: Mark MemoryAllocation() and related methods deprecated

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -113,6 +113,11 @@ Deprecated Functionality
 
 - ``supervisor_rotation_format_func`` is renamed to ``archiver_rotation_format_func``
 
+- The ```MemoryAllocation()``` function implemented by a number of interfaces
+  is now deprecated. In testing we found that the values returned were mostly
+  incorrect and weren't useful. The ```val_size``` and ```global_sizes``` BIF
+  methods have also both been marked deprecated.
+
 Zeek 4.0.0
 ==========
 

--- a/src/CCL.h
+++ b/src/CCL.h
@@ -26,6 +26,7 @@ public:
 	void ReplaceSyms(int_list* new_syms)
 				{ delete syms; syms = new_syms; }
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const;
 
 protected:

--- a/src/CompHash.h
+++ b/src/CompHash.h
@@ -30,6 +30,7 @@ public:
 	// Given a hash key, recover the values used to create it.
 	ListValPtr RecoverVals(const HashKey& k) const;
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const { return padded_sizeof(*this) + util::pad_size(size); }
 
 protected:

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -381,17 +381,23 @@ void Connection::FlipRoles()
 
 unsigned int Connection::MemoryAllocation() const
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return session::Session::MemoryAllocation() + padded_sizeof(*this)
 		+ (timers.MemoryAllocation() - padded_sizeof(timers))
 		+ (conn_val ? conn_val->MemoryAllocation() : 0)
 		+ (adapter ? adapter->MemoryAllocation(): 0)
 		// primary_PIA is already contained in the analyzer tree.
 		;
+#pragma GCC diagnostic pop
 	}
 
 unsigned int Connection::MemoryAllocationVal() const
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return conn_val ? conn_val->MemoryAllocation() : 0;
+#pragma GCC diagnostic pop
 	}
 
 void Connection::Describe(ODesc* d) const

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -187,7 +187,9 @@ public:
 	// Statistics.
 
 	// Just a lower bound.
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const override;
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocationVal() const override;
 
 	static uint64_t TotalConnections()

--- a/src/DFA.cc
+++ b/src/DFA.cc
@@ -426,10 +426,13 @@ unsigned int DFA_Machine::MemoryAllocation() const
 	dfa_state_cache->GetStats(&s);
 
 	// FIXME: Count *ec?
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return padded_sizeof(*this)
 		+ s.mem
 		+ padded_sizeof(*start_state)
 		+ nfa->MemoryAllocation();
+#pragma GCC diagnostic pop
 	}
 
 bool DFA_Machine::StateSetToDFA_State(NFA_state_list* state_set,

--- a/src/DFA.h
+++ b/src/DFA.h
@@ -123,6 +123,7 @@ public:
 	void Describe(ODesc* d) const override;
 	void Dump(FILE* f);
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const;
 
 protected:

--- a/src/Dict.cc
+++ b/src/Dict.cc
@@ -772,7 +772,10 @@ void Dictionary::DumpKeys() const
 	if ( binary )
 		{
 		char key = char(random() % 26) + 'A';
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		sprintf(key_file, "%d.%d.%zu-%c.key", Length(), max_distance, MemoryAllocation()/Length(), key);
+#pragma GCC diagnostic pop
 		std::ofstream f(key_file, std::ios::binary|std::ios::out|std::ios::trunc);
 		for ( int idx = 0; idx < Capacity(); idx++ )
 			if ( ! table[idx].Empty() )
@@ -785,7 +788,10 @@ void Dictionary::DumpKeys() const
 	else
 		{
 		char key = char(random() % 26) + 'A';
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		sprintf(key_file, "%d.%d.%zu-%d.ckey",Length(), max_distance, MemoryAllocation()/Length(), key);
+#pragma GCC diagnostic pop
 		std::ofstream f(key_file, std::ios::out|std::ios::trunc);
 		for ( int idx = 0; idx < Capacity(); idx++ )
 			if ( ! table[idx].Empty() )
@@ -833,10 +839,13 @@ void Dictionary::Dump(int level) const
 	int distances[DICT_NUM_DISTANCES];
 	int max_distance = 0;
 	DistanceStats(max_distance, distances, DICT_NUM_DISTANCES);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	printf("cap %'7d ent %'7d %'-7d load %.2f max_dist %2d mem %10zu mem/ent %3zu key/ent %3d lg %2d remaps %1d remap_end %4d ",
 		Capacity(), Length(), MaxLength(), (double)Length()/(table? Capacity() : 1),
 		max_distance, MemoryAllocation(), (MemoryAllocation())/(Length()?Length():1), key_size / (Length()?Length():1),
 		log2_buckets, remaps, remap_end);
+#pragma GCC diagnostic pop
 	if ( Length() > 0 )
 		{
 		for (int i = 0; i < DICT_NUM_DISTANCES-1; i++)

--- a/src/Dict.h
+++ b/src/Dict.h
@@ -337,6 +337,7 @@ public:
 	// Remove all entries.
 	void Clear();
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	size_t MemoryAllocation() const;
 
 	/// The capacity of the table, Buckets + Overflow Size.

--- a/src/Frag.h
+++ b/src/Frag.h
@@ -83,6 +83,7 @@ public:
 
 	size_t Size() const	{ return fragments.size(); }
 	size_t MaxFragments() const 	{ return max_fragments; }
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	uint32_t MemoryAllocation() const;
 
 private:

--- a/src/Hash.h
+++ b/src/Hash.h
@@ -261,6 +261,7 @@ public:
 	int Size() const	{ return size; }
 	hash_t Hash() const	{ return hash; }
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const	{ return padded_sizeof(*this) + util::pad_size(size); }
 
 	static hash_t HashBytes(const void* bytes, int size);

--- a/src/IPAddr.h
+++ b/src/IPAddr.h
@@ -384,6 +384,7 @@ public:
 	 */
 	void ConvertToThreadingValue(threading::Value::addr_t* v) const;
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const { return padded_sizeof(*this); }
 
 	/**
@@ -646,6 +647,7 @@ public:
 		prefix.ConvertToThreadingValue(&v->prefix);
 		}
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const { return padded_sizeof(*this); }
 
 	/**

--- a/src/List.h
+++ b/src/List.h
@@ -158,6 +158,7 @@ public:
 		return max_entries;
 		}
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	int MemoryAllocation() const
 		{ return padded_sizeof(*this) + util::pad_size(max_entries * sizeof(T)); }
 

--- a/src/NFA.cc
+++ b/src/NFA.cc
@@ -157,9 +157,12 @@ void NFA_State::Dump(FILE* f)
 
 unsigned int NFA_State::TotalMemoryAllocation() const
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return padded_sizeof(*this)
 		+ xtions.MemoryAllocation() - padded_sizeof(xtions)
 		+ (epsclosure ? epsclosure->MemoryAllocation() : 0);
+#pragma GCC diagnostic pop
 	}
 
 NFA_Machine::NFA_Machine(NFA_State* first, NFA_State* final)

--- a/src/NFA.h
+++ b/src/NFA.h
@@ -62,6 +62,7 @@ public:
 	void Dump(FILE* f);
 
 	// Recursivly count all the reachable states.
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int TotalMemoryAllocation() const;
 
 protected:
@@ -118,8 +119,14 @@ public:
 	void Describe(ODesc* d) const override;
 	void Dump(FILE* f);
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const
-		{ return padded_sizeof(*this) + first_state->TotalMemoryAllocation(); }
+		{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+		return padded_sizeof(*this) + first_state->TotalMemoryAllocation();
+#pragma GCC diagnostic pop
+		}
 
 protected:
 	NFA_State* first_state;

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -416,14 +416,20 @@ unsigned int Specific_RE_Matcher::MemoryAllocation() const
 	{
 	unsigned int size = 0;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	for ( int i = 0; i < ccl_list.length(); ++i )
 		size += ccl_list[i]->MemoryAllocation();
+#pragma GCC diagnostic pop
 
 	size += util::pad_size(sizeof(CCL*) * ccl_dict.size());
 	for ( const auto& entry : ccl_dict )
 		{
 		size += padded_sizeof(std::string) + util::pad_size(sizeof(std::string::value_type) * entry.first.size());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		size += entry.second->MemoryAllocation();
+#pragma GCC diagnostic pop
 		}
 
 	for ( const auto& entry : defs )
@@ -432,6 +438,8 @@ unsigned int Specific_RE_Matcher::MemoryAllocation() const
 		size += padded_sizeof(std::string) + util::pad_size(sizeof(std::string::value_type) * entry.second.size());
 		}
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return size + padded_sizeof(*this)
 		+ (pattern_text ? util::pad_size(strlen(pattern_text) + 1) : 0)
 		+ ccl_list.MemoryAllocation() - padded_sizeof(ccl_list)
@@ -440,6 +448,7 @@ unsigned int Specific_RE_Matcher::MemoryAllocation() const
 		+ padded_sizeof(*any_ccl)
 		+ padded_sizeof(*accepted) // NOLINT(bugprone-sizeof-container)
 		+ accepted->size() * padded_sizeof(AcceptingSet::key_type);
+#pragma GCC diagnostic pop
 	}
 
 static RE_Matcher* matcher_merge(const RE_Matcher* re1, const RE_Matcher* re2,

--- a/src/RE.h
+++ b/src/RE.h
@@ -115,6 +115,7 @@ public:
 
 	void Dump(FILE* f);
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const;
 
 protected:
@@ -232,11 +233,15 @@ public:
 	// the main ("explicit") constructor was used.
 	const char* OrigText() const	{ return orig_text.c_str(); }
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const
 		{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		return padded_sizeof(*this)
 			+ (re_anywhere ? re_anywhere->MemoryAllocation() : 0)
 			+ (re_exact ? re_exact->MemoryAllocation() : 0);
+#pragma GCC diagnostic pop
 		}
 
 protected:

--- a/src/Reassem.h
+++ b/src/Reassem.h
@@ -282,9 +282,11 @@ public:
 	void Describe(ODesc* d) const override;
 
 	// Sum over all data buffered in some reassembler.
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	static uint64_t TotalMemoryAllocation()	{ return total_size; }
 
 	// Data buffered by type of reassembler.
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	static uint64_t MemoryAllocation(ReassemblerType rtype);
 
 	void SetMaxOldBlocks(uint32_t count)	{ max_old_blocks = count; }

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -127,7 +127,10 @@ void ProfileLogger::Log()
 		run_state::network_time, (utime + stime) - (first_utime + first_stime),
 		utime - first_utime, stime - first_stime, rtime - first_rtime));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	int conn_mem_use = expensive ? session_mgr->SessionMemoryUsage() : 0;
+#pragma GCC diagnostic pop
 	double avg_conn_mem_use = 0;
 
 	if ( expensive && session_mgr->CurrentSessions() != 0 )
@@ -135,6 +138,8 @@ void ProfileLogger::Log()
 
 	// TODO: This previously output the number of connections, but now that we're storing sessions
 	// as well as connections, this might need to be renamed.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	file->Write(util::fmt("%.06f Conns: total=%" PRIu64 " current=%" PRIu64 "/%" PRIi32 " mem=%" PRIi32 "K avg=%.1f table=%" PRIu32 "K connvals=%" PRIu32 "K\n",
 		run_state::network_time,
 		Connection::TotalConnections(),
@@ -145,6 +150,7 @@ void ProfileLogger::Log()
 		expensive ? session_mgr->MemoryAllocation() / 1024 : 0,
 		expensive ? session_mgr->SessionMemoryUsageVals() / 1024 : 0
 		));
+#pragma GCC diagnostic pop
 
 	session::Stats s;
 	session_mgr->GetStats(s);
@@ -178,8 +184,11 @@ void ProfileLogger::Log()
 	file->Write(util::fmt("%.06f Connections expired due to inactivity: %" PRIu64 "\n",
 	                      run_state::network_time, killed_by_inactivity));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	file->Write(util::fmt("%.06f Total reassembler data: %" PRIu64 "K\n", run_state::network_time,
 	                      Reassembler::TotalMemoryAllocation() / 1024));
+#pragma GCC diagnostic pop
 
 	// Signature engine.
 	if ( expensive && rule_matcher )
@@ -274,7 +283,10 @@ void ProfileLogger::Log()
 				{
 				const auto& v = id->GetVal();
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 				size = v->MemoryAllocation();
+#pragma GCC diagnostic pop
 				mem += size;
 
 				bool print = false;

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -335,6 +335,8 @@ unsigned int TypeList::MemoryAllocation() const
 	{
 	unsigned int size = 0;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	for ( const auto& t : types )
 		size += t->MemoryAllocation();
 
@@ -343,6 +345,7 @@ unsigned int TypeList::MemoryAllocation() const
 	return Type::MemoryAllocation()
 		+ padded_sizeof(*this) - padded_sizeof(Type)
 		+ size;
+#pragma GCC diagnostic pop
 	}
 
 int IndexType::MatchesIndex(detail::ListExpr* const index) const

--- a/src/Type.h
+++ b/src/Type.h
@@ -250,6 +250,7 @@ public:
 	void Describe(ODesc* d) const override;
 	virtual void DescribeReST(ODesc* d, bool roles_only = false) const;
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	virtual unsigned MemoryAllocation() const;
 
 	void SetName(const std::string& arg_name) { name = arg_name; }
@@ -347,6 +348,7 @@ public:
 
 	void Describe(ODesc* d) const override;
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const override;
 
 protected:

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -816,7 +816,10 @@ AddrVal::~AddrVal()
 
 unsigned int AddrVal::MemoryAllocation() const
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return padded_sizeof(*this) + addr_val->MemoryAllocation();
+#pragma GCC diagnostic pop
 	}
 
 ValPtr AddrVal::SizeVal() const
@@ -881,7 +884,10 @@ int SubNetVal::Width() const
 
 unsigned int SubNetVal::MemoryAllocation() const
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return padded_sizeof(*this) + subnet_val->MemoryAllocation();
+#pragma GCC diagnostic pop
 	}
 
 ValPtr SubNetVal::SizeVal() const
@@ -1003,7 +1009,10 @@ void StringVal::ValDescribe(ODesc* d) const
 
 unsigned int StringVal::MemoryAllocation() const
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return padded_sizeof(*this) + string_val->MemoryAllocation();
+#pragma GCC diagnostic pop
 	}
 
 StringValPtr StringVal::Replace(
@@ -1213,7 +1222,10 @@ void PatternVal::ValDescribe(ODesc* d) const
 
 unsigned int PatternVal::MemoryAllocation() const
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return padded_sizeof(*this) + re_val->MemoryAllocation();
+#pragma GCC diagnostic pop
 	}
 
 ValPtr PatternVal::DoClone(CloneState* state)
@@ -1326,12 +1338,15 @@ ValPtr ListVal::DoClone(CloneState* state)
 
 unsigned int ListVal::MemoryAllocation() const
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	unsigned int size = 0;
 	for ( const auto& val : vals )
 		size += val->MemoryAllocation();
 
 	size += util::pad_size(vals.capacity() * sizeof(decltype(vals)::value_type));
 	return size + padded_sizeof(*this) + type->MemoryAllocation();
+#pragma GCC diagnostic pop
 	}
 
 TableEntryVal* TableEntryVal::Clone(Val::CloneState* state)
@@ -2764,6 +2779,8 @@ unsigned int TableVal::MemoryAllocation() const
 	{
 	unsigned int size = 0;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	for ( const auto& ve : *table_val )
 		{
 		auto* tv = ve.GetValue<TableEntryVal*>();
@@ -2774,6 +2791,7 @@ unsigned int TableVal::MemoryAllocation() const
 
 	return size + padded_sizeof(*this) + table_val->MemoryAllocation()
 		+ table_hash->MemoryAllocation();
+#pragma GCC diagnostic pop
 	}
 
 std::unique_ptr<detail::HashKey> TableVal::MakeHashKey(const Val& index) const
@@ -3139,7 +3157,10 @@ unsigned int RecordVal::MemoryAllocation() const
 		{
 		auto f_i = GetField(i);
 		if ( f_i )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 			size += f_i->MemoryAllocation();
+#pragma GCC diagnostic pop
 		}
 
 	size += util::pad_size(record_val->capacity() * sizeof(ZVal));

--- a/src/Val.h
+++ b/src/Val.h
@@ -112,6 +112,7 @@ public:
 	virtual ValPtr SizeVal() const;
 
 	// Bytes in total value object.
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	virtual unsigned int MemoryAllocation() const;
 
 	// Add this value to the given value (if appropriate).
@@ -486,6 +487,7 @@ public:
 
 	const IPAddr& Get() const	{ return *addr_val; }
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const override;
 
 protected:
@@ -515,6 +517,7 @@ public:
 
 	const IPPrefix& Get() const	{ return *subnet_val; }
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const override;
 
 protected:
@@ -549,6 +552,7 @@ public:
 
 	const String* Get() const	{ return string_val; }
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const override;
 
 	StringValPtr Replace(RE_Matcher* re, const String& repl,
@@ -610,6 +614,7 @@ public:
 
 	const RE_Matcher* Get() const	{ return re_val; }
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const override;
 
 protected:
@@ -659,6 +664,7 @@ public:
 
 	void Describe(ODesc* d) const override;
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const override;
 
 protected:
@@ -932,6 +938,7 @@ public:
 	// the function in the frame allowing it to capture its closure.
 	void InitDefaultFunc(detail::Frame* f);
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const override;
 
 	void ClearTimer(detail::Timer* t)
@@ -1399,6 +1406,7 @@ public:
 	RecordValPtr CoerceTo(RecordTypePtr other,
 	                      bool allow_orphaning = false);
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const override;
 	void DescribeReST(ODesc* d) const override;
 

--- a/src/ZeekString.h
+++ b/src/ZeekString.h
@@ -130,6 +130,7 @@ public:
 	// XXX and to_upper; the latter doesn't use String::ToUpper().
 	void ToUpper();
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation() const;
 
 	// Returns new string containing the substring of this string,

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -764,6 +764,8 @@ void Analyzer::AppendNewChildren()
 
 unsigned int Analyzer::MemoryAllocation() const
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	unsigned int mem = padded_sizeof(*this)
 		+ (timers.MemoryAllocation() - padded_sizeof(timers));
 
@@ -777,6 +779,7 @@ unsigned int Analyzer::MemoryAllocation() const
 		mem += a->MemoryAllocation();
 
 	return mem;
+#pragma GCC diagnostic pop
 	}
 
 void Analyzer::UpdateConnVal(RecordVal *conn_val)

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -595,6 +595,7 @@ public:
 	/**
 	 * Internal method.
 	 */
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	virtual unsigned int MemoryAllocation() const;
 
 protected:

--- a/src/session/Manager.cc
+++ b/src/session/Manager.cc
@@ -293,7 +293,10 @@ unsigned int Manager::SessionMemoryUsage()
 		return 0;
 
 	for ( const auto& entry : session_map )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		mem += entry.second->MemoryAllocation();
+#pragma GCC diagnostic pop
 
 	return mem;
 	}
@@ -307,7 +310,10 @@ unsigned int Manager::SessionMemoryUsageVals()
 		return 0;
 
 	for ( const auto& entry : session_map )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		mem += entry.second->MemoryAllocationVal();
+#pragma GCC diagnostic pop
 
 	return mem;
 	}
@@ -318,12 +324,15 @@ unsigned int Manager::MemoryAllocation()
 		// Connections have been flushed already.
 		return 0;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return SessionMemoryUsage()
 		+ padded_sizeof(*this)
 		+ (session_map.size() * (sizeof(SessionMap::key_type) + sizeof(SessionMap::value_type)))
 		+ zeek::detail::fragment_mgr->MemoryAllocation();
 		// FIXME: MemoryAllocation() not implemented for rest.
 		;
+#pragma GCC diagnostic pop
 	}
 
 void Manager::InsertSession(detail::Key key, Session* session)

--- a/src/session/Manager.h
+++ b/src/session/Manager.h
@@ -92,14 +92,29 @@ public:
 	[[deprecated("Remove in v5.1. Use CurrentSessions().")]]
 	unsigned int CurrentConnections() { return CurrentSessions(); }
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int SessionMemoryUsage();
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int SessionMemoryUsageVals();
 
 	[[deprecated("Remove in v5.1. Use SessionMemoryUsage().")]]
-	unsigned int ConnectionMemoryUsage() { return SessionMemoryUsage(); }
+	unsigned int ConnectionMemoryUsage()
+		{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+		return SessionMemoryUsage();
+#pragma GCC diagnostic pop
+		}
 	[[deprecated("Remove in v5.1. Use SessionMemoryUsageVals().")]]
-	unsigned int ConnectionMemoryUsageConnVals() { return SessionMemoryUsageVals(); }
+	unsigned int ConnectionMemoryUsageConnVals()
+		{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+		return SessionMemoryUsageVals();
+#pragma GCC diagnostic pop
+		}
 
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	unsigned int MemoryAllocation();
 
 private:

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -105,14 +105,22 @@ public:
 	 * Return the memory allocation required by the session record. This requires at
 	 * least one call to Get() first in order to setup the record object.
 	 */
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	virtual unsigned int MemoryAllocationVal() const = 0;
 
 	[[deprecated("Remove in v5.1. Use MemoryAllocationVal().")]]
-	unsigned int MemoryAllocationConnVal() const { return MemoryAllocationVal(); }
+	unsigned int MemoryAllocationConnVal() const
+		{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+		return MemoryAllocationVal();
+#pragma GCC diagnostic pop
+		}
 
 	/**
 	 * A lower-bound calculation of how much memory a session object is using.
 	 */
+	[[deprecated("Remove in v5.1. MemoryAllocation() is deprecated and will be removed. See GHI-572.")]]
 	virtual unsigned int MemoryAllocation() const;
 
 	/**

--- a/src/stats.bif
+++ b/src/stats.bif
@@ -220,10 +220,13 @@ function get_reassembler_stats%(%): ReassemblerStats
 	auto r = zeek::make_intrusive<zeek::RecordVal>(ReassemblerStats);
 	int n = 0;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	r->Assign(n++, Reassembler::MemoryAllocation(zeek::REASSEM_FILE));
 	r->Assign(n++, Reassembler::MemoryAllocation(zeek::REASSEM_FRAG));
 	r->Assign(n++, Reassembler::MemoryAllocation(zeek::REASSEM_TCP));
 	r->Assign(n++, Reassembler::MemoryAllocation(zeek::REASSEM_UNKNOWN));
+#pragma GCC diagnostic pop
 
 	return r;
 	%}

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -1256,9 +1256,12 @@ function same_object%(o1: any, o2: any%): bool
 ## v: The value
 ##
 ## Returns: The number of bytes that *v* occupies.
-function val_size%(v: any%): count
+function val_size%(v: any%): count &deprecated="Remove in v5.1. MemoryAllocation() is deprecated and will be removed."
 	%{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return zeek::val_mgr->Count(v->MemoryAllocation());
+#pragma GCC diagnostic pop
 	%}
 
 ## Resizes a vector.
@@ -1946,7 +1949,7 @@ function packet_source%(%): PacketSource
 ## Returns: A table that maps variable names to their sizes.
 ##
 ## .. zeek:see:: global_ids
-function global_sizes%(%): var_sizes
+function global_sizes%(%): var_sizes &deprecated="Remove in v5.1. MemoryAllocation() is deprecated and will be removed."
 	%{
 	auto sizes = zeek::make_intrusive<zeek::TableVal>(IntrusivePtr{zeek::NewRef{}, var_sizes});
 	const auto& globals = zeek::detail::global_scope()->Vars();
@@ -1957,7 +1960,10 @@ function global_sizes%(%): var_sizes
 		if ( id->HasVal() )
 			{
 			auto id_name = zeek::make_intrusive<zeek::StringVal>(id->Name());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 			auto id_size = zeek::val_mgr->Count(id->GetVal()->MemoryAllocation());
+#pragma GCC diagnostic pop
 			sizes->Assign(std::move(id_name), std::move(id_size));
 			}
 		}


### PR DESCRIPTION
This PR marks all of the `MemoryAllocation` methods as deprecated to be removed in 5.1. It also marks a few BIF methods as deprecated.

Fixes #572