### PR TITLE
Check for -1 return from FieldOffset() in Val::HasField()

### DIFF
--- a/src/Val.h
+++ b/src/Val.h
@@ -1218,7 +1218,7 @@ public:
 	bool HasField(const char *field) const
 		{
 		int idx = GetType()->AsRecordType()->FieldOffset(field);
-		return HasField(idx);
+		return (idx != -1) && HasField(idx);
 		}
 
 	/**


### PR DESCRIPTION
This one is dumb and I feel silly for missing it in the earlier PR only to have Coverity point it out to me.

Fixes Coverity 1457804