### PR TITLE
GH-1500: Mark BasicThread::Done to be ignored by ThreadSanitizer

### DIFF
--- a/src/threading/BasicThread.h
+++ b/src/threading/BasicThread.h
@@ -191,7 +191,7 @@ protected:
 	void Kill();
 
 	/** Called by child thread's launcher when it's done processing. */
-	void Done();
+    ZEEK_DISABLE_TSAN void Done();
 
 private:
 	// thread entry function.

--- a/zeek-config.h.in
+++ b/zeek-config.h.in
@@ -272,3 +272,19 @@ extern const char* BRO_VERSION_FUNCTION();
 	#define ZEEK_LSAN_DISABLE(x)
 	#define ZEEK_LSAN_DISABLE_SCOPE(x)
 #endif
+
+#if defined(__SANITIZE_THREAD__)
+	#define ZEEK_TSAN
+#endif
+
+#if defined(__has_feature)
+	#if __has_feature(thread_sanitizer)
+		#define ZEEK_TSAN
+	#endif
+#endif
+
+#if defined(ZEEK_TSAN)
+	#define ZEEK_DISABLE_TSAN __attribute__((no_sanitize("thread")))
+#else
+	#define ZEEK_DISABLE_TSAN
+#endif


### PR DESCRIPTION
There's a known false positive with the atomic variables in this method that triggers a complaint from ThreadSanitizer. Marking it as ignored avoids the warning.