### PR TITLE
Remove remaining vestigial IDMEF support code

### DIFF
--- a/src/Options.cc
+++ b/src/Options.cc
@@ -122,11 +122,6 @@ void usage(const char* prog, int code)
 #endif
 	fprintf(stderr, "    --pseudo-realtime[=<speedup>]  | enable pseudo-realtime for performance evaluation (default 1)\n");
 	fprintf(stderr, "    -j|--jobs                      | enable supervisor mode\n");
-
-#ifdef USE_IDMEF
-	fprintf(stderr, "    -n|--idmef-dtd <idmef-msg.dtd> | specify path to IDMEF DTD file\n");
-#endif
-
 	fprintf(stderr, "    --test                         | run unit tests ('--test -h' for help, only when compiling with ENABLE_ZEEK_UNIT_TESTS)\n");
 	fprintf(stderr, "    $ZEEKPATH                      | file search path (%s)\n", util::zeek_path().c_str());
 	fprintf(stderr, "    $ZEEK_PLUGIN_PATH              | plugin search path (%s)\n", util::zeek_plugin_path());
@@ -337,9 +332,7 @@ Options parse_cmdline(int argc, char** argv)
 #ifdef	DEBUG
 		{"debug",		required_argument,	nullptr,	'B'},
 #endif
-#ifdef	USE_IDMEF
-		{"idmef-dtd",		required_argument,	nullptr,	'n'},
-#endif
+
 #ifdef	USE_PERFTOOLS_DEBUG
 		{"mem-leaks",	no_argument,		nullptr,	'm'},
 		{"mem-profile",	no_argument,		nullptr,	'M'},
@@ -514,12 +507,6 @@ Options parse_cmdline(int argc, char** argv)
 			break;
 		case 'M':
 			rval.perftools_profile = 1;
-			break;
-#endif
-
-#ifdef USE_IDMEF
-		case 'n':
-			rval.libidmef_dtd_path = optarg;
 			break;
 #endif
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -70,7 +70,6 @@ struct Options {
 	std::optional<std::string> random_seed_output_file;
 	std::optional<std::string> process_status_file;
 	std::optional<std::string> zeekygen_config_file;
-	std::string libidmef_dtd_file = "idmef-message.dtd";
 
 	std::set<std::string> plugins_to_load;
 	std::vector<std::string> scripts_to_load;

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -12,12 +12,6 @@
 #include <list>
 #include <optional>
 
-#ifdef USE_IDMEF
-extern "C" {
-#include <libidmef/idmefxml.h>
-}
-#endif
-
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
@@ -528,14 +522,6 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 
 	if ( r != SQLITE_OK )
 		reporter->Error("Failed to initialize sqlite3: %s", sqlite3_errstr(r));
-
-#ifdef USE_IDMEF
-	char* libidmef_dtd_path_cstr = new char[options.libidmef_dtd_file.size() + 1];
-	safe_strncpy(libidmef_dtd_path_cstr, options.libidmef_dtd_file.data(),
-	             options.libidmef_dtd_file.size());
-	globalsInit(libidmef_dtd_path_cstr);	// Init LIBIDMEF globals
-	createCurrentDoc("1.0");		// Set a global XML document
-#endif
 
 	timer_mgr = new PQ_TimerMgr();
 


### PR DESCRIPTION
I can't identify anything that uses it, and you can't actually get a `USE_IDMEF` build via our configure / cmake setup.

Resolves #1626.