### PR TITLE
Fix package name for CMake on CentOS 8

### DIFF
--- a/ci/centos-8/Dockerfile
+++ b/ci/centos-8/Dockerfile
@@ -7,7 +7,7 @@ RUN dnf config-manager --set-enabled powertools
 
 RUN dnf -y update && dnf -y install \
     git \
-    cmake3 \
+    cmake \
     make \
     gcc \
     gcc-c++ \


### PR DESCRIPTION
Apparently, CentOS updated its `cmake` package since first creating the `Dockerfile` and it seems like we can just use the default `cmake` package now:

```
# dnf info cmake
Last metadata expiration check: 0:02:23 ago on Tue 29 Jun 2021 11:38:31 AM UTC.
Available Packages
Name         : cmake
Version      : 3.18.2
```