### PR TITLE
Use mallinfo2() instead of mallinfo() when available

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -25,7 +25,7 @@
 #include <openssl/md5.h>
 #include <openssl/sha.h>
 
-#ifdef HAVE_MALLINFO
+#if defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)
 # include <malloc.h>
 #endif
 
@@ -2188,9 +2188,12 @@ void get_memory_usage(uint64_t* total, uint64_t* malloced)
 	{
 	uint64_t ret_total;
 
-#ifdef HAVE_MALLINFO
+#if defined(HAVE_MALLINFO2) || defined(HAVE_MALLINFO)
+#ifdef HAVE_MALLINFO2
+	struct mallinfo2 mi = mallinfo2();
+#else
 	struct mallinfo mi = mallinfo();
-
+#endif
 	if ( malloced )
 		*malloced = mi.uordblks;
 #endif

--- a/zeek-config.h.in
+++ b/zeek-config.h.in
@@ -22,6 +22,9 @@
 /* Define if you have the `mallinfo' function. */
 #cmakedefine HAVE_MALLINFO
 
+/* Define if you have the `mallinfo2' function. */
+#cmakedefine HAVE_MALLINFO2
+
 /* Define if you have the <memory.h> header file. */
 #cmakedefine HAVE_MEMORY_H
 


### PR DESCRIPTION
glibc 2.33 deprecates mallinfo in favor of a struct that returns its members as size_ts instead of ints. The mallinfo2 struct has identical member names, so its use is otherwise transparent.

Example in our CI: [Fedora 34](https://cirrus-ci.com/task/5393599387926528?logs=build#L2273)