### PR TITLE
Fix a number of Coverity findings

### DIFF
--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -512,7 +512,7 @@ int CompositeHash::SingleTypeKeySize(Type* bt, const Val* v,
 			if ( ! v )
 				return (optional && ! calc_static_size) ? sz : 0;
 
-			const RecordVal* rv = v ? v->AsRecordVal() : nullptr;
+			const RecordVal* rv = v->AsRecordVal();
 			RecordType* rt = bt->AsRecordType();
 			int num_fields = rt->NumFields();
 

--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -67,7 +67,7 @@ void KeyedHash::Hash256(const void* bytes, uint64_t size, hash256_t* result)
 
 hash64_t KeyedHash::StaticHash64(const void* bytes, uint64_t size)
 	{
-	hash64_t result;
+	hash64_t result = 0;
 	highwayhash::InstructionSets::Run<highwayhash::HighwayHash>(cluster_highwayhash_key, reinterpret_cast<const char *>(bytes), size, &result);
 	return result;
 	}

--- a/src/logging/writers/sqlite/SQLite.cc
+++ b/src/logging/writers/sqlite/SQLite.cc
@@ -169,15 +169,16 @@ bool SQLite::DoInit(const WriterInfo& info, int arg_num_fields,
 			}
 
 		create += fieldname;
-		sqlite3_free(fieldname);
 
 		string type = GetTableType(field->type, field->subtype);
 		if ( type == "" )
 			{
 			InternalError(Fmt("Could not determine type for field %u:%s", i, fieldname));
+			sqlite3_free(fieldname);
 			return false;
 			}
 
+		sqlite3_free(fieldname);
 		create += " " + type;
 
 		/* if ( !field->optional ) {

--- a/src/scan.l
+++ b/src/scan.l
@@ -106,9 +106,9 @@ public:
 
 	YY_BUFFER_STATE buffer_state;
 	std::string restore_module;
-	const char* name;
-	int line;
-	int level;
+	const char* name = nullptr;
+	int line = 0;
+	int level = 0;
 };
 
 // A stack of input buffers we're scanning.  file_stack[len-1] is the

--- a/src/script_opt/Reduce.cc
+++ b/src/script_opt/Reduce.cc
@@ -959,6 +959,7 @@ TraversalCode CSE_ValidityChecker::PreExpr(const Expr* e)
 			return TC_ABORTALL;
 			}
 		}
+		break;
 
 	case EXPR_APPEND_TO:
 		// This doesn't directly change any identifiers, but does


### PR DESCRIPTION
- 1458048: Use-after-free in the SQLite logger
- 1457823: Missing a break statement in script-opt reduction
- 1453966: Dead code in CompHash
- 1445417: Unintialized variable in StaticHash64
- 1437716: Unintialized variables in FileInfo in scan.l

I made this a draft PR temporarily for the CI checks.