### PR TITLE
Update private networks list

### DIFF
--- a/scripts/base/utils/site.zeek
+++ b/scripts/base/utils/site.zeek
@@ -14,33 +14,75 @@ export {
 	option private_address_space: set[subnet] = {
 		## "This network", see :rfc:`791`
 		0.0.0.0/8,
+		## 0.0.0.0/8 as a 6to4 address, see :rfc:`791` and :rfc:`3056`
+		[2002::]/24,
+
 		## Private-Use, see :rfc:`1918`
 		10.0.0.0/8,
+		## 10.0.0.0/8 as a 6to4 address, see :rfc:`1918` and :rfc:`3056`
+		[2002:a00::]/24,
+
 		## Shared Address Space (also known as Carrier-grade NAT), see :rfc:`6598`
 		100.64.0.0/10,
+		## 100.64.0.0/10 as a 6to4 address, see :rfc:`6598` and :rfc:`3056`
+		[2002:6440::]/26,
+
 		## Loopback, see :rfc:`1122`
 		127.0.0.0/8,
+		## 127.0.0.0/8 as a 6to4 address, see :rfc:`1122` and :rfc:`3056`
+		[2002:7f00::]/24,
+
 		## Link Local, see :rfc:`3927`
 		169.254.0.0/16,
+		## 169.254.0.0/16 as a 6to4 address, see :rfc:`3927` and :rfc:`3056`
+		[2002:a9fe::]/32,
+
 		## Private-Use, see :rfc:`1918`
 		172.16.0.0/12,
+		## 172.16.0.0/12 as a 6to4 address, see :rfc:`1918` and :rfc:`3056`
+		[2002:ac10::]/28,
+
 		## IETF Protocol Assignments, see :rfc:`6890`
 		192.0.0.0/24,
+		## 192.0.0.0/24 as a 6to4 address, see :rfc:`6890` and :rfc:`3056`
+		[2002:c000::]/40,
+
 		## Documentation (TEST-NET-1), see :rfc:`5737`
 		192.0.2.0/24,
+		## 192.0.2.0/24 as a 6to4 address, see :rfc:`5737` and :rfc:`3056`
+		[2002:c000:200::]/40,
+
 		## Private-Use, see :rfc:`1918`
 		192.168.0.0/16,
+		## 192.168.0.0/16 as a 6to4 address, see :rfc:`1918` and :rfc:`3056`
+		[2002:c0a8::]/32,
+
 		## Benchmarking, see :rfc:`2544`
 		198.18.0.0/15,
+		## 198.18.0.0/15 as a 6to4 address, see :rfc:`2544` and :rfc:`3056`
+		[2002:c612::]/31,
+
 		## Documentation (TEST-NET-2), see :rfc:`5737`
 		198.51.100.0/24,
+		## 198.51.100.0/24 as a 6to4 address, see :rfc:`5737` and :rfc:`3056`
+		[2002:c633:6400::]/40,
+
 		## Documentation (TEST-NET-3), see :rfc:`5737`
 		203.0.113.0/24,
+		## 203.0.113.0/24 as a 6to4 address, see :rfc:`5737` and :rfc:`3056`
+		[2002:cb00:7100::]/40,
+
 		## Reserved, see :rfc:`1112`
 		240.0.0.0/4,
+		## 240.0.0.0/4 as a 6to4 address, see :rfc:`1112` and :rfc:`3056`
+		[2002:f000::]/20,
+
 		## Limited Broadcast, see :rfc:`919` and :rfc:`8190`
 		255.255.255.255/32,
-		
+		## 255.255.255.255/32 as a 6to4 address, see :rfc:`8190` and :rfc:`3056`
+		[2002:ffff:ffff::]/48,
+
+
 		## Unspecified Address, see :rfc:`4291`
 		[::]/128,
 		## Loopback Address, see :rfc:`4291`

--- a/scripts/base/utils/site.zeek
+++ b/scripts/base/utils/site.zeek
@@ -12,96 +12,96 @@ export {
 	## See the `IPv4 Special-Purpose Address Registry <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_
 	## and the `IPv6 Special-Purpose Address Registry <https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml>`_
 	option private_address_space: set[subnet] = {
-		## "This network", see :rfc:`791`
+		# "This network", see :rfc:`791`
 		0.0.0.0/8,
-		## 0.0.0.0/8 as a 6to4 address, see :rfc:`791` and :rfc:`3056`
+		# 0.0.0.0/8 as a 6to4 address, see :rfc:`791` and :rfc:`3056`
 		[2002::]/24,
 
-		## Private-Use, see :rfc:`1918`
+		# Private-Use, see :rfc:`1918`
 		10.0.0.0/8,
-		## 10.0.0.0/8 as a 6to4 address, see :rfc:`1918` and :rfc:`3056`
+		# 10.0.0.0/8 as a 6to4 address, see :rfc:`1918` and :rfc:`3056`
 		[2002:a00::]/24,
 
-		## Shared Address Space (also known as Carrier-grade NAT), see :rfc:`6598`
+		# Shared Address Space (also known as Carrier-grade NAT), see :rfc:`6598`
 		100.64.0.0/10,
-		## 100.64.0.0/10 as a 6to4 address, see :rfc:`6598` and :rfc:`3056`
+		# 100.64.0.0/10 as a 6to4 address, see :rfc:`6598` and :rfc:`3056`
 		[2002:6440::]/26,
 
-		## Loopback, see :rfc:`1122`
+		# Loopback, see :rfc:`1122`
 		127.0.0.0/8,
-		## 127.0.0.0/8 as a 6to4 address, see :rfc:`1122` and :rfc:`3056`
+		# 127.0.0.0/8 as a 6to4 address, see :rfc:`1122` and :rfc:`3056`
 		[2002:7f00::]/24,
 
-		## Link Local, see :rfc:`3927`
+		# Link Local, see :rfc:`3927`
 		169.254.0.0/16,
-		## 169.254.0.0/16 as a 6to4 address, see :rfc:`3927` and :rfc:`3056`
+		# 169.254.0.0/16 as a 6to4 address, see :rfc:`3927` and :rfc:`3056`
 		[2002:a9fe::]/32,
 
-		## Private-Use, see :rfc:`1918`
+		# Private-Use, see :rfc:`1918`
 		172.16.0.0/12,
-		## 172.16.0.0/12 as a 6to4 address, see :rfc:`1918` and :rfc:`3056`
+		# 172.16.0.0/12 as a 6to4 address, see :rfc:`1918` and :rfc:`3056`
 		[2002:ac10::]/28,
 
-		## IETF Protocol Assignments, see :rfc:`6890`
+		# IETF Protocol Assignments, see :rfc:`6890`
 		192.0.0.0/24,
-		## 192.0.0.0/24 as a 6to4 address, see :rfc:`6890` and :rfc:`3056`
+		# 192.0.0.0/24 as a 6to4 address, see :rfc:`6890` and :rfc:`3056`
 		[2002:c000::]/40,
 
-		## Documentation (TEST-NET-1), see :rfc:`5737`
+		# Documentation (TEST-NET-1), see :rfc:`5737`
 		192.0.2.0/24,
-		## 192.0.2.0/24 as a 6to4 address, see :rfc:`5737` and :rfc:`3056`
+		# 192.0.2.0/24 as a 6to4 address, see :rfc:`5737` and :rfc:`3056`
 		[2002:c000:200::]/40,
 
-		## Private-Use, see :rfc:`1918`
+		# Private-Use, see :rfc:`1918`
 		192.168.0.0/16,
-		## 192.168.0.0/16 as a 6to4 address, see :rfc:`1918` and :rfc:`3056`
+		# 192.168.0.0/16 as a 6to4 address, see :rfc:`1918` and :rfc:`3056`
 		[2002:c0a8::]/32,
 
-		## Benchmarking, see :rfc:`2544`
+		# Benchmarking, see :rfc:`2544`
 		198.18.0.0/15,
-		## 198.18.0.0/15 as a 6to4 address, see :rfc:`2544` and :rfc:`3056`
+		# 198.18.0.0/15 as a 6to4 address, see :rfc:`2544` and :rfc:`3056`
 		[2002:c612::]/31,
 
-		## Documentation (TEST-NET-2), see :rfc:`5737`
+		# Documentation (TEST-NET-2), see :rfc:`5737`
 		198.51.100.0/24,
-		## 198.51.100.0/24 as a 6to4 address, see :rfc:`5737` and :rfc:`3056`
+		# 198.51.100.0/24 as a 6to4 address, see :rfc:`5737` and :rfc:`3056`
 		[2002:c633:6400::]/40,
 
-		## Documentation (TEST-NET-3), see :rfc:`5737`
+		# Documentation (TEST-NET-3), see :rfc:`5737`
 		203.0.113.0/24,
-		## 203.0.113.0/24 as a 6to4 address, see :rfc:`5737` and :rfc:`3056`
+		# 203.0.113.0/24 as a 6to4 address, see :rfc:`5737` and :rfc:`3056`
 		[2002:cb00:7100::]/40,
 
-		## Reserved, see :rfc:`1112`
+		# Reserved, see :rfc:`1112`
 		240.0.0.0/4,
-		## 240.0.0.0/4 as a 6to4 address, see :rfc:`1112` and :rfc:`3056`
+		# 240.0.0.0/4 as a 6to4 address, see :rfc:`1112` and :rfc:`3056`
 		[2002:f000::]/20,
 
-		## Limited Broadcast, see :rfc:`919` and :rfc:`8190`
+		# Limited Broadcast, see :rfc:`919` and :rfc:`8190`
 		255.255.255.255/32,
-		## 255.255.255.255/32 as a 6to4 address, see :rfc:`8190` and :rfc:`3056`
+		# 255.255.255.255/32 as a 6to4 address, see :rfc:`8190` and :rfc:`3056`
 		[2002:ffff:ffff::]/48,
 
 
-		## Unspecified Address, see :rfc:`4291`
+		# Unspecified Address, see :rfc:`4291`
 		[::]/128,
-		## Loopback Address, see :rfc:`4291`
+		# Loopback Address, see :rfc:`4291`
 		[::1]/128,
-		## IPv4-mapped Address, see :rfc:`4291`
+		# IPv4-mapped Address, see :rfc:`4291`
 		[::ffff:0:0]/96,
-		## IPv4-IPv6 Translation, see :rfc:`8215`
+		# IPv4-IPv6 Translation, see :rfc:`8215`
 		[64:ff9b:1::]/48,
-		## Discard-Only Address Block, see :rfc:`6666`
+		# Discard-Only Address Block, see :rfc:`6666`
 		[100::]/64,
-		## IETF Protocol Assignments, see :rfc:`2928`
+		# IETF Protocol Assignments, see :rfc:`2928`
 		[2001::]/23,
-		## Benchmarking, see :rfc:`5180`
+		# Benchmarking, see :rfc:`5180`
 		[2001:2::]/48,
-		## Documentation, see :rfc:`3849`
+		# Documentation, see :rfc:`3849`
 		[2001:db8::]/32,
-		## Unique-Local, see :rfc:`4193` and :rfc:`8190`
+		# Unique-Local, see :rfc:`4193` and :rfc:`8190`
 		[fc00::]/7,
-		## Link-Local Unicast, see :rfc:`4291`
+		# Link-Local Unicast, see :rfc:`4291`
 		[fe80::]/10,
 	};
 

--- a/scripts/base/utils/site.zeek
+++ b/scripts/base/utils/site.zeek
@@ -5,16 +5,62 @@
 module Site;
 
 export {
-	## Address space that is considered private and unrouted.
-	## By default it has RFC defined non-routable IPv4 address space.
+	## A list of subnets that are considered private address space.
+	##
+	## By default, it has address blocks defined by IANA as not being routable over the Internet.
+	##
+	## See the `IPv4 Special-Purpose Address Registry <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_
+	## and the `IPv6 Special-Purpose Address Registry <https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml>`_
 	option private_address_space: set[subnet] = {
+		## "This network", see :rfc:`791`
+		0.0.0.0/8,
+		## Private-Use, see :rfc:`1918`
 		10.0.0.0/8,
-		192.168.0.0/16,
-		172.16.0.0/12,
-		100.64.0.0/10,  # RFC6598 Carrier Grade NAT
+		## Shared Address Space (also known as Carrier-grade NAT), see :rfc:`6598`
+		100.64.0.0/10,
+		## Loopback, see :rfc:`1122`
 		127.0.0.0/8,
-		[fe80::]/10,
+		## Link Local, see :rfc:`3927`
+		169.254.0.0/16,
+		## Private-Use, see :rfc:`1918`
+		172.16.0.0/12,
+		## IETF Protocol Assignments, see :rfc:`6890`
+		192.0.0.0/24,
+		## Documentation (TEST-NET-1), see :rfc:`5737`
+		192.0.2.0/24,
+		## Private-Use, see :rfc:`1918`
+		192.168.0.0/16,
+		## Benchmarking, see :rfc:`2544`
+		198.18.0.0/15,
+		## Documentation (TEST-NET-2), see :rfc:`5737`
+		198.51.100.0/24,
+		## Documentation (TEST-NET-3), see :rfc:`5737`
+		203.0.113.0/24,
+		## Reserved, see :rfc:`1112`
+		240.0.0.0/4,
+		## Limited Broadcast, see :rfc:`919` and :rfc:`8190`
+		255.255.255.255/32,
+		
+		## Unspecified Address, see :rfc:`4291`
+		[::]/128,
+		## Loopback Address, see :rfc:`4291`
 		[::1]/128,
+		## IPv4-mapped Address, see :rfc:`4291`
+		[::ffff:0:0]/96,
+		## IPv4-IPv6 Translation, see :rfc:`8215`
+		[64:ff9b:1::]/48,
+		## Discard-Only Address Block, see :rfc:`6666`
+		[100::]/64,
+		## IETF Protocol Assignments, see :rfc:`2928`
+		[2001::]/23,
+		## Benchmarking, see :rfc:`5180`
+		[2001:2::]/48,
+		## Documentation, see :rfc:`3849`
+		[2001:db8::]/32,
+		## Unique-Local, see :rfc:`4193` and :rfc:`8190`
+		[fc00::]/7,
+		## Link-Local Unicast, see :rfc:`4291`
+		[fe80::]/10,
 	};
 
 	## Networks that are considered "local".  Note that ZeekControl sets


### PR DESCRIPTION
I was seeing some odd behavior with some v6 space that we use that's reserved for internal use only. This was missing from `Site::private_address_space`, and then I realized that many more were missing.

This branch updates that list to address space that IANA has reserved for special usage and is marked as NOT being globally routable. This brings what Zeek considers to be "non-public" IP space in line with Chrome, the W3C spec, and Python's ipaddress module.

The data came from:

https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml

6to4 address ranges are a bit of a special case (and are marked as such by IANA). If the address maps to a public IPv4 address, it CAN technically be globally routed. If the address maps to a private IPv4 address, though, it's equivalent to that address and should not be globally routed. This matches how browsers treat these addresses.

Edit: Previously I thought that 127.0.0.1/8 (local nets) was not included in Zeek, and this was a change, but that was not correct.