### PR TITLE
Reorder fields in some classes for more compact memory layout

### DIFF
--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -159,6 +159,7 @@ protected:
 	char* dir;	// directory in which cache_name resides
 
 	bool did_init;
+	int asyncs_pending;
 
 	RecordTypePtr dm_rec;
 
@@ -235,8 +236,6 @@ protected:
 
 	typedef std::priority_queue<AsyncRequest*, std::vector<AsyncRequest*>, AsyncRequestCompare> TimeoutQueue;
 	TimeoutQueue asyncs_timeouts;
-
-	int asyncs_pending;
 
 	unsigned long num_requests;
 	unsigned long successful;

--- a/src/Desc.h
+++ b/src/Desc.h
@@ -200,17 +200,16 @@ protected:
 	bool is_short;
 	bool want_quotes;
 	bool want_determinism;
+	bool do_flush;
+	bool include_stats;
 
 	int indent_with_spaces;
+	int indent_level;
 
 	using escape_set = std::set<std::string>;
 	escape_set escape_sequences; // additional sequences of chars to escape
 
 	File* f;	// or the file we're using.
-
-	int indent_level;
-	bool do_flush;
-	bool include_stats;
 
 	std::set<const Type*> encountered_types;
 };

--- a/src/Dict.cc
+++ b/src/Dict.cc
@@ -28,8 +28,8 @@ class [[deprecated("Remove in v5.1. Use the standard-library-compatible version 
 public:
 	IterCookie(Dictionary* d) : d(d) {}
 
-	bool robust = false;
 	Dictionary* d = nullptr;
+	bool robust = false;
 
 	// Index for the next valid entry. -1 is the default, meaning we haven't started
 	// iterating yet.

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -76,7 +76,7 @@ const char* expr_name(BroExprTag t)
 	return expr_names[int(t)];
 	}
 
-Expr::Expr(BroExprTag arg_tag) : tag(arg_tag), type(nullptr), paren(false)
+Expr::Expr(BroExprTag arg_tag) : tag(arg_tag), paren(false), type(nullptr)
 	{
 	SetLocationInfo(&start_location, &end_location);
 	}

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -411,8 +411,8 @@ protected:
 	[[noreturn]] void RuntimeErrorWithCallStack(const std::string& msg) const;
 
 	BroExprTag tag;
-	TypePtr type;
 	bool paren;
+	TypePtr type;
 
 	// The original expression from which this statement was
 	// derived, if any.  Used as an aid for generating meaningful
@@ -907,10 +907,10 @@ protected:
 	bool TypeCheckArithmetics(TypeTag bt1, TypeTag bt2);
 
 	bool is_init;
+	bool is_temp = false; // Optimization related
+
 	ValPtr val;	// optional
 
-	// Optimization-related:
-	bool is_temp = false;
 };
 
 class IndexSliceAssignExpr final : public AssignExpr {

--- a/src/Frag.cc
+++ b/src/Frag.cc
@@ -295,8 +295,7 @@ void FragReassembler::BlockInserted(DataBlockMap::const_iterator /* it */)
 		{
 		struct ip* reassem4 = (struct ip*) pkt_start;
 		reassem4->ip_len = htons(frag_size + proto_hdr_len);
-		reassembled_pkt = std::make_unique<IP_Hdr>(reassem4, true);
-		reassembled_pkt->reassembled = true;
+		reassembled_pkt = std::make_unique<IP_Hdr>(reassem4, true, true);
 		DeleteTimer();
 		}
 
@@ -305,8 +304,7 @@ void FragReassembler::BlockInserted(DataBlockMap::const_iterator /* it */)
 		struct ip6_hdr* reassem6 = (struct ip6_hdr*) pkt_start;
 		reassem6->ip6_plen = htons(frag_size + proto_hdr_len - 40);
 		const IPv6_Hdr_Chain* chain = new IPv6_Hdr_Chain(reassem6, next_proto, n);
-		reassembled_pkt = std::make_unique<IP_Hdr>(reassem6, true, n, chain);
-		reassembled_pkt->reassembled = true;
+		reassembled_pkt = std::make_unique<IP_Hdr>(reassem6, true, n, chain, true);
 		DeleteTimer();
 		}
 

--- a/src/IP.h
+++ b/src/IP.h
@@ -288,9 +288,10 @@ public:
 	 * already checked that the header is not truncated.
 	 * @param arg_ip4 pointer to memory containing an IPv4 packet.
 	 * @param arg_del whether to take ownership of \a arg_ip4 pointer's memory.
+	 * @param reassembled whether this header is for a reassembled packet.
 	 */
-	IP_Hdr(const struct ip* arg_ip4, bool arg_del)
-		: ip4(arg_ip4), del(arg_del)
+	IP_Hdr(const struct ip* arg_ip4, bool arg_del, bool reassembled=false)
+		: ip4(arg_ip4), del(arg_del), reassembled(reassembled)
 		{
 		}
 
@@ -304,11 +305,12 @@ public:
 	 * @param arg_del whether to take ownership of \a arg_ip6 pointer's memory.
 	 * @param len the packet's length in bytes.
 	 * @param c an already-constructed header chain to take ownership of.
+	 * @param reassembled whether this header is for a reassembled packet.
 	 */
 	IP_Hdr(const struct ip6_hdr* arg_ip6, bool arg_del, int len,
-	       const IPv6_Hdr_Chain* c = nullptr)
+	       const IPv6_Hdr_Chain* c = nullptr, bool reassembled=false)
 		: ip6(arg_ip6), ip6_hdrs(c ? c : new IPv6_Hdr_Chain(ip6, len)),
-		  del(arg_del)
+		  del(arg_del), reassembled(reassembled)
 		{
 		}
 
@@ -524,16 +526,14 @@ public:
 	 */
 	RecordValPtr ToPktHdrVal(RecordValPtr pkt_hdr, int sindex) const;
 
-	/**
-	 * Denotes whether this header is from a set of packet fragments.
-	 */
-	bool reassembled = false;
+	bool Reassembled() const { return reassembled; }
 
 private:
 	const struct ip* ip4 = nullptr;
 	const struct ip6_hdr* ip6 = nullptr;
 	const IPv6_Hdr_Chain* ip6_hdrs = nullptr;
-	bool del;
+	bool del = false;
+	bool reassembled = false;
 };
 
 } // namespace zeek

--- a/src/NFA.h
+++ b/src/NFA.h
@@ -67,14 +67,13 @@ public:
 
 protected:
 	int sym;	// if SYM_CCL, then use ccl
+	int id;	// number that uniquely identifies this state
 	CCL* ccl;	// if nil, then use sym
 	int accept;
 
 	// Whether the first transition points backwards.  Used
 	// to avoid reference-counting loops.
 	bool first_trans_is_back_ref;
-
-	int id;	// number that uniquely identifies this state
 
 	NFA_state_list xtions;
 	NFA_state_list* epsclosure;

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -153,8 +153,8 @@ private:
 	friend inline void Ref(Obj* o);
 	friend inline void Unref(Obj* o);
 
-	bool notify_plugins = false;
 	int ref_cnt = 1;
+	bool notify_plugins = false;
 
 	// If non-zero, do not print runtime errors.  Useful for
 	// speculative evaluation.

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -915,12 +915,13 @@ public:
 		R_INIT_VECTOR,	// field requires a new vector
 	} init_type;
 
+	bool def_coerce = false;	// whether coercion's required
+
 	// For R_INIT_DIRECT/R_INIT_DIRECT_MANAGED:
 	ZVal direct_init;
 
 	detail::ExprPtr def_expr;
 	TypePtr def_type;
-	bool def_coerce = false;	// whether coercion's required
 
 	RecordTypePtr r_type;	// for R_INIT_RECORD
 	TableTypePtr t_type;	// for R_INIT_TABLE

--- a/src/packet_analysis/protocol/ip/IPBasedAnalyzer.cc
+++ b/src/packet_analysis/protocol/ip/IPBasedAnalyzer.cc
@@ -100,7 +100,7 @@ bool IPBasedAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* pkt
 
 	// If the packet is reassembled, disable packet dumping because the
 	// pointer math to dump the data wouldn't work.
-	if ( pkt->ip_hdr->reassembled )
+	if ( pkt->ip_hdr->Reassembled() )
 		pkt->dump_packet = false;
 	else if ( conn->RecordPackets() )
 		{

--- a/src/script_opt/ScriptOpt.h
+++ b/src/script_opt/ScriptOpt.h
@@ -121,12 +121,12 @@ protected:
 	std::shared_ptr<ProfileFunc> pf;
 	int priority;
 
+	// Whether to skip optimizing this function.
+	bool skip = false;
+
 	// If we're saving this function in a file, this is the name
 	// of the file to use.
 	std::string save_file;
-
-	// Whether to skip optimizing this function.
-	bool skip = false;
 };
 
 

--- a/src/supervisor/Supervisor.h
+++ b/src/supervisor/Supervisor.h
@@ -119,13 +119,13 @@ public:
 		 */
 		BifEnum::Supervisor::ClusterRole role;
 		/**
-		 * The host/IP at which the cluster node is listening for connections.
-		 */
-		std::string host;
-		/**
 		 * The TCP port number at which the cluster node listens for connections.
 		 */
 		int port;
+		/**
+		 * The host/IP at which the cluster node is listening for connections.
+		 */
+		std::string host;
 		/**
 		 * The interface name from which the node read/analyze packets.
 		 * Typically used by worker nodes.
@@ -324,10 +324,10 @@ private:
 
 	Config config;
 	pid_t stem_pid;
+	int last_signal = -1;
 	std::unique_ptr<detail::PipePair> stem_pipe;
 	detail::LineBufferedPipe stem_stdout;
 	detail::LineBufferedPipe stem_stderr;
-	int last_signal = -1;
 	detail::Flare signal_flare;
 	NodeMap nodes;
 	std::string msg_buffer;

--- a/src/threading/BasicThread.h
+++ b/src/threading/BasicThread.h
@@ -204,8 +204,8 @@ private:
 	bool killed;	// Set to true once forcefully killed.
 
 	// For implementing Fmt().
+	uint32_t buf_len;
 	char* buf;
-	unsigned int buf_len;
 
 	// For implementating Strerror().
 	char* strerr_buffer;


### PR DESCRIPTION
This reduces the memory used by zeek by ~1% with the 2009-M57-day11-18 trace file. The big culprit here is `Expr`, which while only being reduced by 8 bytes, also reduces the size of all of the child objects of that class.

These two commits should be merged into release/4.1 also.