### PR TITLE
Fix generate-docs github action to send email when it fails

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -3,9 +3,6 @@ name: Generate Documentation
 on:
   schedule:
     - cron: '0 0 * * *'
-  push:
-    branches:
-      - topic/timw/send-email-on-docs-action-failure
 
 jobs:
   generate:
@@ -95,3 +92,16 @@ jobs:
           git add doc
           git status
           git commit -m 'Update doc submodule [nomail] [skip ci]' && git push auth master || /bin/true
+
+      - name: Send email
+        if: failure()
+        uses: dawidd6/action-send-mail@v3.4.1
+        with:
+          server_address: ${{secrets.SMTP_HOST}}
+          server_port: ${{secrets.SMTP_PORT}}
+          username: ${{secrets.SMTP_USER}}
+          password: ${{secrets.SMTP_PASS}}
+          subject: generate-docs Github Action failed!
+          body: generate-docs job of ${{github.repository}} Failed! See https://github.com/${{github.repository}}/actions/runs/${{github.run_id}} for details.
+          to: ${{secrets.MAIL_TO}}
+          from: Github Actions <${{secrets.MAIL_FROM}}>


### PR DESCRIPTION
This fixes the generate-docs github action to send an email on failure. Currently it's sending it to one of the zeek commits addresses, but I can add set it to something else if preferred. It should be reasonably low noise.