### PR TITLE
Use Cirrus's new greedy mode for parallelizing builds and tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,6 +18,8 @@ mobile_ipv6_config: &MOBILE_IPV6_CONFIG --build-type=release --enable-cpp-tests 
 resources_template: &RESOURCES_TEMPLATE
   cpu: *CPUS
   memory: *MEMORY
+  # For greediness, see https://medium.com/cirruslabs/introducing-greedy-container-instances-29aad06dc2b4
+  greedy: true
 
 macos_resources_template: &MACOS_RESOURCES_TEMPLATE
   # https://medium.com/cirruslabs/new-macos-task-execution-architecture-for-cirrus-ci-604250627c94

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,15 +1,18 @@
 #! /usr/bin/env bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+. ${SCRIPT_DIR}/common.sh
+
 set -e
 set -x
 
 # If we're on macOS, use --osx-sysroot to ensure we can find the SDKs from Xcode. This avoids
 # some problems with Catalina specifically, but it doesn't break anything on Big Sur either.
-if [ "${CIRRUS_OS}" == "darwin" ]; then
+if [[ "${CIRRUS_OS}" == "darwin" ]]; then
     export ZEEK_CI_CONFIGURE_FLAGS="${ZEEK_CI_CONFIGURE_FLAGS} --osx-sysroot=$(xcrun --show-sdk-path)"
 fi
 
-if [ "${ZEEK_CI_CREATE_ARTIFACT}" != "1" ]; then
+if [[ "${ZEEK_CI_CREATE_ARTIFACT}" != "1" ]]; then
     ./configure ${ZEEK_CI_CONFIGURE_FLAGS}
     cd build
     make -j ${ZEEK_CI_CPUS}

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -1,0 +1,12 @@
+# Common material sourced by Bash CI scripts in this directory
+
+# On Cirrus, oversubscribe the CPUs when on Linux. This uses Cirrus' "greedy" feature.
+if [[ "${CIRRUS_OS}" == linux ]]; then
+    if [[ -n "${ZEEK_CI_CPUS}" ]]; then
+        ZEEK_CI_CPUS=$(( 2 * ${ZEEK_CI_CPUS} ))
+    fi
+
+    if [[ -n "${ZEEK_CI_BTEST_JOBS}" ]]; then
+        ZEEK_CI_BTEST_JOBS=$(( 2 * ${ZEEK_CI_BTEST_JOBS} ))
+    fi
+fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -16,6 +16,9 @@ if [[ -z "${CIRRUS_CI}" ]]; then
     ZEEK_CI_BTEST_RETRIES=2
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+. ${SCRIPT_DIR}/common.sh
+
 function pushd
     {
     command pushd "$@" > /dev/null || exit 1


### PR DESCRIPTION
Greedy mode is a way to use spare capacity in the Cirrus-provided instances at no extra cost to the resource budget:

https://medium.com/cirruslabs/introducing-greedy-container-instances-29aad06dc2b4

This oversubscribes our cores 2x, which testing shows we actually run with at times: speedup is around a third on average for builds, and a bit more than that for testing.