### PR TITLE
Sessions: Use unordered_map for improved performance

### DIFF
--- a/src/Sessions.h
+++ b/src/Sessions.h
@@ -3,10 +3,11 @@
 #pragma once
 
 #include <sys/types.h> // for u_char
-#include <map>
+#include <unordered_map>
 #include <utility>
 
 #include "zeek/Frag.h"
+#include "zeek/Hash.h"
 #include "zeek/PacketFilter.h"
 #include "zeek/NetVar.h"
 #include "zeek/analyzer/protocol/tcp/Stats.h"
@@ -39,6 +40,12 @@ struct SessionStats {
 	size_t num_fragments;
 	size_t max_fragments;
 	uint64_t num_packets;
+};
+
+struct ConnIDKeyHash {
+	std::size_t operator()(const zeek::detail::ConnIDKey& k) const {
+		return detail::HashKey::HashBytes(&k, sizeof(zeek::detail::ConnIDKey));
+	}
 };
 
 class NetSessions {
@@ -133,7 +140,7 @@ public:
 protected:
 	friend class ConnCompressor;
 
-	using ConnectionMap = std::map<detail::ConnIDKey, Connection*>;
+	using ConnectionMap = std::unordered_map<detail::ConnIDKey, Connection*, ConnIDKeyHash>;
 
 	Connection* NewConn(const detail::ConnIDKey& k, double t, const ConnID* id,
 	                    const u_char* data, int proto, uint32_t flow_label,


### PR DESCRIPTION
Hey,

(Note: This is against `release/4.0`.  `master` looks somewhat different, but seems to be using `std::map` in `sessions/Manager.h`, so may still apply there.)

we're observing `memcmp` showing on systems running Zeek 4.0 as one of the hottest function in perf profiles (credits to @JustinAzoff for bringing it up first I believe).

It's fairly visible on systems where each worker handles ~20k active TCP connections.


After looking a bit, one culprit seems to be `std::map` usage in `Sessions` and the `ConnIDKey` `operator<` implementation.

Instead of trying to improve `operator<`, this PR proposes to switch the `ConnectionMap` over to `std::unordered_map` using `HashKey::HashBytes` as hash function over the whole of `ConnIDKey`.

For an artificially generated [pcap](https://github.com/awelzel/pcaps/raw/master/50k-tcp-conns.pcap.gz) with 50k concurrent TCP connections this improves `zeek -r` user time locally from 11.8s to 9.2s (~22%).

This seems rather significant, so wondering a bit if `std::map` vs `std::unordered_map` had been a topic for `Sessions` and if there's anything inherently wrong with letting go of the ordering?


Ran tests as follows:
```
# base release/4.0
$ ZEEKPATH=$(../build/zeek-path-dev ) time taskset -c 1 ../build/src/zeek -b -C -r ~/projects/testpcap/randomize/merged.pcap -e 'redef Log::default_writer = Log::WRITER_NONE'
11.80user 0.46system 0:12.30elapsed 99%CPU (0avgtext+0avgdata 589924maxresident)k
0inputs+0outputs (0major+144678minor)pagefaults 0swaps

# unordered_map
$ ZEEKPATH=$(../build/zeek-path-dev ) time taskset -c 1 ../build/src/zeek -b -C -r ~/projects/testpcap/randomize/merged.pcap -e 'redef Log::default_writer = Log::WRITER_NONE'
9.15user 0.50system 0:09.69elapsed 99%CPU (0avgtext+0avgdata 590076maxresident)k
183168inputs+0outputs (4major+144633minor)pagefaults 0swaps
```
