### PR TITLE
analyzers: Lookup ignore_checksums_nets table once, not for every packet

### DIFF
--- a/src/analyzer/protocol/icmp/ICMP.cc
+++ b/src/analyzer/protocol/icmp/ICMP.cc
@@ -47,8 +47,10 @@ void ICMP_Analyzer::DeliverPacket(int len, const u_char* data,
 
 	const struct icmp* icmpp = (const struct icmp*) data;
 
+	static TableValPtr ignore_checksums_nets_table = zeek::id::find_val<TableVal>("ignore_checksums_nets");
+
 	if ( ! zeek::detail::ignore_checksums &&
-	     ! zeek::id::find_val<TableVal>("ignore_checksums_nets")->Contains(ip->IPHeaderSrcAddr()) &&
+	     ! ignore_checksums_nets_table->Contains(ip->IPHeaderSrcAddr()) &&
 	     caplen >= len )
 		{
 		int chksum = 0;

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -275,9 +275,11 @@ const struct tcphdr* TCP_Analyzer::ExtractTCP_Header(const u_char*& data,
 bool TCP_Analyzer::ValidateChecksum(const IP_Hdr* ip, const struct tcphdr* tp,
 				TCP_Endpoint* endpoint, int len, int caplen)
 	{
+	static TableValPtr ignore_checksums_nets_table = zeek::id::find_val<TableVal>("ignore_checksums_nets");
+
 	if ( ! run_state::current_pkt->l3_checksummed &&
 	     ! detail::ignore_checksums &&
-	     ! zeek::id::find_val<TableVal>("ignore_checksums_nets")->Contains(ip->IPHeaderSrcAddr()) &&
+	     ! ignore_checksums_nets_table->Contains(ip->IPHeaderSrcAddr()) &&
 	     caplen >= len && ! endpoint->ValidChecksum(tp, len, ip->IP4_Hdr()) )
 		{
 		Weird("bad_TCP_checksum");

--- a/src/analyzer/protocol/udp/UDP.cc
+++ b/src/analyzer/protocol/udp/UDP.cc
@@ -62,10 +62,12 @@ void UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool is_orig,
 
 	int chksum = up->uh_sum;
 
+	static TableValPtr ignore_checksums_nets_table = zeek::id::find_val<TableVal>("ignore_checksums_nets");
+
 	auto validate_checksum =
 		! run_state::current_pkt->l3_checksummed &&
 		! zeek::detail::ignore_checksums &&
-		! zeek::id::find_val<TableVal>("ignore_checksums_nets")->Contains(ip->IPHeaderSrcAddr()) &&
+		! ignore_checksums_nets_table->Contains(ip->IPHeaderSrcAddr()) &&
 		caplen >=len;
 
 	constexpr auto vxlan_len = 8;

--- a/src/packet_analysis/protocol/ip/IP.cc
+++ b/src/packet_analysis/protocol/ip/IP.cc
@@ -125,8 +125,10 @@ bool IPAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet)
 	if ( packet_filter && packet_filter->Match(packet->ip_hdr, total_len, len) )
 		 return false;
 
+	static TableValPtr ignore_checksums_nets_table = zeek::id::find_val<TableVal>("ignore_checksums_nets");
+
 	if ( ! packet->l2_checksummed && ! detail::ignore_checksums && ip4 &&
-	     ! zeek::id::find_val<TableVal>("ignore_checksums_nets")->Contains(packet->ip_hdr->IPHeaderSrcAddr()) &&
+	     ! ignore_checksums_nets_table->Contains(packet->ip_hdr->IPHeaderSrcAddr()) &&
 	     detail::in_cksum(reinterpret_cast<const uint8_t*>(ip4), ip_hdr_len) != 0xffff )
 		{
 		Weird("bad_IP_checksum", packet);


### PR DESCRIPTION
(This is against release/4.0, mostly for convenience on my end as `master` looks quite different. Mostly looking for feedback if this is a valid performance fix for 4.0, but up for forward porting to master if so.)

Doing a `zeek::id::find` for every packet (multiple times for e.g IP and TCP) is fairly hot, this PR proposes to do it only once using a `static` variable. Not a great change, but mostly to show the difference, happy to hear alternative suggestions.

Using the [pcap](https://github.com/awelzel/pcaps/raw/master/50k-tcp-conns.pcap.gz) from #1697 and actually enabling checksum verification shows user time going from 13.9s to 12.4s after the change (~12%).


```
# before
$ ZEEKPATH=$(../build/zeek-path-dev ) time taskset -c 1 ../build/src/zeek -b -r ~/projects/testpcap/randomize/merged.pcap -e 'redef Log::default_writer = Log::WRITER_NONE'
14.24user 0.46system 0:14.78elapsed 99%CPU (0avgtext+0avgdata 589832maxresident)k
59128inputs+0outputs (15major+144639minor)pagefaults 0swaps

# after
$ ZEEKPATH=$(../build/zeek-path-dev ) time taskset -c 1 ../build/src/zeek -b -r ~/projects/testpcap/randomize/merged.pcap -e 'redef Log::default_writer = Log::WRITER_NONE'
12.47user 0.48system 0:12.99elapsed 99%CPU (0avgtext+0avgdata 590068maxresident)k
0inputs+0outputs (0major+144649minor)pagefaults 0swaps
```

Ran each 3 times and averaged, fwiw.

--
As an aside, it seems this was changed for the TCP analyzer in `master` to be once per connections / analyzer instantiation, but other analyzers still do it for every packet.

(cc @jlucovsky , @chandanchowdhury)