### PR TITLE
Fix a use-after-free during shutdown

### DIFF
--- a/src/RunState.cc
+++ b/src/RunState.cc
@@ -422,8 +422,6 @@ void delete_run()
 	{
 	util::detail::set_processing_status("TERMINATING", "delete_run");
 
-	delete session_mgr;
-
 	for ( int i = 0; i < zeek::detail::NUM_ADDR_ANONYMIZATION_METHODS; ++i )
 		delete zeek::detail::ip_anonymizer[i];
 	}

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -64,6 +64,7 @@
 #include "zeek/iosource/Manager.h"
 #include "zeek/broker/Manager.h"
 #include "zeek/telemetry/Manager.h"
+#include "zeek/session/Manager.h"
 
 #include "zeek/binpac_zeek.h"
 #include "zeek/module_util.h"
@@ -334,6 +335,7 @@ static void terminate_bro()
 	delete reporter;
 	delete plugin_mgr;
 	delete val_mgr;
+	delete session_mgr;
 	delete fragment_mgr;
 	delete telemetry_mgr;
 


### PR DESCRIPTION
I have no idea how the sanitizer builds on CI didn't trigger this, but one of the fuzzers did locally.

```
==8013==ERROR: AddressSanitizer: heap-use-after-free on address 0x603001670360 at pc 0x00010afea98f bp 0x7ffee71aeaf0 sp 0x7ffee71aeae8
READ of size 8 at 0x603001670360 thread T0
    #0 0x10afea98e in std::__1::map<zeek::session::detail::Key, zeek::session::Session*, std::__1::less<zeek::session::detail::Key>, std::__1::allocator<std::__1::pair<zeek::session::detail::Key const, zeek::session::Session*> > >::size() const map:1127
    #1 0x10afab508 in zeek::session::Manager::CurrentSessions() Manager.h:89
    #2 0x10afaad8f in zeek::BifFunc::get_conn_stats_bif(zeek::detail::Frame*, std::__1::vector<zeek::IntrusivePtr<zeek::Val>, std::__1::allocator<zeek::IntrusivePtr<zeek::Val> > > const*) stats.bif:91
    #3 0x10afcc1af in zeek::detail::BuiltinFunc::Invoke(std::__1::vector<zeek::IntrusivePtr<zeek::Val>, std::__1::allocator<zeek::IntrusivePtr<zeek::Val> > >*, zeek::detail::Frame*) const Func.cc:796
    #4 0x10af04cc8 in zeek::detail::CallExpr::Eval(zeek::detail::Frame*) const Expr.cc:4501
    #5 0x10aef1127 in zeek::detail::AssignExpr::Eval(zeek::detail::Frame*) const Expr.cc:2554
    #6 0x10b10f4ee in zeek::detail::ExprStmt::Exec(zeek::detail::Frame*, zeek::detail::StmtFlowType&) Stmt.cc:405
    #7 0x10b1191ef in zeek::detail::StmtList::Exec(zeek::detail::Frame*, zeek::detail::StmtFlowType&) Stmt.cc:1630
    #8 0x10afc7be3 in zeek::detail::ScriptFunc::Invoke(std::__1::vector<zeek::IntrusivePtr<zeek::Val>, std::__1::allocator<zeek::IntrusivePtr<zeek::Val> > >*, zeek::detail::Frame*) const Func.cc:430
    #9 0x10aeb072f in zeek::EventHandler::Call(std::__1::vector<zeek::IntrusivePtr<zeek::Val>, std::__1::allocator<zeek::IntrusivePtr<zeek::Val> > >*, bool) EventHandler.cc:107
    #10 0x10aeadd16 in zeek::Event::Dispatch(bool) Event.cc:60
    #11 0x10aeae897 in zeek::EventMgr::Drain() Event.cc:162
    #12 0x10adb3357 in zeek::detail::terminate_bro() zeek-setup.cc:301
    #13 0x10adb2d19 in zeek::detail::cleanup(bool) zeek-setup.cc:933
    #14 0x108a5c05e in main standalone-driver.cc:69
    #15 0x7fff20606f5c in start+0x0 (libdyld.dylib:x86_64+0x15f5c)

0x603001670360 is located 16 bytes inside of 32-byte region [0x603001670350,0x603001670370)
freed by thread T0 here:
    #0 0x110e5905d in wrap__ZdlPv+0x7d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x5505d)
    #1 0x10b0dfa98 in zeek::run_state::detail::delete_run() RunState.cc:410
    #2 0x10adb2d14 in zeek::detail::cleanup(bool) zeek-setup.cc:932
    #3 0x108a5c05e in main standalone-driver.cc:69
    #4 0x7fff20606f5c in start+0x0 (libdyld.dylib:x86_64+0x15f5c)

previously allocated by thread T0 here:
    #0 0x110e58c3d in wrap__Znwm+0x7d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x54c3d)
    #1 0x10b0de214 in zeek::run_state::detail::init_run(std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, std::__1::optional<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > const&, bool) RunState.cc:195
    #2 0x10adac720 in zeek::detail::setup(int, char**, zeek::Options*) zeek-setup.cc:796
    #3 0x108a54be0 in LLVMFuzzerInitialize fuzzer-setup.h:42
    #4 0x108a5bca2 in main standalone-driver.cc:21
    #5 0x7fff20606f5c in start+0x0 (libdyld.dylib:x86_64+0x15f5c)
```