### PR TITLE
Use unordered_map to store sessions for performance reasons

### DIFF
--- a/src/session/Key.cc
+++ b/src/session/Key.cc
@@ -70,4 +70,14 @@ bool Key::operator<(const Key& rhs) const
 	return memcmp(data, rhs.data, size) < 0;
 	}
 
+bool Key::operator==(const Key& rhs) const
+	{
+	if ( size != rhs.size )
+		return false;
+	else if ( type != rhs.type )
+		return false;
+
+	return memcmp(data, rhs.data, size) == 0;
+	}
+
 } // namespace zeek::session::detail

--- a/src/session/Key.h
+++ b/src/session/Key.h
@@ -4,8 +4,11 @@
 
 #include <cstddef>
 #include <cstdint>
+#include "zeek/Hash.h"
 
 namespace zeek::session::detail {
+
+struct KeyHash;
 
 /**
  * This type is used as the key for the map in SessionManager. It represents a
@@ -57,12 +60,23 @@ public:
 	void CopyData();
 
 	bool operator<(const Key& rhs) const;
+	bool operator==(const Key& rhs) const;
+
+	std::size_t Hash() const {
+		return zeek::detail::HashKey::HashBytes(data, size);
+	}
 
 private:
+	friend struct KeyHash;
+
 	const uint8_t* data = nullptr;
 	size_t size = 0;
 	size_t type = CONNECTION_KEY_TYPE;
 	bool copied = false;
+};
+
+struct KeyHash {
+	std::size_t operator()(const Key& k) const { return k.Hash(); }
 };
 
 } // namespace zeek::session::detail

--- a/src/session/Manager.cc
+++ b/src/session/Manager.cc
@@ -218,9 +218,17 @@ void Manager::Insert(Session* s, bool remove_existing)
 
 void Manager::Drain()
 	{
-	for ( const auto& entry : session_map )
+	std::vector<const detail::Key*> keys;
+	keys.reserve(session_map.size());
+
+	for ( auto& entry : session_map )
+		keys.push_back(&(entry.first));
+	std::sort(keys.begin(), keys.end(), [](const detail::Key* a, const detail::Key* b) {
+		                                    return *a < *b; });
+
+	for ( const auto* k : keys )
 		{
-		Session* tc = entry.second;
+		Session* tc = session_map.at(*k);
 		tc->Done();
 		tc->RemovalEvent();
 		}

--- a/src/session/Manager.cc
+++ b/src/session/Manager.cc
@@ -218,19 +218,34 @@ void Manager::Insert(Session* s, bool remove_existing)
 
 void Manager::Drain()
 	{
-	std::vector<const detail::Key*> keys;
-	keys.reserve(session_map.size());
-
-	for ( auto& entry : session_map )
-		keys.push_back(&(entry.first));
-	std::sort(keys.begin(), keys.end(), [](const detail::Key* a, const detail::Key* b) {
-		                                    return *a < *b; });
-
-	for ( const auto* k : keys )
+	// If a random seed was passed in, we're most likely in testing mode and need the
+	// order of the sessions to be consistent. Sort the keys to force that order
+	// every run.
+	if ( zeek::util::detail::have_random_seed() )
 		{
-		Session* tc = session_map.at(*k);
-		tc->Done();
-		tc->RemovalEvent();
+		std::vector<const detail::Key*> keys;
+		keys.reserve(session_map.size());
+
+		for ( auto& entry : session_map )
+			keys.push_back(&(entry.first));
+		std::sort(keys.begin(), keys.end(), [](const detail::Key* a, const detail::Key* b) {
+			                                    return *a < *b; });
+
+		for ( const auto* k : keys )
+			{
+			Session* tc = session_map.at(*k);
+			tc->Done();
+			tc->RemovalEvent();
+			}
+		}
+	else
+		{
+		for ( const auto& entry : session_map )
+			{
+			Session* tc = entry.second;
+			tc->Done();
+			tc->RemovalEvent();
+			}
 		}
 	}
 

--- a/src/session/Manager.h
+++ b/src/session/Manager.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <sys/types.h> // for u_char
-#include <map>
+#include <unordered_map>
 #include <utility>
 
 #include "zeek/Frag.h"
@@ -119,7 +119,7 @@ public:
 
 private:
 
-	using SessionMap = std::map<detail::Key, Session*>;
+	using SessionMap = std::unordered_map<detail::Key, Session*, detail::KeyHash>;
 
 	// Inserts a new connection into the sessions map. If a connection with
 	// the same key already exists in the map, it will be overwritten by


### PR DESCRIPTION
This results in a fairly significant (8-9%) speedup on one of our benchmark files:

```
master:
Average time spent: 232.22 seconds
Average memory usage: 2361918 KB

branch:
Average time spent: 210.72 seconds
Average memory usage: 2360969 KB
```

The extra sorting bits in `Manager::Drain()` are for consistency with the btest output.