### PR TITLE
Fix  Infinite loop inside RotationTimer #1689

### DIFF
--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -152,7 +152,7 @@ void PQ_TimerMgr::Expire()
 int PQ_TimerMgr::DoAdvance(double new_t, int max_expire)
 	{
 	Timer* timer = Top();
-	for ( num_expired = 0; (num_expired < max_expire || max_expire == 0) &&
+	for ( num_expired = 0; (num_expired < max_expire ) &&
 		     timer && timer->Time() <= new_t; ++num_expired )
 		{
 		last_timestamp = timer->Time();

--- a/src/util.cc
+++ b/src/util.cc
@@ -885,9 +885,10 @@ double calc_next_rotate(double current, double interval, double base)
 	double startofday = mktime(&t);
 
 	// current < startofday + base + i * interval <= current + interval
-	return startofday + base +
+	double delta_t = startofday + base +
 		ceil((current - startofday - base) / interval) * interval -
 			current;
+        return delta_t > 0.0 ? delta_t: interval;
 	}
 
 void terminate_processing()


### PR DESCRIPTION
Below changes are made to fix infinite loop inside  InstallRotationTimer function of src/logging/Manager.cc (https://github.com/zeek/zeek/blob/master/src/logging/Manager.cc#L1478). 

Infinite loop will result when the below two actions happen together.

1. Passing max_expire=0 do Advance() allowing "endless" timer expiration
2. Endlessly adding timers due to calc_next_rotate() returning 0.0

to fix the first case, the special condition max_expire == 0 is removed from DoAdvance function and for the latter,  calc_next_rotate will now either return a delta> 0 or the interval itself.

Please refer https://github.com/zeek/zeek/issues/1689 for detailed discussions.

