### PR TITLE
Simplify the supervisor's listen() on default address/port

### DIFF
--- a/scripts/base/frameworks/broker/main.zeek
+++ b/scripts/base/frameworks/broker/main.zeek
@@ -286,6 +286,7 @@ export {
 	global listen: function(a: string &default = default_listen_address,
 	                        p: port &default = default_port,
 	                        retry: interval &default = default_listen_retry): port;
+
 	## Initiate a remote connection.
 	##
 	## a: an address to connect to, e.g. "localhost" or "127.0.0.1".

--- a/scripts/base/frameworks/supervisor/main.zeek
+++ b/scripts/base/frameworks/supervisor/main.zeek
@@ -43,9 +43,10 @@ event zeek_init() &priority=10
 	{
 	if ( Supervisor::is_supervisor() && SupervisorControl::enable_listen )
 		{
-		Broker::listen(Broker::default_listen_address,
-			       Broker::default_port,
-			       Broker::default_listen_retry);
+		# This may fail, possibly with scheduled retries. Any failures
+		# already get logged by the listen() implementation, so we don't
+		# report additionally.
+		Broker::listen();
 		}
 
 	Broker::subscribe(SupervisorControl::topic_prefix);


### PR DESCRIPTION
A small tweak we meant to get into 4.1 still, but ran out of time for. @rsmmr, we didn't even need a new `Broker::listen_default()` — I missed the fact that `Broker::listen()` already defaults to the default values when not providing them.