### PR TITLE
Don't build any btest artifacts if --disable-btest is given

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,8 +539,10 @@ if ( GooglePerftools_INCLUDE_DIR )
     set(ZEEK_CONFIG_GooglePerftools_INCLUDE_DIR ${GooglePerftools_INCLUDE_DIR})
 endif ()
 
-set(ZEEK_CONFIG_BTEST_TOOLS_DIR ${ZEEK_ROOT_DIR}/share/btest)
-install(DIRECTORY DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR})
+if ( INSTALL_BTEST ) 
+    set(ZEEK_CONFIG_BTEST_TOOLS_DIR ${ZEEK_ROOT_DIR}/share/btest)
+    install(DIRECTORY DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR})
+endif ()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zeek-config.in
                ${CMAKE_CURRENT_BINARY_DIR}/zeek-config @ONLY)
@@ -641,11 +643,14 @@ endif ()
 if (CMAKE_BUILD_TYPE)
     string(TOUPPER ${CMAKE_BUILD_TYPE} BuildType)
 endif ()
-
-if ( INSTALL_BTEST_PCAPS )
-    set(_install_btest_tools_msg "all")
+if ( INSTALL_BTEST)
+    if ( INSTALL_BTEST_PCAPS )
+        set(_install_btest_tools_msg "all")
+    else ()
+        set(_install_btest_tools_msg "no pcaps")
+    endif ()
 else ()
-    set(_install_btest_tools_msg "no pcaps")
+    set(_install_btest_tools_msg "none")
 endif ()
 
 message(

--- a/configure
+++ b/configure
@@ -69,7 +69,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --disable-auxtools     don't build or install auxiliary tools
     --disable-archiver     don't build or install zeek-archiver tool
     --disable-btest        don't install BTest
-    --disable-btest-pcaps  don't install Zeek's BTest input pcaps
+    --disable-btest-pcaps  don't install Zeek's BTest input pcaps. Redundant if --disable-btest is given
     --disable-python       don't try to build python bindings for Broker
     --disable-broker-tests don't try to build Broker unit tests
     --disable-zkg          don't install zkg

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,8 +1,9 @@
-install(DIRECTORY scripts/ DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/scripts
-    USE_SOURCE_PERMISSIONS
-    FILES_MATCHING PATTERN "diff-*")
-install(FILES btest/random.seed DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/data)
-
-if ( INSTALL_BTEST_PCAPS )
-    install(DIRECTORY btest/Traces/ DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/data/pcaps)
+if ( INSTALL_BTEST)
+    install(DIRECTORY scripts/ DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/scripts
+        USE_SOURCE_PERMISSIONS
+        FILES_MATCHING PATTERN "diff-*")
+    install(FILES btest/random.seed DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/data)
+    if ( INSTALL_BTEST_PCAPS )
+        install(DIRECTORY btest/Traces/ DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/data/pcaps)
+    endif ()
 endif ()


### PR DESCRIPTION
Some Btest tooling under btest/data and btest/scripts is still built if --disable-btest and --disable-btest-pcaps is passed to configure.

This commit adds a check in CMakeList file to ensure that does not happen. It also modifies the configure help to state that --disable-btest-pcaps is redundant if --disable-btest is passed

Resolves #1725 