### PR TITLE
Trivial signedness warning fix

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -2425,8 +2425,7 @@ static bool check_ok_utf8(const unsigned char* start, const unsigned char* end)
 	if ( result != conversionOK )
 		return false;
 
-	if ( ( output[0] >= 0x0000 && output[0] <= 0x001F ) ||
-	     ( output[0] == 0x007F ) ||
+	if ( ( output[0] <= 0x001F ) || ( output[0] == 0x007F ) ||
 	     ( output[0] >= 0x0080 && output[0] <= 0x009F ) )
 		// Control characters
 		return false;


### PR DESCRIPTION
This fixes

```
/home/christian/data/zeek/zeek-master/src/util.cc: In function ‘std::string zeek::util::json_escape_utf8(const string&)’:
/home/christian/data/zeek/zeek-master/src/util.cc:2506:52: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
 2506 |                                 for ( int i = 0; i < char_size; i++ )
      |                                                  ~~^~~~~~~~~~~
```