### PR TITLE
Fix signed integer overflow in PIA on big sequence number holes

### DIFF
--- a/src/analyzer/protocol/pia/PIA.cc
+++ b/src/analyzer/protocol/pia/PIA.cc
@@ -64,7 +64,8 @@ void PIA::AddToBuffer(Buffer* buffer, uint64_t seq, int len, const u_char* data,
 	else
 		buffer->head = buffer->tail = b;
 
-	buffer->size += len;
+	if ( data )
+		buffer->size += len;
 	}
 
 void PIA::AddToBuffer(Buffer* buffer, int len, const u_char* data, bool is_orig,


### PR DESCRIPTION
This patch fixes a signed integer overflow in PIA. When starting a
connection, and then ack-ing ~0x7FFFFFFF (INT32_MAX) bytes, the integer
holding the size of buffered bytes will overflow.

This change simply switches that count to only count bytes that were
actually seen on the wire. In my opinion, this is actually the desired
beavior here - the size is only used to decide if buffering should be
continued, as well as for the output of some debug messages (which, in
my opinion, so far is wrong if there are TCP holes).

This fixes GH-1709. Please see that ticket for more discussion.