### PR TITLE
Allow `-B` flag in non-Debug builds, but ignore it.

### DIFF
--- a/src/Options.cc
+++ b/src/Options.cc
@@ -12,6 +12,8 @@
 #endif
 
 #include <algorithm>
+#include <cstdio>
+#include <cstdlib>
 #include <sstream>
 
 #include "zeek/bsd-getopt-long.h"
@@ -328,10 +330,7 @@ Options parse_cmdline(int argc, char** argv)
 		{"watchdog",		no_argument,		nullptr,	'W'},
 		{"print-id",		required_argument,	nullptr,	'I'},
 		{"status-file",		required_argument,	nullptr,	'U'},
-
-#ifdef	DEBUG
 		{"debug",		required_argument,	nullptr,	'B'},
-#endif
 
 #ifdef	USE_PERFTOOLS_DEBUG
 		{"mem-leaks",	no_argument,		nullptr,	'm'},
@@ -437,11 +436,17 @@ Options parse_cmdline(int argc, char** argv)
 			rval.pcap_output_file = optarg;
 			break;
 
-#ifdef DEBUG
 		case 'B':
+#ifdef DEBUG
 			rval.debug_log_streams = optarg;
-			break;
+#else
+			if ( util::streq(optarg, "help") )
+				{
+					fprintf(stderr,"debug streams unavailable\n");
+					exit(1);
+				}
 #endif
+			break;
 
 		case 'C':
 			rval.ignore_checksums = true;


### PR DESCRIPTION
The `-B` flag allows to enable debug streams in Debug builds. We
previously didn't support passing the flag for other builds. With that
whether an invocation of `zeek` executed or not depended on the way zeek
was built.

With this patch we accept and parse the flag when passed in the
invocation, but ignore any requests for actual debug streams in
non-Debug builds (no streams are available). If `-B help` is passed we
emit a message and abort.