### PR TITLE
Add some additional fixes for ThreadSanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,10 @@ if ( ZEEK_SANITIZERS )
             set(ZEEK_SANITIZERS "${ZEEK_SANITIZERS},")
         endif ()
 
+        if ( _sanitizer STREQUAL "thread" )
+            set(ZEEK_TSAN true)
+        endif ()
+
         if ( NOT _sanitizer STREQUAL "undefined" )
             set(ZEEK_SANITIZERS "${ZEEK_SANITIZERS}${_sanitizer}")
             continue()

--- a/src/input/readers/sqlite/SQLite.cc
+++ b/src/input/readers/sqlite/SQLite.cc
@@ -82,7 +82,9 @@ bool SQLite::DoInit(const ReaderInfo& info, int arg_num_fields, const threading:
 
 	// Allow connections to same DB to use single data/schema cache. Also
 	// allows simultaneous writes to one file.
+#ifndef ZEEK_TSAN
 	sqlite3_enable_shared_cache(1);
+#endif
 
 	if ( Info().mode != MODE_MANUAL )
 		{

--- a/src/logging/writers/sqlite/SQLite.cc
+++ b/src/logging/writers/sqlite/SQLite.cc
@@ -122,7 +122,9 @@ bool SQLite::DoInit(const WriterInfo& info, int arg_num_fields,
 
 	// Allow connections to same DB to use single data/schema cache. Also
 	// allows simultaneous writes to one file.
+#ifndef ZEEK_TSAN
 	sqlite3_enable_shared_cache(1);
+#endif
 
 	num_fields = arg_num_fields;
 	fields = arg_fields;

--- a/src/threading/MsgThread.cc
+++ b/src/threading/MsgThread.cc
@@ -202,7 +202,9 @@ Message::~Message()
 
 MsgThread::MsgThread() : BasicThread(), queue_in(this, nullptr), queue_out(nullptr, this)
 	{
-	cnt_sent_in = cnt_sent_out = 0;
+	cnt_sent_in.store(0);
+	cnt_sent_out.store(0);
+
 	main_finished = false;
 	child_finished = false;
 	child_sent_finish = false;
@@ -457,8 +459,8 @@ void MsgThread::Run()
 
 void MsgThread::GetStats(Stats* stats)
 	{
-	stats->sent_in = cnt_sent_in;
-	stats->sent_out = cnt_sent_out;
+	stats->sent_in = cnt_sent_in.load();
+	stats->sent_out = cnt_sent_out.load();
 	stats->pending_in = queue_in.Size();
 	stats->pending_out = queue_out.Size();
 	queue_in.GetStats(&stats->queue_in_stats);

--- a/src/threading/MsgThread.h
+++ b/src/threading/MsgThread.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "zeek/DebugLogger.h"
 #include "zeek/threading/BasicThread.h"
 #include "zeek/threading/Queue.h"
@@ -335,8 +337,8 @@ private:
 	Queue<BasicInputMessage *> queue_in;
 	Queue<BasicOutputMessage *> queue_out;
 
-	uint64_t cnt_sent_in;	// Counts message sent to child.
-	uint64_t cnt_sent_out;	// Counts message sent by child.
+	std::atomic<uint64_t> cnt_sent_in;	// Counts message sent to child.
+	std::atomic<uint64_t> cnt_sent_out;	// Counts message sent by child.
 
 	bool main_finished;	// Main thread is finished, meaning child_finished propagated back through message queue.
 	bool child_finished;	// Child thread is finished.

--- a/testing/btest/scripts/base/frameworks/logging/sqlite/simultaneous-writes.zeek
+++ b/testing/btest/scripts/base/frameworks/logging/sqlite/simultaneous-writes.zeek
@@ -2,6 +2,10 @@
 #
 # @TEST-REQUIRES: which sqlite3
 # @TEST-REQUIRES: has-writer Zeek::SQLiteWriter
+
+# Don't run this test if we build with '--sanitizers=thread' because we
+# disable the shared cache in that case due to a SQLite bug.
+# @TEST-REQUIRES: grep -q "#define ZEEK_TSAN" zeek-config.h || test $? == 0
 # @TEST-GROUP: sqlite
 #
 # @TEST-EXEC: zeek -b %INPUT
@@ -87,4 +91,3 @@ event zeek_init()
 	Log::write(SSH::LOG, out);
 	Log::write(SSH::LOG2, out);
 }
-

--- a/zeek-config.h.in
+++ b/zeek-config.h.in
@@ -276,13 +276,17 @@ extern const char* BRO_VERSION_FUNCTION();
 	#define ZEEK_LSAN_DISABLE_SCOPE(x)
 #endif
 
+// This part is dependent on calling configure with '--sanitizers=thread'
+// and not manually setting CFLAGS/CXXFLAGS to include --fsanitize=thread.
+// This is because some of the unit tests only work when built without
+// TSan, at least until SQLite opts to fix their problems with atomics.
 #if defined(__SANITIZE_THREAD__)
-	#define ZEEK_TSAN
+	#cmakedefine ZEEK_TSAN
 #endif
 
 #if defined(__has_feature)
 	#if __has_feature(thread_sanitizer)
-		#define ZEEK_TSAN
+		#cmakedefine ZEEK_TSAN
 	#endif
 #endif
 


### PR DESCRIPTION
When reviewing, make sure to look at the commit messages for the two sqlite fixes, as they provide more context for those fixes.