### PR TITLE
Minor updates to the external-testsuite scripts

### DIFF
--- a/testing/external/.gitignore
+++ b/testing/external/.gitignore
@@ -1,5 +1,4 @@
 *.git
 diag.log
-bro-testing*
 zeek-testing*
 .proxy

--- a/testing/external/Makefile
+++ b/testing/external/Makefile
@@ -1,6 +1,6 @@
 
 PUBLIC_REPO=https://github.com/zeek/zeek-testing
-REPOS=`./scripts/find-git-repos `
+REPOS=`./scripts/find-git-repos`
 
 DIAG=diag.log
 

--- a/testing/external/README
+++ b/testing/external/README
@@ -81,19 +81,21 @@ script to set that up:
 
 .. console:
 
-    > ./scripts/create-new-repo <repo-name> <repo-url>
+    > ./scripts/create-new-repo <repo-name> [<repo-url>]
 
-The first argument is the local name of the repository (it will be
-cloned into ``<repo-name>``); and the second is the URL of the git
-repository. The repository will be initialized with a few standard
-directories as well as a skeleton test in ``<name>/tests``. You can
-then edit files as needed. You add trace files by editing
-``Traces/traces.cfg``; see the comments in there. For each trace, you
-also need to calculate a checksum with ``md5sum`` and put it into
-``<url>.md5sum``. The scripts use this to decide if they need to
-redownload the trace. Accordingly, if you update a trace, make sure to
-also recalculate its checksum. Note that the traces will be downloaded
-to ``Traces/`` but must not be added to the git repostiory; there's a
-``.gitignore`` installed to prevent that.
+The first argument is the local name of the repository (it will be initialized
+in a ``<repo-name>`` directory). The second, optional argument is the URL of the
+git repository. The repository will be initialized with a few standard
+directories as well as a skeleton test in ``<name>/tests``. You can then edit
+files as needed. When provided, the remote URL is added as the origin remote.
+The script does not otherwise interact with the remote.
+
+You add trace files by editing ``Traces/traces.cfg``; see the comments in
+there. For each trace, you also need to calculate a checksum with ``md5sum`` and
+put it into ``<url>.md5sum``. The scripts use this to decide if they need to
+redownload the trace. Accordingly, if you update a trace, make sure to also
+recalculate its checksum. Note that the traces will be downloaded to ``Traces/``
+but must not be added to the git repostiory; there's a ``.gitignore`` installed
+to prevent that.
 
 

--- a/testing/external/scripts/create-new-repo
+++ b/testing/external/scripts/create-new-repo
@@ -1,31 +1,26 @@
 #! /usr/bin/env bash
+#
+# Helper script for creating new external testing repos. See the
+# README for details.
 
 cwd=`pwd`
 
-if [ $# != 2 ]; then
-    echo "usage: $0 <name> <dst-repo-dir>"
+if [ -z "$1" ]; then
+    echo "usage: $0 <name> [<dst-repo-url>]"
     exit 1
 fi
 
 name=`pwd`/$1
 repo=$2
 
-if [ -e $repo ]; then
-    echo "$repo already exists, aborting."
-    exit 1
-fi
-
 if [ -e $name ]; then
     echo "$name already exists, aborting."
     exit 1
 fi
 
-mkdir $repo
-( cd $repo && git init --bare )
-
-git clone $repo $name
-
+mkdir $name
 cd $name
+git init
 
 for dir in tests Baseline; do
     mkdir $dir
@@ -42,4 +37,7 @@ cp $cwd/`dirname $0`/skel/.gitignore .
 git add * .gitignore
 
 git commit -m "Repository initialized."
-git push origin master
+
+if [ -n "$repo" ]; then
+    git remote add origin $repo
+fi

--- a/testing/external/subdir-btest.cfg
+++ b/testing/external/subdir-btest.cfg
@@ -21,6 +21,6 @@ DIST=%(testbase)s/../../..
 BUILD=%(testbase)s/../../../build
 ZEEK_PROFILER_FILE=%(testbase)s/.tmp/script-coverage/XXXXXX
 ZEEK_DNS_FAKE=1
-# For fedora 21 - they disable MD5 for certificate verification and need setting an environment variable to permit it.
+# Fedora/CentOS/RedHat have MD5 disabled for certificate verification and need setting an environment variable to permit it:
 OPENSSL_ENABLE_MD5_VERIFY=1
 UBSAN_OPTIONS=print_stacktrace=1


### PR DESCRIPTION
This is a small set of changes in response to me actually trying for the first time to create an external testsuite.  Mainly I found that `create-new-repo` doesn't work as advertised so I tweaked it a bit. Rest is tidying. Let me know if I'm missing something re. that `Baseline` folder — it doesn't seem to do anything in `external`.