### PR TITLE
Add TSval and TSecr to SYN_packet

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -589,6 +589,8 @@ type SYN_packet: record {
 	win_scale: int;	##< The window scale option if present, or -1 if not.
 	MSS: count;	##< The maximum segment size if present, or 0 if not.
 	SACK_OK: bool;	##< True if the *SACK* option is present.
+	TSval: int &optional;	##< The TCP TS value if present.
+	TSecr: int &optional;	##< The TCP TS echo reply if present.
 };
 
 ## Packet capture statistics.  All counts are cumulative.


### PR DESCRIPTION
This PR:
- adds TSval and TSecr to `SYN_packet`
- updates the tests accordingly