### PR TITLE
Added four new opnum mappings for MS-OAUT IDispatch methods

### DIFF
--- a/scripts/base/protocols/dce-rpc/consts.zeek
+++ b/scripts/base/protocols/dce-rpc/consts.zeek
@@ -2197,6 +2197,12 @@ export {
 		["5422fd3a-d4b8-4cef-a12e-e87d4ca22e90",0x08] = "GetCAPropertyInfo",
 		["5422fd3a-d4b8-4cef-a12e-e87d4ca22e90",0x09] = "Ping2",
 
+        # IDispatch - MSDN Ref: OLE Automation Protocol [ms-oaut]
+        ["00020400-0000-0000-c000-000000000046",0x03] = "GetTypeInfoCount",
+        ["00020400-0000-0000-c000-000000000046",0x04] = "GetTypeInfo",
+        ["00020400-0000-0000-c000-000000000046",0x05] = "GetIDsOfNames",
+        ["00020400-0000-0000-c000-000000000046",0x06] = "Invoke",
+
 		# IDMNotify - MSDN Ref: Disk Mgmt Remote Protocol [ms-dmrp]
 		["d2d79df7-3400-11d0-b40b-00aa005ff586",0x00] = "ObjectsChanged",
 


### PR DESCRIPTION
Added four new mappings for the OLE Automation Protocol to be included in the `dce_rpc.log` output, according to the opnums listed on https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-oaut/ac9c502b-ac1c-4202-8ad4-048ac98afcc9. These operations are interesting since they may be an indication for command execution over DCOM.
