### PR TITLE
Use `brew update` instead of `brew update-reset` in CI macOS prepare script

### DIFF
--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -5,6 +5,6 @@ sysctl hw.model hw.machine hw.ncpu hw.physicalcpu hw.logicalcpu
 set -e
 set -x
 
-brew update-reset
+brew update
 brew upgrade cmake openssl
 brew install swig bison


### PR DESCRIPTION
Using `brew update-reset` causes homebrew to reset to homebrew's HEAD commit, which may be buggy and broken. This is currently the case on the homebrew repo, and it's causing all of our macOS builds to fail.

It appears whatever Cirrus was doing previously on their Catalina VM is no longer a problem, and so update-reset isn't required anymore. Switch to `brew update` to make sure we still get newer versions of the packages, but is actually a versioned release of homebrew.

This PR is just to verify that everything on CI is kosher on a full build, and I'll cherry-pick it directly into `master`, `release/4.0`, and `release/4.1`.