### PR TITLE
Avoid allocation of 0 length strings on new conns

### DIFF
--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -271,7 +271,8 @@ const RecordValPtr& Connection::GetVal()
 
 	conn_val->AssignTime(3, start_time); // ###
 	conn_val->AssignInterval(4, last_time - start_time);
-	conn_val->Assign(6, history);
+	if ( history.size() )
+		conn_val->Assign(6, history);
 
 	conn_val->SetOrigin(this);
 


### PR DESCRIPTION
New connections already do

    conn_val->Assign(6, val_mgr->EmptyString());

This second assignment was effectively doing

    conn_val->Assign(6, "")

for all new connections, causing a new empty ZeekString to be allocated.

On a pcap containing 100% syn packets this gives a noticeable perf improvement.

    Benchmark #1: zeek.orig -r /data/pcaps/scan.pcap
      Time (mean ± σ):     47.082 s ±  0.547 s    [User: 57.555 s, System: 9.114 s]
      Range (min … max):   46.516 s … 47.834 s    5 runs

    Benchmark #2: zeek -r /data/pcaps/scan.pcap
      Time (mean ± σ):     45.260 s ±  0.378 s    [User: 55.438 s, System: 8.537 s]
      Range (min … max):   44.783 s … 45.789 s    5 runs

    Summary
      'zeek -r /data/pcaps/scan.pcap' ran
        1.04 ± 0.01 times faster than 'zeek.orig -r /data/pcaps/scan.pcap'