### PR TITLE
Fixing homebrew, again.

### DIFF
--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -6,5 +6,5 @@ set -e
 set -x
 
 brew update
-brew upgrade cmake openssl
+brew upgrade cmake openssl@1.1
 brew install swig bison


### PR DESCRIPTION
Homebrew has apparently decided that you have to explicitly specify the version of openssl you're upgrading, even though it's never required that before. This, of course, breaks our CI workflow. Thanks Homebrew.