### PR TITLE
Add .dockerignore to suppress btest artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/.tmp
+**/.btest.failed.dat
+**/diag.log


### PR DESCRIPTION
We run btest in CI between image build and upload, and since its artifacts
weren't suppressed, the discrepancy caused the Dockerfile COPY to cache-miss.