### PR TITLE
Fix issue with broken libpcaps that return repeat packets

### DIFF
--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -247,6 +247,14 @@ bool PcapSource::ExtractNextPacket(Packet* pkt)
 	++stats.received;
 	stats.bytes_received += header->len;
 
+	// Some versions of libpcap (myricom) are somewhat broken and will return a duplicate
+	// packet if there are no more packets available. Namely, it returns the exact same
+	// packet structure (including the header) out of the library without reinitializing
+	// any of the values. If we set the header lengths to zero here, we can keep from
+	// processing it a second time.
+	header->len = 0;
+	header->caplen = 0;
+
 	return true;
 	}
 


### PR DESCRIPTION
This is apparently a problem with the Myricom version of libpcap, where
instead of returning a null or a zero if no packets are available, it
returns the previous packet. This causes Zeek to improperly parse the
packet and crash. We thought we had fixed this previously with a check
for a null packet but that fix was not enough.

Thank you to @JustinAzoff for this fix and to a couple of users for testing it.