### PR TITLE
GHI-1766: Remove address from Site::private_address_space that converts into 0.0.0.0/0

### DIFF
--- a/scripts/base/utils/site.zeek
+++ b/scripts/base/utils/site.zeek
@@ -87,8 +87,6 @@ export {
 		[::]/128,
 		# Loopback Address, see :rfc:`4291`
 		[::1]/128,
-		# IPv4-mapped Address, see :rfc:`4291`
-		[::ffff:0:0]/96,
 		# IPv4-IPv6 Translation, see :rfc:`8215`
 		[64:ff9b:1::]/48,
 		# Discard-Only Address Block, see :rfc:`6666`


### PR DESCRIPTION
This address was added in https://github.com/zeek/zeek/commit/632182d1a9cfa3cf5f030ff7d7dd1555fba04e7c. Unfortunately it automatically converts to 0.0.0.0/0 which effectively adds all of the ipv4 space to the list of private addresses. The conversion looks like it's doing the correct thing, so this PR just removes the address from the list.

Fixes #1766
