### PR TITLE
Bump highwayhash submodule to pull in another FreeBSD header fix

### DIFF
--- a/ci/debian-9-32bit/Dockerfile
+++ b/ci/debian-9-32bit/Dockerfile
@@ -2,6 +2,10 @@ FROM i386/debian:9
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 221001
+
 RUN apt-get update && apt-get -y install \
     git \
     cmake \

--- a/ci/debian-9/Dockerfile
+++ b/ci/debian-9/Dockerfile
@@ -2,6 +2,10 @@ FROM debian:9
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 221001
+
 RUN apt-get update && apt-get -y install \
     git \
     cmake \

--- a/ci/freebsd/prepare.sh
+++ b/ci/freebsd/prepare.sh
@@ -7,6 +7,7 @@ set -x
 
 env ASSUME_ALWAYS_YES=YES pkg bootstrap
 pkg install -y bash git cmake swig bison python3 base64
+pkg upgrade -y curl
 pyver=`python3 -c 'import sys; print(f"py{sys.version_info[0]}{sys.version_info[1]}")'`
 pkg install -y $pyver-sqlite3 $pyver-pip
 pip install junit2html


### PR DESCRIPTION
@leres noticed another header include ordering problem in Highwayhash that broke the build on recent FreeBSD 14's, and got it fixed upstream. This pulls us up to their latest to include this fix (and an unrelated OpenBSD issue that seems fine for us to include).

I'll add this to the backport pile for the next round.