### PR TITLE
CI tweaks: fix private testsuite in forks, FreeBSD 11.4 -> 14.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -227,6 +227,20 @@ macos_catalina_task:
   << : *MACOS_RESOURCES_TEMPLATE
 
 # FreeBSD EOL timelines: https://www.freebsd.org/security/security.html#sup
+freebsd14_task:
+  freebsd_instance:
+    # We don't support FreeBSD 14 yet, this is a purely informative task
+    image_family: freebsd-14-0-snap
+    cpu: 8
+    # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
+    memory: 8GB
+
+    allow_failures: true
+    skip_notification: true
+
+  prepare_script: ./ci/freebsd/prepare.sh
+  << : *CI_TEMPLATE
+
 freebsd13_task:
   freebsd_instance:
     # FreeBSD 13 EOL: January 31, 2026
@@ -241,16 +255,6 @@ freebsd12_task:
   freebsd_instance:
     # FreeBSD 12 EOL: June 30, 2024
     image_family: freebsd-12-2
-    cpu: 8
-    # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
-    memory: 8GB
-  prepare_script: ./ci/freebsd/prepare.sh
-  << : *CI_TEMPLATE
-
-freebsd11_task:
-  freebsd_instance:
-    # FreeBSD 11 EOL: September 30, 2021
-    image_family: freebsd-11-4
     cpu: 8
     # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
     memory: 8GB

--- a/ci/init-external-repos.sh
+++ b/ci/init-external-repos.sh
@@ -31,9 +31,10 @@ fi
 make update-traces
 cd ..
 
+# When running in Cirrus for the main repo, try to clone the private testsuite.
 # Note that this script is also called when populating the public cache, so
 # the zeek-testing-private dir could have been created/populated already.
-if [[ -n "${CIRRUS_CI}" ]] && [[ ! -d zeek-testing-private ]]; then
+if [[ -n "${CIRRUS_CI}" ]] && [[ "${CIRRUS_REPO_OWNER}" == "zeek" ]] && [[ ! -d zeek-testing-private ]]; then
     # If we're running this on Cirrus, the SSH key won't be available to PRs,
     # so don't make any of this fail the task in that case.  (But technically,
     # the key is also available in PRs for people with write access to the


### PR DESCRIPTION
The `ci/init-external-repos.sh` script currently breaks builds in external forks of the Zeek tree because cloning the private testsuite fails. We now skip this part altogether if the repo owner (ie. the org) is not `zeek` — according to my understanding encrypted variables can only ever work in the repo they were set up in, anyway.

FreeBSD 11.4 is now EOL (see https://www.freebsd.org/security/#sup) so let's drop it from CI. I think it makes sense to start running 14.0 snapshots instead. Since 14.0 isn't released yet we don't want to support it, so the build is informational and failure won't break otherwise successful runs.