### PR TITLE
Apply some missing clang-format changes

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -4328,8 +4328,7 @@ InExpr::InExpr(ExprPtr arg_op1, ExprPtr arg_op2)
 			return;
 			}
 
-		if ( op2->GetType()->Tag() == TYPE_TABLE &&
-		     op2->GetType()->AsTableType()->IsSubNetIndex() )
+		if ( op2->GetType()->Tag() == TYPE_TABLE && op2->GetType()->AsTableType()->IsSubNetIndex() )
 			{
 			SetType(base_type(TYPE_BOOL));
 			return;

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -1696,7 +1696,7 @@ bool DNS_Interpreter::ParseRR_CAA(detail::DNS_MsgInfo* msg, const u_char*& data,
 	}
 
 bool DNS_Interpreter::ParseRR_SVCB(detail::DNS_MsgInfo* msg, const u_char*& data, int& len,
-								   int rdlength, const u_char* msg_start, const RR_Type& svcb_type)
+                                   int rdlength, const u_char* msg_start, const RR_Type& svcb_type)
 	{
 	const u_char* data_start = data;
 	// the smallest SVCB/HTTPS rr is 3 bytes:
@@ -1721,12 +1721,13 @@ bool DNS_Interpreter::ParseRR_SVCB(detail::DNS_MsgInfo* msg, const u_char*& data
 		{
 		target_name[0] = '.';
 		target_name[1] = '\0';
-		name_end = target_name+1;
+		name_end = target_name + 1;
 		}
 
 	SVCB_DATA svcb_data = {
 		.svc_priority = svc_priority,
-		.target_name = make_intrusive<StringVal>(new String(target_name, name_end - target_name, true)),
+		.target_name = make_intrusive<StringVal>(
+			new String(target_name, name_end - target_name, true)),
 	};
 
 	// TODO: parse svcparams
@@ -1735,21 +1736,22 @@ bool DNS_Interpreter::ParseRR_SVCB(detail::DNS_MsgInfo* msg, const u_char*& data
 	std::ptrdiff_t parsed_bytes = data - data_start;
 	if ( parsed_bytes < rdlength )
 		{
-		len -= ( rdlength - parsed_bytes );
-		data += ( rdlength - parsed_bytes );
+		len -= (rdlength - parsed_bytes);
+		data += (rdlength - parsed_bytes);
 		}
 
-	switch( svcb_type )
+	switch ( svcb_type )
 		{
 		case detail::TYPE_SVCB:
 			analyzer->EnqueueConnEvent(dns_SVCB, analyzer->ConnVal(), msg->BuildHdrVal(),
-									msg->BuildAnswerVal(), msg->BuildSVCB_Val(svcb_data));
+			                           msg->BuildAnswerVal(), msg->BuildSVCB_Val(svcb_data));
 			break;
 		case detail::TYPE_HTTPS:
 			analyzer->EnqueueConnEvent(dns_HTTPS, analyzer->ConnVal(), msg->BuildHdrVal(),
-									msg->BuildAnswerVal(), msg->BuildSVCB_Val(svcb_data));
+			                           msg->BuildAnswerVal(), msg->BuildSVCB_Val(svcb_data));
 			break;
-		default: break; // unreachable. for suppressing compiler warnings.
+		default:
+			break; // unreachable. for suppressing compiler warnings.
 		}
 	return true;
 	}

--- a/src/analyzer/protocol/dns/DNS.h
+++ b/src/analyzer/protocol/dns/DNS.h
@@ -71,7 +71,9 @@ enum RR_Type
 	TYPE_DS = 43, ///< Delegation signer (RFC 4034)
 	TYPE_NSEC3 = 50,
 	TYPE_NSEC3PARAM = 51, ///< Contains the NSEC3 parameters (RFC 5155)
-	TYPE_SVCB = 64, ///< SerViCe Binding (RFC draft: https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-07#section-1.1)
+	TYPE_SVCB =
+	64, ///< SerViCe Binding (RFC draft:
+	    ///< https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-07#section-1.1)
 	TYPE_HTTPS = 65, ///< HTTPS record (HTTPS specific SVCB resource record)
 	// Obsoleted
 	TYPE_SPF = 99, ///< Alternative: storing SPF data in TXT records, using the same format (RFC
@@ -150,7 +152,8 @@ enum DNSSEC_Digest
 	SHA384 = 4,
 	};
 
-///< all keys are defined in RFC draft https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-07#section-14.3.2
+///< all keys are defined in RFC draft
+///< https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-07#section-14.3.2
 enum SVCPARAM_Key
 	{
 	mandatory = 0,
@@ -415,7 +418,7 @@ protected:
 	bool ParseRR_LOC(detail::DNS_MsgInfo* msg, const u_char*& data, int& len, int rdlength,
 	                 const u_char* msg_start);
 	bool ParseRR_SVCB(detail::DNS_MsgInfo* msg, const u_char*& data, int& len, int rdlength,
-	                 const u_char* msg_start, const RR_Type& svcb_type);
+	                  const u_char* msg_start, const RR_Type& svcb_type);
 	void SendReplyOrRejectEvent(detail::DNS_MsgInfo* msg, EventHandlerPtr event,
 	                            const u_char*& data, int& len, String* question_name,
 	                            String* original_name);

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -21,12 +21,17 @@ enum IPFamily
 	IPv6
 	};
 
+// Force these files to stay in this order. Normally, clang-format
+// wants to move sys/types.h to the end of this block, but that
+// breaks FreeBSD builds.
+// clang-format off
 #include <sys/types.h>
 #include <arpa/inet.h>
 #include <assert.h>
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
 #include <netinet/ip.h>
+// clang-format on
 #ifdef HAVE_LINUX
 #define __FAVOR_BSD
 #endif


### PR DESCRIPTION
Some of these are from a recent third-party PR where clang-format wasn't applied to the changes.