### PR TITLE
GH-693: use pcap_dump_open_append where supported

### DIFF
--- a/src/iosource/pcap/Dumper.cc
+++ b/src/iosource/pcap/Dumper.cc
@@ -68,11 +68,15 @@ void PcapDumper::Open()
 
 	else
 		{
+#ifdef HAVE_PCAP_DUMP_OPEN_APPEND
+		dumper = pcap_dump_open_append(pd, props.path.c_str());
+#else
 		// Old file and we need to append, which, unfortunately,
 		// is not supported by libpcap. So, we have to hack a
-		// little bit, knowing that pcap_dumpter_t is, in fact,
+		// little bit, knowing that pcap_dumper_t is, in fact,
 		// a FILE ... :-(
 		dumper = (pcap_dumper_t*)fopen(props.path.c_str(), "a");
+#endif
 		if ( ! dumper )
 			{
 			Error(util::fmt("can't open dump %s: %s", props.path.c_str(), strerror(errno)));

--- a/testing/btest/bifs/dump_current_packet.zeek
+++ b/testing/btest/bifs/dump_current_packet.zeek
@@ -5,6 +5,10 @@
 # @TEST-EXEC: btest-diff 1.hex
 # @TEST-EXEC: btest-diff 2.hex
 
+# Run the same test a second time, which will try to write to an
+# existing file and shouldn't crash a sanitizer build.
+# @TEST-EXEC: zeek -b -r $TRACES/wikipedia.trace %INPUT
+
 # Note that the hex output will contain global pcap header information,
 # including Zeek's snaplen setting (so maybe check that out in the case
 # you are reading this message due to this test failing in the future).

--- a/zeek-config.h.in
+++ b/zeek-config.h.in
@@ -49,6 +49,9 @@
 /* Define if you have the <pcap-int.h> header file. */
 #cmakedefine HAVE_PCAP_INT_H
 
+/* Define if libpcap supports pcap_dump_open_append(). */
+#cmakedefine HAVE_PCAP_DUMP_OPEN_APPEND
+
 /* line editing & history powers */
 #cmakedefine HAVE_READLINE
 


### PR DESCRIPTION
This PR adds support for `pcap_dump_open_append` on platforms where libpcap has that method. This mitigates a hack that introduces some undefined behavior on certain platforms. I would have removed the `fopen` hack altogether, except that we still support CentOS 7 which has an old enough libpcap to not have this method.

Fixes #693

There's a branch in the cmake repo that needs to be merged when this PR is merged.