### PR TITLE
CI updates: Fedora 35, macOS Monterey/Catalina, no docker push in forks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -219,16 +219,16 @@ alpine_task:
 
 # Apple doesn't publish official long-term support timelines.
 # We aim to support both the current and previous macOS release.
-macos_big_sur_task:
+macos_monterey_task:
   macos_instance:
-    image: big-sur-xcode-12.5
+    image: monterey-xcode-13.1
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_RESOURCES_TEMPLATE
 
-macos_catalina_task:
+macos_big_sur_task:
   macos_instance:
-    image: catalina-xcode
+    image: big-sur-xcode-12.5
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_RESOURCES_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -93,6 +93,13 @@ env:
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
+fedora35_task:
+  container:
+    # Fedora 35 EOL: Around Dec 2022
+    dockerfile: ci/fedora-35/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
 fedora34_task:
   container:
     # Fedora 34 EOL: Around May 2022

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,7 @@ jobs:
       # Create and boot a loader. This will e.g., provide caching
       # so we avoid rebuilds of the same image after this step.
       - uses: docker/setup-buildx-action@v1
+
       - name: Build
         uses: docker/build-push-action@v2
         with:
@@ -43,6 +44,7 @@ jobs:
       - name: Get version
         id: version
         run: echo "::set-output name=RELEASE_VERSION::$(cat VERSION)"
+
       - name: Compute target tag
         id: target
         env:
@@ -65,15 +67,16 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        # Secrets for the login are not available for pull requests.
-        if: github.event_name == 'push'
+        # Don't publish on forks. Also note that secrets for the login are not
+        # available for pull requests, so trigger on pushes only.
+        if: github.repository == 'zeek/zeek' && github.event_name == 'push'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push
         # Only publish if we did compute a tag.
-        if: github.event_name == 'push' && steps.target.outputs.tag != ''
+        if: github.repository == 'zeek/zeek' && github.event_name == 'push' && steps.target.outputs.tag != ''
         uses: docker/build-push-action@v2
         with:
           context: ./

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -10,6 +10,11 @@ set -x
 # some problems with Catalina specifically, but it doesn't break anything on Big Sur either.
 if [[ "${CIRRUS_OS}" == "darwin" ]]; then
     export ZEEK_CI_CONFIGURE_FLAGS="${ZEEK_CI_CONFIGURE_FLAGS} --osx-sysroot=$(xcrun --show-sdk-path)"
+
+    # Starting with Monterey & Xcode 13.1 we need to help it find OpenSSL
+    if [ -d /usr/local/opt/openssl@1.1/lib/pkgconfig ]; then
+        export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig
+    fi
 fi
 
 if [[ "${ZEEK_CI_CREATE_ARTIFACT}" != "1" ]]; then

--- a/ci/fedora-35/Dockerfile
+++ b/ci/fedora-35/Dockerfile
@@ -1,0 +1,23 @@
+FROM fedora:35
+
+RUN dnf -y install \
+    bison \
+    cmake \
+    diffutils \
+    findutils \
+    flex \
+    git \
+    gcc \
+    gcc-c++ \
+    libpcap-devel \
+    make \
+    openssl-devel \
+    python3-devel \
+    python3-pip\
+    sqlite \
+    swig \
+    which \
+    zlib-devel \
+  && dnf clean all && rm -rf /var/cache/dnf
+
+RUN pip3 install junit2html


### PR DESCRIPTION
Let me know if the tweak to `ci/build.sh` looks okay to you. Without it, the build fails on Monterey because it cannot find an OpenSSL development environment.

Also, I noticed that in my personal fork of Zeek the Github action for our docker builds still tried to push to Docker Hub, so I'm adding `if`s to ensure this happens only in the main repo.