### PR TITLE
GH-1819: Handle recursive types when describing type in binary mode

### DIFF
--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1326,9 +1326,14 @@ void RecordType::DescribeFields(ODesc* d) const
 			d->AddCount(types->length());
 			for ( const auto& type : *types )
 				{
-				type->type->Describe(d);
-				d->SP();
 				d->Add(type->id);
+				d->SP();
+
+				if ( d->FindType(type->type.get()) )
+					d->Add("<recursion>");
+				else
+					type->type->Describe(d);
+
 				d->SP();
 				}
 			}

--- a/testing/btest/core/recursive-types.zeek
+++ b/testing/btest/core/recursive-types.zeek
@@ -1,0 +1,22 @@
+# @TEST-EXEC: zeek -b %INPUT
+
+# global_ids() here contains some types that are recursive, in that
+# arguments to functions contain chained references to the type that
+# defines the function. This tests that we don't crash when
+# attempting to call Describe() on those types in binary-mode.
+event zeek_init()
+	{
+	local sh: string = "";
+	local gi =  global_ids();
+        for (myfunc in gi)
+		{
+		if(gi[myfunc]?$value)
+			{
+			if(strstr(myfunc,"lambda") > 0)
+				{
+				sh = sha256_hash(gi[myfunc]$value);
+				print(sh);
+				}
+			}
+		}
+	}


### PR DESCRIPTION
This slightly changes the output when describing the fields of a `RecordType` in non-human-readable format, but it properly detects and avoids recursion issues when describing those types.

Fixes #1819 