### PR TITLE
Install include headers from `src/3rdparty/`.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -620,6 +620,13 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/
 )
 
 install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/ConvertUTF.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/bro_inet_ntop.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/bsd-getopt-long.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/modp_numtoa.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/nb_dns.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/patricia.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/setsignal.h
         ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/sqlite3.h
         DESTINATION include/zeek/3rdparty
 )


### PR DESCRIPTION
This is a fixup commit for 72cbc7cd13b7c1bda98658104431c3b530ff68d6
where we move some header files from `src/` to `src/3rdparty/` but
missed adding install rules for these header. Since some of these
headers are exposed in installed headers they need to be installed as
well.