### PR TITLE
Clean up fully after successful Docker btests

### DIFF
--- a/docker/btest/Makefile
+++ b/docker/btest/Makefile
@@ -1,11 +1,11 @@
 DIAG=diag.log
 BTEST=../../auxil/btest/btest
 
-all: cleanup btest-verbose
+all: btest-verbose clean
 
 # Showing all tests.
 btest-verbose:
 	@$(BTEST) -d -j -f $(DIAG)
 
-cleanup:
-	@rm -f $(DIAG)
+clean:
+	@rm -rf $(DIAG) .tmp .btest.failed.dat


### PR DESCRIPTION
This is a deja-vu because I know we've fixed this before — or meant to. In our Docker build setup, the btests run after the image build and before the push of the image to the remote repo. If Docker detects a difference in the source tree, the push will trigger a full rebuild of the image (costing another ~20 mins). Whenever btest leaves artifacts around after a successful test, this happens. (It's okay if it leaves stuff around after a failing test, because the image push won't happen then, and we want to collect artifacts.)

This tightens the list of things we clean up, and moves the cleanup _after_ the image build. Example: https://github.com/zeek/zeek/runs/4231747375?check_suite_focus=true
