### PR TITLE
Trimming C++ script compilation

### DIFF
--- a/src/script_opt/CPP/Inits.cc
+++ b/src/script_opt/CPP/Inits.cc
@@ -240,6 +240,9 @@ void CPPCompile::GenStandaloneActivation()
 
 	for ( const auto& func : funcs )
 		{
+		if ( func.ShouldSkip() )
+			continue;
+
 		auto f = func.Func();
 		auto fname = BodyName(func);
 		auto bname = Canonicalize(fname.c_str()) + "_zf";

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -382,19 +382,6 @@ static void generate_CPP(std::unique_ptr<ProfileFuncs>& pfs)
 
 	auto hm = std::make_unique<CPPHashManager>(hash_name.c_str());
 
-	if ( analysis_options.gen_CPP )
-		{
-		if ( analysis_options.only_func )
-			{ // deactivate all functions except the target one
-			for ( auto& func : funcs )
-				{
-				auto fn = func.Func()->Name();
-				if ( *analysis_options.only_func != fn )
-					func.SetSkip(true);
-				}
-			}
-		}
-
 	const auto gen_name = hash_dir + "CPP-gen.cc";
 	const auto addl_name = hash_dir + "CPP-gen-addl.h";
 
@@ -550,6 +537,19 @@ void analyze_scripts()
 	     ! analysis_options.report_CPP && ! analysis_options.use_CPP )
 		// No work to do, avoid profiling overhead.
 		return;
+
+	if ( analysis_options.gen_CPP )
+		{
+		if ( analysis_options.only_func )
+			{ // deactivate all functions except the target one
+			for ( auto& func : funcs )
+				{
+				auto fn = func.Func()->Name();
+				if ( *analysis_options.only_func != fn )
+					func.SetSkip(true);
+				}
+			}
+		}
 
 	// Now that everything's parsed and BiF's have been initialized,
 	// profile the functions.

--- a/src/script_opt/ZAM/Ops.in
+++ b/src/script_opt/ZAM/Ops.in
@@ -1099,7 +1099,7 @@ eval	auto v = frame[z.v2].double_val;
 		ZAM_run_time_error(z.loc, "underflow converting double to count");
 		break;
 		}
-	if ( v > UINT64_MAX )
+	if ( v > static_cast<double>(UINT64_MAX) )
 		{
 		ZAM_run_time_error(z.loc, "overflow converting double to count");
 		break;

--- a/src/script_opt/ZAM/Stmt.cc
+++ b/src/script_opt/ZAM/Stmt.cc
@@ -379,6 +379,13 @@ const ZAMStmt ZAMCompiler::GenCond(const Expr* e, int& branch_v)
 	else
 		branch_v = 2;
 
+// clang 10 gets perturbed that the indentation of the "default" in the
+// following switch block doesn't match that of the cases that we include
+// from "ZAM-Conds.h".  It really shouldn't worry about indentation mismatches
+// across included files since those are not indicative of possible
+// logic errors, but Oh Well.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmisleading-indentation"
 	switch ( e->Tag() )
 		{
 #include "ZAM-Conds.h"
@@ -386,6 +393,7 @@ const ZAMStmt ZAMCompiler::GenCond(const Expr* e, int& branch_v)
 		default:
 			reporter->InternalError("bad expression type in ZAMCompiler::GenCond");
 		}
+#pragma GCC diagnostic pop
 
 	// Not reached.
 	}


### PR DESCRIPTION
This PR leverages the now-merged reworking of how compiled-to-C++ scripts are initialized to greatly reduce the quantity of such initializations when doing partial compilation (such as via `--optimize-only=XYZ`).  The PR also includes tweaks to address a couple of Clang 10 warnings that Johanna flagged.  These are unrelated (they're in the ZAM code rather than the CPP code) but so simple that it seemed convenient enough to just bundle them here.