### PR TITLE
Fix a number of Coverity findings

### DIFF
--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -501,6 +501,11 @@ bool CompositeHash::SingleValHash(HashKey& hk, const Val* v, Type* bt, bool type
 			return true;
 		}
 
+	// All of the rest of the code here depends on v not being null, since it needs
+	// to get values from it.
+	if ( ! v )
+		return false;
+
 	switch ( t )
 		{
 		case TYPE_INTERNAL_INT:
@@ -695,7 +700,7 @@ bool CompositeHash::SingleValHash(HashKey& hk, const Val* v, Type* bt, bool type
 			}
 			break;
 
-		case TYPE_INTERNAL_ERROR:
+		default:
 			return false;
 		}
 

--- a/src/packet_analysis/protocol/gtpv1/gtpv1-analyzer.pac
+++ b/src/packet_analysis/protocol/gtpv1/gtpv1-analyzer.pac
@@ -610,7 +610,9 @@ connection GTPv1_Conn(zeek_analyzer: ZeekPacketAnalyzer)
 	%}
 
 	%init{
-		valid_orig = valid_resp = false;
+		valid_orig = false;
+		valid_resp = false;
+		packet = nullptr;
 	%}
 
 	function valid(orig: bool): bool

--- a/src/packet_analysis/protocol/tcp/TCPSessionAdapter.cc
+++ b/src/packet_analysis/protocol/tcp/TCPSessionAdapter.cc
@@ -422,7 +422,7 @@ static zeek::RecordValPtr build_syn_packet_val(bool is_orig, const zeek::IP_Hdr*
 	if ( TSval )
 		v->Assign(8, *TSval);
 
-	if ( TSval )
+	if ( TSecr )
 		v->Assign(9, *TSecr);
 
 	return v;

--- a/src/script_opt/ZAM/ZInst.h
+++ b/src/script_opt/ZAM/ZInst.h
@@ -64,9 +64,9 @@ public:
 		}
 
 	// Create a stub instruction that will be populated later.
-	ZInst() { }
+	ZInst() = default;
 
-	virtual ~ZInst() { }
+	virtual ~ZInst() = default;
 
 	// Methods for printing out the instruction for debugging/maintenance.
 	void Dump(bro_uint_t inst_num, const FrameReMap* mappings) const;
@@ -93,8 +93,8 @@ public:
 	// Returns a string describing the constant.
 	std::string ConstDump() const;
 
-	ZOp op;
-	ZAMOpType op_type;
+	ZOp op = OP_NOP;
+	ZAMOpType op_type = OP_X;
 
 	// Usually indices into frame, though sometimes hold integer constants.
 	// When an instruction has both frame slots and integer constants,


### PR DESCRIPTION
1466460: Uninitialized field in gtp-analyzer.pac
1462465: Null pointer dereference in CompositeHash::SingleValHash
1462463: Copy/paste error in TCPSessionAdapter::build_syn_packet_val
1462067: Uninitialized fields in Zinst