### PR TITLE
GH-1873: Deprecate the tag types differently to avoid type clashes

### DIFF
--- a/src/Tag.cc
+++ b/src/Tag.cc
@@ -62,7 +62,7 @@ Tag& Tag::operator=(const Tag& other)
 	return *this;
 	}
 
-Tag& Tag::operator=(const Tag&& other) noexcept
+Tag& Tag::operator=(Tag&& other) noexcept
 	{
 	if ( this != &other )
 		{

--- a/src/Tag.h
+++ b/src/Tag.h
@@ -19,19 +19,19 @@ class EnumType;
 using EnumTypePtr = IntrusivePtr<EnumType>;
 
 /**
- * Class to identify an analyzer type.
+ * Class to identify an plugin component type.
  *
- * Each analyzer type gets a tag consisting of a main type and subtype. The
- * former is an identifier that's unique across all analyzer classes. The latter is
- * passed through to the analyzer instances for their use, yet not further
- * interpreted by the analyzer infrastructure; it allows an analyzer to
- * branch out into a set of sub-analyzers internally. Jointly, main type and
- * subtype form an analyzer "tag". Each unique tag corresponds to a single
- * "analyzer" from the user's perspective. At the script layer, these tags
- * are mapped into enums of type \c Analyzer::Tag or Files::Tag. Internally,
- * the analyzer::Manager and file_analysis::Manager maintain the mapping of tag
- * to analyzer (and it also assigns them their main types), and
- * analyzer::Component and file_analysis::Component create new tag.
+ * Each component type gets a tag consisting of a main type and subtype. The
+ * former is an identifier that's unique across all component classes. The latter is
+ * passed through to the component instances for their use, yet not further
+ * interpreted by the component infrastructure; it allows a component to
+ * branch out into a set of sub-components internally. Jointly, main type and
+ * subtype form a component "tag". Each unique tag corresponds to a single
+ * "component" from the user's perspective. At the script layer, these tags
+ * are mapped into enums of type \c Component::Tag or Files::Tag. Internally,
+ * the component::Manager and file_analysis::Manager maintain the mapping of tag
+ * to component (and it also assigns them their main types), and
+ * component::Component and file_analysis::Component create new tag.
  *
  * The Tag class supports all operations necessary to act as an index in a
  * \c std::map.
@@ -40,12 +40,12 @@ class Tag
 	{
 public:
 	/**
-	 * Type for the analyzer's main type.
+	 * Type for the component's main type.
 	 */
 	using type_t = uint32_t;
 
 	/**
-	 * Type for the analyzer's subtype.
+	 * Type for the component's subtype.
 	 */
 	using subtype_t = uint32_t;
 
@@ -73,7 +73,7 @@ public:
 	 * @param type The main type. Note that the manager class manages the
 	 * the value space internally, so noone else should assign main types.
 	 *
-	 * @param subtype The sub type, which is left to an analyzer for
+	 * @param subtype The sub type, which is left to a component for
 	 * interpretation. By default it's set to zero.
 	 */
 	Tag(const EnumTypePtr& etype, type_t type, subtype_t subtype = 0);
@@ -81,11 +81,11 @@ public:
 	/**
 	 * Constructor.
 	 *
-	 * @param type The main type. Note that the \a analyzer::Manager
+	 * @param type The main type. Note that the \a component::Manager
 	 * manages the value space internally, so noone else should assign
 	 * any main types.
 	 *
-	 * @param subtype The sub type, which is left to an analyzer for
+	 * @param subtype The sub type, which is left to an component for
 	 * interpretation. By default it's set to zero.
 	 */
 	explicit Tag(type_t type, subtype_t subtype = 0);
@@ -93,7 +93,7 @@ public:
 	/**
 	 * Constructor.
 	 *
-	 * @param val An enum value of script type \c Analyzer::Tag.
+	 * @param val An enum value of script type \c Component::Tag.
 	 */
 	explicit Tag(EnumValPtr val);
 
@@ -105,7 +105,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	virtual ~Tag();
+	~Tag();
 
 	/**
 	 * Assignment operator.
@@ -115,7 +115,7 @@ public:
 	/**
 	 * Move assignment operator.
 	 */
-	Tag& operator=(const Tag&& other) noexcept;
+	Tag& operator=(Tag&& other) noexcept;
 
 	/**
 	 * Compares two tags for equality.
@@ -157,7 +157,7 @@ public:
 
 	/**
 	 * Returns false if the tag represents an error value rather than a
-	 * legal analyzer type.
+	 * legal component type.
 	 */
 	explicit operator bool() const { return *this != Error; }
 

--- a/src/analyzer/Tag.h
+++ b/src/analyzer/Tag.h
@@ -4,11 +4,149 @@
 
 #include "zeek/zeek-config.h"
 
+#include <string>
+
 #include "zeek/Tag.h"
+#include "zeek/Val.h"
 
 namespace zeek::analyzer
 	{
 
-using Tag [[deprecated("Remove in v5.1. Use zeek::Tag.")]] = zeek::Tag;
+/**
+ * This class implements a wrapper around zeek::Tag , presenting the same interface as that
+ * member object. It previously implemented a full tag object for this type of plugin
+ * component, but that functionality was merged into zeek::Tag and the separate tag types were
+ * deprecated. This class will eventually be removed per the Zeek deprecation policy.
+ */
+class [[deprecated("Remove in v5.1. Use zeek::Tag.")]] Tag
+	{
+public:
+	/**
+	 * Type for the component's main type.
+	 */
+	using type_t = zeek::Tag::type_t;
+
+	/**
+	 * Type for the component's subtype.
+	 */
+	using subtype_t = zeek::Tag::subtype_t;
+
+	/**
+	 * Returns the tag's main type.
+	 */
+	zeek::Tag::type_t Type() const { return tag.Type(); }
+
+	/**
+	 * Returns the tag's subtype.
+	 */
+	zeek::Tag::subtype_t Subtype() const { return tag.Subtype(); }
+
+	/**
+	 * Default constructor. This initializes the tag with an error value
+	 * that will make \c operator \c bool return false.
+	 */
+	Tag() : tag() { }
+
+	/**
+	 * Constructor.
+	 *
+	 * @param etype the script-layer enum type associated with the tag.
+	 *
+	 * @param type The main type. Note that the manager class manages the
+	 * the value space internally, so noone else should assign main types.
+	 *
+	 * @param subtype The sub type, which is left to a component for
+	 * interpretation. By default it's set to zero.
+	 */
+	Tag(const EnumTypePtr& etype, zeek::Tag::type_t type, zeek::Tag::subtype_t subtype = 0)
+		: tag(etype, type, subtype)
+		{
+		}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param type The main type. Note that the component's Manager
+	 * manages the value space internally, so noone else should assign
+	 * any main types.
+	 *
+	 * @param subtype The sub type, which is left to a component for
+	 * interpretation. By default it's set to zero.
+	 */
+	explicit Tag(zeek::Tag::type_t type, zeek::Tag::subtype_t subtype = 0) : tag(type, subtype) { }
+
+	/**
+	 * Constructor.
+	 *
+	 * @param val An enum value of script type \c Analyzer::Tag.
+	 */
+	explicit Tag(EnumValPtr val) : tag(val) { }
+
+	/*
+	 * Copy constructor.
+	 */
+	Tag(const Tag& other) : tag(other.tag) { }
+
+	/**
+	 * Destructor.
+	 */
+	~Tag() { }
+
+	/**
+	 * Assignment operator.
+	 */
+	Tag& operator=(const Tag& other)
+		{
+		tag = other.tag;
+		return *this;
+		}
+
+	/**
+	 * Move assignment operator.
+	 */
+	Tag& operator=(Tag&& other) noexcept
+		{
+		tag = other.tag;
+		return *this;
+		}
+
+	/**
+	 * Compares two tags for equality.
+	 */
+	bool operator==(const Tag& other) const { return tag == other.tag; }
+
+	/**
+	 * Compares two tags for inequality.
+	 */
+	bool operator!=(const Tag& other) const { return tag != other.tag; }
+
+	/**
+	 * Compares two tags for less-than relationship.
+	 */
+	bool operator<(const Tag& other) const { return tag < other.tag; }
+
+	/**
+	 * Returns the numerical values for main and subtype inside a string
+	 * suitable for printing. This is primarily for debugging.
+	 */
+	std::string AsString() const { return tag.AsString(); }
+
+	/**
+	 * Returns the script-layer enum that corresponds to this tag.
+	 * The returned value does not have its ref-count increased.
+	 *
+	 * @param etype the script-layer enum type associated with the tag.
+	 */
+	const EnumValPtr& AsVal() const { return tag.AsVal(); }
+
+	/**
+	 * Returns false if the tag represents an error value rather than a
+	 * legal component type.
+	 */
+	explicit operator bool() const { return static_cast<bool>(tag); }
+
+private:
+	zeek::Tag tag;
+	};
 
 	} // namespace zeek::analyzer

--- a/src/file_analysis/Tag.h
+++ b/src/file_analysis/Tag.h
@@ -4,11 +4,149 @@
 
 #include "zeek/zeek-config.h"
 
+#include <string>
+
 #include "zeek/Tag.h"
+#include "zeek/Val.h"
 
 namespace zeek::file_analysis
 	{
 
-using Tag [[deprecated("Remove in v5.1. Use zeek::Tag.")]] = zeek::Tag;
+/**
+ * This class implements a wrapper around zeek::Tag , presenting the same interface as that
+ * member object. It previously implemented a full tag object for this type of plugin
+ * component, but that functionality was merged into zeek::Tag and the separate tag types were
+ * deprecated. This class will eventually be removed per the Zeek deprecation policy.
+ */
+class [[deprecated("Remove in v5.1. Use zeek::Tag.")]] Tag
+	{
+public:
+	/**
+	 * Type for the component's main type.
+	 */
+	using type_t = zeek::Tag::type_t;
+
+	/**
+	 * Type for the component's subtype.
+	 */
+	using subtype_t = zeek::Tag::subtype_t;
+
+	/**
+	 * Returns the tag's main type.
+	 */
+	zeek::Tag::type_t Type() const { return tag.Type(); }
+
+	/**
+	 * Returns the tag's subtype.
+	 */
+	zeek::Tag::subtype_t Subtype() const { return tag.Subtype(); }
+
+	/**
+	 * Default constructor. This initializes the tag with an error value
+	 * that will make \c operator \c bool return false.
+	 */
+	Tag() : tag() { }
+
+	/**
+	 * Constructor.
+	 *
+	 * @param etype the script-layer enum type associated with the tag.
+	 *
+	 * @param type The main type. Note that the manager class manages the
+	 * the value space internally, so noone else should assign main types.
+	 *
+	 * @param subtype The sub type, which is left to a component for
+	 * interpretation. By default it's set to zero.
+	 */
+	Tag(const EnumTypePtr& etype, zeek::Tag::type_t type, zeek::Tag::subtype_t subtype = 0)
+		: tag(etype, type, subtype)
+		{
+		}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param type The main type. Note that the component's Manager
+	 * manages the value space internally, so noone else should assign
+	 * any main types.
+	 *
+	 * @param subtype The sub type, which is left to a component for
+	 * interpretation. By default it's set to zero.
+	 */
+	explicit Tag(zeek::Tag::type_t type, zeek::Tag::subtype_t subtype = 0) : tag(type, subtype) { }
+
+	/**
+	 * Constructor.
+	 *
+	 * @param val An enum value of script type \c Files::Tag.
+	 */
+	explicit Tag(EnumValPtr val) : tag(val) { }
+
+	/*
+	 * Copy constructor.
+	 */
+	Tag(const Tag& other) : tag(other.tag) { }
+
+	/**
+	 * Destructor.
+	 */
+	~Tag() { }
+
+	/**
+	 * Assignment operator.
+	 */
+	Tag& operator=(const Tag& other)
+		{
+		tag = other.tag;
+		return *this;
+		}
+
+	/**
+	 * Move assignment operator.
+	 */
+	Tag& operator=(Tag&& other) noexcept
+		{
+		tag = other.tag;
+		return *this;
+		}
+
+	/**
+	 * Compares two tags for equality.
+	 */
+	bool operator==(const Tag& other) const { return tag == other.tag; }
+
+	/**
+	 * Compares two tags for inequality.
+	 */
+	bool operator!=(const Tag& other) const { return tag != other.tag; }
+
+	/**
+	 * Compares two tags for less-than relationship.
+	 */
+	bool operator<(const Tag& other) const { return tag < other.tag; }
+
+	/**
+	 * Returns the numerical values for main and subtype inside a string
+	 * suitable for printing. This is primarily for debugging.
+	 */
+	std::string AsString() const { return tag.AsString(); }
+
+	/**
+	 * Returns the script-layer enum that corresponds to this tag.
+	 * The returned value does not have its ref-count increased.
+	 *
+	 * @param etype the script-layer enum type associated with the tag.
+	 */
+	const EnumValPtr& AsVal() const { return tag.AsVal(); }
+
+	/**
+	 * Returns false if the tag represents an error value rather than a
+	 * legal component type.
+	 */
+	explicit operator bool() const { return static_cast<bool>(tag); }
+
+private:
+	zeek::Tag tag;
+	};
 
 	} // namespace zeek::file_analysis

--- a/src/input/Tag.h
+++ b/src/input/Tag.h
@@ -4,11 +4,149 @@
 
 #include "zeek/zeek-config.h"
 
+#include <string>
+
 #include "zeek/Tag.h"
+#include "zeek/Val.h"
 
 namespace zeek::input
 	{
 
-using Tag [[deprecated("Remove in v5.1. Use zeek::Tag.")]] = zeek::Tag;
+/**
+ * This class implements a wrapper around zeek::Tag , presenting the same interface as that
+ * member object. It previously implemented a full tag object for this type of plugin
+ * component, but that functionality was merged into zeek::Tag and the separate tag types were
+ * deprecated. This class will eventually be removed per the Zeek deprecation policy.
+ */
+class [[deprecated("Remove in v5.1. Use zeek::Tag.")]] Tag
+	{
+public:
+	/**
+	 * Type for the component's main type.
+	 */
+	using type_t = zeek::Tag::type_t;
+
+	/**
+	 * Type for the component's subtype.
+	 */
+	using subtype_t = zeek::Tag::subtype_t;
+
+	/**
+	 * Returns the tag's main type.
+	 */
+	zeek::Tag::type_t Type() const { return tag.Type(); }
+
+	/**
+	 * Returns the tag's subtype.
+	 */
+	zeek::Tag::subtype_t Subtype() const { return tag.Subtype(); }
+
+	/**
+	 * Default constructor. This initializes the tag with an error value
+	 * that will make \c operator \c bool return false.
+	 */
+	Tag() : tag() { }
+
+	/**
+	 * Constructor.
+	 *
+	 * @param etype the script-layer enum type associated with the tag.
+	 *
+	 * @param type The main type. Note that the manager class manages the
+	 * the value space internally, so noone else should assign main types.
+	 *
+	 * @param subtype The sub type, which is left to a component for
+	 * interpretation. By default it's set to zero.
+	 */
+	Tag(const EnumTypePtr& etype, zeek::Tag::type_t type, zeek::Tag::subtype_t subtype = 0)
+		: tag(etype, type, subtype)
+		{
+		}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param type The main type. Note that the component's Manager
+	 * manages the value space internally, so noone else should assign
+	 * any main types.
+	 *
+	 * @param subtype The sub type, which is left to a component for
+	 * interpretation. By default it's set to zero.
+	 */
+	explicit Tag(zeek::Tag::type_t type, zeek::Tag::subtype_t subtype = 0) : tag(type, subtype) { }
+
+	/**
+	 * Constructor.
+	 *
+	 * @param val An enum value of script type \c Input::Tag.
+	 */
+	explicit Tag(EnumValPtr val) : tag(val) { }
+
+	/*
+	 * Copy constructor.
+	 */
+	Tag(const Tag& other) : tag(other.tag) { }
+
+	/**
+	 * Destructor.
+	 */
+	~Tag() { }
+
+	/**
+	 * Assignment operator.
+	 */
+	Tag& operator=(const Tag& other)
+		{
+		tag = other.tag;
+		return *this;
+		}
+
+	/**
+	 * Move assignment operator.
+	 */
+	Tag& operator=(Tag&& other) noexcept
+		{
+		tag = other.tag;
+		return *this;
+		}
+
+	/**
+	 * Compares two tags for equality.
+	 */
+	bool operator==(const Tag& other) const { return tag == other.tag; }
+
+	/**
+	 * Compares two tags for inequality.
+	 */
+	bool operator!=(const Tag& other) const { return tag != other.tag; }
+
+	/**
+	 * Compares two tags for less-than relationship.
+	 */
+	bool operator<(const Tag& other) const { return tag < other.tag; }
+
+	/**
+	 * Returns the numerical values for main and subtype inside a string
+	 * suitable for printing. This is primarily for debugging.
+	 */
+	std::string AsString() const { return tag.AsString(); }
+
+	/**
+	 * Returns the script-layer enum that corresponds to this tag.
+	 * The returned value does not have its ref-count increased.
+	 *
+	 * @param etype the script-layer enum type associated with the tag.
+	 */
+	const EnumValPtr& AsVal() const { return tag.AsVal(); }
+
+	/**
+	 * Returns false if the tag represents an error value rather than a
+	 * legal component type.
+	 */
+	explicit operator bool() const { return static_cast<bool>(tag); }
+
+private:
+	zeek::Tag tag;
+	};
 
 	} // namespace zeek::input

--- a/src/logging/Tag.h
+++ b/src/logging/Tag.h
@@ -4,11 +4,149 @@
 
 #include "zeek/zeek-config.h"
 
+#include <string>
+
 #include "zeek/Tag.h"
+#include "zeek/Val.h"
 
 namespace zeek::logging
 	{
 
-using Tag [[deprecated("Remove in v5.1. Use zeek::Tag.")]] = zeek::Tag;
+/**
+ * This class implements a wrapper around zeek::Tag , presenting the same interface as that
+ * member object. It previously implemented a full tag object for this type of plugin
+ * component, but that functionality was merged into zeek::Tag and the separate tag types were
+ * deprecated. This class will eventually be removed per the Zeek deprecation policy.
+ */
+class [[deprecated("Remove in v5.1. Use zeek::Tag.")]] Tag
+	{
+public:
+	/**
+	 * Type for the component's main type.
+	 */
+	using type_t = zeek::Tag::type_t;
+
+	/**
+	 * Type for the component's subtype.
+	 */
+	using subtype_t = zeek::Tag::subtype_t;
+
+	/**
+	 * Returns the tag's main type.
+	 */
+	zeek::Tag::type_t Type() const { return tag.Type(); }
+
+	/**
+	 * Returns the tag's subtype.
+	 */
+	zeek::Tag::subtype_t Subtype() const { return tag.Subtype(); }
+
+	/**
+	 * Default constructor. This initializes the tag with an error value
+	 * that will make \c operator \c bool return false.
+	 */
+	Tag() : tag() { }
+
+	/**
+	 * Constructor.
+	 *
+	 * @param etype the script-layer enum type associated with the tag.
+	 *
+	 * @param type The main type. Note that the manager class manages the
+	 * the value space internally, so noone else should assign main types.
+	 *
+	 * @param subtype The sub type, which is left to a component for
+	 * interpretation. By default it's set to zero.
+	 */
+	Tag(const EnumTypePtr& etype, zeek::Tag::type_t type, zeek::Tag::subtype_t subtype = 0)
+		: tag(etype, type, subtype)
+		{
+		}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param type The main type. Note that the \a logging::Manager
+	 * manages the value space internally, so noone else should assign
+	 * any main types.
+	 *
+	 * @param subtype The sub type, which is left to a component for
+	 * interpretation. By default it's set to zero.
+	 */
+	explicit Tag(zeek::Tag::type_t type, zeek::Tag::subtype_t subtype = 0) : tag(type, subtype) { }
+
+	/**
+	 * Constructor.
+	 *
+	 * @param val An enum value of script type \c Logger::Tag.
+	 */
+	explicit Tag(EnumValPtr val) : tag(val) { }
+
+	/*
+	 * Copy constructor.
+	 */
+	Tag(const Tag& other) : tag(other.tag) { }
+
+	/**
+	 * Destructor.
+	 */
+	~Tag() { }
+
+	/**
+	 * Assignment operator.
+	 */
+	Tag& operator=(const Tag& other)
+		{
+		tag = other.tag;
+		return *this;
+		}
+
+	/**
+	 * Move assignment operator.
+	 */
+	Tag& operator=(Tag&& other) noexcept
+		{
+		tag = other.tag;
+		return *this;
+		}
+
+	/**
+	 * Compares two tags for equality.
+	 */
+	bool operator==(const Tag& other) const { return tag == other.tag; }
+
+	/**
+	 * Compares two tags for inequality.
+	 */
+	bool operator!=(const Tag& other) const { return tag != other.tag; }
+
+	/**
+	 * Compares two tags for less-than relationship.
+	 */
+	bool operator<(const Tag& other) const { return tag < other.tag; }
+
+	/**
+	 * Returns the numerical values for main and subtype inside a string
+	 * suitable for printing. This is primarily for debugging.
+	 */
+	std::string AsString() const { return tag.AsString(); }
+
+	/**
+	 * Returns the script-layer enum that corresponds to this tag.
+	 * The returned value does not have its ref-count increased.
+	 *
+	 * @param etype the script-layer enum type associated with the tag.
+	 */
+	const EnumValPtr& AsVal() const { return tag.AsVal(); }
+
+	/**
+	 * Returns false if the tag represents an error value rather than a
+	 * legal component type.
+	 */
+	explicit operator bool() const { return static_cast<bool>(tag); }
+
+private:
+	zeek::Tag tag;
+	};
 
 	} // namespace zeek::logging

--- a/src/packet_analysis/Tag.h
+++ b/src/packet_analysis/Tag.h
@@ -4,11 +4,149 @@
 
 #include "zeek/zeek-config.h"
 
+#include <string>
+
 #include "zeek/Tag.h"
+#include "zeek/Val.h"
 
 namespace zeek::packet_analysis
 	{
 
-using Tag [[deprecated("Remove in v5.1. Use zeek::Tag.")]] = zeek::Tag;
+/**
+ * This class implements a wrapper around zeek::Tag , presenting the same interface as that
+ * member object. It previously implemented a full tag object for this type of plugin
+ * component, but that functionality was merged into zeek::Tag and the separate tag types were
+ * deprecated. This class will eventually be removed per the Zeek deprecation policy.
+ */
+class [[deprecated("Remove in v5.1. Use zeek::Tag.")]] Tag
+	{
+public:
+	/**
+	 * Type for the component's main type.
+	 */
+	using type_t = zeek::Tag::type_t;
+
+	/**
+	 * Type for the component's subtype.
+	 */
+	using subtype_t = zeek::Tag::subtype_t;
+
+	/**
+	 * Returns the tag's main type.
+	 */
+	zeek::Tag::type_t Type() const { return tag.Type(); }
+
+	/**
+	 * Returns the tag's subtype.
+	 */
+	zeek::Tag::subtype_t Subtype() const { return tag.Subtype(); }
+
+	/**
+	 * Default constructor. This initializes the tag with an error value
+	 * that will make \c operator \c bool return false.
+	 */
+	Tag() : tag() { }
+
+	/**
+	 * Constructor.
+	 *
+	 * @param etype the script-layer enum type associated with the tag.
+	 *
+	 * @param type The main type. Note that the manager class manages the
+	 * the value space internally, so noone else should assign main types.
+	 *
+	 * @param subtype The sub type, which is left to a component for
+	 * interpretation. By default it's set to zero.
+	 */
+	Tag(const EnumTypePtr& etype, zeek::Tag::type_t type, zeek::Tag::subtype_t subtype = 0)
+		: tag(etype, type, subtype)
+		{
+		}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param type The main type. Note that the component's Manager
+	 * manages the value space internally, so noone else should assign
+	 * any main types.
+	 *
+	 * @param subtype The sub type, which is left to a component for
+	 * interpretation. By default it's set to zero.
+	 */
+	explicit Tag(zeek::Tag::type_t type, zeek::Tag::subtype_t subtype = 0) : tag(type, subtype) { }
+
+	/**
+	 * Constructor.
+	 *
+	 * @param val An enum value of script type \c PacketAnalyzer::Tag.
+	 */
+	explicit Tag(EnumValPtr val) : tag(val) { }
+
+	/*
+	 * Copy constructor.
+	 */
+	Tag(const Tag& other) : tag(other.tag) { }
+
+	/**
+	 * Destructor.
+	 */
+	~Tag() { }
+
+	/**
+	 * Assignment operator.
+	 */
+	Tag& operator=(const Tag& other)
+		{
+		tag = other.tag;
+		return *this;
+		}
+
+	/**
+	 * Move assignment operator.
+	 */
+	Tag& operator=(Tag&& other) noexcept
+		{
+		tag = other.tag;
+		return *this;
+		}
+
+	/**
+	 * Compares two tags for equality.
+	 */
+	bool operator==(const Tag& other) const { return tag == other.tag; }
+
+	/**
+	 * Compares two tags for inequality.
+	 */
+	bool operator!=(const Tag& other) const { return tag != other.tag; }
+
+	/**
+	 * Compares two tags for less-than relationship.
+	 */
+	bool operator<(const Tag& other) const { return tag < other.tag; }
+
+	/**
+	 * Returns the numerical values for main and subtype inside a string
+	 * suitable for printing. This is primarily for debugging.
+	 */
+	std::string AsString() const { return tag.AsString(); }
+
+	/**
+	 * Returns the script-layer enum that corresponds to this tag.
+	 * The returned value does not have its ref-count increased.
+	 *
+	 * @param etype the script-layer enum type associated with the tag.
+	 */
+	const EnumValPtr& AsVal() const { return tag.AsVal(); }
+
+	/**
+	 * Returns false if the tag represents an error value rather than a
+	 * legal component type.
+	 */
+	explicit operator bool() const { return static_cast<bool>(tag); }
+
+private:
+	zeek::Tag tag;
+	};
 
 	} // namespace zeek::packet_analysis


### PR DESCRIPTION
This PR restores the individual Tag classes, but makes them wrappers around a `zeek::Tag` member variable. The only thing I think is missing is a constructor/assignment operator from `zeek::Tag`, but it might not be necessary so I left it out.

Fixes #1873 