### PR TITLE
Move dce/rpc operation mapping from response to request

### DIFF
--- a/scripts/base/protocols/dce-rpc/main.zeek
+++ b/scripts/base/protocols/dce-rpc/main.zeek
@@ -161,11 +161,6 @@ event dce_rpc_request(c: connection, fid: count, ctx_id: count, opnum: count, st
 		{
 		c$dce_rpc$ts = network_time();
 		}
-	}
-
-event dce_rpc_response(c: connection, fid: count, ctx_id: count, opnum: count, stub_len: count) &priority=5
-	{
-	set_session(c, fid);
 
 	# In the event that the binding wasn't seen, but the pipe
 	# name is known, go ahead and see if we have a pipe name to


### PR DESCRIPTION
Move the mapping of endpoints and operations from the response to the request. This allows for usage of the mapped values in further processing in subsequent `dce_rpc_request` or `dce_rpc_request_stub` events. 