### PR TITLE
GH-1768: Properly cleanup existing log stream when recreated on with the same ID

### DIFF
--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -311,8 +311,11 @@ bool Manager::CreateStream(EnumVal* id, RecordVal* sval)
 		streams.push_back(nullptr);
 
 	if ( streams[idx] )
-		// We already know this one, delete the previous definition.
-		delete streams[idx];
+		{
+		// We already know this one. Clean up the old version before making
+		// a new one.
+		RemoveStream(idx);
+		}
 
 	// Create new stream.
 	streams[idx] = new Stream;
@@ -334,7 +337,11 @@ bool Manager::CreateStream(EnumVal* id, RecordVal* sval)
 bool Manager::RemoveStream(EnumVal* id)
 	{
 	unsigned int idx = id->AsEnum();
+	return RemoveStream(idx);
+	}
 
+bool Manager::RemoveStream(unsigned int idx)
+	{
 	if ( idx >= streams.size() || ! streams[idx] )
 		return false;
 

--- a/src/logging/Manager.h
+++ b/src/logging/Manager.h
@@ -299,6 +299,8 @@ private:
 	bool CompareFields(const Filter* filter, const WriterFrontend* writer);
 	bool CheckFilterWriterConflict(const WriterInfo* winfo, const Filter* filter);
 
+	bool RemoveStream(unsigned int idx);
+
 	std::vector<Stream*> streams; // Indexed by stream enum.
 	int rotations_pending; // Number of rotations not yet finished.
 	FuncPtr rotation_format_func;


### PR DESCRIPTION
This fixes #1768. We're not properly shutting down the writers when removing/recreating an existing stream, so when the message thread gets back around to that writer again, it crashes. This fixes it by just calling the existing `RemoveStream` method instead of deleting the stream directly. Debug logging shows the new stream gets created and the writer is recreated as well:

```
1638565140.227588/1638565140.237180 [logging] Created new logging stream 'Test::LOG', raising event <none>
1638565140.227588/1638565140.237283 [logging] No filter 'default' for removing from stream 'Test::LOG'
1638565140.227588/1638565140.237295 [logging] Created new filter 'default' for stream 'Test::LOG'
1638565140.227588/1638565140.237301 [logging]    writer    : Log::WRITER_ASCII
1638565140.227588/1638565140.237306 [logging]    path      : test
1638565140.227588/1638565140.237310 [logging]    path_func : not set
1638565140.227588/1638565140.237315 [logging]    policy    : not set
1638565140.227588/1638565140.237320 [logging]    field         ts: time
1638565140.227588/1638565140.237324 [logging]    field        msg: string
1638565140.227588/1638565140.237890 [logging] Scheduled rotation timer for test/Log::WRITER_ASCII to 1638565200.000000
1638565140.227588/1638565140.237920 [logging] Wrote record to filter 'default' on stream 'Test::LOG'
1638565140.227588/1638565140.237963 [logging] Removed writer 'test/Log::WRITER_ASCII' from stream 'Test::LOG'
1638565140.227588/1638565140.238002 [logging] Removed logging stream 'Test::LOG'
1638565140.227588/1638565140.238016 [logging] Created new logging stream 'Test::LOG', raising event <none>
1638565140.227588/1638565140.238139 [logging] No filter 'default' for removing from stream 'Test::LOG'
1638565140.227588/1638565140.238155 [logging] Created new filter 'default' for stream 'Test::LOG'
1638565140.227588/1638565140.238162 [logging]    writer    : Log::WRITER_ASCII
1638565140.227588/1638565140.238167 [logging]    path      : test
1638565140.227588/1638565140.238172 [logging]    path_func : not set
1638565140.227588/1638565140.238177 [logging]    policy    : not set
1638565140.227588/1638565140.238182 [logging]    field         ts: time
1638565140.227588/1638565140.238187 [logging]    field        msg: string
1638565142.228218/1638565142.228508 [logging] Scheduled rotation timer for test/Log::WRITER_ASCII to 1638565200.000000
1638565142.228218/1638565142.228570 [logging] Wrote record to filter 'default' on stream 'Test::LOG'
```