### PR TITLE
update script-to-C++ compilation for new record constructor internals

### DIFF
--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -670,8 +670,30 @@ string CPPCompile::GenRecordConstructorExpr(const Expr* e)
 			vals += ", ";
 		}
 
-	return string("record_constructor__CPP({") + vals + "}, " + "cast_intrusive<RecordType>(" +
-	       GenTypeName(t) + "))";
+	vals = string("{") + vals + "}";
+
+	const auto& map = rc->Map();
+
+	if ( map )
+		{
+		string map_vals;
+		for ( auto m : *map )
+			{
+			if ( ! map_vals.empty() )
+				map_vals += ", ";
+
+			map_vals += to_string(m);
+			}
+
+		map_vals = string("{") + map_vals + "}";
+
+		return string("record_constructor_map__CPP(") + vals + ", " + map_vals +
+		       ", cast_intrusive<RecordType>(" + GenTypeName(t) + "))";
+		}
+
+	else
+		return string("record_constructor__CPP(") + vals + ", cast_intrusive<RecordType>(" +
+		       GenTypeName(t) + "))";
 	}
 
 string CPPCompile::GenSetConstructorExpr(const Expr* e)

--- a/src/script_opt/CPP/RuntimeOps.cc
+++ b/src/script_opt/CPP/RuntimeOps.cc
@@ -224,6 +224,17 @@ RecordValPtr record_constructor__CPP(vector<ValPtr> vals, RecordTypePtr t)
 	return rv;
 	}
 
+RecordValPtr record_constructor_map__CPP(vector<ValPtr> vals, vector<int> map, RecordTypePtr t)
+	{
+	auto rv = make_intrusive<RecordVal>(move(t));
+	auto n = vals.size();
+
+	for ( auto i = 0u; i < n; ++i )
+		rv->Assign(map[i], vals[i]);
+
+	return rv;
+	}
+
 VectorValPtr vector_constructor__CPP(vector<ValPtr> vals, VectorTypePtr t)
 	{
 	auto vv = make_intrusive<VectorVal>(move(t));

--- a/src/script_opt/CPP/RuntimeOps.h
+++ b/src/script_opt/CPP/RuntimeOps.h
@@ -140,6 +140,10 @@ extern TableValPtr table_constructor__CPP(std::vector<ValPtr> indices, std::vect
 // assigned to the corresponding elements of the given vector of values.
 extern RecordValPtr record_constructor__CPP(std::vector<ValPtr> vals, RecordTypePtr t);
 
+// Same, but with a map when using a named constructor.
+extern RecordValPtr record_constructor_map__CPP(std::vector<ValPtr> vals, std::vector<int> map,
+                                                RecordTypePtr t);
+
 // Constructs a vector of the given type, populated with the given values.
 extern VectorValPtr vector_constructor__CPP(std::vector<ValPtr> vals, VectorTypePtr t);
 


### PR DESCRIPTION
The compile-to-C++ compiler needed updating to support a recent change to constructing records (one that uses a static map specifying which positions to fill in the record).