### PR TITLE
Improve error message for clash between variable and function name

### DIFF
--- a/src/Var.cc
+++ b/src/Var.cc
@@ -618,8 +618,14 @@ void begin_func(IDPtr id, const char* module_name, FunctionFlavor flavor, bool i
 	std::optional<FuncType::Prototype> prototype;
 
 	if ( id->GetType() )
+		{
+		if ( id->GetType()->Tag() != TYPE_FUNC )
+			{
+			id->Error("Function clash with previous definition with incompatible type", t.get());
+			reporter->FatalError("invalid definition of '%s' (see previous errors)", id->Name());
+			}
 		prototype = get_prototype(id, t);
-
+		}
 	else if ( is_redef )
 		id->Error("redef of not-previously-declared value");
 


### PR DESCRIPTION
The previous error message was very cryptic and led to an abort.

Fixes GH-1832