### PR TITLE
Fix some issues reported by `null` undefined-behavior sanitizer

### DIFF
--- a/scripts/base/frameworks/analyzer/main.zeek
+++ b/scripts/base/frameworks/analyzer/main.zeek
@@ -53,7 +53,7 @@ export {
 	## ports: The set of well-known ports to associate with the analyzer.
 	##
 	## Returns: True if the ports were successfully registered.
-	global register_for_ports: function(tag: AllAnalyzers::Tag, ports: set[port]) : bool;
+	global register_for_ports: function(tag: Analyzer::Tag, ports: set[port]) : bool;
 
 	## Registers an individual well-known port for an analyzer. If a future
 	## connection on this port is seen, the analyzer will be automatically
@@ -65,7 +65,7 @@ export {
 	## p: The well-known port to associate with the analyzer.
 	##
 	## Returns: True if the port was successfully registered.
-	global register_for_port: function(tag: AllAnalyzers::Tag, p: port) : bool;
+	global register_for_port: function(tag: Analyzer::Tag, p: port) : bool;
 
 	## Returns a set of all well-known ports currently registered for a
 	## specific analyzer.

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1903,6 +1903,11 @@ bool same_type(const Type& arg_t1, const Type& arg_t2, bool is_init, bool match_
 			if ( (tl1 || tl2) && ! (tl1 && tl2) )
 				return false;
 
+			// If one is a set and one isn't, they shouldn't
+			// be considered the same type.
+			if ( (t1->IsSet() && ! t2->IsSet()) || (t2->IsSet() && ! t1->IsSet()) )
+				return false;
+
 			const auto& y1 = t1->Yield();
 			const auto& y2 = t2->Yield();
 
@@ -2015,6 +2020,12 @@ bool same_type(const Type& arg_t1, const Type& arg_t2, bool is_init, bool match_
 
 			if ( ! same_type(tl1, tl2, is_init, match_record_field_names) )
 				result = false;
+			else if ( t1->IsSet() && t2->IsSet() )
+				// Sets don't have yield types because they don't have values. If
+				// both types are sets, and we already matched on the indices
+				// above consider that a success. We already checked the case
+				// where only one of the two is a set earlier.
+				result = true;
 			else
 				{
 				const auto& y1 = t1->Yield();

--- a/src/Type.h
+++ b/src/Type.h
@@ -828,21 +828,37 @@ extern bool same_type(const Type& t1, const Type& t2, bool is_init = false,
 inline bool same_type(const TypePtr& t1, const TypePtr& t2, bool is_init = false,
                       bool match_record_field_names = true)
 	{
+	// If the pointers are identical, the type should be the same type.
+	if ( t1.get() == t2.get() )
+		return true;
+
 	return same_type(*t1, *t2, is_init, match_record_field_names);
 	}
 inline bool same_type(const Type* t1, const Type* t2, bool is_init = false,
                       bool match_record_field_names = true)
 	{
+	// If the pointers are identical, the type should be the same type.
+	if ( t1 == t2 )
+		return true;
+
 	return same_type(*t1, *t2, is_init, match_record_field_names);
 	}
 inline bool same_type(const TypePtr& t1, const Type* t2, bool is_init = false,
                       bool match_record_field_names = true)
 	{
+	// If the pointers are identical, the type should be the same type.
+	if ( t1.get() == t2 )
+		return true;
+
 	return same_type(*t1, *t2, is_init, match_record_field_names);
 	}
 inline bool same_type(const Type* t1, const TypePtr& t2, bool is_init = false,
                       bool match_record_field_names = true)
 	{
+	// If the pointers are identical, the type should be the same type.
+	if ( t1 == t2.get() )
+		return true;
+
 	return same_type(*t1, *t2, is_init, match_record_field_names);
 	}
 


### PR DESCRIPTION
- Add simple pointer-value check to `same_type` to avoid doing a bunch of work if the arguments point to the same object.
- Types for the `Analyzer::register_for_port(s)` functions in script-land differed between the definition and implementation. This wasn't directly reported by ubsan, but I noticed it while trying to fix the others.
- Attempt to avoid checks involving yield types where a `TableType` was created via the `set` keyword. Sets don't have yield types because they don't have values, only keys.