### PR TITLE
Docs/comment pass over the cluster controller framework

### DIFF
--- a/scripts/policy/frameworks/cluster/agent/__load__.zeek
+++ b/scripts/policy/frameworks/cluster/agent/__load__.zeek
@@ -1,5 +1,4 @@
-# The entry point for the cluster agent. It only runs bootstrap logic for
-# launching via the Supervisor. If we're not running the Supervisor, this does
-# nothing.
+##! The entry point for the cluster agent. It runs bootstrap logic for launching
+##! the agent process via Zeek's Supervisor.
 
 @load ./boot

--- a/scripts/policy/frameworks/cluster/agent/api.zeek
+++ b/scripts/policy/frameworks/cluster/agent/api.zeek
@@ -1,44 +1,107 @@
+##! The event API of cluster agents. Most endpoints consist of event pairs,
+##! where the agent answers a request event with a corresponding response
+##! event. Such event pairs share the same name prefix and end in "_request" and
+##! "_response", respectively.
+
 @load base/frameworks/supervisor/control
 @load policy/frameworks/cluster/controller/types
 
 module ClusterAgent::API;
 
 export {
+	## A simple versioning scheme, used to track basic compatibility of
+	## controller and agent.
 	const version = 1;
+
 
 	# Agent API events
 
-	# The controller uses this event to convey a new cluster
-	# configuration to the agent. Once processed, the agent
-	# responds with the response event.
+	## The controller sends this event to convey a new cluster configuration
+	## to the agent. Once processed, the agent responds with the response
+	## event.
+	##
+	## reqid: a request identifier string, echoed in the response event.
+	##
+	## config: a :zeek:see:`ClusterController::Types::Configuration` record
+	##     describing the cluster topology. Note that this contains the full
+	##     topology, not just the part pertaining to this agent. That's because
+	##     the cluster framework requires full cluster visibility to establish
+	##     the needed peerings.
+	##
 	global set_configuration_request: event(reqid: string,
 	    config: ClusterController::Types::Configuration);
+
+	## Response to a set_configuration_request event. The agent sends
+	## this back to the controller.
+	##
+	## reqid: the request identifier used in the request event.
+	##
+	## result: the result record.
+	##
 	global set_configuration_response: event(reqid: string,
 	    result: ClusterController::Types::Result);
 
-	# The controller uses this event to confirm to the agent
-	# that it is part of the current cluster. The agent
-	# acknowledges with the response event.
+
+	## The controller sends this event to confirm to the agent that it is
+	## part of the current cluster topology. The agent acknowledges with the
+	## corresponding response event.
+	##
+	## reqid: a request identifier string, echoed in the response event.
+	##
 	global agent_welcome_request: event(reqid: string);
+
+	## Response to an agent_welcome_request event. The agent sends this
+	## back to the controller.
+	##
+	## reqid: the request identifier used in the request event.
+	##
+	## result: the result record.
+	##
 	global agent_welcome_response: event(reqid: string,
 	    result: ClusterController::Types::Result);
 
-	# The controller sends this event to convey that the agent is not
-	# currently required. This status may later change, depending on
-	# updates from the client, so the peering can remain active. The
-	# agent releases any cluster-related resources when processing the
-	# request.
+
+	## The controller sends this event to convey that the agent is not
+	## currently required. This status may later change, depending on
+	## updates from the client, so the Broker-level peering can remain
+	## active. The agent releases any cluster-related resources (including
+	## shutdown of existing Zeek cluster nodes) when processing the request,
+	## and confirms via the response event. Shutting down an agent at this
+	## point has no operational impact on the running cluster.
+	##
+	## reqid: a request identifier string, echoed in the response event.
+	##
 	global agent_standby_request: event(reqid: string);
+
+	## Response to an agent_standby_request event. The agent sends this
+	## back to the controller.
+	##
+	## reqid: the request identifier used in the request event.
+	##
+	## result: the result record.
+	##
 	global agent_standby_response: event(reqid: string,
 	    result: ClusterController::Types::Result);
 
+
 	# Notification events, agent -> controller
 
-	# The agent sends this upon peering as a "check in", informing the
-	# controller that an agent of the given name is now available to
-	# communicate with.
+	## The agent sends this event upon peering as a "check-in", informing
+	## the controller that an agent of the given name is now available to
+	## communicate with. It is a controller-level equivalent of
+	## `:zeek:see:`Broker::peer_added`.
+	##
+	## instance: an instance name, really the agent's name as per :zeek:see:`ClusterAgent::name`.
+	##
+	## host: the IP address of the agent. (This may change in the future.)
+	##
+	## api_version: the API version of this agent.
+	##
 	global notify_agent_hello: event(instance: string, host: addr,
 	    api_version: count);
+
+
+	# The following are not yet implemented.
 
 	# Report node state changes.
 	global notify_change: event(instance: string,
@@ -51,4 +114,4 @@ export {
 
 	# Report informational message.
 	global notify_log: event(instance: string, msg: string, node: string &default="");
-}
+	}

--- a/scripts/policy/frameworks/cluster/agent/boot.zeek
+++ b/scripts/policy/frameworks/cluster/agent/boot.zeek
@@ -1,3 +1,9 @@
+##! The cluster agent boot logic runs in Zeek's supervisor and instructs it to
+##! launch an agent process. The agent's main logic resides in main.zeek,
+##! similarly to other frameworks. The new process will execute that script.
+##!
+##! If the current process is not the Zeek supervisor, this does nothing.
+
 @load ./config
 
 # The agent needs the supervisor to listen for node management requests.  We

--- a/scripts/policy/frameworks/cluster/agent/config.zeek
+++ b/scripts/policy/frameworks/cluster/agent/config.zeek
@@ -1,51 +1,83 @@
+##! Configuration settings for a cluster agent.
+
 @load policy/frameworks/cluster/controller/types
 
 module ClusterAgent;
 
 export {
-	# The name this agent uses to represent the cluster instance
-	# it manages. When the environment variable isn't set and there's,
-	# no redef, this falls back to "agent-<hostname>".
+	## The name this agent uses to represent the cluster instance it
+	## manages. Defaults to the value of the ZEEK_AGENT_NAME environment
+	## variable. When that is unset and you don't redef the value,
+	## the implementation defaults to "agent-<hostname>".
 	const name = getenv("ZEEK_AGENT_NAME") &redef;
 
-	# Agent stdout/stderr log files to produce in Zeek's working
-	# directory. If empty, no such logs will result. The actual
-	# log files have the agent's name (as per above) dot-prefixed.
+	## Agent stdout log configuration. If the string is non-empty, Zeek will
+	## produce a free-form log (i.e., not one governed by Zeek's logging
+	## framework) in Zeek's working directory. The final log's name is
+	## "<name>.<suffix>", where the name is taken from :zeek:see:`ClusterAgent::name`,
+	## and the suffix is defined by the following variable. If left empty,
+	## no such log results.
+	##
+	## Note that the agent also establishes a "proper" Zeek log via the
+	## :zeek:see:`ClusterController::Log` module.
 	const stdout_file_suffix = "agent.stdout" &redef;
+
+	## Agent stderr log configuration. Like :zeek:see:`ClusterAgent::stdout_file_suffix`,
+	## but for the stderr stream.
 	const stderr_file_suffix = "agent.stderr" &redef;
 
-	# The address and port the agent listens on. When
-	# undefined, falls back to configurable default values.
+	## The network address the agent listens on. This only takes effect if
+	## the agent isn't configured to connect to the controller (see
+	## :zeek:see:`ClusterAgent::controller`). By default this uses the value of the
+	## ZEEK_AGENT_ADDR environment variable, but you may also redef to
+	## a specific value. When empty, the implementation falls back to
+	## :zeek:see:`ClusterAgent::default_address`.
 	const listen_address = getenv("ZEEK_AGENT_ADDR") &redef;
+
+	## The fallback listen address if :zeek:see:`ClusterAgent::listen_address`
+	## remains empty. Unless redefined, this uses Broker's own default listen
+	## address.
 	const default_address = Broker::default_listen_address &redef;
 
+	## The network port the agent listens on. Counterpart to
+	## :zeek:see:`ClusterAgent::listen_address`, defaulting to the ZEEK_AGENT_PORT
+	## environment variable.
 	const listen_port = getenv("ZEEK_AGENT_PORT") &redef;
+
+	## The fallback listen port if :zeek:see:`ClusterAgent::listen_port` remains empty.
 	const default_port = 2151/tcp &redef;
 
-	# The agent communicates under to following topic prefix,
-	# suffixed with "/<name>" (see above):
+	## The agent's Broker topic prefix. For its own communication, the agent
+	## suffixes this with "/<name>", based on :zeek:see:`ClusterAgent::name`.
 	const topic_prefix = "zeek/cluster-control/agent" &redef;
 
-	# The coordinates of the controller. When defined, it means
-	# agents peer with (connect to) the controller; otherwise the
-	# controller knows all agents and peers with them.
+	## The network coordinates of the controller. When defined, the agent
+	## peers with (and connects to) the controller; otherwise the controller
+	## will peer (and connect to) the agent, listening as defined by
+	## :zeek:see:`ClusterAgent::listen_address` and :zeek:see:`ClusterAgent::listen_port`.
 	const controller: Broker::NetworkInfo = [
 		$address="0.0.0.0", $bound_port=0/unknown] &redef;
 
-	# Agent and controller currently log only, not via the data cluster's
-	# logger. (This might get added later.) For now, this means that
-	# if both write to the same log file, it gets garbled. The following
-	# lets you specify the working directory specifically for the agent.
+	## An optional custom output directory for the agent's stdout and stderr
+	## logs. Agent and controller currently only log locally, not via the
+	## data cluster's logger node. (This might change in the future.) This
+	## means that if both write to the same log file, the output gets
+	## garbled.
 	const directory = "" &redef;
 
-	# Working directory for data cluster nodes. When relative, note
-	# that this will apply from the working directory of the agent,
-	# since it creates data cluster nodes.
+	## The working directory for data cluster nodes created by this
+	## agent. If you make this a relative path, note that the path is
+	## relative to the agent's working directory, since it creates data
+	## cluster nodes.
 	const cluster_directory = "" &redef;
 
-	# The following functions return the effective network endpoint
-	# information for this agent, in two related forms.
+	## Returns a :zeek:see:`ClusterController::Types::Instance` describing this
+	## instance (its agent name plus listening address/port, as applicable).
 	global instance: function(): ClusterController::Types::Instance;
+
+	## Returns a :zeek:see:`Broker::EndpointInfo` record for this instance.
+	## Similar to :zeek:see:`ClusterAgent::instance`, but with slightly different
+	## data format.
 	global endpoint_info: function(): Broker::EndpointInfo;
 }
 

--- a/scripts/policy/frameworks/cluster/agent/main.zeek
+++ b/scripts/policy/frameworks/cluster/agent/main.zeek
@@ -1,3 +1,8 @@
+##! This is the main "runtime" of a cluster agent. Zeek does not load this
+##! directly; rather, the agent's bootstrapping module (in ./boot.zeek)
+##! specifies it as the script to run in the node newly created via Zeek's
+##! supervisor.
+
 @load base/frameworks/broker
 
 @load policy/frameworks/cluster/controller/config

--- a/scripts/policy/frameworks/cluster/controller/__load__.zeek
+++ b/scripts/policy/frameworks/cluster/controller/__load__.zeek
@@ -1,5 +1,4 @@
-# The entry point for the cluster controller. It only runs bootstrap logic for
-# launching via the Supervisor. If we're not running the Supervisor, this does
-# nothing.
+##! The entry point for the cluster controller. It runs bootstrap logic for
+##! launching the controller process via Zeek's Supervisor.
 
 @load ./boot

--- a/scripts/policy/frameworks/cluster/controller/api.zeek
+++ b/scripts/policy/frameworks/cluster/controller/api.zeek
@@ -1,31 +1,96 @@
+##! The event API of cluster controllers. Most endpoints consist of event pairs,
+##! where the controller answers a zeek-client request event with a
+##! corresponding response event. Such event pairs share the same name prefix
+##! and end in "_request" and "_response", respectively.
+
 @load ./types
 
 module ClusterController::API;
 
 export {
+	## A simple versioning scheme, used to track basic compatibility of
+	## controller, agents, and zeek-client.
 	const version = 1;
 
-	# Triggered when the operational instances align with desired ones, as
-	# defined by the latest cluster config sent by the client.
-	global notify_agents_ready: event(instances: set[string]);
 
+	## zeek-client sends this event to request a list of the currently
+	## peered agents/instances.
+	##
+	## reqid: a request identifier string, echoed in the response event.
+	##
 	global get_instances_request: event(reqid: string);
+
+	## Response to a get_instances_request event. The controller sends
+	## this back to the client.
+	##
+	## reqid: the request identifier used in the request event.
+	##
+	## result: the result record. Its data member is a
+	##     :zeek:see:`ClusterController::Types::Instance` record.
+	##
 	global get_instances_response: event(reqid: string,
 	    result: ClusterController::Types::Result);
 
+
+	## zeek-client sends this event to establish a new cluster configuration,
+	## including the full cluster topology. The controller processes the update
+	## and relays it to the agents. Once each has responded (or a timeout occurs)
+	## the controller sends a corresponding response event back to the client.
+	##
+	## reqid: a request identifier string, echoed in the response event.
+	##
+	## config: a :zeek:see:`ClusterController::Types::Configuration` record
+	##     specifying the cluster configuration.
+	##
 	global set_configuration_request: event(reqid: string,
 	    config: ClusterController::Types::Configuration);
+
+	## Response to a set_configuration_request event. The controller sends
+	## this back to the client.
+	##
+	## reqid: the request identifier used in the request event.
+	##
+	## result: a vector of :zeek:see:`ClusterController::Types::Result` records.
+	##     Each member captures one agent's response.
+	##
 	global set_configuration_response: event(reqid: string,
 	    result: ClusterController::Types::ResultVec);
+
 
 	# Testing events. These don't provide operational value but expose
 	# internal functionality, triggered by test cases.
 
-	# This event causes no further action (other than getting logged) if
-	# set_state is F. When T, the controller establishes request state. The
-	# conroller only ever sends the response event when this state times
-	# out.
+	## This event causes no further action (other than getting logged) if
+	## with_state is F. When T, the controller establishes request state, and
+	## the controller only ever sends the response event when this state times
+	## out.
+	##
+	## reqid: a request identifier string, echoed in the response event when
+	##     with_state is T.
+	##
+	## with_state: flag indicating whether the controller should keep (and
+	##     time out) request state for this request.
+	##
 	global test_timeout_request: event(reqid: string, with_state: bool);
+
+	## Response to a test_timeout_request event. The controller sends this
+	## back to the client if the original request had the with_state flag.
+	##
+	## reqid: the request identifier used in the request event.
+	##
 	global test_timeout_response: event(reqid: string,
 	    result: ClusterController::Types::Result);
+
+
+	# Notification events, agent -> controller
+
+	## The controller triggers this event when the operational cluster
+	## instances align with the ones desired by the cluster
+	## configuration. It's essentially a cluster management readiness
+	## event. This event is currently only used by the controller and not
+	## published to other topics.
+	##
+	## instances: the set of instance names now ready.
+	##
+	global notify_agents_ready: event(instances: set[string]);
 	}

--- a/scripts/policy/frameworks/cluster/controller/boot.zeek
+++ b/scripts/policy/frameworks/cluster/controller/boot.zeek
@@ -1,3 +1,10 @@
+##! The cluster controller's boot logic runs in Zeek's supervisor and instructs
+##! it to launch the controller process. The controller's main logic resides in
+##! main.zeek, similarly to other frameworks. The new process will execute that
+##! script.
+##!
+##! If the current process is not the Zeek supervisor, this does nothing.
+
 @load ./config
 
 event zeek_init()

--- a/scripts/policy/frameworks/cluster/controller/config.zeek
+++ b/scripts/policy/frameworks/cluster/controller/config.zeek
@@ -1,51 +1,78 @@
+##! Configuration settings for the cluster controller.
+
 @load policy/frameworks/cluster/agent/config
 
 module ClusterController;
 
 export {
-	# The name of this controller in the cluster.
-	# Without the environment variable and no redef, this
-	# falls back to "controller-<hostname>".
+	## The name of this controller. Defaults to the value of the
+	## ZEEK_CONTROLLER_NAME environment variable. When that is unset and the
+	## user doesn't redef the value, the implementation defaults to
+	## "controller-<hostname>".
 	const name = getenv("ZEEK_CONTROLLER_NAME") &redef;
 
-	# Controller stdout/stderr log files to produce in Zeek's
-	# working directory. If empty, no such logs will result.
+	## The controller's stdout log name. If the string is non-empty, Zeek will
+	## produce a free-form log (i.e., not one governed by Zeek's logging
+	## framework) in Zeek's working directory. If left empty, no such log
+	## results.
+	##
+	## Note that the controller also establishes a "proper" Zeek log via the
+	## :zeek:see:`ClusterController::Log` module.
 	const stdout_file = "controller.stdout" &redef;
+
+	## The controller's stderr log name. Like :zeek:see:`ClusterController::stdout_file`,
+	## but for the stderr stream.
 	const stderr_file = "controller.stderr" &redef;
 
-	# The address and port the controller listens on. When
-	# undefined, falls back to the default_address, which you can
-	# likewise customize.
+	## The network address the controller listens on. By default this uses
+	## the value of the ZEEK_CONTROLLER_ADDR environment variable, but you
+	## may also redef to a specific value. When empty, the implementation
+	## falls back to :zeek:see:`ClusterController::default_address`.
 	const listen_address = getenv("ZEEK_CONTROLLER_ADDR") &redef;
+
+	## The fallback listen address if :zeek:see:`ClusterController::listen_address`
+	## remains empty. Unless redefined, this uses Broker's own default
+	## listen address.
 	const default_address = Broker::default_listen_address &redef;
 
+	## The network port the controller listens on. Counterpart to
+	## :zeek:see:`ClusterController::listen_address`, defaulting to the
+	## ZEEK_CONTROLLER_PORT environment variable.
 	const listen_port = getenv("ZEEK_CONTROLLER_PORT") &redef;
+
+	## The fallback listen port if :zeek:see:`ClusterController::listen_port`
+	## remains empty.
 	const default_port = 2150/tcp &redef;
 
-	# A more aggressive default retry interval (vs default 30s)
+	## The controller's connect retry interval. Defaults to a more
+	## aggressive value compared to Broker's 30s.
 	const connect_retry = 1sec &redef;
 
-	# The controller listens for messages on this topic:
+	## The controller's Broker topic. Clients send requests to this topic.
 	const topic = "zeek/cluster-control/controller" &redef;
 
-	# The role of this node in cluster management. Agent and
-	# controller both redef this. Used during logging.
+	## The role of this process in cluster management. Agent and controller
+	## both redefine this. Used during logging.
 	const role = ClusterController::Types::NONE &redef;
 
-	# The timeout for request state. Applies both to state kept for client
-	# requests, as well as state in the agents for requests to the
-	# supervisor.
+	## The timeout for request state. Such state (see the :zeek:see:`ClusterController::Request`
+	## module) ties together request and response event pairs. The timeout causes
+	## its cleanup in the absence of a timely response. It applies both to
+	## state kept for client requests, as well as state in the agents for
+	## requests to the supervisor.
 	const request_timeout = 10sec &redef;
 
-	# Agent and controller currently log only, not via the data cluster's
-	# logger. (This might get added later.) For now, this means that
-	# if both write to the same log file, it gets garbled. The following
-	# lets you specify the working directory specifically for the agent.
+	## An optional custom output directory for the controller's stdout and
+	## stderr logs. Agent and controller currently only log locally, not via
+	## the data cluster's logger node. (This might change in the future.)
+	## This means that if both write to the same log file, the output gets
+	## garbled.
 	const directory = "" &redef;
 
-	# The following functions return the effective network endpoint
-	# information for this controller, in two related forms.
+	## Returns a :zeek:see:`Broker::NetworkInfo` record describing the controller.
 	global network_info: function(): Broker::NetworkInfo;
+
+	## Returns a :zeek:see:`Broker::EndpointInfo` record describing the controller.
 	global endpoint_info: function(): Broker::EndpointInfo;
 }
 

--- a/scripts/policy/frameworks/cluster/controller/log.zeek
+++ b/scripts/policy/frameworks/cluster/controller/log.zeek
@@ -1,3 +1,8 @@
+##! This module implements straightforward logging abilities for cluster
+##! controller and agent. It uses Zeek's logging framework, and works only for
+##! nodes managed by the supervisor. In this setting Zeek's logging framework
+##! operates locally, i.e., this logging does not involve any logger nodes.
+
 @load ./config
 
 module ClusterController::Log;
@@ -9,6 +14,7 @@ export {
 	## A default logging policy hook for the stream.
 	global log_policy: Log::PolicyHook;
 
+	## The controller/agent log supports four different log levels.
 	type Level: enum {
 		DEBUG,
 		INFO,
@@ -16,7 +22,7 @@ export {
 		ERROR,
 	};
 
-	## The record type which contains the column fields of the cluster log.
+	## The record type containing the column fields of the agent/controller log.
 	type Info: record {
 		## The time at which a cluster message was generated.
 		ts:       time;
@@ -30,11 +36,32 @@ export {
 		message:  string;
 	} &log;
 
+	## The log level in use for this node.
 	global log_level = DEBUG &redef;
 
+	## A debug-level log message writer.
+	##
+	## message: the message to log.
+	##
 	global debug: function(message: string);
+
+	## An info-level log message writer.
+	##
+	## message: the message to log.
+	##
 	global info: function(message: string);
+
+	## A warning-level log message writer.
+	##
+	## message: the message to log.
+	##
 	global warning: function(message: string);
+
+	## An error-level log message writer. (This only logs a message, it does not
+	## terminate Zeek or have other runtime effects.)
+	##
+	## message: the message to log.
+	##
 	global error: function(message: string);
 }
 

--- a/scripts/policy/frameworks/cluster/controller/main.zeek
+++ b/scripts/policy/frameworks/cluster/controller/main.zeek
@@ -1,3 +1,8 @@
+##! This is the main "runtime" of the cluster controller. Zeek does not load
+##! this directly; rather, the controller's bootstrapping module (in ./boot.zeek)
+##! specifies it as the script to run in the node newly created via Zeek's
+##! supervisor.
+
 @load base/frameworks/broker
 
 @load policy/frameworks/cluster/agent/config

--- a/scripts/policy/frameworks/cluster/controller/types.zeek
+++ b/scripts/policy/frameworks/cluster/controller/types.zeek
@@ -1,4 +1,6 @@
-# Types for the Cluster Controller framework. These are used by both agent and controller.
+##! This module holds the basic types needed for the Cluster Controller
+##! framework. These are used by both agent and controller, and several
+##! have corresponding equals in the zeek-client implementation.
 
 module ClusterController::Types;
 
@@ -14,19 +16,19 @@ export {
 
 	## A Zeek-side option with value.
 	type Option: record {
-		name: string;  # Name of option
-		value: string; # Value of option
+		name: string;  ##< Name of option
+		value: string; ##< Value of option
 	};
 
 	## Configuration describing a Zeek instance running a Cluster
 	## Agent. Normally, there'll be one instance per cluster
 	## system: a single physical system.
 	type Instance: record {
-		# Unique, human-readable instance name
+		## Unique, human-readable instance name
 		name: string;
-		# IP address of system
+		## IP address of system
 		host: addr;
-		# Agent listening port. Not needed if agents connect to controller.
+		## Agent listening port. Not needed if agents connect to controller.
 		listen_port: port &optional;
 	};
 
@@ -35,30 +37,30 @@ export {
 	## State that a Cluster Node can be in. State changes trigger an
 	## API notification (see notify_change()).
 	type State: enum {
-		Running,  # Running and operating normally
-		Stopped,  # Explicitly stopped
-		Failed,   # Failed to start; and permanently halted
-		Crashed,  # Crashed, will be restarted,
-		Unknown,  # State not known currently (e.g., because of lost connectivity)
+		Running,  ##< Running and operating normally
+		Stopped,  ##< Explicitly stopped
+		Failed,   ##< Failed to start; and permanently halted
+		Crashed,  ##< Crashed, will be restarted,
+		Unknown,  ##< State not known currently (e.g., because of lost connectivity)
 	};
 
 	## Configuration describing a Cluster Node process.
 	type Node: record {
-		name: string;                        # Cluster-unique, human-readable node name
-		instance: string;                    # Name of instance where node is to run
-		p: port;                             # Port on which this node will listen
-		role: Supervisor::ClusterRole;       # Role of the node.
-		state: State;                        # Desired, or current, run state.
-		scripts: vector of string &optional; # Additional Zeek scripts for node
-		options: set[Option] &optional;      # Zeek options for node
-		interface: string &optional;         # Interface to sniff
-		cpu_affinity: int &optional;         # CPU/core number to pin to
-		env: table[string] of string &default=table(); # Custom environment vars
+		name: string;                        ##< Cluster-unique, human-readable node name
+		instance: string;                    ##< Name of instance where node is to run
+		p: port;                             ##< Port on which this node will listen
+		role: Supervisor::ClusterRole;       ##< Role of the node.
+		state: State;                        ##< Desired, or current, run state.
+		scripts: vector of string &optional; ##< Additional Zeek scripts for node
+		options: set[Option] &optional;      ##< Zeek options for node
+		interface: string &optional;         ##< Interface to sniff
+		cpu_affinity: int &optional;         ##< CPU/core number to pin to
+		env: table[string] of string &default=table(); ##< Custom environment vars
 	};
 
-	# Data structure capturing a cluster's complete configuration.
+	## Data structure capturing a cluster's complete configuration.
 	type Configuration: record {
-		id: string &default=unique_id(""); # Unique identifier for a particular configuration
+		id: string &default=unique_id(""); ##< Unique identifier for a particular configuration
 
 		## The instances in the cluster.
 		instances: set[Instance] &default=set();
@@ -67,14 +69,14 @@ export {
 		nodes: set[Node] &default=set();
 	};
 
-	# Return value for request-response API event pairs
+	## Return value for request-response API event pairs
 	type Result: record {
-		reqid: string;                # Request ID of operation this result refers to
-		instance: string &default=""; # Name of associated instance (for context)
-		success: bool &default=T;     # True if successful
-		data: any &optional;          # Addl data returned for successful operation
-		error: string &default="";    # Descriptive error on failure
-		node: string &optional;       # Name of associated node (for context)
+		reqid: string;                ##< Request ID of operation this result refers to
+		instance: string &default=""; ##< Name of associated instance (for context)
+		success: bool &default=T;     ##< True if successful
+		data: any &optional;          ##< Addl data returned for successful operation
+		error: string &default="";    ##< Descriptive error on failure
+		node: string &optional;       ##< Name of associated node (for context)
 	};
 
 	type ResultVec: vector of Result;

--- a/scripts/policy/frameworks/cluster/controller/util.zeek
+++ b/scripts/policy/frameworks/cluster/controller/util.zeek
@@ -1,6 +1,14 @@
+##! Utility functions for the cluster controller framework, available to agent
+##! and controller.
+
 module ClusterController::Util;
 
 export {
+	## Renders a set of strings to an alphabetically sorted vector.
+	##
+	## ss: the string set to convert.
+	##
+	## Returns: the vector of all strings in ss.
 	global set_to_vector: function(ss: set[string]): vector of string;
 }
 


### PR DESCRIPTION
This is a comments-only changeset to add Zeekygen documentation to the cluster controller. I've verified that it builds the docs cleanly. I was tempted to go ahead and merge it but will leave it here for review ... @timwoj if you'd like to get started right away with the Zeek 4.2 release then please feel free to merge. Or we can sync up briefly in the morning. Thanks! 