### PR TITLE
Fix for avoiding de-ref of nil pointer

### DIFF
--- a/src/Func.cc
+++ b/src/Func.cc
@@ -706,8 +706,12 @@ broker::expected<broker::data> ScriptFunc::SerializeClosure() const
 	{
 	if ( captures_frame )
 		return captures_frame->SerializeCopyFrame();
-	else
+
+	if ( closure )
 		return closure->SerializeClosureFrame(outer_ids);
+
+	// No captures/closures, return an empty vector.
+	return broker::vector{};
 	}
 
 void ScriptFunc::Describe(ODesc* d) const


### PR DESCRIPTION
This PR addresses the nil-pointer dereference error flagged in https://github.com/zeek/zeek/issues/1895.