### PR TITLE
Enable null check for UBSan

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -271,7 +271,7 @@ openssl30_task:
 sanitizer_task:
   container:
     # Just uses a recent/common distro to run memory error/leak checks.
-    dockerfile: ci/ubuntu-18.04/Dockerfile
+    dockerfile: ci/ubuntu-20.04/Dockerfile
     cpu: 4
     # AddressSanitizer uses a lot more memory than a typical config.
     memory: 12GB

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ if ( ZEEK_SANITIZERS )
                 # list(APPEND _check_list "implicit-integer-sign-change") # Not truly UB
                 list(APPEND _check_list "integer-divide-by-zero")
                 list(APPEND _check_list "nonnull-attribute")
-                # list(APPEND _check_list "null") # TODO: fix associated errors
+                list(APPEND _check_list "null")
                 # list(APPEND _check_list "nullability-arg") # Not normally part of "undefined"
                 # list(APPEND _check_list "nullability-assign") # Not normally part of "undefined"
                 # list(APPEND _check_list "nullability-return") # Not normally part of "undefined"

--- a/src/script_opt/ZAM/ZBody.cc
+++ b/src/script_opt/ZAM/ZBody.cc
@@ -296,8 +296,8 @@ ValPtr ZBody::DoExec(Frame* f, int start_pc, StmtFlowType& flow)
 		auto& z = insts[pc];
 
 #ifdef DEBUG
-		int profile_pc;
-		double profile_CPU;
+		int profile_pc = 0;
+		double profile_CPU = 0.0;
 
 		if ( do_profile )
 			{


### PR DESCRIPTION
With the merging of https://github.com/zeek/zeek/pull/1926, all of the remaining failures for the `null` UndefinedBehaviorSanitizer checks have been fixed. This means we can now enable it in CI. This PR closes https://github.com/zeek/zeek/issues/1895.