### PR TITLE
Make some StringVal functions const

### DIFF
--- a/src/Val.cc
+++ b/src/Val.cc
@@ -953,17 +953,17 @@ ValPtr StringVal::SizeVal() const
 	return val_mgr->Count(string_val->Len());
 	}
 
-int StringVal::Len()
+int StringVal::Len() const
 	{
 	return AsString()->Len();
 	}
 
-const u_char* StringVal::Bytes()
+const u_char* StringVal::Bytes() const
 	{
 	return AsString()->Bytes();
 	}
 
-const char* StringVal::CheckString()
+const char* StringVal::CheckString() const
 	{
 	return AsString()->CheckString();
 	}

--- a/src/Val.h
+++ b/src/Val.h
@@ -533,9 +533,9 @@ public:
 
 	ValPtr SizeVal() const override;
 
-	int Len();
-	const u_char* Bytes();
-	const char* CheckString();
+	int Len() const;
+	const u_char* Bytes() const;
+	const char* CheckString() const;
 
 	// Note that one needs to de-allocate the return value of
 	// ExpandedString() to avoid a memory leak.


### PR DESCRIPTION
I noticed these while working on the TLS changes - I do not see a good reason why they should not be const.