### PR TITLE
Add unit tests to DNS_Mgr

### DIFF
--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -21,11 +21,13 @@ class RecordType;
 class Val;
 class ListVal;
 class TableVal;
+class StringVal;
 
 template <class T> class IntrusivePtr;
 using ValPtr = IntrusivePtr<Val>;
 using ListValPtr = IntrusivePtr<ListVal>;
 using TableValPtr = IntrusivePtr<TableVal>;
+using StringValPtr = IntrusivePtr<StringVal>;
 
 	} // namespace zeek
 
@@ -65,7 +67,7 @@ public:
 	// a set of addr.
 	TableValPtr LookupHost(const char* host);
 
-	ValPtr LookupAddr(const IPAddr& addr);
+	StringValPtr LookupAddr(const IPAddr& addr);
 
 	// Define the directory where to store the data.
 	void SetDir(const char* arg_dir) { dir = util::copy_string(arg_dir); }
@@ -108,6 +110,12 @@ public:
 	void GetStats(Stats* stats);
 
 	void Terminate();
+
+	/**
+	 * This method is used to call the private Process() method during unit testing
+	 * and shouldn't be used otherwise.
+	 */
+	void TestProcess();
 
 protected:
 	friend class LookupCallback;
@@ -183,38 +191,9 @@ protected:
 
 		bool IsAddrReq() const { return name.empty(); }
 
-		void Resolved(const char* name)
-			{
-			for ( CallbackList::iterator i = callbacks.begin(); i != callbacks.end(); ++i )
-				{
-				(*i)->Resolved(name);
-				delete *i;
-				}
-			callbacks.clear();
-			processed = true;
-			}
-
-		void Resolved(TableVal* addrs)
-			{
-			for ( CallbackList::iterator i = callbacks.begin(); i != callbacks.end(); ++i )
-				{
-				(*i)->Resolved(addrs);
-				delete *i;
-				}
-			callbacks.clear();
-			processed = true;
-			}
-
-		void Timeout()
-			{
-			for ( CallbackList::iterator i = callbacks.begin(); i != callbacks.end(); ++i )
-				{
-				(*i)->Timeout();
-				delete *i;
-				}
-			callbacks.clear();
-			processed = true;
-			}
+		void Resolved(const char* name);
+		void Resolved(TableVal* addrs);
+		void Timeout();
 		};
 
 	using AsyncRequestAddrMap = std::map<IPAddr, AsyncRequest*>;

--- a/src/Dict.h
+++ b/src/Dict.h
@@ -168,7 +168,9 @@ public:
 	DictIterator& operator=(DictIterator&& that);
 
 	reference operator*() { return *curr; }
+	reference operator*() const { return *curr; }
 	pointer operator->() { return curr; }
+	pointer operator->() const { return curr; }
 
 	DictIterator& operator++();
 	DictIterator operator++(int)

--- a/src/Val.h
+++ b/src/Val.h
@@ -823,6 +823,7 @@ public:
 	// so errors can arise for compound sets such as sets-of-sets.
 	// See https://bro-tracker.atlassian.net/browse/BIT-1949.
 	bool EqualTo(const TableVal& v) const;
+	bool EqualTo(const TableValPtr& v) const { return EqualTo(*(v.get())); }
 
 	// Returns true if this set is a subset (not necessarily proper)
 	// of the given set.


### PR DESCRIPTION
This is technically part of the work for #1635 but it seemed stand-alone enough to merge in ahead of all of that work begin finished. The tests here increase coverage for DNS_Mgr.cc from ~16% to ~80%. It doesn't fully test timeouts and such from `nb_dns` because that relies on the server actually failing to respond in a timely manner. There's one test that's commented out because I don't have ipv6 configured on my network so it fails to connect.

The branch `topic/timw/doctest-2.4.8` in the zeek-3rdparty repo needs to be merged at the same time.