### PR TITLE
changing "Bro" -> "Zeek" in source tree comments

### DIFF
--- a/src/DbgBreakpoint.h
+++ b/src/DbgBreakpoint.h
@@ -1,4 +1,4 @@
-// Structures and methods for implementing breakpoints in the Bro debugger.
+// Structures and methods for implementing breakpoints in the Zeek debugger.
 
 #pragma once
 

--- a/src/DbgDisplay.h
+++ b/src/DbgDisplay.h
@@ -1,4 +1,4 @@
-// Structures and methods for implementing watches in the Bro debugger.
+// Structures and methods for implementing watches in the Zeek debugger.
 
 #pragma once
 

--- a/src/DbgHelp.cc
+++ b/src/DbgHelp.cc
@@ -1,4 +1,4 @@
-// Bro Debugger Help
+// Zeek Debugger Help
 
 #include "zeek/zeek-config.h"
 

--- a/src/DbgWatch.h
+++ b/src/DbgWatch.h
@@ -1,4 +1,4 @@
-// Structures and methods for implementing watches in the Bro debugger.
+// Structures and methods for implementing watches in the Zeek debugger.
 
 #pragma once
 

--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -1,4 +1,4 @@
-// Debugging support for Bro policy files.
+// Debugging support for Zeek policy files.
 
 #include "zeek/Debug.h"
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -1,4 +1,4 @@
-// Debugging support for Bro policy files.
+// Debugging support for Zeek policy files.
 
 #pragma once
 

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -1,4 +1,4 @@
-// Support routines to help deal with Bro debugging commands and
+// Support routines to help deal with Zeek debugging commands and
 // implementation of most commands.
 
 #include "zeek/DebugCmds.h"

--- a/src/DebugCmds.h
+++ b/src/DebugCmds.h
@@ -1,4 +1,4 @@
-// Support routines to help deal with Bro debugging commands and
+// Support routines to help deal with Zeek debugging commands and
 // implementation of most commands.
 
 #pragma once

--- a/src/Event.cc
+++ b/src/Event.cc
@@ -136,7 +136,7 @@ void EventMgr::Drain()
 
 	draining = true;
 
-	// Past Bro versions drained as long as there events, including when
+	// Past Zeek versions drained as long as there events, including when
 	// a handler queued new events during its execution. This could lead
 	// to endless loops in case a handler kept triggering its own event.
 	// We now limit this to just a couple of rounds. We do more than

--- a/src/EventRegistry.h
+++ b/src/EventRegistry.h
@@ -1,4 +1,4 @@
-// Each event raised/handled by Bro is registered in the EventRegistry.
+// Each event raised/handled by Zeek is registered in the EventRegistry.
 
 #pragma once
 

--- a/src/PolicyFile.h
+++ b/src/PolicyFile.h
@@ -8,7 +8,7 @@
 //	(probably in the lexer). Then later any function that so desires
 //	can call a relevant function. Note that since it caches the contents,
 //	changes to the policy files will not be reflected until restart,
-//	which is probably good since it'll always display the code that Bro
+//	which is probably good since it'll always display the code that Zeek
 //	is actually using.
 
 // policy_filename arguments should be absolute or relative paths;

--- a/src/RandTest.cc
+++ b/src/RandTest.cc
@@ -9,7 +9,7 @@
         without fee is hereby granted, without any conditions or restrictions.
         This software is provided “as is” without express or implied warranty.
 
-    Modified for Bro by Seth Hall - July 2010
+    Modified for Zeek/Bro by Seth Hall - July 2010
 */
 
 #include "zeek/RandTest.h"

--- a/src/RuleCondition.h
+++ b/src/RuleCondition.h
@@ -122,7 +122,7 @@ private:
 	Comp comp;
 	};
 
-// Implements "eval" which evaluates the given Bro identifier.
+// Implements "eval" which evaluates the given Zeek identifier.
 class RuleConditionEval : public RuleCondition
 	{
 public:

--- a/src/RuleMatcher.h
+++ b/src/RuleMatcher.h
@@ -74,7 +74,7 @@ using maskedvalue_list = PList<MaskedValue>;
 using string_list = PList<char>;
 using bstr_list = PList<String>;
 
-// Get values from Bro's script-level variables.
+// Get values from Zeek's script-level variables.
 extern void id_to_maskedvallist(const char* id, maskedvalue_list* append_to,
                                 std::vector<IPPrefix>* prefix_vector = nullptr);
 extern char* id_to_str(const char* id);

--- a/src/RunState.cc
+++ b/src/RunState.cc
@@ -190,7 +190,7 @@ void init_run(const std::optional<std::string>& interface,
 		if ( const auto& id = zeek::detail::global_scope()->Find("trace_output_file") )
 			id->SetVal(make_intrusive<StringVal>(writefile));
 		else
-			reporter->Error("trace_output_file not defined in bro.init");
+			reporter->Error("trace_output_file not defined");
 		}
 
 	zeek::detail::init_ip_addr_anonymizers();
@@ -472,7 +472,7 @@ double pseudo_realtime = 0.0;
 double network_time = 0.0; // time according to last packet timestamp
                            // (or current time)
 double processing_start_time = 0.0; // time started working on current pkt
-double zeek_start_time = 0.0; // time Bro started.
+double zeek_start_time = 0.0; // time Zeek started.
 double zeek_start_network_time; // timestamp of first packet
 bool terminating = false; // whether we're done reading and finishing up
 bool is_parsing = false;

--- a/src/RunState.h
+++ b/src/RunState.h
@@ -93,10 +93,10 @@ extern double pseudo_realtime;
 // queue.
 extern double processing_start_time;
 
-// When the Bro process was started.
+// When the Zeek process was started.
 extern double zeek_start_time;
 
-// Time at which the Bro process was started with respect to network time,
+// Time at which the Zeek process was started with respect to network time,
 // i.e. the timestamp of the first packet.
 extern double zeek_start_network_time;
 
@@ -106,7 +106,7 @@ extern double network_time;
 // True if we're a in the process of cleaning-up just before termination.
 extern bool terminating;
 
-// True if Bro is currently parsing scripts.
+// True if Zeek is currently parsing scripts.
 extern bool is_parsing;
 
 extern const zeek::Packet* current_pkt;

--- a/src/ScriptCoverageManager.h
+++ b/src/ScriptCoverageManager.h
@@ -13,7 +13,7 @@ namespace zeek::detail
 class Stmt;
 
 /**
- * A simple class for managing stats of Bro script coverage across Bro runs.
+ * A simple class for managing stats of Zeek script coverage across Zeek runs.
  */
 class ScriptCoverageManager
 	{
@@ -22,7 +22,7 @@ public:
 	virtual ~ScriptCoverageManager();
 
 	/**
-	 * Imports Bro script Stmt usage information from file pointed to by
+	 * Imports Zeek script Stmt usage information from file pointed to by
 	 * environment variable ZEEK_PROFILER_FILE.
 	 *
 	 * @return: true if usage info was read, otherwise false.

--- a/src/Val.h
+++ b/src/Val.h
@@ -822,7 +822,7 @@ public:
 	// Returns true if this set contains the same members as the
 	// given set.  Note that comparisons are done using hash keys,
 	// so errors can arise for compound sets such as sets-of-sets.
-	// See https://bro-tracker.atlassian.net/browse/BIT-1949.
+	// See https://github.com/zeek/zeek/issues/151.
 	bool EqualTo(const TableVal& v) const;
 
 	// Returns true if this set is a subset (not necessarily proper)
@@ -1355,7 +1355,7 @@ public:
 	TableValPtr GetRecordFieldsVal() const;
 
 	// This is an experiment to associate a Obj within the
-	// event engine to a record value in bro script.
+	// event engine to a record value in Zeek script.
 	void SetOrigin(Obj* o) { origin = o; }
 	Obj* GetOrigin() const { return origin; }
 

--- a/src/ZeekString.h
+++ b/src/ZeekString.h
@@ -102,7 +102,7 @@ public:
 	static constexpr int EXPANDED_STRING = // the original style
 		ESC_HEX;
 
-	static constexpr int BRO_STRING_LITERAL = // as in a Bro string literal
+	static constexpr int BRO_STRING_LITERAL = // as in a Bro/Zeek string literal
 		ESC_ESC | ESC_QUOT | ESC_HEX;
 
 	// Renders a string into a newly allocated character array that
@@ -193,7 +193,7 @@ extern int Bstr_cmp(const String* s1, const String* s2);
 // which would be necessary if String were used. Unlike String,
 // the string should not be deallocated on destruction.
 //
-// "BroConstString" might be a better name here.
+// "ZeekConstString" might be a better name here.
 
 struct data_chunk_t
 	{

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -523,7 +523,7 @@ public:
 	void RemoveSupportAnalyzer(SupportAnalyzer* analyzer);
 
 	/**
-	 * Signals Bro's protocol detection that the analyzer has recognized
+	 * Signals Zeek's protocol detection that the analyzer has recognized
 	 * the input to indeed conform to the expected protocol. This should
 	 * be called as early as possible during a connection's life-time. It
 	 * may turn into \c protocol_confirmed event at the script-layer (but
@@ -537,7 +537,7 @@ public:
 	ProtocolConfirmation(zeek::Tag tag = zeek::Tag());
 
 	/**
-	 * Signals Bro's protocol detection that the analyzer has found a
+	 * Signals Zeek's protocol detection that the analyzer has found a
 	 * severe protocol violation that could indicate that it's not
 	 * parsing the expected protocol. This turns into \c
 	 * protocol_violation events at the script-layer (one such event is
@@ -577,7 +577,7 @@ public:
 	virtual void AnalyzerConfirmation(zeek::Tag tag = zeek::Tag());
 
 	/**
-	 * Signals Bro's protocol detection that the analyzer has found a
+	 * Signals Zeek's protocol detection that the analyzer has found a
 	 * severe protocol violation that could indicate that it's not
 	 * parsing the expected protocol. This turns into \c
 	 * analyzer_violation events at the script-layer (one such event is
@@ -683,7 +683,7 @@ protected:
 	 *
 	 * @param  t The absolute time when the timer will fire.
 	 *
-	 * @param do_expire If true, the timer will also fire when Bro
+	 * @param do_expire If true, the timer will also fire when Zeek
 	 * terminates even if \a t has not been reache yet.
 	 *
 	 * @param type The timer's type.
@@ -899,7 +899,7 @@ private:
 	SupportAnalyzer* sibling;
 	};
 
-// The following need to be consistent with bro.init.
+// The following need to be consistent with zeek.init.
 #define CONTENTS_NONE 0
 #define CONTENTS_ORIG 1
 #define CONTENTS_RESP 2

--- a/src/analyzer/Component.h
+++ b/src/analyzer/Component.h
@@ -83,7 +83,7 @@ public:
 
 	/**
 	 * Returns whether the analyzer supports partial connections. Partial
-	 * connections are those where Bro starts processing payload
+	 * connections are those where Zeek starts processing payload
 	 * mid-stream, after missing the beginning.
 	 */
 	bool Partial() const { return partial; }

--- a/src/analyzer/Manager.h
+++ b/src/analyzer/Manager.h
@@ -3,7 +3,7 @@
 /**
  * The central management unit for registering and instantiating analyzers.
  *
- * For each protocol that Bro supports, there's one class derived from
+ * For each protocol that Zeek supports, there's one class derived from
  * analyzer::Analyzer. Once we have decided that a connection's payload is to
  * be parsed as a given protocol, we instantiate the corresponding
  * analyzer-derived class and add the new instance as a child node into the
@@ -71,7 +71,7 @@ public:
 
 	/**
 	 * Second-stage initialization of the manager. This is called late
-	 * during Bro's initialization after any scripts are processed.
+	 * during Zeek's initialization after any scripts are processed.
 	 */
 	void InitPostScript();
 

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -11,7 +11,7 @@
 
 // Here are a few things to do:
 //
-// 1. Add a Bro internal function 'stop_deliver_data_of_entity' so
+// 1. Add a Zeek internal function 'stop_deliver_data_of_entity' so
 // that the engine does not decode and deliver further data for the
 // entity (which may speed up the engine by avoiding copying).
 //

--- a/src/analyzer/protocol/mime/MIME.h
+++ b/src/analyzer/protocol/mime/MIME.h
@@ -191,7 +191,7 @@ protected:
 
 // The reason I separate MIME_Message as an abstract class is to
 // present the *interface* separated from its implementation to
-// generate Bro events.
+// generate Zeek events.
 
 class MIME_Message
 	{

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -1,4 +1,4 @@
-// This code contributed to Bro by Florian Schimandl, Hugh Dollman and
+// This code contributed to Zeek/Bro by Florian Schimandl, Hugh Dollman and
 // Robin Sommer.
 
 #include "zeek/analyzer/protocol/pop3/POP3.h"

--- a/src/analyzer/protocol/pop3/POP3.h
+++ b/src/analyzer/protocol/pop3/POP3.h
@@ -1,4 +1,4 @@
-// This code contributed to Bro by Florian Schimandl and Hugh Dollman.
+// This code contributed to Zeek/Bro by Florian Schimandl and Hugh Dollman.
 //
 // An analyser for the POP3 protocol.
 

--- a/src/analyzer/protocol/rpc/NFS.h
+++ b/src/analyzer/protocol/rpc/NFS.h
@@ -68,7 +68,7 @@ protected:
 	                                BifEnum::NFS3::status_t status);
 
 	// Consumes the file data in the RPC message. Depending on NFS::return_data* consts
-	// in bro.init returns NULL or the data as string val:
+	// in zeek.init returns NULL or the data as string val:
 	//   * offset is the offset of the read/write call
 	//   * size is the amount of bytes read (or requested to be written),
 	StringValPtr nfs3_file_data(const u_char*& buf, int& n, uint64_t offset, int size);

--- a/src/analyzer/protocol/tcp/ContentLine.cc
+++ b/src/analyzer/protocol/tcp/ContentLine.cc
@@ -349,7 +349,7 @@ void ContentLine_Analyzer::CheckNUL()
 
 void ContentLine_Analyzer::SkipBytesAfterThisLine(int64_t length)
 	{
-	// This is a little complicated because Bro has to handle
+	// This is a little complicated because Zeek has to handle
 	// both CR and CRLF as a line break. When a line is delivered,
 	// it's possible that only a CR is seen, and we may not know
 	// if an LF is following until we see the next packet.  If an

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -1173,7 +1173,7 @@ struct data_type_getter
 		{
 		// Note that Broker uses vectors to store record data, so there's
 		// no actual way to tell if this data was originally associated
-		// with a Bro record.
+		// with a Zeek record.
 		return BifType::Enum::Broker::DataType->GetEnumVal(BifEnum::Broker::VECTOR);
 		}
 	};

--- a/src/broker/Data.h
+++ b/src/broker/Data.h
@@ -33,8 +33,8 @@ extern OpaqueTypePtr opaque_of_record_iterator;
 TransportProto to_zeek_port_proto(broker::port::protocol tp);
 
 /**
- * Create a Broker::Data value from a Bro value.
- * @param v the Bro value to convert to a Broker data value.
+ * Create a Broker::Data value from a Zeek value.
+ * @param v the Zeek value to convert to a Broker data value.
  * @return a Broker::Data value, where the optional field is set if the conversion
  * was possible, else it is unset.
  */
@@ -56,17 +56,17 @@ RecordValPtr make_data_val(broker::data d);
 EnumValPtr get_data_type(RecordVal* v, zeek::detail::Frame* frame);
 
 /**
- * Convert a Bro value to a Broker data value.
- * @param v a Bro value.
- * @return a Broker data value if the Bro value could be converted to one.
+ * Convert a Zeek value to a Broker data value.
+ * @param v a Zeek value.
+ * @return a Broker data value if the Zeek value could be converted to one.
  */
 broker::expected<broker::data> val_to_data(const Val* v);
 
 /**
- * Convert a Broker data value to a Bro value.
+ * Convert a Broker data value to a Zeek value.
  * @param d a Broker data value.
  * @param type the expected type of the value to return.
- * @return a pointer to a new Bro value or a nullptr if the conversion was not
+ * @return a pointer to a new Zeek value or a nullptr if the conversion was not
  * possible.
  */
 ValPtr data_to_val(broker::data d, Type* type);
@@ -87,7 +87,7 @@ broker::data threading_field_to_data(const threading::Field* f);
 threading::Field* data_to_threading_field(broker::data d);
 
 /**
- * A Bro value which wraps a Broker data value.
+ * A Zeek value which wraps a Broker data value.
  */
 class DataVal : public OpaqueVal
 	{
@@ -99,7 +99,7 @@ public:
 	ValPtr castTo(zeek::Type* t);
 	bool canCastTo(zeek::Type* t) const;
 
-	// Returns the Bro type that scripts use to represent a Broker data
+	// Returns the Zeek type that scripts use to represent a Broker data
 	// instance. This may be wrapping the opaque value inside another
 	// type.
 	static const TypePtr& ScriptDataType();
@@ -160,7 +160,7 @@ struct type_name_getter
 	};
 
 /**
- * Retrieve Broker data value associated with a Broker::Data Bro value.
+ * Retrieve Broker data value associated with a Broker::Data Zeek value.
  * @param v a Broker::Data value.
  * @param f used to get location information on error.
  * @return a reference to the wrapped Broker data value.  A runtime interpreter
@@ -172,7 +172,7 @@ broker::data& opaque_field_to_data(zeek::RecordVal* v, zeek::detail::Frame* f);
  * Retrieve variant data from a Broker data value.
  * @tparam T a type that the variant may contain.
  * @param d a Broker data value to get variant data out of.
- * @param tag a Bro tag which corresponds to T (just used for error reporting).
+ * @param tag a Zeek tag which corresponds to T (just used for error reporting).
  * @param f used to get location information on error.
  * @return a refrence to the requested type in the variant Broker data.
  * A runtime interpret exception is thrown if trying to access a type which

--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -77,7 +77,7 @@ struct Stats
 	};
 
 /**
- * Manages various forms of communication between peer Bro processes
+ * Manages various forms of communication between peer Zeek processes
  * or other external applications via use of the Broker messaging library.
  */
 class Manager : public iosource::IOSource
@@ -96,7 +96,7 @@ public:
 	~Manager() override;
 
 	/**
-	 * Initialization of the manager. This is called late during Bro's
+	 * Initialization of the manager. This is called late during Zeek's
 	 * initialization after any scripts are processed.
 	 */
 	void InitPostScript();
@@ -223,7 +223,7 @@ public:
 	 * @param topic a topic string associated with the event message.
 	 * Peers advertise interest by registering a subscription to some prefix
 	 * of this topic name.
-	 * @param event a Bro event value.
+	 * @param event a Zeek event value.
 	 * @return true if automatic event sending is now enabled.
 	 */
 	bool AutoPublishEvent(std::string topic, Val* event);

--- a/src/file_analysis/Manager.h
+++ b/src/file_analysis/Manager.h
@@ -49,13 +49,13 @@ public:
 
 	/**
 	 * First-stage initializion of the manager. This is called early on
-	 * during Bro's initialization, before any scripts are processed.
+	 * during Zeek's initialization, before any scripts are processed.
 	 */
 	void InitPreScript();
 
 	/**
 	 * Second-stage initialization of the manager. This is called late
-	 * during Bro's initialization after any scripts are processed.
+	 * during Zeek's initialization after any scripts are processed.
 	 */
 	void InitPostScript();
 
@@ -384,7 +384,7 @@ protected:
 	 * Evaluate timeout policy for a file and remove the File object mapped to
 	 * \a file_id if needed.
 	 * @param file_id the file identifier/hash.
-	 * @param is_termination whether the Manager (and probably Bro) is in a
+	 * @param is_termination whether the Manager (and probably Zeek) is in a
 	 *        terminating state.  If true, then the timeout cannot be postponed.
 	 */
 	void Timeout(const std::string& file_id, bool is_terminating = run_state::terminating);

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -150,8 +150,8 @@ private:
 /**
  * This class wraps an OpenSSL X509 data structure.
  *
- * We need these to be able to pass OpenSSL pointers around in Bro
- * script-land. Otherwise, we cannot verify certificates from Bro
+ * We need these to be able to pass OpenSSL pointers around in Zeek
+ * script-land. Otherwise, we cannot verify certificates from Zeek
  * scriptland
  */
 class X509Val : public OpaqueVal

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -30,7 +30,7 @@ namespace zeek::input
 /**
  * InputHashes are used as Dictionaries to store the value and index hashes
  * for all lines currently stored in a table. Index hash is stored as
- * HashKey*, because it is thrown into other Bro functions that need the
+ * HashKey*, because it is thrown into other Zeek functions that need the
  * complex structure of it. For everything we do (with values), we just take
  * the hash_t value and compare it directly with "=="
  */
@@ -1889,7 +1889,7 @@ void Manager::SendEvent(EventHandlerPtr ev, list<Val*> events) const
 		event_mgr.Enqueue(ev, std::move(vl), util::detail::SOURCE_LOCAL);
 	}
 
-// Convert a bro list value to a bro record value.
+// Convert a Zeek list value to a Zeek record value.
 // I / we could think about moving this functionality to val.cc
 RecordVal* Manager::ListValToRecordVal(ListVal* list, RecordType* request_type, int* position) const
 	{
@@ -2067,7 +2067,7 @@ int Manager::GetValueLength(const Value* val) const
 	}
 
 // Given a threading::value, copy the raw data bytes into *data and return how many bytes were
-// copied. Used for hashing the values for lookup in the bro table
+// copied. Used for hashing the values for lookup in the Zeek table
 int Manager::CopyValue(char* data, const int startpos, const Value* val) const
 	{
 	assert(val->present); // presence has to be checked elsewhere
@@ -2243,7 +2243,7 @@ zeek::detail::HashKey* Manager::HashValues(const int num_elements, const Value* 
 	return key;
 	}
 
-// convert threading value to Bro value
+// convert threading value to Zeek value
 // have_error is a reference to a boolean which is set to true as soon as an error occurs.
 // When have_error is set to true at the beginning of the function, it is assumed that
 // an error already occurred in the past and processing is aborted.
@@ -2440,7 +2440,7 @@ Manager::Stream* Manager::FindStream(ReaderFrontend* reader) const
 	return nullptr;
 	}
 
-// Function is called on Bro shutdown.
+// Function is called on Zeek shutdown.
 // Signal all frontends that they will cease operation.
 void Manager::Terminate()
 	{

--- a/src/input/Manager.h
+++ b/src/input/Manager.h
@@ -99,12 +99,12 @@ public:
 	bool RemoveStream(const std::string& id);
 
 	/**
-	 * Signals the manager to shutdown at Bro's termination.
+	 * Signals the manager to shutdown at Zeek's termination.
 	 */
 	void Terminate();
 
 	/**
-	 * Checks if a Bro type can be used for data reading. Note that
+	 * Checks if a Zeek type can be used for data reading. Note that
 	 * this function only applies to input streams; the logging framework
 	 * has an equivalent function; however we support logging of a wider
 	 * variety of types (e.g. functions).
@@ -229,11 +229,11 @@ private:
 	// startpos.
 	int CopyValue(char* data, const int startpos, const threading::Value* val) const;
 
-	// Convert Threading::Value to an internal Bro Type (works with Records).
+	// Convert Threading::Value to an internal Zeek Type (works with Records).
 	Val* ValueToVal(const Stream* i, const threading::Value* val, Type* request_type,
 	                bool& have_error) const;
 
-	// Convert Threading::Value to an internal Bro list type.
+	// Convert Threading::Value to an internal Zeek list type.
 	Val* ValueToIndexVal(const Stream* i, int num_fields, const RecordType* type,
 	                     const threading::Value* const* vals, bool& have_error) const;
 
@@ -244,7 +244,7 @@ private:
 
 	Val* RecordValToIndexVal(RecordVal* r) const;
 
-	// Converts a Bro ListVal to a RecordVal given the record type.
+	// Converts a Zeek ListVal to a RecordVal given the record type.
 	RecordVal* ListValToRecordVal(ListVal* list, RecordType* request_type, int* position) const;
 
 	// Internally signal errors, warnings, etc.

--- a/src/input/ReaderBackend.h
+++ b/src/input/ReaderBackend.h
@@ -300,7 +300,7 @@ protected:
 	void Put(threading::Value** val);
 
 	/**
-	 * Method allowing a reader to delete a specific value from a Bro
+	 * Method allowing a reader to delete a specific value from a Zeek
 	 * table.
 	 *
 	 * If the receiving stream is an event stream, only a removed event
@@ -312,7 +312,7 @@ protected:
 	void Delete(threading::Value** val);
 
 	/**
-	 * Method allowing a reader to clear a Bro table.
+	 * Method allowing a reader to clear a Zeek table.
 	 *
 	 * If the receiving stream is an event stream, this is ignored.
 	 *

--- a/src/input/readers/config/Config.cc
+++ b/src/input/readers/config/Config.cc
@@ -239,7 +239,7 @@ bool Config::DoUpdate()
 
 		// we only send the event if the underlying value has changed. Let's check that.
 		// (Yes, this means we keep all configuration options in memory twice - once here in
-		// the reader and once in memory in Bro; that is difficult to change.
+		// the reader and once in memory in Zeek; that is difficult to change.
 		auto search = option_values.find(key);
 		if ( search != option_values.end() && search->second == value )
 			{

--- a/src/iosource/BPF_Program.cc
+++ b/src/iosource/BPF_Program.cc
@@ -63,7 +63,7 @@ namespace zeek::iosource::detail
 	{
 
 // Simple heuristic to identify filters that always match, so that we can
-// skip the filtering in that case. "ip or not ip" is Bro's default filter.
+// skip the filtering in that case. "ip or not ip" is Zeek's default filter.
 static bool filter_matches_anything(const char* filter)
 	{
 	return (! filter) || strlen(filter) == 0 || strcmp(filter, "ip or not ip") == 0;

--- a/src/iosource/Component.h
+++ b/src/iosource/Component.h
@@ -115,7 +115,7 @@ public:
 
 	/**
 	 * Generates a human-readable description of the component. This goes
-	 * into the output of \c "bro -NN".
+	 * into the output of \c "zeek -NN".
 	 */
 	void DoDescribe(ODesc* d) const override;
 
@@ -164,7 +164,7 @@ public:
 
 	/**
 	 * Generates a human-readable description of the component. This goes
-	 * into the output of \c "bro -NN".
+	 * into the output of \c "zeek -NN".
 	 */
 	void DoDescribe(ODesc* d) const override;
 

--- a/src/iosource/IOSource.h
+++ b/src/iosource/IOSource.h
@@ -6,7 +6,7 @@ namespace zeek::iosource
 	{
 
 /**
- * Interface class for components providing/consuming data inside Bro's main
+ * Interface class for components providing/consuming data inside Zeek's main
  * loop.
  */
 class IOSource

--- a/src/iosource/Manager.h
+++ b/src/iosource/Manager.h
@@ -85,7 +85,7 @@ public:
 	/**
 	 * Opens a new packet source.
 	 *
-	 * @param path The interface or file name, as one would give to Bro \c -i.
+	 * @param path The interface or file name, as one would give to zeek \c -i.
 	 *
 	 * @param is_live True if \a path represents a live interface, false
 	 * for a file.
@@ -101,7 +101,7 @@ public:
 	 *
 	 * @param append True to append if \a path already exists.
 	 *
-	 * @return The new packet dumper, or null if an error occured.
+	 * @return The new packet dumper, or null if an error occurred.
 	 */
 	PktDumper* OpenPktDumper(const std::string& path, bool append);
 

--- a/src/iosource/PktSrc.cc
+++ b/src/iosource/PktSrc.cc
@@ -110,7 +110,7 @@ void PktSrc::Closed()
 
 void PktSrc::Error(const std::string& msg)
 	{
-	// We don't report this immediately, Bro will ask us for the error
+	// We don't report this immediately, Zeek will ask us for the error
 	// once it notices we aren't open.
 	errbuf = msg;
 	DBG_LOG(DBG_PKTIO, "Error with source %s: %s", IsOpen() ? props.path.c_str() : "<not open>",

--- a/src/logging/Manager.h
+++ b/src/logging/Manager.h
@@ -226,7 +226,7 @@ public:
 	bool Flush(EnumVal* id);
 
 	/**
-	 * Signals the manager to shutdown at Bro's termination.
+	 * Signals the manager to shutdown at Zeek's termination.
 	 */
 	void Terminate();
 

--- a/src/logging/WriterBackend.h
+++ b/src/logging/WriterBackend.h
@@ -243,7 +243,7 @@ public:
 	 * @param close: The timestamp when the origina file was closed.
 	 *
 	 * @param terminating: True if the original rotation request occured
-	 * due to the main Bro process shutting down.
+	 * due to the main Zeek process shutting down.
 	 */
 	bool FinishedRotation(const char* new_name, const char* old_name, double open, double close,
 	                      bool terminating);
@@ -363,7 +363,7 @@ protected:
 	 * @param close The network time when the *current* file was closed.
 	 *
 	 * @param terminating Indicates whether the rotation request occurs
-	 * due the main Bro prcoess terminating (and not because we've
+	 * due the main Zeek prcoess terminating (and not because we've
 	 * reached a regularly scheduled time for rotation).
 	 */
 	virtual bool DoRotate(const char* rotated_path, double open, double close,

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -391,7 +391,7 @@ bool Ascii::InitFormatter()
 		if ( enable_utf_8 )
 			desc.EnableUTF8();
 
-		// Use the default "Bro logs" format.
+		// Use the default "Zeek logs" format.
 		desc.EnableEscaping();
 		desc.AddEscapeSequence(separator);
 		threading::formatter::Ascii::SeparatorInfo sep_info(separator, set_separator, unset_field,

--- a/src/module_util.h
+++ b/src/module_util.h
@@ -1,5 +1,5 @@
 //
-// These functions are used by both Bro and bifcl.
+// These functions are used by both Zeek and bifcl.
 //
 
 #pragma once

--- a/src/packet_analysis/Analyzer.h
+++ b/src/packet_analysis/Analyzer.h
@@ -141,7 +141,7 @@ public:
 	virtual void AnalyzerConfirmation(session::Session* session, zeek::Tag tag = zeek::Tag());
 
 	/**
-	 * Signals Bro's protocol detection that the analyzer has found a
+	 * Signals Zeek's protocol detection that the analyzer has found a
 	 * severe protocol violation that could indicate that it's not
 	 * parsing the expected protocol. This turns into \c
 	 * analyzer_violation events at the script-layer (one such event is

--- a/src/packet_analysis/protocol/tcp/TCPSessionAdapter.cc
+++ b/src/packet_analysis/protocol/tcp/TCPSessionAdapter.cc
@@ -566,7 +566,7 @@ void TCPSessionAdapter::Process(bool is_orig, const struct tcphdr* tp, int len,
 
 	if ( seq_underflow && ! flags.RST() )
 		// Can't tell if if this is a retransmit/out-of-order or something
-		// before the sequence Bro initialized the endpoint at or the TCP is
+		// before the sequence Zeek initialized the endpoint at or the TCP is
 		// just broken and sending garbage sequences.  In either case, some
 		// standard analysis doesn't apply (e.g. reassembly).
 		Weird("TCP_seq_underflow_or_misorder");

--- a/src/plugin/Component.h
+++ b/src/plugin/Component.h
@@ -101,7 +101,7 @@ public:
 
 	/**
 	 * Returns a textual representation of the component. This goes into
-	 * the output of "bro -NN".
+	 * the output of "zeek -NN".
 	 *
 	 * By default, this just outputs the type and the name. Derived
 	 * versions can override DoDescribe() to add type specific details.

--- a/src/plugin/Manager.h
+++ b/src/plugin/Manager.h
@@ -108,7 +108,7 @@ public:
 
 	/**
 	 * First-stage initializion of the manager. This is called early on
-	 * during Bro's initialization, before any scripts are processed, and
+	 * during Zeek's initialization, before any scripts are processed, and
 	 * forwards to the corresponding Plugin methods.
 	 */
 	void InitPreScript();
@@ -121,7 +121,7 @@ public:
 
 	/**
 	 * Third-stage initialization of the manager. This is called late during
-	 * Bro's initialization after any scripts are processed, and forwards to
+	 * Zeek's initialization after any scripts are processed, and forwards to
 	 * the corresponding Plugin methods.
 	 */
 	void InitPostScript();
@@ -206,8 +206,8 @@ public:
 	/**
 	 * Registers interest in an event by a plugin, even if there's no handler
 	 * for it. Normally a plugin receives events through HookQueueEvent()
-	 * only if Bro actually has code to execute for it. By calling this
-	 * method, the plugin tells Bro to raise the event even if there's no
+	 * only if Zeek actually has code to execute for it. By calling this
+	 * method, the plugin tells Zeek to raise the event even if there's no
 	 * correspondong handler; it will then go into HookQueueEvent() just as
 	 * any other.
 	 *
@@ -218,7 +218,7 @@ public:
 	void RequestEvent(EventHandlerPtr handler, Plugin* plugin);
 
 	/**
-	 * Register interest in the destruction of a Obj instance. When Bro's
+	 * Register interest in the destruction of a Obj instance. When Zeek's
 	 * reference counting triggers the objects destructor to run, the \a
 	 * HookBroObjDtor will be called.
 	 *
@@ -233,9 +233,9 @@ public:
 	/**
 	 * Hook that gives plugins a chance to take over loading an input
 	 * file. This method must be called between InitPreScript() and
-	 * InitPostScript() for each input file Bro is about to load, either
+	 * InitPostScript() for each input file Zeek is about to load, either
 	 * given on the command line or via @load script directives. The hook can
-	 * take over the file, in which case Bro must not further process it
+	 * take over the file, in which case Zeek must not further process it
 	 * otherwise.
 	 *
 	 * @return 1 if a plugin took over the file and loaded it successfully; 0
@@ -248,10 +248,10 @@ public:
 	/**
 	 * Hook that gives plugins a chance to take over loading an input file,
 	 * including replacing the file's content. This method must be called
-	 * between InitPreScript() and InitPostScript() for each input file Bro is
+	 * between InitPreScript() and InitPostScript() for each input file Zeek is
 	 * about to load, either given on the command line or via @load script
-	 * directives. The hook can take over the file, in which case Bro must not
-	 * further process it otherwise; or provide its content, in which case Bro
+	 * directives. The hook can take over the file, in which case Zeek must not
+	 * further process it otherwise; or provide its content, in which case Zeek
 	 * must use that and ignore the original file.
 	 *
 	 * @return tuple where the first element is 1 if a plugin took over the
@@ -397,7 +397,7 @@ public:
 	 *
 	 * @param conn The associated connection
 	 *
-	 * @param addl Additional Bro values; typically will be passed to the event
+	 * @param addl Additional Zeek values; typically will be passed to the event
 	 *             by the reporter framework.
 	 *
 	 * @param location True if event expects location information

--- a/src/plugin/Plugin.h
+++ b/src/plugin/Plugin.h
@@ -283,7 +283,7 @@ public:
 		}
 
 	/**
-	 * Constructor with a Bro value argument.
+	 * Constructor with a Zeek value argument.
 	 */
 	explicit HookArgument(const Val* a)
 		{
@@ -292,7 +292,7 @@ public:
 		}
 
 	/**
-	 * Constructor with a list of Bro values argument.
+	 * Constructor with a list of Zeek values argument.
 	 */
 	explicit HookArgument(const ValPList* a)
 		{
@@ -453,7 +453,7 @@ public:
 		}
 
 	/**
-	 * Returns the value for a Bro value argument. The argument's type must
+	 * Returns the value for a Zeek value argument. The argument's type must
 	 * match accordingly.
 	 */
 	const Val* AsVal() const
@@ -463,7 +463,7 @@ public:
 		}
 
 	/**
-	 * Returns the value for a Bro wrapped value argument.  The argument's type must
+	 * Returns the value for a Zeek wrapped value argument.  The argument's type must
 	 * match accordingly.
 	 */
 	const std::pair<bool, Val*> AsFuncResult() const
@@ -473,7 +473,7 @@ public:
 		}
 
 	/**
-	 * Returns the value for a Bro frame argument.  The argument's type must
+	 * Returns the value for a Zeek frame argument.  The argument's type must
 	 * match accordingly.
 	 */
 	const zeek::detail::Frame* AsFrame() const
@@ -503,7 +503,7 @@ public:
 		}
 
 	/**
-	 * Returns the value for a list of Bro values argument. The argument's type must
+	 * Returns the value for a list of Zeek values argument. The argument's type must
 	 * match accordingly.
 	 */
 	const ValPList* AsValList() const
@@ -584,7 +584,7 @@ using HookArgumentList = std::list<HookArgument>;
 /**
  * Base class for all plugins.
  *
- * Plugins encapsulate functionality that extends one or more of Bro's major
+ * Plugins encapsulate functionality that extends one or more of Zeek's major
  * subsystems, such as analysis of a specific protocol, or logging output in
  * a particular format. A plugin acts a logical container that can provide a
  * set of functionality. Specifically, it may:
@@ -599,7 +599,7 @@ using HookArgumentList = std::list<HookArgument>;
  *   they'll be defined in *.bif files, but a plugin can also create them
  *   internally.
  *
- * - Provide hooks (aka callbacks) into Bro's core processing to inject
+ * - Provide hooks (aka callbacks) into Zeek's core processing to inject
  *   and/or alter functionality.
  *
  * A plugin needs to explicitly register all the functionality it provides.
@@ -699,7 +699,7 @@ public:
 	 *
 	 * Note that this method is rarely the right one to use. As it's for
 	 * informational purposes only, the plugin still needs to register
-	 * the BiF items themselves with the corresponding Bro parts. Doing
+	 * the BiF items themselves with the corresponding Zeek parts. Doing
 	 * so can be tricky, and it's recommned to instead define BiF items
 	 * in separate *.bif files that the plugin then pulls in. If defined
 	 * there, one does *not* need to call this method.
@@ -711,8 +711,8 @@ public:
 	void AddBifItem(const std::string& name, BifItem::Type type);
 
 	/**
-	 * Adds a file to the list of files that Bro loads at startup. This
-	 * will normally be a Bro script, but it passes through the plugin
+	 * Adds a file to the list of files that Zeek loads at startup. This
+	 * will normally be a Zeek script, but it passes through the plugin
 	 * system as well to load files with other extensions as supported by
 	 * any of the current plugins. In other words, calling this method is
 	 * similar to giving a file on the command line. Note that the file
@@ -732,7 +732,7 @@ protected:
 	friend class Manager;
 
 	/**
-	 * First-stage initialization of the plugin called early during Bro's
+	 * First-stage initialization of the plugin called early during Zeek's
 	 * startup, before scripts are parsed. This can be overridden by
 	 * derived classes; they must however call the parent's
 	 * implementation.
@@ -740,7 +740,7 @@ protected:
 	virtual void InitPreScript();
 
 	/**
-	 * Second-stage initialization of the plugin called late during Bro's
+	 * Second-stage initialization of the plugin called late during Zeek's
 	 * startup, after scripts are parsed. This can be overridden by
 	 * derived classes; they must however call the parent's
 	 * implementation.
@@ -768,12 +768,12 @@ protected:
 
 	/**
 	 * Enables a hook. The corresponding virtual method will now be
-	 * called as Bro's processing proceeds. Note that enabling hooks can
-	 * have performance impact as many trigger frequently inside Bro's
+	 * called as Zeek's processing proceeds. Note that enabling hooks can
+	 * have performance impact as many trigger frequently inside Zeek's
 	 * main processing path.
 	 *
 	 * Note that while hooks may be enabled/disabled dynamically at any
-	 * time, the output of Bro's \c -NN option will only reflect their
+	 * time, the output of Zeek's \c -NN option will only reflect their
 	 * state at startup time. Usually one should call this method for a
 	 * plugin's hooks in either the plugin's constructor or in
 	 * InitPreScript().
@@ -788,7 +788,7 @@ protected:
 	void EnableHook(HookType hook, int priority = 0);
 
 	/**
-	 * Disables a hook. Bro will no longer call the corresponding virtual
+	 * Disables a hook. Zeek will no longer call the corresponding virtual
 	 * method.
 	 *
 	 * @param hook The hook to disable.
@@ -803,9 +803,9 @@ protected:
 
 	/**
 	 * Registers interest in an event, even if there's no handler for it.
-	 * Normally a plugin receives events through HookQueueEvent() only if Bro
+	 * Normally a plugin receives events through HookQueueEvent() only if Zeek
 	 * actually has code to execute for it. By calling this method, the
-	 * plugin tells Bro to raise the event even if there's no correspondong
+	 * plugin tells Zeek to raise the event even if there's no correspondong
 	 * handler; it will then go into HookQueueEvent() just as any other.
 	 *
 	 * @param handler The event handler being interested in.
@@ -814,7 +814,7 @@ protected:
 
 	/**
 	 * Registers interest in the destruction of a Obj instance. When
-	 * Bro's reference counting triggers the objects destructor to run,
+	 * Zeek's reference counting triggers the objects destructor to run,
 	 * \a HookBroObjDtor will be called.
 	 *
 	 * Note that his can get expensive if triggered for many objects.
@@ -828,10 +828,10 @@ protected:
 	/**
 	 * Hook into loading input files. This method will be called between
 	 * InitPreScript() and InitPostScript(), but with no further order or
-	 * timing guaranteed. It will be called once for each input file Bro
+	 * timing guaranteed. It will be called once for each input file Zeek
 	 * is about to load, either given on the command line or via @load
 	 * script directives. The hook can take over the file, in which case
-	 * Bro will not further process it otherwise.
+	 * Zeek will not further process it otherwise.
 	 *
 	 * @param type The type of load encountered: script load, signatures load,
 	 *             or plugin load.
@@ -839,13 +839,13 @@ protected:
 	 * @param file The filename that was passed to @load. Only includes
 	 *             an extension if it was given in @load.
 	 *
-	 * @param resolved The file or directory name Bro resolved from
+	 * @param resolved The file or directory name Zeek resolved from
 	 *                 the given path and is going to load. Empty string
-	 *                 if Bro was not able to resolve a path.
+	 *                 if Zeek was not able to resolve a path.
 	 *
 	 * @return 1 if the plugin took over the file and loaded it
 	 * successfully; 0 if the plugin took over the file but had trouble
-	 * loading it (Bro will abort in this case, and the plugin should
+	 * loading it (Zeek will abort in this case, and the plugin should
 	 * have printed an error message); and -1 if the plugin wasn't
 	 * interested in the file at all.
 	 */
@@ -856,10 +856,10 @@ protected:
 	 * Hook into loading input files, with extended capabilities. This method
 	 * will be called between InitPreScript() and InitPostScript(), but with no
 	 * further order or timing guaranteed. It will be called once for each
-	 * input file Bro is about to load, either given on the command line or via
+	 * input file Zeek is about to load, either given on the command line or via
 	 * @load script directives. The hook can take over the file, in which case
-	 * Bro will not further process it otherwise. It can, alternatively, also
-	 * provide the file content as a string, which Bro will then process just
+	 * Zeek will not further process it otherwise. It can, alternatively, also
+	 * provide the file content as a string, which Zeek will then process just
 	 * as if it had read it from a file.
 	 *
 	 * @param type The type of load encountered: script load, signatures load,
@@ -868,21 +868,21 @@ protected:
 	 * @param file The filename that was passed to @load. Only includes
 	 *             an extension if it was given in @load.
 	 *
-	 * @param resolved The file or directory name Bro resolved from
+	 * @param resolved The file or directory name Zeek resolved from
 	 *                 the given path and is going to load. Empty string
-	 *                 if Bro was not able to resolve a path.
+	 *                 if Zeek was not able to resolve a path.
 	 *
 	 * @return tuple of an integer and an optional string, where: the integer
 	 * must be 1 if the plugin takes over loading the file (see below); 0 if
 	 * the plugin wanted to take over the file but had trouble loading it
 	 * (processing will abort in this case, and the plugin should have printed
-	 * an error message); and -1 if the plugin wants Bro to proceeed processing
+	 * an error message); and -1 if the plugin wants Zeek to proceeed processing
 	 * the file normally. If the plugins takes over by returning 1, there are
 	 * two cases: if the second tuple element remains unset, the plugin handled
-	 * the loading completely internally; Bro will not do anything further with
+	 * the loading completely internally; Zeek will not do anything further with
 	 * it. Alternatively, the plugin may optionally return the acutal content
 	 * to use for the file as a string through the tuple's second element. If
-	 * so, Bro will ignore the file on disk and use that provided content
+	 * so, Zeek will ignore the file on disk and use that provided content
 	 * instead (including when there's actually no physical file in place on
 	 * disk at all, and loading would have hence failed otherwise).
 	 */
@@ -959,7 +959,7 @@ protected:
 
 	/**
 	 * Hook for destruction of objects registered with
-	 * RequestBroObjDtor(). When Bro's reference counting triggers the
+	 * RequestBroObjDtor(). When Zeek's reference counting triggers the
 	 * objects destructor to run, this method will be run. It may also
 	 * run for other objects that this plugin has not registered for.
 	 *
@@ -1041,7 +1041,7 @@ protected:
 	 *
 	 * @param conn The associated connection
 	 *
-	 * @param addl Additional Bro values; typically will be passed to the event
+	 * @param addl Additional Zeek values; typically will be passed to the event
 	 *             by the reporter framework.
 	 *
 	 * @param location True if event expects location information

--- a/src/probabilistic/Hasher.h
+++ b/src/probabilistic/Hasher.h
@@ -49,7 +49,7 @@ public:
 	 * @param data A pointer to contiguous data that should be crunched into a
 	 * seed. If 0, the function tries to find a global_hash_seed script variable
 	 * to derive a seed from. If this variable does not exist, the function uses
-	 * the initial seed generated at Bro startup.
+	 * the initial seed generated at Zeek startup.
 	 *
 	 * @param size The number of bytes of *data*.
 	 *
@@ -148,7 +148,7 @@ public:
 
 	/**
 	 * Constructs an hash function seeded with a given seed and an
-	 * optional extra seed to replace the initial Bro seed.
+	 * optional extra seed to replace the initial Zeek seed.
 	 *
 	 * @param arg_seed The seed to use for this instance.
 	 */

--- a/src/probabilistic/Topk.h
+++ b/src/probabilistic/Topk.h
@@ -58,7 +58,7 @@ public:
 
 	/**
 	 * Call this when a new value is encountered. Note that on the first
-	 * call, the Bro type of the value types that are counted is set. All
+	 * call, the Zeek type of the value types that are counted is set. All
 	 * following calls to encountered have to specify the same type.
 	 *
 	 * @param value The encountered element
@@ -81,7 +81,7 @@ public:
 	 * certain val. Returns 0 if the val is unknown (and logs the error
 	 * to reporter).
 	 *
-	 * @param value Bro value to get counts for
+	 * @param value Zeek value to get counts for
 	 *
 	 * @returns internal count for val, 0 if unknown
 	 */
@@ -91,7 +91,7 @@ public:
 	 * Get the current epsilon tracked in the top-k data structure for a
 	 * certain val.
 	 *
-	 * @param value Bro value to get epsilons for
+	 * @param value Zeek value to get epsilons for
 	 *
 	 * @returns the epsilon. Returns 0 if the val is unknown (and logs
 	 * the error to reporter)

--- a/src/re-scan.l
+++ b/src/re-scan.l
@@ -1,4 +1,4 @@
-/* scan.l - scanner for Bro regular expressions */
+/* scan.l - scanner for Zeek regular expressions */
 
 /*
  * See the file "COPYING" in the main distribution directory for copyright.

--- a/src/rule-scan.l
+++ b/src/rule-scan.l
@@ -218,7 +218,7 @@ finger	{ rules_lval.val = zeek::detail::Rule::FINGER; return TOK_PATTERN_TYPE; }
 
 %%
 
-// We're about to parse a Bro policy-layer symbol.
+// We're about to parse a Zeek policy-layer symbol.
 void begin_PS()
 	{
 	BEGIN(PS);

--- a/src/telemetry/Manager.h
+++ b/src/telemetry/Manager.h
@@ -32,7 +32,7 @@ public:
 	virtual ~Manager();
 
 	/**
-	 * Initialization of the manager. This is called late during Bro's
+	 * Initialization of the manager. This is called late during Zeek's
 	 * initialization after any scripts are processed.
 	 */
 	virtual void InitPostScript();

--- a/src/threading/BasicThread.h
+++ b/src/threading/BasicThread.h
@@ -27,7 +27,7 @@ public:
 	 * Creates a new thread object. Instantiating the object does however
 	 * not yet start the actual OS thread, that requires calling Start().
 	 *
-	 * Only Bro's main thread may create new thread instances.
+	 * Only Zeek's main thread may create new thread instances.
 	 *
 	 * @param name A descriptive name for thread the thread. This may
 	 * show up in messages to the user.
@@ -68,7 +68,7 @@ public:
 	 * executing Run(). Note that one can't restart a thread after a
 	 * Stop(), doing so will be ignored.
 	 *
-	 * Only Bro's main thread must call this method.
+	 * Only Zeek's main thread must call this method.
 	 */
 	void Start();
 
@@ -83,7 +83,7 @@ public:
 	 * Calling this method has no effect if Start() hasn't been executed
 	 * yet.
 	 *
-	 * Only Bro's main thread must call this method.
+	 * Only Zeek's main thread must call this method.
 	 */
 	void SignalStop();
 
@@ -94,7 +94,7 @@ public:
 	 * yet. If this is executed without calling SignalStop() first,
 	 * results are undefined.
 	 *
-	 * Only Bro's main thread must call this method.
+	 * Only Zeek's main thread must call this method.
 	 */
 	void WaitForStop();
 
@@ -143,14 +143,14 @@ protected:
 
 	/**
 	 * Executed with Start(). This is a hook into starting the thread. It
-	 * will be called from Bro's main thread after the OS thread has been
+	 * will be called from Zeek's main thread after the OS thread has been
 	 * started.
 	 */
 	virtual void OnStart() { }
 
 	/**
 	 * Executed with SignalStop(). This is a hook into preparing the
-	 * thread for stopping. It will be called from Bro's main thread
+	 * thread for stopping. It will be called from Zeek's main thread
 	 * before the thread has been signaled to stop.
 	 */
 	virtual void OnSignalStop() { }
@@ -159,7 +159,7 @@ protected:
 	 * Executed with WaitForStop(). This is a hook into waiting for the
 	 * thread to stop. It must be overridden by derived classes and only
 	 * return once the thread has indeed finished processing. The method
-	 * will be called from Bro's main thread.
+	 * will be called from Zeek's main thread.
 	 */
 	virtual void OnWaitForStop() = 0;
 
@@ -171,7 +171,7 @@ protected:
 	/**
 	 * Destructor. This will be called by the manager.
 	 *
-	 * Only Bro's main thread may delete thread instances.
+	 * Only Zeek's main thread may delete thread instances.
 	 *
 	 */
 	virtual ~BasicThread();

--- a/src/threading/Formatter.h
+++ b/src/threading/Formatter.h
@@ -107,7 +107,7 @@ public:
 	static std::string Render(const Value::subnet_t& subnet);
 
 	/**
-	 * Convert a double into a string. This renders the double with Bro's
+	 * Convert a double into a string. This renders the double with Zeek's
 	 * standard precision.
 	 *
 	 * This is a helper function that formatter implementations may use.

--- a/src/threading/Manager.h
+++ b/src/threading/Manager.h
@@ -35,7 +35,7 @@ protected:
  * In addition to basic threads, the manager also provides additional
  * functionality specific to MsgThread instances. In particular, it polls
  * their outgoing message queue on a regular basis and feeds data sent into
- * the rest of Bro. It also triggers the regular heartbeats.
+ * the rest of Zeek. It also triggers the regular heartbeats.
  */
 class Manager
 	{

--- a/src/threading/MsgThread.h
+++ b/src/threading/MsgThread.h
@@ -29,7 +29,7 @@ class KillMeMessage;
 
 /**
  * A specialized thread that provides bi-directional message passing between
- * Bro's main thread and the child thread. Messages are instances of
+ * Zeek's main thread and the child thread. Messages are instances of
  * BasicInputMessage and BasicOutputMessage for message sent \a to the child
  * thread and received \a from the child thread, respectively.
  *
@@ -45,7 +45,7 @@ public:
 	 * Constructor. It automatically registers the thread with the
 	 * threading::Manager.
 	 *
-	 * Only Bro's main thread may instantiate a new thread.
+	 * Only Zeek's main thread may instantiate a new thread.
 	 */
 	MsgThread();
 
@@ -77,7 +77,7 @@ public:
 	 * Allows the child thread to send a specified Zeek event. The given Vals
 	 * must match the values expected by the event.
 	 *
-	 * @param name name of the bro event to send
+	 * @param name name of the Zeek event to send
 	 *
 	 * @param num_vals number of entries in \a vals
 	 *
@@ -129,7 +129,7 @@ public:
 
 	/**
 	 * Reports a fatal error from the child thread. The main thread will
-	 * pass this to the Reporter once received. Bro will terminate after
+	 * pass this to the Reporter once received. Zeek will terminate after
 	 * the message has been reported.
 	 *
 	 * Only the child thread may call this method.
@@ -140,7 +140,7 @@ public:
 
 	/**
 	 * Reports a fatal error from the child thread. The main thread will
-	 * pass this to the Reporter once received. Bro will terminate with a
+	 * pass this to the Reporter once received. Zeek will terminate with a
 	 * core dump after the message has been reported.
 	 *
 	 * Only the child thread may call this method.
@@ -151,7 +151,7 @@ public:
 
 	/**
 	 * Reports a potential internal problem from the child thread. The
-	 * main thread will pass this to the Reporter once received. Bro will
+	 * main thread will pass this to the Reporter once received. Zeek will
 	 * continue normally.
 	 *
 	 * Only the child thread may call this method.
@@ -162,7 +162,7 @@ public:
 
 	/**
 	 * Reports an internal program error from the child thread. The main
-	 * thread will pass this to the Reporter once received. Bro will
+	 * thread will pass this to the Reporter once received. Zeek will
 	 * terminate with a core dump after the message has been reported.
 	 *
 	 * Only the child thread may call this method.
@@ -353,7 +353,7 @@ private:
 	};
 
 /**
- * Base class for all message between Bro's main process and a MsgThread.
+ * Base class for all message between Zeek's main process and a MsgThread.
  */
 class Message
 	{
@@ -389,7 +389,7 @@ private:
 	};
 
 /**
- * Base class for messages sent from Bro's main thread to a child MsgThread.
+ * Base class for messages sent from Zeek's main thread to a child MsgThread.
  */
 class BasicInputMessage : public Message
 	{
@@ -404,7 +404,7 @@ protected:
 	};
 
 /**
- * Base class for messages sent from a child MsgThread to Bro's main thread.
+ * Base class for messages sent from a child MsgThread to Zeek's main thread.
  */
 class BasicOutputMessage : public Message
 	{

--- a/src/threading/Queue.h
+++ b/src/threading/Queue.h
@@ -21,7 +21,7 @@ namespace zeek::threading
  * The implementation uses multiple queues and reads/writes in rotary fashion
  * in an attempt to limit contention.
  *
- * All Queue instances must be instantiated by Bro's main thread.
+ * All Queue instances must be instantiated by Zeek's main thread.
  *
  * TODO: Unclear how critical performance is for this qeueue. We could likely
  * optimize it further if helpful.

--- a/src/threading/SerialTypes.cc
+++ b/src/threading/SerialTypes.cc
@@ -73,7 +73,7 @@ std::string Field::TypeName() const
 	{
 	std::string n;
 
-	// We do not support tables, if the internal Bro type is table it
+	// We do not support tables, if the internal Zeek type is table it
 	// always is a set.
 	if ( type == TYPE_TABLE )
 		n = "set";

--- a/src/util.h
+++ b/src/util.h
@@ -169,7 +169,7 @@ void seed_random(unsigned int seed);
 void set_thread_name(const char* name, pthread_t tid = pthread_self());
 
 // Each event source that may generate events gets an internally unique ID.
-// This is always LOCAL for a local Bro. For remote event sources, it gets
+// This is always LOCAL for a local Zeek. For remote event sources, it gets
 // assigned by the RemoteSerializer.
 //
 // FIXME: Find a nicer place for this type definition.

--- a/src/version.c.in
+++ b/src/version.c.in
@@ -5,7 +5,7 @@ char version[] = "@VERSION@";
 
 // A C function that has the current version built into its name.
 // One can link a shared library against this to ensure that it won't
-// load if the version of the main Bro binary differs compared to
+// load if the version of the main Zeek binary differs compared to
 // what the library was compiled against.
 const char* BRO_VERSION_FUNCTION()
 {

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -304,7 +304,7 @@ static void terminate_bro()
 	if ( profiling_logger )
 		{
 		// FIXME: There are some occasional crashes in the memory
-		// allocation code when killing Bro.  Disabling this for now.
+		// allocation code when killing Zeek.  Disabling this for now.
 		if ( ! (signal_val == SIGTERM || signal_val == SIGINT) )
 			profiling_logger->Log();
 

--- a/src/zeekygen/Manager.cc
+++ b/src/zeekygen/Manager.cc
@@ -61,11 +61,11 @@ Manager::Manager(const string& arg_config, const string& bro_command)
 	if ( getenv("ZEEK_DISABLE_ZEEKYGEN") )
 		disabled = true;
 
-	// If running bro without the "-X" option, then we don't need bro_mtime.
+	// If running Zeek without the "-X" option, then we don't need bro_mtime.
 	if ( disabled || arg_config.empty() )
 		return;
 
-	// Find the absolute or relative path to bro by checking each PATH
+	// Find the absolute or relative path to Zeek by checking each PATH
 	// component and also the current directory (so that this works if
 	// bro_command is a relative path).
 	const char* env_path = getenv("PATH");
@@ -73,9 +73,9 @@ Manager::Manager(const string& arg_config, const string& bro_command)
 	string path_to_bro = util::find_file(bro_command, path);
 	struct stat s;
 
-	// One way that find_file() could fail is when bro is located in
+	// One way that find_file() could fail is when Zeek is located in
 	// a PATH component that starts with a tilde (such as "~/bin").  A simple
-	// workaround is to just run bro with a relative or absolute path.
+	// workaround is to just run Zeek with a relative or absolute path.
 	if ( path_to_bro.empty() || stat(path_to_bro.c_str(), &s) < 0 )
 		reporter->InternalError("Zeekygen can't get mtime of zeek binary %s (try again by "
 		                        "specifying the absolute or relative path to Zeek): %s",

--- a/src/zeekygen/Manager.h
+++ b/src/zeekygen/Manager.h
@@ -58,8 +58,8 @@ public:
 	 * Ctor.
 	 * @param config Path to a Zeekygen config file if documentation is to be
 	 * written to disk.
-	 * @param bro_command The command used to invoke the bro process.
-	 * It's used when checking for out-of-date targets.  If the bro binary is
+	 * @param bro_command The command used to invoke the Zeek process.
+	 * It's used when checking for out-of-date targets.  If the Zeek binary is
 	 * newer then a target, it needs to be rebuilt.
 	 */
 	Manager(const std::string& config, const std::string& bro_command);
@@ -88,15 +88,15 @@ public:
 	void GenerateDocs() const;
 
 	/**
-	 * Register Bro script for which information/documentation will be gathered.
-	 * @param path Absolute path to Bro script.
+	 * Register Zeek script for which information/documentation will be gathered.
+	 * @param path Absolute path to Zeek script.
 	 */
 	void Script(const std::string& path);
 
 	/**
-	 * Register Bro script dependency ("@load").
-	 * @param path Absolute path to a Bro script.
-	 * @param dep Absolute path to a Bro script being "@load"d from script given
+	 * Register Zeek script dependency ("@load").
+	 * @param path Absolute path to a Zeek script.
+	 * @param dep Absolute path to a Zeek script being "@load"d from script given
 	 * by \a path.
 	 */
 	void ScriptDependency(const std::string& path, const std::string& dep);
@@ -104,7 +104,7 @@ public:
 	/**
 	 * Register a module usage (script may export identifiers in to the
 	 * module namespace).
-	 * @param path Absolute path to a Bro script.
+	 * @param path Absolute path to a Zeek script.
 	 * @param module The module which script given by \a path is using.
 	 */
 	void ModuleUsage(const std::string& path, const std::string& module);
@@ -128,7 +128,7 @@ public:
 	 * gathered.
 	 * @param id The identifier of the record type which has the field.
 	 * @param field The field name/type information.
-	 * @param path Absolute path to a Bro script in which this field is
+	 * @param path Absolute path to a Zeek script in which this field is
 	 * declared.  This can be different from the place where the record type
 	 * is declared due to redefs.
 	 * @param from_redef  The field is from a record redefinition.
@@ -139,7 +139,7 @@ public:
 	/**
 	 * Register a redefinition of a particular identifier.
 	 * @param id The identifier being redef'd.
-	 * @param path Absolute path to a Bro script doing the redef.
+	 * @param path Absolute path to a Zeek script doing the redef.
 	 * @param ic The initialization class that was used (e.g. =, +=, -=).
 	 * @param init_expr The intiialization expression that was used.
 	 */
@@ -150,7 +150,7 @@ public:
 
 	/**
 	 * Register Zeekygen script summary content.
-	 * @param path Absolute path to a Bro script.
+	 * @param path Absolute path to a Zeek script.
 	 * @param comment Zeekygen-style summary comment ("##!") to associate with
 	 * script given by \a path.
 	 */
@@ -209,7 +209,7 @@ public:
 	 * @param target_file output file of a Zeekygen target.
 	 * @param dependencies all dependencies of the target.
 	 * @return true if modification time of \a target_file is newer than
-	 * modification time of Bro binary, Zeekygen config file, and all
+	 * modification time of Zeek binary, Zeekygen config file, and all
 	 * dependencies, else false.
 	 */
 	template <class T>

--- a/src/zeekygen/ScriptInfo.cc
+++ b/src/zeekygen/ScriptInfo.cc
@@ -340,7 +340,7 @@ void ScriptInfo::DoInitPostScript()
 		state_vars.push_back(info);
 		}
 
-	// The following enum types are automatically created internally in Bro,
+	// The following enum types are automatically created internally in Zeek,
 	// so just manually associating them with scripts for now.
 	if ( name == "base/frameworks/input/main.zeek" )
 		{

--- a/src/zeekygen/ScriptInfo.h
+++ b/src/zeekygen/ScriptInfo.h
@@ -27,7 +27,7 @@ using id_info_set = std::set<IdentifierInfo*, IdInfoComp>;
 using id_info_list = std::list<IdentifierInfo*>;
 
 /**
- * Information about a Bro script.
+ * Information about a Zeek script.
  */
 class ScriptInfo : public Info
 	{

--- a/src/zeekygen/Target.cc
+++ b/src/zeekygen/Target.cc
@@ -260,7 +260,7 @@ void AnalyzerTarget::DoFindDependencies(const std::vector<Info*>& infos)
 	{
 	// TODO: really should add to dependency list the tag type's ID and
 	// all bif items for matching analyzer plugins, but that's all dependent
-	// on the bro binary itself, so I'm cheating.
+	// on the Zeek binary itself, so I'm cheating.
 	}
 
 void AnalyzerTarget::DoGenerate() const

--- a/src/zeekygen/Target.h
+++ b/src/zeekygen/Target.h
@@ -43,7 +43,7 @@ struct TargetFile
 
 /**
  * A Zeekygen target abstract base class.  A target is generally any portion of
- * documentation that Bro can build.  It's identified by a type (e.g. script,
+ * documentation that Zeek can build.  It's identified by a type (e.g. script,
  * identifier, package), a pattern (e.g. "example.zeek", "HTTP::Info"), and
  * a path to an output file.
  */


### PR DESCRIPTION
I've been pointwise fixing up references to "Bro"/"bro" in the source code to instead be to Zeek, and decided to just make a full pass doing so.  This PR addresses all of the references in the main source code's comments (no semantic changes), other than rare instances that need to remain as-is.  While it touches a lot of files, and thus will be somewhat disruptive to concurrent branches, it also represents about 20 minutes of hard typing 😏 so I'm not wedded to making these changes at this time if folks would rather wait.