### PR TITLE
String/StringVal: Replace char*/string constructors with string_view

### DIFF
--- a/src/Val.cc
+++ b/src/Val.cc
@@ -939,9 +939,7 @@ StringVal::StringVal(int length, const char* s)
 	{
 	}
 
-StringVal::StringVal(const char* s) : StringVal(new String(s)) { }
-
-StringVal::StringVal(const string& s) : StringVal(s.length(), s.data()) { }
+StringVal::StringVal(std::string_view s) : StringVal(s.length(), s.data()) { }
 
 StringVal::~StringVal()
 	{

--- a/src/Val.h
+++ b/src/Val.h
@@ -527,8 +527,7 @@ class StringVal final : public Val
 	{
 public:
 	explicit StringVal(String* s);
-	explicit StringVal(const char* s);
-	explicit StringVal(const std::string& s);
+	StringVal(std::string_view s);
 	StringVal(int length, const char* s);
 	~StringVal() override;
 

--- a/src/ZeekString.cc
+++ b/src/ZeekString.cc
@@ -47,12 +47,7 @@ String::String(const u_char* str, int arg_n, bool add_NUL) : String()
 	Set(str, arg_n, add_NUL);
 	}
 
-String::String(const char* str) : String()
-	{
-	Set(str);
-	}
-
-String::String(const std::string& str) : String()
+String::String(std::string_view str) : String()
 	{
 	Set(str);
 	}
@@ -147,29 +142,19 @@ void String::Set(const u_char* str, int len, bool add_NUL)
 	use_free_to_delete = false;
 	}
 
-void String::Set(const char* str)
+void String::Set(std::string_view str)
 	{
 	Reset();
 
-	if ( str )
+	if ( str.data() )
 		{
-		n = strlen(str);
+		n = str.size();
 		b = new u_char[n + 1];
-		memcpy(b, str, n + 1);
+		memcpy(b, str.data(), n);
+		b[n] = 0;
 		final_NUL = true;
 		use_free_to_delete = false;
 		}
-	}
-
-void String::Set(const std::string& str)
-	{
-	Reset();
-
-	n = str.size();
-	b = new u_char[n + 1];
-	memcpy(b, str.c_str(), n + 1);
-	final_NUL = true;
-	use_free_to_delete = false;
 	}
 
 void String::Set(const String& str)

--- a/src/ZeekString.h
+++ b/src/ZeekString.h
@@ -43,8 +43,7 @@ public:
 
 	// Constructors creating internal copies of the data passed in.
 	String(const u_char* str, int arg_n, bool add_NUL);
-	explicit String(const char* str);
-	explicit String(const std::string& str);
+	String(std::string_view str);
 	String(const String& bs);
 
 	// Constructor that takes owernship of the vector passed in.
@@ -72,8 +71,7 @@ public:
 	// contents to a copy of the string given by the arguments.
 	//
 	void Set(const u_char* str, int len, bool add_NUL = true);
-	void Set(const char* str);
-	void Set(const std::string& str);
+	void Set(std::string_view str);
 	void Set(const String& str);
 
 	void SetUseFreeToDelete(int use_it) { use_free_to_delete = use_it; }


### PR DESCRIPTION
This was something small I noticed while working on the DNS code. String and StringVal both have constructors that take both `char*` and `const std::string&`, which makes them good candidates for just having a single constructor that takes a `std::string_view`.