### PR TITLE
Updates to the cluster controller scripts to fix the docs build

### DIFF
--- a/scripts/policy/frameworks/cluster/agent/api.zeek
+++ b/scripts/policy/frameworks/cluster/agent/api.zeek
@@ -56,7 +56,7 @@ export {
 	## reqid: the request identifier used in the request event.
 	##
 	## result: a :zeek:see:`ClusterController::Types::Result` record. Its data
-	##     member is a vector of :zeek:see:`ClusterController::Types::NodeState`
+	##     member is a vector of :zeek:see:`ClusterController::Types::NodeStatus`
 	##     records, covering the nodes at this instance. The result may also
 	##     indicate failure, with error messages indicating what went wrong.
 	##

--- a/scripts/policy/frameworks/cluster/agent/main.zeek
+++ b/scripts/policy/frameworks/cluster/agent/main.zeek
@@ -13,10 +13,15 @@
 
 module ClusterAgent::Runtime;
 
-# Request state specific to supervisor interactions
-type SupervisorState: record {
-	node: string;
-};
+# This export is mainly to appease Zeekygen's need to understand redefs of the
+# Request record below. Without it, it fails to establish link targets for the
+# tucked-on types.
+export {
+	## Request state specific to the agent's Supervisor interactions.
+	type SupervisorState: record {
+		node: string; ##< Name of the node the Supervisor is acting on.
+	};
+}
 
 redef record ClusterController::Request::Request += {
 	supervisor_state: SupervisorState &optional;

--- a/scripts/policy/frameworks/cluster/controller/api.zeek
+++ b/scripts/policy/frameworks/cluster/controller/api.zeek
@@ -73,7 +73,7 @@ export {
 	##
 	## result: a :zeek:type`vector` of :zeek:see:`ClusterController::Types::Result`
 	##     records. Each record covers one cluster instance. Each record's data
-	##     member is a vector of :zeek:see:`ClusterController::Types::NodeState`
+	##     member is a vector of :zeek:see:`ClusterController::Types::NodeStatus`
 	##     records, covering the nodes at that instance. Results may also indicate
 	##     failure, with error messages indicating what went wrong.
 	global get_nodes_response: event(reqid: string,

--- a/scripts/policy/frameworks/cluster/controller/main.zeek
+++ b/scripts/policy/frameworks/cluster/controller/main.zeek
@@ -15,19 +15,31 @@
 
 module ClusterController::Runtime;
 
-# Request state specific to the set_configuration request/response events
-type SetConfigurationState: record {
-	config: ClusterController::Types::Configuration;
-	requests: set[string] &default=set();
-};
+# This export is mainly to appease Zeekygen's need to understand redefs of the
+# Request record below. Without it, it fails to establish link targets for the
+# tucked-on types.
+export {
+	## Request state specific to
+	## :zeek:see:`ClusterController::API::set_configuration_request` and
+	## :zeek:see:`ClusterController::API::set_configuration_response`.
+	type SetConfigurationState: record {
+		## The cluster configuration established with this request
+		config: ClusterController::Types::Configuration;
+		## Request state for every controller/agent transaction.
+		requests: set[string] &default=set();
+	};
 
-# Request state specific to the get_nodes request/response events
-type GetNodesState: record {
-	requests: set[string] &default=set();
-};
+	## Request state specific to
+	## :zeek:see:`ClusterController::API::get_nodes_request` and
+	## :zeek:see:`ClusterController::API::get_nodes_response`.
+	type GetNodesState: record {
+		## Request state for every controller/agent transaction.
+		requests: set[string] &default=set();
+	};
 
-# Dummy state for testing events.
-type TestState: record { };
+	## Dummy state for internal state-keeping test cases.
+	type TestState: record { };
+}
 
 redef record ClusterController::Request::Request += {
 	set_configuration_state: SetConfigurationState &optional;

--- a/scripts/policy/frameworks/cluster/controller/request.zeek
+++ b/scripts/policy/frameworks/cluster/controller/request.zeek
@@ -8,7 +8,12 @@
 module ClusterController::Request;
 
 export {
-	## Request records track each request's state.
+	## Request records track state associated with a request/response event
+	## pair. Calls to
+	## :zeek:see:`ClusterController::Request::create` establish such state
+	## when an entity sends off a request event, while
+	## :zeek:see:`ClusterController::Request::finish` clears the state when
+	## a corresponding response event comes in, or the state times out.
 	type Request: record {
 		## Each request has a hopfully unique ID provided by the requester.
 		id: string;


### PR DESCRIPTION
Mostly trivial changes, except for one aspect: if a module exports a record type
and that record bears Zeekygen comments, then redefs that add to the record in
another module cannot be private to that module. Zeekygen will complain with
"unknown target" errors, even when such redefs have Zeekygen comments. So this
commits also adds two export-blocks that aren't technically required at this point.