### PR TITLE
Expand generate-docs Github workflow to test docs build on PRs

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,8 +1,13 @@
 name: Generate Documentation
 
 on:
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   generate:
@@ -15,7 +20,6 @@ jobs:
           token: ${{ secrets.ZEEK_BOT_TOKEN }}
 
       - name: Sync Submodules
-        shell: bash
         run: |
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
@@ -58,7 +62,6 @@ jobs:
           ( cd build && make -j 3 )
 
       - name: Generate Docs
-        shell: bash
         run: |
           git config --global user.name zeek-bot
           git config --global user.email info@zeek.org
@@ -76,16 +79,19 @@ jobs:
           echo "*** Check for Sphinx Warnings ***"
           grep -q WARNING make.out && exit 1
           rm make.out
-          echo "*** Pushing zeek-docs Changes ***"
+
+      - name: Push zeek-docs Changes
+        if: github.event_name == 'schedule'
+        run: |
+          cd doc
           git remote set-url origin "https://zeek-bot:${{ secrets.ZEEK_BOT_TOKEN }}@github.com/zeek/zeek-docs"
           git add scripts/ script-reference/
           git status
           git commit -m "Generate docs" && git push || /bin/true
-          cd ..
 
       - name: Update zeek-docs Submodule
+        if: github.event_name == 'schedule'
         run: |
-          echo "*** Update zeek/doc Submodule ***"
           git config --global user.name zeek-bot
           git config --global user.email info@zeek.org
           git remote add auth "https://zeek-bot:${{ secrets.ZEEK_BOT_TOKEN }}@github.com/zeek/zeek"


### PR DESCRIPTION
This adds pull requests as a trigger event and runs the doc submodule
commit/push as well as the submodule bump only on the original scheduled runs.