### PR TITLE
remove deprecated union and timer types, addressing #1898

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -4275,8 +4275,6 @@ ScheduleExpr::ScheduleExpr(ExprPtr arg_when, EventExprPtr arg_event)
 
 	if ( bt != TYPE_TIME && bt != TYPE_INTERVAL )
 		ExprError("schedule expression requires a time or time interval");
-	else
-		SetType(base_type(TYPE_TIMER));
 	}
 
 bool ScheduleExpr::IsPure() const

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -42,21 +42,19 @@ const char* type_name(TypeTag t)
 		"string", // 7
 		"pattern", // 8
 		"enum", // 9
-		"timer", // 10
-		"port", // 11
-		"addr", // 12
-		"subnet", // 13
-		"any", // 14
-		"table", // 15
-		"union", // 16
-		"record", // 17
-		"types", // 18
-		"func", // 19
-		"file", // 20
-		"vector", // 21
-		"opaque", // 22
-		"type", // 23
-		"error", // 24
+		"port", // 10
+		"addr", // 11
+		"subnet", // 12
+		"any", // 13
+		"table", // 14
+		"record", // 15
+		"types", // 16
+		"func", // 17
+		"file", // 18
+		"vector", // 19
+		"opaque", // 20
+		"type", // 21
+		"error", // 22
 	};
 
 	if ( int(t) >= NUM_TYPES )
@@ -208,7 +206,6 @@ TypePtr Type::ShallowClone()
 		case TYPE_INTERVAL:
 		case TYPE_STRING:
 		case TYPE_PATTERN:
-		case TYPE_TIMER:
 		case TYPE_PORT:
 		case TYPE_ADDR:
 		case TYPE_SUBNET:
@@ -1870,7 +1867,6 @@ bool same_type(const Type& arg_t1, const Type& arg_t2, bool is_init, bool match_
 		case TYPE_INTERVAL:
 		case TYPE_STRING:
 		case TYPE_PATTERN:
-		case TYPE_TIMER:
 		case TYPE_PORT:
 		case TYPE_ADDR:
 		case TYPE_SUBNET:
@@ -1971,9 +1967,6 @@ bool same_type(const Type& arg_t1, const Type& arg_t2, bool is_init, bool match_
 		case TYPE_FILE:
 		case TYPE_TYPE:
 			break;
-
-		case TYPE_UNION:
-			reporter->Error("union type in same_type()");
 		}
 
 	// If we get to here, then we're dealing with a type with
@@ -2190,7 +2183,6 @@ bool is_assignable(TypeTag t)
 		case TYPE_STRING:
 		case TYPE_PATTERN:
 		case TYPE_ENUM:
-		case TYPE_TIMER:
 		case TYPE_PORT:
 		case TYPE_ADDR:
 		case TYPE_SUBNET:
@@ -2210,9 +2202,6 @@ bool is_assignable(TypeTag t)
 
 		case TYPE_VOID:
 			return false;
-
-		case TYPE_UNION:
-			reporter->Error("union type in is_assignable()");
 		}
 
 	return false;
@@ -2269,7 +2258,6 @@ TypePtr merge_types(const TypePtr& arg_t1, const TypePtr& arg_t2)
 		case TYPE_INTERVAL:
 		case TYPE_STRING:
 		case TYPE_PATTERN:
-		case TYPE_TIMER:
 		case TYPE_PORT:
 		case TYPE_ADDR:
 		case TYPE_SUBNET:
@@ -2470,10 +2458,6 @@ TypePtr merge_types(const TypePtr& arg_t1, const TypePtr& arg_t2)
 				}
 
 			return make_intrusive<FileType>(merge_types(t1->Yield(), t2->Yield()));
-
-		case TYPE_UNION:
-			reporter->InternalError("union type in merge_types()");
-			return nullptr;
 
 		default:
 			reporter->InternalError("bad type in merge_types()");

--- a/src/Type.h
+++ b/src/Type.h
@@ -49,21 +49,19 @@ enum TypeTag
 	TYPE_STRING, // 7
 	TYPE_PATTERN, // 8
 	TYPE_ENUM, // 9
-	TYPE_TIMER, // 10
-	TYPE_PORT, // 11
-	TYPE_ADDR, // 12
-	TYPE_SUBNET, // 13
-	TYPE_ANY, // 14
-	TYPE_TABLE, // 15
-	TYPE_UNION, // 16
-	TYPE_RECORD, // 17
-	TYPE_LIST, // 18
-	TYPE_FUNC, // 19
-	TYPE_FILE, // 20
-	TYPE_VECTOR, // 21
-	TYPE_OPAQUE, // 22
-	TYPE_TYPE, // 23
-	TYPE_ERROR // 24
+	TYPE_PORT, // 10
+	TYPE_ADDR, // 11
+	TYPE_SUBNET, // 12
+	TYPE_ANY, // 13
+	TYPE_TABLE, // 14
+	TYPE_RECORD, // 15
+	TYPE_LIST, // 16
+	TYPE_FUNC, // 17
+	TYPE_FILE, // 18
+	TYPE_VECTOR, // 19
+	TYPE_OPAQUE, // 20
+	TYPE_TYPE, // 21
+	TYPE_ERROR // 22
 #define NUM_TYPES (int(TYPE_ERROR) + 1)
 	};
 
@@ -126,10 +124,8 @@ constexpr InternalTypeTag to_internal_type_tag(TypeTag tag) noexcept
 			return TYPE_INTERNAL_SUBNET;
 
 		case TYPE_PATTERN:
-		case TYPE_TIMER:
 		case TYPE_ANY:
 		case TYPE_TABLE:
-		case TYPE_UNION:
 		case TYPE_RECORD:
 		case TYPE_LIST:
 		case TYPE_FUNC:
@@ -951,7 +947,7 @@ inline bool IsInterval(TypeTag t)
 // True if the given type tag corresponds to a record type.
 inline bool IsRecord(TypeTag t)
 	{
-	return (t == TYPE_RECORD || t == TYPE_UNION);
+	return (t == TYPE_RECORD);
 	}
 
 // True if the given type tag corresponds to a function type.

--- a/src/ZVal.cc
+++ b/src/ZVal.cc
@@ -104,8 +104,6 @@ ZVal::ZVal(ValPtr v, const TypePtr& t)
 			break;
 
 		case TYPE_ERROR:
-		case TYPE_TIMER:
-		case TYPE_UNION:
 		case TYPE_VOID:
 			reporter->InternalError("bad type in ZVal constructor");
 		}
@@ -185,8 +183,6 @@ ZVal::ZVal(const TypePtr& t)
 			break;
 
 		case TYPE_ERROR:
-		case TYPE_TIMER:
-		case TYPE_UNION:
 		case TYPE_VOID:
 			reporter->InternalError("bad type in ZVal constructor");
 		}
@@ -275,8 +271,6 @@ ValPtr ZVal::ToVal(const TypePtr& t) const
 			break;
 
 		case TYPE_ERROR:
-		case TYPE_TIMER:
-		case TYPE_UNION:
 		case TYPE_VOID:
 		default:
 			v = nullptr;

--- a/src/parse.y
+++ b/src/parse.y
@@ -18,7 +18,7 @@
 %token TOK_PORT TOK_PRINT TOK_RECORD TOK_REDEF
 %token TOK_REMOVE_FROM TOK_RETURN TOK_SCHEDULE TOK_SET
 %token TOK_STRING TOK_SUBNET TOK_SWITCH TOK_TABLE
-%token TOK_TIME TOK_TIMEOUT TOK_TIMER TOK_TYPE TOK_UNION TOK_VECTOR TOK_WHEN
+%token TOK_TIME TOK_TIMEOUT TOK_TYPE TOK_VECTOR TOK_WHEN
 %token TOK_WHILE TOK_AS TOK_IS
 
 %token TOK_ATTR_ADD_FUNC TOK_ATTR_DEFAULT TOK_ATTR_OPTIONAL TOK_ATTR_REDEF
@@ -1023,11 +1023,6 @@ type:
 				$$ = base_type(TYPE_PATTERN)->Ref();
 				}
 
-	|	TOK_TIMER	{
-				set_location(@1);
-				$$ = base_type(TYPE_TIMER)->Ref();
-				}
-
 	|	TOK_PORT	{
 				set_location(@1);
 				$$ = base_type(TYPE_PORT)->Ref();
@@ -1068,13 +1063,6 @@ type:
 				{
 				set_location(@1, @5);
 				$$ = new RecordType($4);
-				}
-
-	|	TOK_UNION '{' type_list '}'
-				{
-				set_location(@1, @4);
-				reporter->Error("union type not implemented");
-				$$ = 0;
 				}
 
 	|	TOK_ENUM '{' { set_location(@1); parse_new_enum(); } enum_body '}'

--- a/src/scan.l
+++ b/src/scan.l
@@ -297,9 +297,7 @@ switch	return TOK_SWITCH;
 table	return TOK_TABLE;
 time	return TOK_TIME;
 timeout	return TOK_TIMEOUT;
-timer	return TOK_TIMER;
 type	return TOK_TYPE;
-union	return TOK_UNION;
 vector	return TOK_VECTOR;
 when	return TOK_WHEN;
 

--- a/src/script_opt/CPP/RuntimeInits.cc
+++ b/src/script_opt/CPP/RuntimeInits.cc
@@ -279,7 +279,6 @@ void CPP_TypeInits::Generate(InitsManager* im, vector<TypePtr>& ivec, int offset
 		case TYPE_PORT:
 		case TYPE_STRING:
 		case TYPE_TIME:
-		case TYPE_TIMER:
 		case TYPE_VOID:
 		case TYPE_SUBNET:
 		case TYPE_FILE:

--- a/src/script_opt/CPP/Types.cc
+++ b/src/script_opt/CPP/Types.cc
@@ -141,8 +141,6 @@ const char* CPPCompile::TypeTagName(TypeTag tag)
 			return "TYPE_TABLE";
 		case TYPE_TIME:
 			return "TYPE_TIME";
-		case TYPE_TIMER:
-			return "TYPE_TIMER";
 		case TYPE_TYPE:
 			return "TYPE_TYPE";
 		case TYPE_VECTOR:
@@ -302,7 +300,6 @@ shared_ptr<CPP_InitInfo> CPPCompile::RegisterType(const TypePtr& tp)
 		case TYPE_PORT:
 		case TYPE_STRING:
 		case TYPE_TIME:
-		case TYPE_TIMER:
 		case TYPE_VOID:
 		case TYPE_SUBNET:
 		case TYPE_FILE:

--- a/src/script_opt/ProfileFunc.cc
+++ b/src/script_opt/ProfileFunc.cc
@@ -576,8 +576,6 @@ void ProfileFuncs::TraverseValue(const ValPtr& v)
 		case TYPE_STRING:
 		case TYPE_SUBNET:
 		case TYPE_TIME:
-		case TYPE_TIMER:
-		case TYPE_UNION:
 		case TYPE_VOID:
 			break;
 
@@ -777,8 +775,6 @@ p_hash_type ProfileFuncs::HashType(const Type* t)
 		case TYPE_STRING:
 		case TYPE_SUBNET:
 		case TYPE_TIME:
-		case TYPE_TIMER:
-		case TYPE_UNION:
 		case TYPE_VOID:
 			h = merge_p_hashes(h, p_hash(t));
 			break;


### PR DESCRIPTION
This removes the timer and union types, along the lines of PR 1973.