### PR TITLE
Fix document generation

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
+          token: ${{ secrets.ZEEK_BOT_TOKEN }}
 
       - name: Switch doc submodule to master
         run: cd doc && git checkout master
@@ -78,20 +79,21 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           cd doc
-          git remote set-url origin "https://zeek-bot:${{ secrets.ZEEK_BOT_TOKEN }}@github.com/zeek/zeek-docs"
           git add scripts/ script-reference/
           git status
-          git commit -m "Generate docs" && git push || /bin/true
+          # git commit errors when there's nothing to commit, so guard it
+          # with a check that detects whether there's anything to commit/push.
+          git diff-index --quiet HEAD || { git commit -m "Generate docs" && git push; }
 
       - name: Update zeek-docs Submodule
         if: github.event_name == 'schedule'
         run: |
           git config --global user.name zeek-bot
           git config --global user.email info@zeek.org
-          git remote add auth "https://zeek-bot:${{ secrets.ZEEK_BOT_TOKEN }}@github.com/zeek/zeek"
           git add doc
           git status
-          git commit -m 'Update doc submodule [nomail] [skip ci]' && git push auth master || /bin/true
+          # Similar logic here: proceed only if there's a change in the submodule.
+          git diff-index --quiet HEAD || { git commit -m 'Update doc submodule [nomail] [skip ci]' && git push; }
 
       - name: Send email
         if: failure()


### PR DESCRIPTION
We broke multi-repo git interaction when we introduced use of "actions/checkout",
because it has subtle implications on auth mechanisms (for details, check action
logs when it conducts a recursive checkout). Thankfully it also helps overcome
these: passing a user token to actions/checkout simplifies multi-repo git interaction,
making it work as it should: you no longer need to think about it. We now use this
approach.

Also tweak the git commit logic: we no longer mask all errors. Seems we mainly
did that to mask "git commit" on no changes erroring out. Instead we now check
whether there's anything to commit, and only do so then. We do this both in the
zeek-docs repo and for the docs submodule bump.

Here's a run with changes (over in my fork):
https://github.com/ckreibich/zeek/actions/runs/1994858558

And a subsequent one, without:
https://github.com/ckreibich/zeek/actions/runs/1995127691