### PR TITLE
Fix incorrect infinite loop instructions added by lower versions of GCC

### DIFF
--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -693,6 +693,10 @@ bool DNS_Interpreter::ParseRR_EDNS(detail::DNS_MsgInfo* msg, const u_char*& data
 	// parse EDNS options
 	while ( len > 0 )
 		{
+#if (defined(__GNUC__) && __GNUC__ < 8)
+		// Older versions of GCC will add strange infinite loop instructions here
+		util::do_not_optimize(len);
+#endif
 		uint16_t option_code = ExtractShort(data, len);
 		int option_len = ExtractShort(data, len);
 		// check for invalid option length

--- a/src/util.h
+++ b/src/util.h
@@ -568,5 +568,25 @@ std::string json_escape_utf8(const std::string& val, bool escape_printable_contr
 std::string json_escape_utf8(const char* val, size_t val_size,
                              bool escape_printable_controls = true);
 
+// The do_not_optimize(...) function can be used to prevent a value or
+// expression from being optimized away by the compiler. This function is
+// intended to add little to no overhead.
+// See: https://youtu.be/nXaxk27zwlk?t=2441
+template <typename T>
+inline __attribute__((always_inline)) void do_not_optimize(const T& value) 
+	{
+	asm volatile("" : : "r,m"(value) : "memory");
+	}
+
+template <class T>
+inline __attribute__((always_inline)) void do_not_optimize(T& value) 
+	{
+#if defined(__clang__)
+  	asm volatile("" : "+r,m"(value) : : "memory");
+#else
+  	asm volatile("" : "+m,r"(value) : : "memory");
+#endif
+	}
+
 	} // namespace util
 	} // namespace zeek


### PR DESCRIPTION
After running zeek for nearly 20 days, the process is not responding. I used GDB to attach the zeek process and found that zeek entered an infinite loop.

`DNS_Interpreter::ParseRR_EDNS`
```asm
    6cd4:	c7 45 00 01 00 00 00 	mov    DWORD PTR [rbp+0x0],0x1
    6cdb:	c7 45 00 01 00 00 00 	mov    DWORD PTR [rbp+0x0],0x1
    6ce2:	eb f0                	jmp    6cd4 <_ZN4zeek8analyzer3dns6detail15DNS_Interpreter12ParseRR_EDNSEPNS2_11DNS_MsgInfoERPKhRiiS7_+0xf4>
```
But when I look at the C++ source code, I can't find where these three lines of instructions come from.

So, I use IDA to decompile DNS.cc.o. Found that GCC 7.3.1 added a strange infinite loop instruction before calling `ExtractShort`
![image](https://user-images.githubusercontent.com/30434507/160223736-535ca566-e1ff-418b-8fa8-9eed28457dc3.png)

Pseudocode:
![image](https://user-images.githubusercontent.com/30434507/160223049-c6ad75ad-3da3-4b09-b6ef-fb71c5bca7ed.png)

infinite loop will triggered when `len == 1`

I guess it is caused by the compilation optimization bug of GCC 7.3.1

## Solution
Use a higher version of GCC, such as GCC 9.3.1.

Or

Tell the compiler do not to optimize `len`


## Sample
OS: CentOS 7
GCC Version: 7.3.1
Zeek Version: 4.2.0
Build Type: RelWithDebInfo

[GCC7.3.1_RelWithDebInfo_DNS.cc.o.zip](https://github.com/zeek/zeek/files/8354583/GCC7.3.1_RelWithDebInfo_DNS.cc.o.zip)
