### PR TITLE
GH-2009: Add const_cast to fix ZIP analyzer failure on some platforms

### DIFF
--- a/src/analyzer/protocol/zip/ZIP.cc
+++ b/src/analyzer/protocol/zip/ZIP.cc
@@ -59,7 +59,7 @@ void ZIP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	zip->next_in = (Bytef*)data;
 	zip->avail_in = len;
 
-	Bytef* orig_next_in = zip->next_in;
+	auto orig_next_in = zip->next_in;
 	size_t orig_avail_in = zip->avail_in;
 
 	while ( true )


### PR DESCRIPTION
Fixes a simple bug with the zip analyzer on some rare platforms. This PR is mostly just for CI coverage.