### PR TITLE
Add test to ensure enum_to_int's return values are ordered

### DIFF
--- a/testing/btest/Baseline/bifs.enum_to_int/out
+++ b/testing/btest/Baseline/bifs.enum_to_int/out
@@ -5,3 +5,15 @@ C, 2
 AV, 10
 BV, 11
 CV, 12
+T
+T
+T
+T
+T
+T
+T
+T
+T
+T
+T
+T

--- a/testing/btest/bifs/enum_to_int.zeek
+++ b/testing/btest/bifs/enum_to_int.zeek
@@ -18,12 +18,24 @@ export {
 
 event zeek_init()
 	{
-
-
 	print A, enum_to_int(A);
 	print B, enum_to_int(B);
 	print C, enum_to_int(C);
 	print AV, enum_to_int(AV);
 	print BV, enum_to_int(BV);
 	print CV, enum_to_int(CV);
+
+	print enum_to_int(A) != enum_to_int(B);
+	print enum_to_int(A) != enum_to_int(C);
+	print enum_to_int(B) != enum_to_int(C);
+	print enum_to_int(A) < enum_to_int(B);
+	print enum_to_int(A) < enum_to_int(C);
+	print enum_to_int(B) < enum_to_int(C);
+
+	print enum_to_int(AV) != enum_to_int(BV);
+	print enum_to_int(AV) != enum_to_int(CV);
+	print enum_to_int(BV) != enum_to_int(CV);
+	print enum_to_int(AV) < enum_to_int(BV);
+	print enum_to_int(AV) < enum_to_int(CV);
+	print enum_to_int(BV) < enum_to_int(CV);
 	}


### PR DESCRIPTION
The docs say:
> Enumerations do not have associated values or ordering.

however, it appears that the `enum_to_int` return values are ordered and [some Zeek functionality](https://github.com/zeek/zeek/blob/aa8f11fa17f411a50410cf5743d1a66e6809b70c/scripts/policy/frameworks/management/log.zeek#L89=) depends on this. This PR adds tests to assert the ordering behavior.

See relevant [Slack discussion](https://zeekorg.slack.com/archives/CTGDG83B8/p1649694398602929) for more details.