### PR TITLE
Allow analyzer violations to explicitly set tag.

### DIFF
--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -736,7 +736,7 @@ void Analyzer::AnalyzerConfirmation(zeek::Tag arg_tag)
 	event_mgr.Enqueue(analyzer_confirmation, ConnVal(), tval, val_mgr->Count(id));
 	}
 
-void Analyzer::AnalyzerViolation(const char* reason, const char* data, int len)
+void Analyzer::AnalyzerViolation(const char* reason, const char* data, int len, zeek::Tag arg_tag)
 	{
 	if ( ! analyzer_violation )
 		return;
@@ -753,7 +753,7 @@ void Analyzer::AnalyzerViolation(const char* reason, const char* data, int len)
 	else
 		r = make_intrusive<StringVal>(reason);
 
-	const auto& tval = tag.AsVal();
+	const auto& tval = arg_tag ? arg_tag.AsVal() : tag.AsVal();
 	event_mgr.Enqueue(analyzer_violation, ConnVal(), tval, val_mgr->Count(id), std::move(r));
 	}
 

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -590,8 +590,12 @@ public:
 	 * @param data An optional pointer to the malformed data.
 	 *
 	 * @param len If \a data is given, the length of it.
+	 *
+	 * @param tag If tag is given, it overrides the analyzer tag passed to the
+	 * scripting layer; the default is the one of the analyzer itself.
 	 */
-	virtual void AnalyzerViolation(const char* reason, const char* data = nullptr, int len = 0);
+	virtual void AnalyzerViolation(const char* reason, const char* data = nullptr, int len = 0,
+	                               zeek::Tag tag = zeek::Tag());
 
 	/**
 	 * Returns true if ProtocolConfirmation() has been called at least

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -34,7 +34,8 @@ void TCP_ApplicationAnalyzer::Init()
 		SetTCP(static_cast<packet_analysis::TCP::TCPSessionAdapter*>(Parent()));
 	}
 
-void TCP_ApplicationAnalyzer::AnalyzerViolation(const char* reason, const char* data, int len)
+void TCP_ApplicationAnalyzer::AnalyzerViolation(const char* reason, const char* data, int len,
+                                                zeek::Tag tag)
 	{
 	if ( auto* tcp = TCP() )
 		{
@@ -44,7 +45,7 @@ void TCP_ApplicationAnalyzer::AnalyzerViolation(const char* reason, const char* 
 			return;
 		}
 
-	Analyzer::AnalyzerViolation(reason, data, len);
+	Analyzer::AnalyzerViolation(reason, data, len, tag);
 	}
 
 void TCP_ApplicationAnalyzer::DeliverPacket(int len, const u_char* data, bool is_orig, uint64_t seq,

--- a/src/analyzer/protocol/tcp/TCP.h
+++ b/src/analyzer/protocol/tcp/TCP.h
@@ -68,7 +68,8 @@ public:
 
 	// This suppresses violations if the TCP connection wasn't
 	// fully established.
-	void AnalyzerViolation(const char* reason, const char* data = nullptr, int len = 0) override;
+	void AnalyzerViolation(const char* reason, const char* data = nullptr, int len = 0,
+	                       zeek::Tag tag = zeek::Tag()) override;
 
 	// "name" and "val" both now belong to this object, which needs to
 	//  delete them when done with them.

--- a/src/packet_analysis/Analyzer.cc
+++ b/src/packet_analysis/Analyzer.cc
@@ -182,7 +182,7 @@ void Analyzer::AnalyzerConfirmation(session::Session* session, zeek::Tag arg_tag
 	}
 
 void Analyzer::AnalyzerViolation(const char* reason, session::Session* session, const char* data,
-                                 int len)
+                                 int len, zeek::Tag arg_tag)
 	{
 	if ( ! analyzer_violation )
 		return;
@@ -201,7 +201,7 @@ void Analyzer::AnalyzerViolation(const char* reason, session::Session* session, 
 	else
 		r = make_intrusive<StringVal>(reason);
 
-	const auto& tval = tag.AsVal();
+	const auto& tval = arg_tag ? arg_tag.AsVal() : tag.AsVal();
 	event_mgr.Enqueue(analyzer_violation, session->GetVal(), tval, val_mgr->Count(0), std::move(r));
 	}
 

--- a/src/packet_analysis/Analyzer.h
+++ b/src/packet_analysis/Analyzer.h
@@ -156,7 +156,8 @@ public:
 	 * @param len If \a data is given, the length of it.
 	 */
 	virtual void AnalyzerViolation(const char* reason, session::Session* session,
-	                               const char* data = nullptr, int len = 0);
+	                               const char* data = nullptr, int len = 0,
+	                               zeek::Tag tag = zeek::Tag());
 
 	/**
 	 * Returns true if ProtocolConfirmation() has been called at least


### PR DESCRIPTION
We could already pass an overriding tag to
`Analyzer::AnalyzerConfirmation()`, but we didn't have that ability
for `AnalyzerViolation`, leading to the two potentially mismatching in
the analyzer they report.

I think this is a candidate for the next 4.2.x bugfix release. I don't think it should break anything.