### PR TITLE
Split asan/ubsan CI builds, add tsan build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,9 @@ memory: &MEMORY 4GB
 
 config: &CONFIG --build-type=release --disable-broker-tests --prefix=$CIRRUS_WORKING_DIR/install
 static_config: &STATIC_CONFIG --build-type=release --disable-broker-tests --enable-static-broker --enable-static-binpac --prefix=$CIRRUS_WORKING_DIR/install
-sanitizer_config: &SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=address,undefined --enable-fuzzers --enable-coverage
+asan_sanitizer_config: &ASAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=address --enable-fuzzers --enable-coverage
+ubsan_sanitizer_config: &UBSAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=undefined --enable-fuzzers
+tsan_sanitizer_config: &TSAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=thread --enable-fuzzers
 mobile_ipv6_config: &MOBILE_IPV6_CONFIG --build-type=release --enable-mobile-ipv6 --disable-broker-tests --prefix=$CIRRUS_WORKING_DIR/install
 openssl30_config: &OPENSSL30_CONFIG --build-type=release --disable-broker-tests --with-openssl=/opt/openssl --prefix=$CIRRUS_WORKING_DIR/install
 
@@ -268,7 +270,7 @@ openssl30_task:
   env:
     ZEEK_CI_CONFIGURE_FLAGS: *OPENSSL30_CONFIG
 
-sanitizer_task:
+asan_sanitizer_task:
   container:
     # Just uses a recent/common distro to run memory error/leak checks.
     dockerfile: ci/ubuntu-20.04/Dockerfile
@@ -277,10 +279,38 @@ sanitizer_task:
     memory: 12GB
   << : *CI_TEMPLATE
   test_fuzzers_script: ./ci/test-fuzzers.sh
-  coverage_script: ./ci/upload-coverage.sh
   env:
     CXXFLAGS: -DZEEK_DICT_DEBUG
-    ZEEK_CI_CONFIGURE_FLAGS: *SANITIZER_CONFIG
-    ZEEK_TAILORED_UB_CHECKS: 1
+    ZEEK_CI_CONFIGURE_FLAGS: *ASAN_SANITIZER_CONFIG
     ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1
+    ASAN_OPTIONS: detect_leaks=1
+
+ubsan_sanitizer_task:
+  container:
+    # Just uses a recent/common distro to run undefined behavior checks.
+    dockerfile: ci/ubuntu-20.04/Dockerfile
+    cpu: 4
+    # AddressSanitizer uses a lot more memory than a typical config.
+    memory: 12GB
+  << : *CI_TEMPLATE
+  test_fuzzers_script: ./ci/test-fuzzers.sh
+  env:
+    CXXFLAGS: -DZEEK_DICT_DEBUG
+    ZEEK_CI_CONFIGURE_FLAGS: *UBSAN_SANITIZER_CONFIG
+    ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1
+    ZEEK_TAILORED_UB_CHECKS: 1
     UBSAN_OPTIONS: print_stacktrace=1
+
+tsan_sanitizer_task:
+  container:
+    # Just uses a recent/common distro to run memory error/leak checks.
+    dockerfile: ci/ubuntu-20.04/Dockerfile
+    cpu: 4
+    # AddressSanitizer uses a lot more memory than a typical config.
+    memory: 12GB
+  << : *CI_TEMPLATE
+  test_fuzzers_script: ./ci/test-fuzzers.sh
+  env:
+    CXXFLAGS: -DZEEK_DICT_DEBUG
+    ZEEK_CI_CONFIGURE_FLAGS: *TSAN_SANITIZER_CONFIG
+    ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1


### PR DESCRIPTION
This PR adds a new build to the CI to run ThreadSanitizer, now that all of the outstanding issues with #1500 are fixed. This also splits the long-running ASan and UBSan builds into separate jobs. Both of those were taking a very long time to complete together, so splitting them apart will hopefully help with that.

Fixes #1500
Fixes #2035