### PR TITLE
Disable object-size analysis if optimization set to -O0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,6 @@ if ( ZEEK_SANITIZERS )
                 # list(APPEND _check_list "nullability-assign") # Not normally part of "undefined"
                 # list(APPEND _check_list "nullability-return") # Not normally part of "undefined"
                 # list(APPEND _check_list "objc-cast") # Not truly UB
-                list(APPEND _check_list "object-size")
                 # list(APPEND _check_list "pointer-overflow") # Not implemented in older GCCs
                 list(APPEND _check_list "return")
                 list(APPEND _check_list "returns-nonnull-attribute")
@@ -189,6 +188,13 @@ if ( ZEEK_SANITIZERS )
                 # list(APPEND _check_list "unsigned-integer-overflow") # Not truly UB
                 list(APPEND _check_list "vla-bound")
                 # list(APPEND _check_list "vptr") # TODO: fix associated errors
+
+                # Clang complains if this one is defined and the optimizer is set to -O0. We
+                # only set that optimization level if NO_OPTIMIZATIONS is passed, so disable
+                # the option if that's set.
+                if ( NOT DEFINED ENV{NO_OPTIMIZATIONS} )
+                    list(APPEND _check_list "object-size")
+                endif ()
 
                 string(REPLACE ";" "," _ub_checks "${_check_list}")
                 set(ZEEK_SANITIZER_UB_CHECKS "${_ub_checks}" CACHE INTERNAL "" FORCE)


### PR DESCRIPTION
Our CMake setup sets the optimization level to `-O0` if the `NO_OPTIMIZATIONS` environment variable is set to 1 during configure. If we also pass `--sanitizers=undefined`, then the compiler (at least Clang, didn't check others) will output this during the build:

```
clang: warning: the object size sanitizer has no effect at -O0, but is explicitly enabled
```

It's a harmless warning, but annoying. This PR disables that analyzer if `NO_OPTIMIZATIONS` is set during the call to `configure`. This appears to persist through re-runs of CMake as well, in the case that a CMake file is changed and the build has to automatically run it.