### PR TITLE
State-holding fix for lambdas

### DIFF
--- a/src/CompHash.h
+++ b/src/CompHash.h
@@ -4,7 +4,7 @@
 
 #include <memory>
 
-#include "zeek/IntrusivePtr.h"
+#include "zeek/Func.h"
 #include "zeek/Type.h"
 
 namespace zeek
@@ -60,6 +60,18 @@ protected:
 	                              bool calc_static_size, bool singleton) const;
 
 	bool EnsureTypeReserve(HashKey& hk, const Val* v, Type* bt, bool type_check) const;
+
+	// The following are for allowing hashing of function values.
+	// These can occur, for example, in sets of predicates that get
+	// iterated over.  We use pointers in order to keep storage
+	// lower for the common case of these not being needed.
+	std::unique_ptr<std::unordered_map<const Func*, uint32_t>> func_to_func_id;
+	std::unique_ptr<std::vector<FuncPtr>> func_id_to_func;
+	void BuildFuncMappings()
+		{
+		func_to_func_id = std::make_unique<std::unordered_map<const Func*, uint32_t>>();
+		func_id_to_func = std::make_unique<std::vector<FuncPtr>>();
+		}
 
 	TypeListPtr type;
 	bool is_singleton = false; // if just one type in index

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -133,20 +133,6 @@ std::string render_call_stack()
 	return rval;
 	}
 
-Func::Func()
-	{
-	unique_id = unique_ids.size();
-	unique_ids.push_back({NewRef{}, this});
-	}
-
-Func::Func(Kind arg_kind) : kind(arg_kind)
-	{
-	unique_id = unique_ids.size();
-	unique_ids.push_back({NewRef{}, this});
-	}
-
-Func::~Func() = default;
-
 void Func::AddBody(detail::StmtPtr /* new_body */,
                    const std::vector<detail::IDPtr>& /* new_inits */, size_t /* new_frame_size */,
                    int /* priority */)
@@ -238,7 +224,6 @@ void Func::CopyStateInto(Func* other) const
 	other->type = type;
 
 	other->name = name;
-	other->unique_id = unique_id;
 	}
 
 void Func::CheckPluginResult(bool handled, const ValPtr& hook_result, FunctionFlavor flavor) const

--- a/src/Func.h
+++ b/src/Func.h
@@ -61,9 +61,7 @@ public:
 		BUILTIN_FUNC
 		};
 
-	explicit Func(Kind arg_kind);
-
-	~Func() override;
+	explicit Func(Kind arg_kind) : kind(arg_kind) { }
 
 	virtual bool IsPure() const = 0;
 	FunctionFlavor Flavor() const { return GetType()->Flavor(); }
@@ -122,14 +120,8 @@ public:
 
 	virtual detail::TraversalCode Traverse(detail::TraversalCallback* cb) const;
 
-	uint32_t GetUniqueFuncID() const { return unique_id; }
-	static const FuncPtr& GetFuncPtrByID(uint32_t id)
-		{
-		return id >= unique_ids.size() ? Func::nil : unique_ids[id];
-		}
-
 protected:
-	Func();
+	Func() = default;
 
 	// Copies this function's state into other.
 	void CopyStateInto(Func* other) const;
@@ -140,10 +132,8 @@ protected:
 	std::vector<Body> bodies;
 	detail::ScopePtr scope;
 	Kind kind = SCRIPT_FUNC;
-	uint32_t unique_id = 0;
 	FuncTypePtr type;
 	std::string name;
-	static inline std::vector<FuncPtr> unique_ids;
 	};
 
 namespace detail


### PR DESCRIPTION
**Today's Zeek Development ProTip:** _`Obj`-derived constructors should not `Ref` themselves._

The backstory: @initconf has been running a recent branch of mine, and also a Broker one, on production traffic at LBL.  He's been finding that they both grow slowly but surely, and unbounded-ly, in memory usage over time.  With a number of trials plus some jemalloc profiling, we isolated this to likely relating to `when` statements and their creation of captures, an MR (3d9d6e953be5ae8b72336031b6e6659222f52cea) merged in last January.

Much scrutiny of code followed, but there was no obvious leak, and running leak-detection didn't point up any problems, though hard to know whether it might only manifest on a live cluster due to Broker communication.

However, reverting to the old-style `when` implementation (luckily still available since it's been deprecated, rather than removed) allowed A/B testing on production traffic and confirmed that the problem was with the new implementation.  This also ruled out the other main potential culprit, scripts that use `when` statements without `timeout` clauses.  (There are quite a few of these.  In general it takes a lot of work to determine whether they ultimately call a BiF that itself manages an internal timeout, like for `lookup_addr()`, and so don't need an explicit `timeout` clause.)

Adding some low-level diagnostic output to track key constructors and destructors eventually allowed identifying the problem.  It's in this code in the `Func` constructor:

> Func::Func()
>         {
>         unique_id = unique_ids.size();
>         unique_ids.push_back({NewRef{}, this});
>         }

What's going on here is that every `Func` object is assigned a unique identifier, and there's an associated vector that maps the identifier back to the `Func` object pointer.

What does the `Func` constructor self-`Ref` have to do with the new `when` capture semantics leading to slow, non-leaky memory growth?  Well, the way that the new implementation works is to turn each `when` into a lambda, and every time the `when` is executed, it creates a new `ScriptFunc` object (stored via an `IntrusivePtr`) that handles the evaluation of the condition along with executing the body or timeout as appropriate.  When the `when` instance goes out of scope, it stops referring to that `ScriptFunc` object, which normally would lead it to being `Unref`'d ... but the object doesn't in fact get deleted, because its reference count is still > 0 thanks to the `Func` constructor's self-`Ref` plus the fact that `ScriptFunc` is derived from `Func`.  This means the `ScriptFunc` object sticks around, _and so does its closure_, which potentially holds a whole bunch of additional state.

To be clear, this isn't a bug in the new `when` implementation - it's just that the new implementation happens to exercise the already problematic `Func` constructor a lot more, due to steadily creating `ScriptFunc` objects during each `when` execution.  For most `ScriptFunc` objects, there's no problem with the self-`Ref` because those objects stick around for the entire script execution.  For lambdas, though, it means that functions produced by executing lambdas stick around forever.  If the lambda has captures, those add to the memory load.  Zeek has had this problem for a long while now, but previously we didn't make heavy use of lambdas, so the state-holding costs have gone unnoticed.

What's the right fix?  Well, the first question is why is that unique `Func` identifier needed in the first place?  It turns out that its sole use is in the `CompHash` class, which needs to be able to represent distinct Zeek functions in hash keys.  The way it does that is using the identifier.  To recover the function from the hash key, it calls the static `Func::GetFuncPtrByID` function.  (You might wonder, like I did, why Zeek script functions would ever appear as hash key elements in the first place.  Turns out they do in usages like

> type RemovalHook: hook(c: connection);
> ...
> removal_hooks: set[RemovalHook];

where the removal_hooks are then iterated over upon `connection_state_remove`.)

Thus, the fix is to shift the tracking of unique identifiers for `Func` objects to where they're actually needed, namely in `CompHash` objects.  This hard-won MR does that.