### PR TITLE
Management framework: consistency fixes around event() vs Broker::publish

### DIFF
--- a/scripts/policy/frameworks/management/controller/api.zeek
+++ b/scripts/policy/frameworks/management/controller/api.zeek
@@ -135,7 +135,7 @@ export {
 	    result: Management::Result);
 
 
-	# Notification events, agent -> controller
+	# Notification events
 
 	## The controller triggers this event when the operational cluster
 	## instances align with the ones desired by the cluster


### PR DESCRIPTION
Minor changeset, see commit.

I'm tempted to switch the generation of events that are exclusively sent to another component to `Broker::publish()` altogether (i.e., drop auto-publishing) since it's more explicit, but it is also a fair bit more verbose ... so holding off for now.