### PR TITLE
Enable vptr undefined behavior check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ if ( ZEEK_SANITIZERS )
                 list(APPEND _check_list "unreachable")
                 # list(APPEND _check_list "unsigned-integer-overflow") # Not truly UB
                 list(APPEND _check_list "vla-bound")
-                # list(APPEND _check_list "vptr") # TODO: fix associated errors
+                list(APPEND _check_list "vptr")
 
                 # Clang complains if this one is defined and the optimizer is set to -O0. We
                 # only set that optimization level if NO_OPTIMIZATIONS is passed, so disable


### PR DESCRIPTION
It appears the issues with CAF and the vptr check were resolved by https://github.com/zeek/zeek/pull/1906. This PR enables that check in the CMake configuration and is mostly just checking that it passes on Cirrus.

Fixes #1176