### PR TITLE
Fix generate-docs action for running on forks.

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -15,10 +15,19 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+      # We only perform a push if the action was triggered via a schedule
+      # event, so we only need to authenticate in that case. Use
+      # unauthenticated access otherwise so this action can e.g., also run from
+      # clones.
       - uses: actions/checkout@v2
+        if: github.event_name == 'schedule'
         with:
           submodules: "recursive"
           token: ${{ secrets.ZEEK_BOT_TOKEN }}
+      - uses: actions/checkout@v2
+        if: github.event_name != 'schedule'
+        with:
+          submodules: "recursive"
 
       - name: Switch doc submodule to master
         run: cd doc && git checkout master
@@ -96,7 +105,9 @@ jobs:
           git diff-index --quiet HEAD || { git commit -m 'Update doc submodule [nomail] [skip ci]' && git push; }
 
       - name: Send email
-        if: failure()
+        # Only send notifications for scheduled runs. Runs from pull requests
+        # show failures in the Github UI.
+        if: failure() && github.event_name == 'schedule'
         uses: dawidd6/action-send-mail@v3.4.1
         with:
           server_address: ${{secrets.SMTP_HOST}}


### PR DESCRIPTION
The generate-docs action previously always required secrets to run so
that it could possibly perform a push (if run from a schedule), and to
send out an email on failure. Since secrets are unavailable for forks
this meant that this action would always fail for PRs from forks.

In this patch we use an unauthenticated clone unless running from a
schedule. This is fine as for PRs this action would just regenerate the
docs to check for errors, but not to actually update them (no push
performed). We also change the failure notification step to only execute
for scheduled runs.