### PR TITLE
Fix a handful of DNS_Mgr issues

### DIFF
--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -1307,7 +1307,6 @@ void DNS_Mgr::IssueAsyncRequests()
 
 		dns_req->MakeRequest(channel, this);
 
-		asyncs_timeouts.push(req);
 		++asyncs_pending;
 		}
 	}
@@ -1401,7 +1400,7 @@ void DNS_Mgr::Flush()
 
 double DNS_Mgr::GetNextTimeout()
 	{
-	if ( asyncs_timeouts.empty() )
+	if ( asyncs_pending == 0 )
 		return -1;
 
 	return run_state::network_time + DNS_TIMEOUT;

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -297,7 +297,7 @@ protected:
 
 	RecordTypePtr dm_rec;
 
-	ares_channel channel;
+	ares_channel channel{};
 
 	using CallbackList = std::list<LookupCallback*>;
 

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -331,10 +331,6 @@ protected:
 	using QueuedList = std::list<AsyncRequest*>;
 	QueuedList asyncs_queued;
 
-	using TimeoutQueue =
-		std::priority_queue<AsyncRequest*, std::vector<AsyncRequest*>, AsyncRequestCompare>;
-	TimeoutQueue asyncs_timeouts;
-
 	unsigned long num_requests = 0;
 	unsigned long successful = 0;
 	unsigned long failed = 0;

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -678,13 +678,28 @@ void Reporter::DoLog(const char* prefix, EventHandlerPtr event, FILE* out, Conne
 
 		s += buffer;
 
+#ifdef ENABLE_ZEEK_UNIT_TESTS
 		if ( doctest::is_running_in_test )
-			MESSAGE(s);
+			{
+			try
+				{
+				MESSAGE(s);
+				}
+			catch ( const doctest::detail::TestFailureException& e )
+				{
+				// If doctest throws an exception, just write the string out to stdout
+				// like normal, just so it's captured somewhere.
+				fprintf(out, "%s\n", s.c_str());
+				}
+			}
 		else
 			{
+#endif
 			s += "\n";
 			fprintf(out, "%s", s.c_str());
+#ifdef ENABLE_ZEEK_UNIT_TESTS
 			}
+#endif
 		}
 
 	if ( alloced )


### PR DESCRIPTION
This PR resolves all of the following that cropped up from automated testing post-merge of the c-ares work:

- Fixes a rare crash involving async DNS lookups. It was detected by oss-fuzz initially. The `asyncs_timeouts` priority queue was used by the old `DNS_Mgr` code to handle timeouts coming from DNS lookups. Now that c-ares handles the timeouts internally for us, there's no reason to continue to track them ourselves.
- Modifies `DNS_Mgr::GetNextTimeout()` to request the next timeout value from c-ares instead of using a fixed value. This shouldn't make a huge difference in the long run about when timeouts happen, but it's possible for those two values to be different and the one from c-ares should be more accurate.
- Pre-initialize the c-ares channel object in DNS_Mgr, which fixes Coverity finding 1488318.
- Wrap the call to doctest's `MESSAGE()` method in `Reporter` in a try/catch block for `doctest::detail::TestFailureException`. This fixes a huge list of findings from Coverity about an uncaught exception. The catch block will simply output the message to stdout like normal, just so the output is captured somewhere.