### PR TITLE
fix for sets containing recursive records

### DIFF
--- a/testing/btest/language/set-opt-record-index.zeek
+++ b/testing/btest/language/set-opt-record-index.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: zeek -b %INPUT  >output 2>&1
+# @TEST-EXEC: zeek %INPUT  >output 2>&1
 # @TEST-EXEC: btest-diff output
 
 # Make sure a set can be indexed with a record that has optional fields
@@ -53,3 +53,7 @@ event zeek_init()
         print f3 in set_of_foo;
 
         }
+
+# Also make sure that we can declare sets of recursive records.
+# This used to crash in Zeek 4.x.
+global crash_me: set[Conn::RemovalHook];


### PR DESCRIPTION
In working on some event tracing issues, I discovered that the following one-liner:

> global crash_me: set[Conn::RemovalHook];

will crash Zeek 4.x.  Amusingly, the problem is the same as the one that @rsmmr flagged in https://github.com/zeek/zeek/pull/2077, namely the presence of recursive records.  This simple PR fixes the issue and updates the test suite to check for it.