### PR TITLE
Reduce repeat allocations of ZeekString/StringVal objects

### DIFF
--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -273,8 +273,12 @@ const RecordValPtr& Connection::GetVal()
 	conn_val->AssignTime(3, start_time); // ###
 	conn_val->AssignInterval(4, last_time - start_time);
 
-	if ( history.size() )
-		conn_val->Assign(6, history);
+	if ( ! history.empty() )
+		{
+		auto v = conn_val->GetFieldAs<StringVal>(6);
+		if ( *v != history )
+			conn_val->Assign(6, history);
+		}
 
 	conn_val->SetOrigin(this);
 

--- a/src/ZeekString.cc
+++ b/src/ZeekString.cc
@@ -115,6 +115,11 @@ bool String::operator==(std::string_view s) const
 	return (memcmp(b, s.data(), n) == 0);
 	}
 
+bool String::operator!=(std::string_view s) const
+	{
+	return ! (*this == s);
+	}
+
 void String::Adopt(byte_vec bytes, int len)
 	{
 	Reset();

--- a/src/ZeekString.h
+++ b/src/ZeekString.h
@@ -56,6 +56,7 @@ public:
 	bool operator==(const String& bs) const;
 	bool operator<(const String& bs) const;
 	bool operator==(std::string_view s) const;
+	bool operator!=(std::string_view s) const;
 
 	byte_vec Bytes() const { return b; }
 	int Len() const { return n; }

--- a/src/analyzer/analyzer.bif
+++ b/src/analyzer/analyzer.bif
@@ -50,7 +50,7 @@ function __name%(atype: AllAnalyzers::Tag%) : string
 	if ( ! component )
 		return zeek::make_intrusive<zeek::StringVal>("<error>");
 
-	return zeek::make_intrusive<zeek::StringVal>(component->CanonicalName());
+	return component->CanonicalNameVal();
 	%}
 
 function __tag%(name: string%) : AllAnalyzers::Tag

--- a/src/file_analysis/analyzer/hash/Hash.cc
+++ b/src/file_analysis/analyzer/hash/Hash.cc
@@ -11,10 +11,14 @@
 namespace zeek::file_analysis::detail
 	{
 
-Hash::Hash(RecordValPtr args, file_analysis::File* file, HashVal* hv, const char* arg_kind)
-	: file_analysis::Analyzer(file_mgr->GetComponentTag(util::to_upper(arg_kind).c_str()),
+StringValPtr MD5::kind_val = make_intrusive<StringVal>("md5");
+StringValPtr SHA1::kind_val = make_intrusive<StringVal>("sha1");
+StringValPtr SHA256::kind_val = make_intrusive<StringVal>("sha256");
+
+Hash::Hash(RecordValPtr args, file_analysis::File* file, HashVal* hv, StringValPtr arg_kind)
+	: file_analysis::Analyzer(file_mgr->GetComponentTag(util::to_upper(arg_kind->ToStdString())),
                               std::move(args), file),
-	  hash(hv), fed(false), kind(arg_kind)
+	  hash(hv), fed(false), kind(std::move(arg_kind))
 	{
 	hash->Init();
 	}
@@ -55,7 +59,7 @@ void Hash::Finalize()
 	if ( ! file_hash )
 		return;
 
-	event_mgr.Enqueue(file_hash, GetFile()->ToVal(), make_intrusive<StringVal>(kind), hash->Get());
+	event_mgr.Enqueue(file_hash, GetFile()->ToVal(), kind, hash->Get());
 	}
 
 	} // namespace zeek::file_analysis::detail

--- a/src/file_analysis/analyzer/hash/Hash.h
+++ b/src/file_analysis/analyzer/hash/Hash.h
@@ -55,7 +55,7 @@ protected:
 	 * @param hv specific hash calculator object.
 	 * @param kind human readable name of the hash algorithm to use.
 	 */
-	Hash(RecordValPtr args, file_analysis::File* file, HashVal* hv, const char* kind);
+	Hash(RecordValPtr args, file_analysis::File* file, HashVal* hv, StringValPtr kind);
 
 	/**
 	 * If some file contents have been seen, finalizes the hash of them and
@@ -66,13 +66,13 @@ protected:
 private:
 	HashVal* hash;
 	bool fed;
-	const char* kind;
+	StringValPtr kind;
 	};
 
 /**
  * An analyzer to produce an MD5 hash of file contents.
  */
-class MD5 : public Hash
+class MD5 final : public Hash
 	{
 public:
 	/**
@@ -87,22 +87,24 @@ public:
 		return file_hash ? new MD5(std::move(args), file) : nullptr;
 		}
 
-protected:
+private:
 	/**
 	 * Constructor.
 	 * @param args the \c AnalyzerArgs value which represents the analyzer.
 	 * @param file the file to which the analyzer will be attached.
 	 */
 	MD5(RecordValPtr args, file_analysis::File* file)
-		: Hash(std::move(args), file, new MD5Val(), "md5")
+		: Hash(std::move(args), file, new MD5Val(), MD5::kind_val)
 		{
 		}
+
+	static StringValPtr kind_val;
 	};
 
 /**
  * An analyzer to produce a SHA1 hash of file contents.
  */
-class SHA1 : public Hash
+class SHA1 final : public Hash
 	{
 public:
 	/**
@@ -117,22 +119,24 @@ public:
 		return file_hash ? new SHA1(std::move(args), file) : nullptr;
 		}
 
-protected:
+private:
 	/**
 	 * Constructor.
 	 * @param args the \c AnalyzerArgs value which represents the analyzer.
 	 * @param file the file to which the analyzer will be attached.
 	 */
 	SHA1(RecordValPtr args, file_analysis::File* file)
-		: Hash(std::move(args), file, new SHA1Val(), "sha1")
+		: Hash(std::move(args), file, new SHA1Val(), SHA1::kind_val)
 		{
 		}
+
+	static StringValPtr kind_val;
 	};
 
 /**
  * An analyzer to produce a SHA256 hash of file contents.
  */
-class SHA256 : public Hash
+class SHA256 final : public Hash
 	{
 public:
 	/**
@@ -147,16 +151,18 @@ public:
 		return file_hash ? new SHA256(std::move(args), file) : nullptr;
 		}
 
-protected:
+private:
 	/**
 	 * Constructor.
 	 * @param args the \c AnalyzerArgs value which represents the analyzer.
 	 * @param file the file to which the analyzer will be attached.
 	 */
 	SHA256(RecordValPtr args, file_analysis::File* file)
-		: Hash(std::move(args), file, new SHA256Val(), "sha256")
+		: Hash(std::move(args), file, new SHA256Val(), SHA256::kind_val)
 		{
 		}
+
+	static StringValPtr kind_val;
 	};
 
 	} // namespace zeek::file_analysis

--- a/src/file_analysis/file_analysis.bif
+++ b/src/file_analysis/file_analysis.bif
@@ -103,8 +103,7 @@ function Files::__stop%(file_id: string%): bool
 ## :zeek:see:`Files::analyzer_name`.
 function Files::__analyzer_name%(tag: Files::Tag%) : string
 	%{
-	const auto& n = zeek::file_mgr->GetComponentName(zeek::IntrusivePtr{zeek::NewRef{}, tag->AsEnumVal()});
-	return zeek::make_intrusive<zeek::StringVal>(n);
+	return zeek::file_mgr->GetComponentNameVal(zeek::IntrusivePtr{zeek::NewRef{}, tag->AsEnumVal()});
 	%}
 
 ## :zeek:see:`Files::file_exists`.

--- a/src/plugin/Component.cc
+++ b/src/plugin/Component.cc
@@ -16,6 +16,7 @@ Component::Component(component::Type arg_type, const std::string& arg_name,
 	  tag_subtype(tag_subtype)
 	{
 	canon_name = util::canonify_name(name);
+	canon_name_val = make_intrusive<StringVal>(canon_name);
 	}
 
 void Component::Describe(ODesc* d) const

--- a/src/plugin/Component.h
+++ b/src/plugin/Component.h
@@ -8,6 +8,7 @@
 
 #include "zeek/Tag.h"
 #include "zeek/Type.h"
+#include "zeek/Val.h"
 
 namespace zeek
 	{
@@ -98,6 +99,7 @@ public:
 	 * ID.
 	 */
 	const std::string& CanonicalName() const { return canon_name; }
+	StringValPtr CanonicalNameVal() const { return canon_name_val; }
 
 	/**
 	 * Returns a textual representation of the component. This goes into
@@ -135,6 +137,7 @@ private:
 	component::Type type;
 	std::string name;
 	std::string canon_name;
+	StringValPtr canon_name_val;
 
 	/** The automatically assigned component tag */
 	zeek::Tag tag;

--- a/src/plugin/ComponentManager.h
+++ b/src/plugin/ComponentManager.h
@@ -13,6 +13,7 @@
 #include "zeek/Type.h"
 #include "zeek/Val.h"
 #include "zeek/Var.h" // for add_type()
+#include "zeek/ZeekString.h"
 #include "zeek/module_util.h"
 #include "zeek/zeekygen/Manager.h"
 
@@ -193,9 +194,7 @@ template <class C> const std::string& ComponentManager<C>::GetComponentName(zeek
 	if ( ! tag )
 		return error;
 
-	C* c = Lookup(tag);
-
-	if ( c )
+	if ( C* c = Lookup(tag) )
 		return c->CanonicalName();
 
 	reporter->InternalWarning("requested name of unknown component tag %s", tag.AsString().c_str());
@@ -204,7 +203,17 @@ template <class C> const std::string& ComponentManager<C>::GetComponentName(zeek
 
 template <class C> const std::string& ComponentManager<C>::GetComponentName(EnumValPtr val) const
 	{
-	return GetComponentName(zeek::Tag(std::move(val)));
+	static const std::string error = "<error>";
+
+	if ( ! val )
+		return error;
+
+	if ( C* c = Lookup(val.get()) )
+		return c->CanonicalName();
+
+	reporter->InternalWarning("requested name of unknown component tag %s",
+	                          val->AsString()->CheckString());
+	return error;
 	}
 
 template <class C> zeek::Tag ComponentManager<C>::GetComponentTag(const std::string& name) const

--- a/src/plugin/ComponentManager.h
+++ b/src/plugin/ComponentManager.h
@@ -75,6 +75,22 @@ public:
 	const std::string& GetComponentName(EnumValPtr val) const;
 
 	/**
+	 * Get a component name from its tag.
+	 *
+	 * @param tag A component's tag.
+	 * @return The canonical component name as a StringValPtr.
+	 */
+	StringValPtr GetComponentNameVal(zeek::Tag tag) const;
+
+	/**
+	 * Get a component name from it's enum value.
+	 *
+	 * @param val A component's enum value.
+	 * @return The canonical component name as a StringValPtr.
+	 */
+	StringValPtr GetComponentNameVal(EnumValPtr val) const;
+
+	/**
 	 * Get a component tag from its name.
 	 *
 	 * @param name A component's canonical name.
@@ -210,6 +226,35 @@ template <class C> const std::string& ComponentManager<C>::GetComponentName(Enum
 
 	if ( C* c = Lookup(val.get()) )
 		return c->CanonicalName();
+
+	reporter->InternalWarning("requested name of unknown component tag %s",
+	                          val->AsString()->CheckString());
+	return error;
+	}
+
+template <class C> StringValPtr ComponentManager<C>::GetComponentNameVal(zeek::Tag tag) const
+	{
+	static auto error = make_intrusive<StringVal>("<error>");
+
+	if ( ! tag )
+		return error;
+
+	if ( C* c = Lookup(tag) )
+		return c->CanonicalNameVal();
+
+	reporter->InternalWarning("requested name of unknown component tag %s", tag.AsString().c_str());
+	return error;
+	}
+
+template <class C> StringValPtr ComponentManager<C>::GetComponentNameVal(EnumValPtr val) const
+	{
+	static auto error = make_intrusive<StringVal>("<error>");
+
+	if ( ! val )
+		return error;
+
+	if ( C* c = Lookup(val.get()) )
+		return c->CanonicalNameVal();
 
 	reporter->InternalWarning("requested name of unknown component tag %s",
 	                          val->AsString()->CheckString());


### PR DESCRIPTION




Fixes #1797

This PR fixes 3 issues that cause large numbers of repeat allocations of the same strings into ZeekString/StringVal objects:
- Connection history
- Analyzer canonical names
- Hash analyzer kinds

From testing with a pcap with 1 million HTTP connections, we get the following allocations for connection history strings (amongst others):
```
1830308 A Allocating a string of len 6: ShADad
1252316 A Allocating a string of len 4: ShAD
```

With the patch in https://github.com/zeek/zeek/commit/1f8d40665846c262e0fcd197a4b9811618e55c0e, these are reduced to:
```
96332 A Allocating a string of len 6: ShADad
96332 A Allocating a string of len 4: ShAD
```

From testing with a pcap with a very large number of SSL connections, we get the following for various analyzers:

```
  43369 A Allocating a string of len 3: SSL
  23460 A Allocating a string of len 4: sha1
  23457 A Allocating a string of len 6: sha256
  23457 A Allocating a string of len 3: md5
  23456 A Allocating a string of len 6: SHA256
  23456 A Allocating a string of len 4: X509
  23456 A Allocating a string of len 4: SHA1
  23456 A Allocating a string of len 3: MD5
```

With the patches in https://github.com/zeek/zeek/commit/a680c2faf004601be51db2611b379e8f25a12b7a and https://github.com/zeek/zeek/commit/b850d1dc515898df211234ba1311c01bf13245ab, these are reduced to:

```
  33415 A Allocating a string of len 3: SSL
      5 A Allocating a string of len 4: sha1
      1 A Allocating a string of len 4: SHA1
      2 A Allocating a string of len 3: md5
      1 A Allocating a string of len 3: MD5
      2 A Allocating a string of len 6: sha256
      1 A Allocating a string of len 6: SHA256
      1 A Allocating a string of len 4: X509
```

https://github.com/zeek/zeek/commit/a680c2faf004601be51db2611b379e8f25a12b7a causes a smattering of extra allocations that don't show up in the unpatched version of the tests, but it's basically 1 or 2 allocations per analyzer/component vs an extra 23000+.

Surprisingly the time savings isn’t as huge as expected, but it does exist. Averaged over 5 reads of `http_many.pcap`, runtime changed from 44.87s to 43.91s (~2%). Averaged over 10 reads of `ssl_many.pcap`, runtime changed from 8.25s to 8.12s (~1.5%). I’ll have longer benchmarks shortly.