### PR TITLE
Implement tail -F semantics for input framework MODE_STREAM

### DIFF
--- a/src/input/readers/raw/Raw.cc
+++ b/src/input/readers/raw/Raw.cc
@@ -36,6 +36,7 @@ Raw::Raw(ReaderFrontend* frontend)
 	firstrun = true;
 	mtime = 0;
 	ino = 0;
+	dev = 0;
 	forcekill = false;
 	offset = 0;
 	separator.assign((const char*)BifConst::InputRaw::record_separator->Bytes(),
@@ -280,10 +281,28 @@ bool Raw::OpenInput()
 	else
 		{
 		file = std::unique_ptr<FILE, int (*)(FILE*)>(fopen(fname.c_str(), "r"), fclose);
+		if ( ! file && Info().mode == MODE_STREAM )
+			{
+			// Watch /dev/null until the file appears
+			file = std::unique_ptr<FILE, int (*)(FILE*)>(fopen("/dev/null", "r"), fclose);
+			}
+
 		if ( ! file )
 			{
 			Error(Fmt("Init: cannot open %s", fname.c_str()));
 			return false;
+			}
+
+		struct stat sb;
+		if ( fstat(fileno(file.get()), &sb) == -1 )
+			{
+			Error(Fmt("Could not get fstat for %s", fname.c_str()));
+			}
+		else
+			{
+			mtime = sb.st_mtime;
+			ino = sb.st_ino;
+			dev = sb.st_dev;
 			}
 
 		if ( ! SetFDFlags(fileno(file.get()), F_SETFD, FD_CLOEXEC) )
@@ -346,6 +365,7 @@ bool Raw::DoInit(const ReaderInfo& info, int num_fields, const Field* const* fie
 	fname = info.source;
 	mtime = 0;
 	ino = 0;
+	dev = 0;
 	execute = false;
 	firstrun = true;
 	int want_fields = 1;
@@ -574,23 +594,59 @@ bool Raw::DoUpdate()
 
 				mtime = sb.st_mtime;
 				ino = sb.st_ino;
+				dev = sb.st_dev;
 				// file changed. reread.
 				//
 				// fallthrough
 				}
 
 			case MODE_MANUAL:
-			case MODE_STREAM:
-				if ( Info().mode == MODE_STREAM && file )
-					{
-					clearerr(file.get()); // remove end of file evil bits
-					break;
-					}
-
 				CloseInput();
 				if ( ! OpenInput() )
 					return false;
 
+				break;
+
+			case MODE_STREAM:
+				// mode may not be used to execute child programs
+				assert(childpid == -1);
+
+				// Clear possible EOF condition
+				if ( file )
+					clearerr(file.get());
+
+				// check if the file has changed
+				struct stat sb;
+				if ( stat(fname.c_str(), &sb) == -1 )
+					{
+					// File was removed
+					break;
+					}
+
+				// Is it the same file?
+				if ( sb.st_ino == ino && sb.st_dev == dev )
+					{
+					break;
+					}
+
+				// File was replaced
+				FILE *tfile;
+				tfile = fopen(fname.c_str(), "r");
+				if ( ! tfile )
+					break;
+
+				// stat newly opened file
+				if ( fstat(fileno(tfile), &sb) == -1 )
+					{
+					Error(Fmt("Could not fstat %s", fname.c_str()));
+					break;
+					}
+				file.reset(nullptr);
+				file = std::unique_ptr<FILE, int (*)(FILE*)>(tfile, fclose);
+				ino = sb.st_ino;
+				dev = sb.st_dev;
+				offset = 0;
+				bufpos = 0;
 				break;
 
 			default:

--- a/src/input/readers/raw/Raw.h
+++ b/src/input/readers/raw/Raw.h
@@ -55,6 +55,7 @@ private:
 	bool firstrun;
 	time_t mtime;
 	ino_t ino;
+	dev_t dev;
 
 	// options set from the script-level.
 	std::string separator;


### PR DESCRIPTION
Open /dev/null if the file is missing during init and wait for file to be created. Collect initial ino, dev, and mtime when first opening the file. Detect if the file has been replaced and open the new version.

This is my initial attempt to solve issue  #2028 and does not include documentation changes.