### PR TITLE
Explicitly define copy and move operators/constructors for ScriptProfileStats

### DIFF
--- a/src/ScriptProfile.h
+++ b/src/ScriptProfile.h
@@ -22,10 +22,16 @@ namespace detail
 class ScriptProfileStats
 	{
 public:
-	ScriptProfileStats() { }
+	ScriptProfileStats() = default;
 	ScriptProfileStats(std::string arg_name) : name(std::move(arg_name)) { }
 
-	virtual ~ScriptProfileStats() { }
+	virtual ~ScriptProfileStats() = default;
+
+	ScriptProfileStats(ScriptProfileStats&&) = default;
+	ScriptProfileStats(const ScriptProfileStats&) = default;
+
+	ScriptProfileStats& operator=(ScriptProfileStats&&) = default;
+	ScriptProfileStats& operator=(const ScriptProfileStats&) = default;
 
 	const auto Name() const { return name; }
 


### PR DESCRIPTION
Fixes Coverity finding 1488768

By defining a destructor, move operations are automatically disabled (see [The rule of five](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all)). Coverity realizes that a move operator here could actually provide some performance increase, and recommends defining it, even if just as `= default`.