### PR TITLE
Add --retry to curl invocations in update-traces

### DIFF
--- a/testing/external/scripts/update-traces
+++ b/testing/external/scripts/update-traces
@@ -53,7 +53,7 @@ cat $cfg | while read line; do
 
     # Get the fingerprint file.
     echo Getting $safe_url.md5sum ...
-    eval "$proxy curl $auth -fsS --anyauth $url.md5sum -o $fp.tmp" || {
+    eval "$proxy curl $auth -fsS --anyauth --retry 2 $url.md5sum -o $fp.tmp" || {
         echo "Error: Could not get $safe_url.md5sum"
         exit 1
     }
@@ -71,7 +71,7 @@ cat $cfg | while read line; do
 
     if [ "$download" = "1" ]; then
         echo Getting $safe_url ...
-        eval "$proxy curl $auth -f --anyauth $url -o $file" || {
+        eval "$proxy curl $auth --retry 2 -f --anyauth $url -o $file" || {
             echo "Error: Could not get $safe_url"
             exit 1
         }


### PR DESCRIPTION
I've seen CI builds fail a few times recently where the download of some of the trace files fails. This seems like a transient failure since retrying the CI task usually succeeds. This PR adds the `--retry` argument to the curl invocations so that it won't just give up on a single failure.

I set the retry count to `2` just to start with. If we see it still having problems, we might consider bumping that up but two retries should probably be enough.