### PR TITLE
GH-2103: Disable leak detection for bifs.footprint in another way

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -283,7 +283,6 @@ asan_sanitizer_task:
     CXXFLAGS: -DZEEK_DICT_DEBUG
     ZEEK_CI_CONFIGURE_FLAGS: *ASAN_SANITIZER_CONFIG
     ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1
-    ZEEK_CI_ASAN_SKIP_TEST: 1
     ASAN_OPTIONS: detect_leaks=1
 
 ubsan_sanitizer_task:

--- a/testing/btest/bifs/footprint.zeek
+++ b/testing/btest/bifs/footprint.zeek
@@ -1,8 +1,7 @@
-# The ASAN CI job complains (correctly!) about this script leaking memory
-# due to the script-level cycles it includes as stress-tests.
-# @TEST-REQUIRES: test "${ZEEK_CI_ASAN_SKIP_TEST}" != "1"
-#
-# @TEST-EXEC: zeek -b %INPUT >out
+# The ASAN leak detection complains (correctly!) about this script
+# leaking memory due to the script-level cycles it includes as
+# stress-tests, so just disable leak checking.
+# @TEST-EXEC: ASAN_OPTIONS="$ASAN_OPTIONS,detect_leaks=0" zeek -b %INPUT >out
 # @TEST-EXEC: btest-diff out
 
 type r1: record {


### PR DESCRIPTION
We already had another btest (`language.copy-cycle`) that disables leak detection. This fixes the `bifs.footprint` btest in a fashion that works correctly if you're running `detect_leaks` outside of the CI environment as well.

Fixes #2103