### PR TITLE
Call pip using python -m flag during FreeBSD CI prep

### DIFF
--- a/ci/freebsd/prepare.sh
+++ b/ci/freebsd/prepare.sh
@@ -10,4 +10,5 @@ pkg install -y bash git cmake swig bison python3 base64
 pkg upgrade -y curl
 pyver=$(python3 -c 'import sys; print(f"py{sys.version_info[0]}{sys.version_info[1]}")')
 pkg install -y $pyver-sqlite3 $pyver-pip
-pip install junit2html
+
+python -m pip install junit2html


### PR DESCRIPTION
FreeBSD 14's py38-pip package apparently lost the `pip` symlink that gets installed in /usr/local/bin, so we can't call it directly anymore. This PR changes the FreeBSD prepare script to just call pip using python's -m flag instead.