### PR TITLE
Remove unnecessary uses of util::fmt()

### DIFF
--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -325,7 +325,7 @@ int dbg_cmd_frame(DebugCmd cmd, const vector<string>& args)
 	// for 'list', 'break', etc.
 	const Stmt* stmt = g_frame_stack[user_frame_number]->GetNextStmt();
 	if ( ! stmt )
-		reporter->InternalError("Assertion failed: %s", "stmt != 0");
+		reporter->InternalError("Assertion failed: stmt is null");
 
 	const Location loc = *stmt->GetLocationInfo();
 	g_debugger_state.last_loc = loc;
@@ -362,7 +362,7 @@ int dbg_cmd_break(DebugCmd cmd, const vector<string>& args)
 
 		Stmt* stmt = g_frame_stack[user_frame_number]->GetNextStmt();
 		if ( ! stmt )
-			reporter->InternalError("Assertion failed: %s", "stmt != 0");
+			reporter->InternalError("Assertion failed: stmt is null");
 
 		DbgBreakpoint* bp = new DbgBreakpoint();
 		bp->SetID(g_debugger_state.NextBPID());

--- a/src/analyzer/protocol/ssl/dtls-analyzer.pac
+++ b/src/analyzer/protocol/ssl/dtls-analyzer.pac
@@ -97,13 +97,13 @@ refine connection SSL_Conn += {
 		// copy data from fragment to buffer
 		if ( ${rec.data}.length() != flength )
 			{
-			zeek_analyzer()->AnalyzerViolation(zeek::util::fmt("DTLS handshake record length does not match packet length"));
+			zeek_analyzer()->AnalyzerViolation("DTLS handshake record length does not match packet length");
 			return true;
 			}
 
 		if ( foffset + flength > length )
 			{
-			zeek_analyzer()->AnalyzerViolation(zeek::util::fmt("DTLS handshake fragment trying to write past end of buffer"));
+			zeek_analyzer()->AnalyzerViolation("DTLS handshake fragment trying to write past end of buffer");
 			return true;
 			}
 
@@ -124,7 +124,7 @@ refine connection SSL_Conn += {
 			uint64 total_length = i->message_last_sequence - i->message_first_sequence;
 			if ( total_length > 30 )
 				{
-				zeek_analyzer()->AnalyzerViolation(zeek::util::fmt("DTLS Message fragmented over more than 30 pieces. Cannot reassemble."));
+				zeek_analyzer()->AnalyzerViolation("DTLS Message fragmented over more than 30 pieces. Cannot reassemble.");
 				return true;
 				}
 

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -47,7 +47,7 @@ STACK_OF(X509)* x509_get_untrusted_stack(zeek::VectorVal* certs_vec)
 		if ( ! x )
 			{
 			sk_X509_free(untrusted_certs);
-			zeek::emit_builtin_error(zeek::util::fmt("No certificate in opaque in stack"));
+			zeek::emit_builtin_error("No certificate in opaque in stack");
 			return 0;
 			}
 
@@ -292,7 +292,7 @@ function x509_ocsp_verify%(certs: x509_opaque_vector, ocsp_reply: string, root_c
 	X509* cert = cert_handle->GetCertificate();
 	if ( ! cert )
 		{
-		zeek::emit_builtin_error(zeek::util::fmt("No certificate in opaque"));
+		zeek::emit_builtin_error("No certificate in opaque");
 		return x509_result_record(-1, "No certificate in opaque");
 		}
 
@@ -577,7 +577,7 @@ function x509_verify%(certs: x509_opaque_vector, root_certs: table_string_of_str
 	X509* cert = cert_handle->GetCertificate();
 	if ( ! cert )
 		{
-		zeek::emit_builtin_error(zeek::util::fmt("No certificate in opaque"));
+		zeek::emit_builtin_error("No certificate in opaque");
 		return x509_result_record(-1, "No certificate in opaque");
 		}
 
@@ -1022,7 +1022,7 @@ function x509_check_cert_hostname%(cert_opaque: opaque of x509, hostname: string
 	X509* cert = cert_handle->GetCertificate();
 	if ( ! cert )
 		{
-		zeek::emit_builtin_error(zeek::util::fmt("No certificate in opaque"));
+		zeek::emit_builtin_error("No certificate in opaque");
 		return zeek::make_intrusive<zeek::StringVal>("");
 		}
 
@@ -1034,14 +1034,14 @@ function x509_check_cert_hostname%(cert_opaque: opaque of x509, hostname: string
 		auto* ex = X509_get_ext(cert, sanpos);
 		if ( ! ex )
 			{
-			zeek::emit_builtin_error(zeek::util::fmt("Could not get SAN from cert"));
+			zeek::emit_builtin_error("Could not get SAN from cert");
 			return zeek::make_intrusive<zeek::StringVal>("");
 			}
 
 		auto *altname = reinterpret_cast<GENERAL_NAMES*>(X509V3_EXT_d2i(ex));
 		if ( ! altname )
 			{
-			zeek::emit_builtin_error(zeek::util::fmt("Could not get names from SAN ext"));
+			zeek::emit_builtin_error("Could not get names from SAN ext");
 			return zeek::make_intrusive<zeek::StringVal>("");
 			}
 
@@ -1079,7 +1079,7 @@ function x509_check_cert_hostname%(cert_opaque: opaque of x509, hostname: string
 		auto* subject = X509_get_subject_name(cert);
 		if ( ! subject )
 			{
-			zeek::emit_builtin_error(zeek::util::fmt("Could not get certificate subject"));
+			zeek::emit_builtin_error("Could not get certificate subject");
 			return zeek::make_intrusive<zeek::StringVal>("");
 			}
 
@@ -1095,7 +1095,7 @@ function x509_check_cert_hostname%(cert_opaque: opaque of x509, hostname: string
 			BIO *bio = BIO_new(BIO_s_mem());
 			if ( ! bio )
 			{
-			zeek::emit_builtin_error(zeek::util::fmt("Could create bio"));
+			zeek::emit_builtin_error("Could create bio");
 			return zeek::make_intrusive<zeek::StringVal>("");
 			}
 			ASN1_STRING_print(bio, X509_NAME_ENTRY_get_data(X509_NAME_get_entry(subject, found_nid)));


### PR DESCRIPTION
I've had these changes sitting on another branch that I never got around to opening a PR for. This PR removes a bunch of unnecessary calls to `util::fmt` where there isn't any format modifiers, or if the only data passed is a static value.