### PR TITLE
Always generate helper scripts for Spicy.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,17 +694,6 @@ if ( NOT DISABLE_SPICY )
         add_dependencies(plugin-Zeek-Spicy spicy)
         add_dependencies(spicyz spicy)
 
-        # Spicy JIT relies on the path of the current executable to figure out
-        # whether it is run from a build or an install tree. This assumption
-        # gets broken for e.g., `spicyz` when running from the build tree
-        # (probably fixable), and also when JIT'ing directly from a `zeek`
-        # invocation (much harder to fix). Instead we generate shell
-        # definitions to support running and using Spicy or spicy-plugin
-        # functionality in the build tree, including JIT'ing directly from
-        # Zeek.
-        configure_file(${CMAKE_SOURCE_DIR}/auxil/spicy/spicy-path.in ${CMAKE_BINARY_DIR}/spicy-path @ONLY)
-        configure_file(${CMAKE_SOURCE_DIR}/auxil/spicy/hilti-cxx-include-dirs.in ${CMAKE_BINARY_DIR}/hilti-cxx-include-dirs @ONLY)
-
         # Also install spicy-plugin's CMake files into Zeek's global `cmake/` folder.
         #
         # NOTE: We do not install spicy-plugin's `FindZeek.cmake` since another
@@ -714,6 +703,21 @@ if ( NOT DISABLE_SPICY )
                 DESTINATION share/zeek/cmake)
     endif ()
 endif ()
+
+# Always generate helper scripts referenced in e.g., `zeek-path-dev.*` so the
+# scripts work in any build configuration. If we do not include Spicy these
+# files have no actual effect.
+#
+# Spicy JIT relies on the path of the current executable to figure out
+# whether it is run from a build or an install tree. This assumption
+# gets broken for e.g., `spicyz` when running from the build tree
+# (probably fixable), and also when JIT'ing directly from a `zeek`
+# invocation (much harder to fix). Instead we generate shell
+# definitions to support running and using Spicy or spicy-plugin
+# functionality in the build tree, including JIT'ing directly from
+# Zeek.
+configure_file(${CMAKE_SOURCE_DIR}/auxil/spicy/spicy-path.in ${CMAKE_BINARY_DIR}/spicy-path @ONLY)
+configure_file(${CMAKE_SOURCE_DIR}/auxil/spicy/hilti-cxx-include-dirs.in ${CMAKE_BINARY_DIR}/hilti-cxx-include-dirs @ONLY)
 
 ########################################################################
 ## Packaging Setup


### PR DESCRIPTION
We previously only generated these files if configuring a build which
included Spicy. This meant that e.g., `zeek-path-dev.*` scripts would
emit errors for non-existing paths if Spicy was not included.

We now always generate the helper scripts so we can reference them
regardless of build configuration. If Spicy is not included the files
will still be sourced, but have no actual effect.