### PR TITLE
Disable Spicy in Zeek Coverity builds

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   scan:
     if: github.repository == 'zeek/zeek'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -32,6 +32,7 @@ jobs:
             python3-pip \
             swig \
             zlib1g-dev \
+            libmaxminddb-dev \
             libkrb5-dev \
             bsdmainutils \
             sqlite3 \
@@ -42,7 +43,7 @@ jobs:
         run: cd auxil/broker/caf && ./configure --prefix=`pwd`/build/install-root && cd build && make -j $(nproc) install
 
       - name: Configure
-        run: ./configure --build-type=debug --with-caf=`pwd`/auxil/broker/caf/build/install-root --disable-broker-tests
+        run: ./configure --build-type=debug --with-caf=`pwd`/auxil/broker/caf/build/install-root --disable-broker-tests --disable-spicy
 
       - name: Fetch Coverity Tools
         env:


### PR DESCRIPTION
This PR also bumps the version of the base image up to Ubuntu 20.04 so we don't have to install a bunch of extra packages to get newer versions of CMake and the compiler.