### PR TITLE
Fix SSL tests on Centos Stream 9

### DIFF
--- a/ci/centos-stream-9/Dockerfile
+++ b/ci/centos-stream-9/Dockerfile
@@ -31,6 +31,10 @@ RUN dnf -y --nobest install \
     swig \
     which \
     zlib-devel \
+    tar \
   && dnf clean all && rm -rf /var/cache/dnf
+
+# Set the crypto policy to allow SHA-1 certificates - which we have in our tests
+RUN dnf -y --nobest install crypto-policies-scripts && update-crypto-policies --set LEGACY
 
 RUN pip3 install junit2html


### PR DESCRIPTION
SHA1 signatures are only allowed in the legacy policy. I have no idea
where this is documented - I found it in a patch for the OpenSSL source
package.

Also adding tar as a specific dependency, since we have a test that
requires it, and at least for me it was not present in a minimal
installation.

Fixes #2115