### PR TITLE
Small change to `build_path()`: don't make result absolute if input dir is empty and file is relative

### DIFF
--- a/scripts/base/utils/paths.zeek
+++ b/scripts/base/utils/paths.zeek
@@ -28,11 +28,13 @@ function extract_path(input: string): string
 ## file_name: the name of the file.
 ##
 ## Returns: the concatenation of the directory path and file name, or just
-##          the file name if it's already an absolute path.
+##          the file name if it's already an absolute path or dir is empty.
 function build_path(dir: string, file_name: string): string
 	{
-	return (file_name == absolute_path_pat) ?
-		file_name : cat(dir, "/", file_name);
+	# Avoid introducing "//" into the result:
+	local sep = ends_with(dir, "/") ? "" : "/";
+	return (file_name == absolute_path_pat || dir == "") ?
+		file_name : cat(dir, sep, file_name);
 	}
 
 ## Returns a compressed path to a file given a directory and file name.

--- a/testing/btest/Baseline/scripts.base.utils.paths/output
+++ b/testing/btest/Baseline/scripts.base.utils.paths/output
@@ -79,7 +79,10 @@ test build_path_compressed()
 /usr/local/bro/share/bro/somefile.zeek
 /usr/local/bro/somefile.zeek
 ===============================
-test build_full_path()
+test build_path()
 ===============================
-/home/bro//policy/somefile.zeek
+/home/bro/policy/somefile.zeek
 /usr/local/bro/share/bro/somefile.zeek
+policy/somefile.zeek
+/usr/local/bro/share/bro/somefile.zeek
+/policy/somefile.zeek

--- a/testing/btest/Baseline/scripts.base.utils.paths/output
+++ b/testing/btest/Baseline/scripts.base.utils.paths/output
@@ -75,14 +75,14 @@ Result: SUCCESS
 ===============================
 test build_path_compressed()
 ===============================
-/home/bro/policy/somefile.zeek
-/usr/local/bro/share/bro/somefile.zeek
-/usr/local/bro/somefile.zeek
+/home/zeek/policy/somefile.zeek
+/usr/local/zeek/share/zeek/somefile.zeek
+/usr/local/zeek/somefile.zeek
 ===============================
 test build_path()
 ===============================
-/home/bro/policy/somefile.zeek
-/usr/local/bro/share/bro/somefile.zeek
+/home/zeek/policy/somefile.zeek
+/usr/local/zeek/share/zeek/somefile.zeek
 policy/somefile.zeek
-/usr/local/bro/share/bro/somefile.zeek
+/usr/local/zeek/share/zeek/somefile.zeek
 /policy/somefile.zeek

--- a/testing/btest/scripts/base/utils/paths.test
+++ b/testing/btest/scripts/base/utils/paths.test
@@ -50,8 +50,10 @@ print build_path_compressed("/home/bro/", "/usr/local/bro/share/bro/somefile.zee
 print build_path_compressed("/home/bro/", "/usr/local/bro/share/../../bro/somefile.zeek");
 
 print "===============================";
-print "test build_full_path()";
+print "test build_path()";
 print "===============================";
 print build_path("/home/bro/", "policy/somefile.zeek");
 print build_path("/home/bro/", "/usr/local/bro/share/bro/somefile.zeek");
-
+print build_path("", "policy/somefile.zeek");
+print build_path("", "/usr/local/bro/share/bro/somefile.zeek");
+print build_path("/", "policy/somefile.zeek");

--- a/testing/btest/scripts/base/utils/paths.test
+++ b/testing/btest/scripts/base/utils/paths.test
@@ -45,15 +45,15 @@ test_extract("here's two dirs: /foo/bar and /foo/baz", "/foo/bar");
 
 print "test build_path_compressed()";
 print "===============================";
-print build_path_compressed("/home/bro/", "policy/somefile.zeek");
-print build_path_compressed("/home/bro/", "/usr/local/bro/share/bro/somefile.zeek");
-print build_path_compressed("/home/bro/", "/usr/local/bro/share/../../bro/somefile.zeek");
+print build_path_compressed("/home/zeek/", "policy/somefile.zeek");
+print build_path_compressed("/home/zeek/", "/usr/local/zeek/share/zeek/somefile.zeek");
+print build_path_compressed("/home/zeek/", "/usr/local/zeek/share/../../zeek/somefile.zeek");
 
 print "===============================";
 print "test build_path()";
 print "===============================";
-print build_path("/home/bro/", "policy/somefile.zeek");
-print build_path("/home/bro/", "/usr/local/bro/share/bro/somefile.zeek");
+print build_path("/home/zeek/", "policy/somefile.zeek");
+print build_path("/home/zeek/", "/usr/local/zeek/share/zeek/somefile.zeek");
 print build_path("", "policy/somefile.zeek");
-print build_path("", "/usr/local/bro/share/bro/somefile.zeek");
+print build_path("", "/usr/local/zeek/share/zeek/somefile.zeek");
 print build_path("/", "policy/somefile.zeek");


### PR DESCRIPTION
If you pass something like `build_path("", "local/file.zeek")` it seems unlikely that you want this translated to `"/local/file.zeek"` rather than `"local/file.zeek"`. (This comes in handy in some upcoming path-munging in the Management framework.)