### PR TITLE
Add DOCKERFILE_VERSION variable to all CI dockerfiles

### DIFF
--- a/ci/alpine/Dockerfile
+++ b/ci/alpine/Dockerfile
@@ -1,5 +1,9 @@
 FROM alpine:latest
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 RUN apk add --no-cache \
   ccache \
   cmake \

--- a/ci/centos-7/Dockerfile
+++ b/ci/centos-7/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:7
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 ENV FLEX_VERSION=2.6.4
 ENV FLEX_DIR=/opt/flex
 

--- a/ci/centos-stream-8/Dockerfile
+++ b/ci/centos-stream-8/Dockerfile
@@ -1,5 +1,9 @@
 FROM quay.io/centos/centos:stream8
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 RUN dnf config-manager --set-enabled powertools
 

--- a/ci/centos-stream-9/Dockerfile
+++ b/ci/centos-stream-9/Dockerfile
@@ -1,5 +1,9 @@
 FROM quay.io/centos/centos:stream9
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 # dnf config-manager isn't available at first, and
 # we need it to install the CRB repo below.
 RUN dnf -y install 'dnf-command(config-manager)'

--- a/ci/debian-10/Dockerfile
+++ b/ci/debian-10/Dockerfile
@@ -2,6 +2,10 @@ FROM debian:10
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"
 

--- a/ci/debian-11/Dockerfile
+++ b/ci/debian-11/Dockerfile
@@ -2,6 +2,10 @@ FROM debian:11
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 RUN apt-get update && apt-get -y install \
     ccache \
     git \

--- a/ci/debian-9-32bit/Dockerfile
+++ b/ci/debian-9-32bit/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 221001
+ENV DOCKERFILE_VERSION 20220519
 
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"

--- a/ci/debian-9/Dockerfile
+++ b/ci/debian-9/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 221001
+ENV DOCKERFILE_VERSION 20220519
 
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"

--- a/ci/fedora-34/Dockerfile
+++ b/ci/fedora-34/Dockerfile
@@ -1,5 +1,9 @@
 FROM fedora:34
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 RUN dnf -y install \
     ccache \
     bison \

--- a/ci/fedora-35/Dockerfile
+++ b/ci/fedora-35/Dockerfile
@@ -1,5 +1,9 @@
 FROM fedora:35
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 RUN dnf -y install \
     ccache \
     bison \

--- a/ci/openssl-3.0/Dockerfile
+++ b/ci/openssl-3.0/Dockerfile
@@ -2,6 +2,10 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 RUN apt-get update && apt-get -y install \
     ccache \
     git \

--- a/ci/opensuse-leap-15.3/Dockerfile
+++ b/ci/opensuse-leap-15.3/Dockerfile
@@ -1,5 +1,9 @@
 FROM opensuse/leap:15.3
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 RUN zypper addrepo https://download.opensuse.org/repositories/openSUSE:Leap:15.2:Update/standard/openSUSE:Leap:15.2:Update.repo \
  && zypper refresh \
  && zypper in -y \

--- a/ci/ubuntu-18.04/Dockerfile
+++ b/ci/ubuntu-18.04/Dockerfile
@@ -2,6 +2,10 @@ FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"
 ENV PATH "${CMAKE_DIR}/bin:${PATH}"

--- a/ci/ubuntu-20.04/Dockerfile
+++ b/ci/ubuntu-20.04/Dockerfile
@@ -2,6 +2,10 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 RUN apt-get update && apt-get -y install \
     ccache \
     git \

--- a/ci/ubuntu-21.10/Dockerfile
+++ b/ci/ubuntu-21.10/Dockerfile
@@ -2,6 +2,10 @@ FROM ubuntu:21.10
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
 RUN apt-get update && apt-get -y install \
     git \
     ccache \


### PR DESCRIPTION
We ran into a bug with the CentOS 9 CI build recently that effectively stemmed from the fact that we hadn't rebuilt that docker instance in a while, and a package update caused something to break in the Zeek tests. This PR adds a new variable to every one of our dockerfiles that allows us to force rebuilds of them. Preferably we'd do this around each release cycle so we can catch these kinds of changes more easily.