### PR TITLE
GH-2054: Allow nulls as separators for join_string_vec

### DIFF
--- a/src/strings.bif
+++ b/src/strings.bif
@@ -102,7 +102,7 @@ function join_string_vec%(vec: string_vec, sep: string%): string
 	for ( unsigned i = 0; i < v->Size(); ++i )
 		{
 		if ( i > 0 )
-			d.Add(sep->CheckString(), 0);
+			d.AddN(reinterpret_cast<const char*>(sep->Bytes()), sep->Len());
 
 		auto e = v->ValAt(i);
 

--- a/testing/btest/Baseline/bifs.join_string/out
+++ b/testing/btest/Baseline/bifs.join_string/out
@@ -3,3 +3,4 @@ this__is__another__test
 thisisanothertest
 Test
 ...hi..there
+this\x00is\x00another\x00test

--- a/testing/btest/bifs/join_string.zeek
+++ b/testing/btest/bifs/join_string.zeek
@@ -18,4 +18,5 @@ event zeek_init()
 	print join_string_vec(c, "");
 	print join_string_vec(d, "-");
 	print join_string_vec(e, ".");
+	print join_string_vec(c, "\x00");
 	}


### PR DESCRIPTION
I'm not the biggest fan of the `reinterpret_cast`, but `Bytes()` returns a `const unsigned char*` and all of the methods in `ODesc` only take `const char*`.