### PR TITLE
Add lookup_autonomous_system() BIF that returns AS number and org

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -984,6 +984,14 @@ type geo_location: record {
 	longitude: double &optional;	##< Longitude.
 } &log;
 
+## GeoIP autonomous system information.
+##
+## .. zeek:see:: lookup_autonomous_system
+type geo_autonomous_system: record {
+	number: count &optional;	##< The autonomous system number.
+	organization: string &optional;	##< Associated organization.
+} &log;
+
 ## The directory containing MaxMind DB (.mmdb) files to use for GeoIP support.
 const mmdb_dir: string = "" &redef;
 

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -4319,7 +4319,7 @@ function lookup_location%(a: addr%) : geo_location
 ## Returns: The number of the ASN that contains *a*.
 ##
 ## .. zeek:see:: lookup_location lookup_autonomous_system
-function lookup_asn%(a: addr%) : count
+function lookup_asn%(a: addr%) : count &deprecated="Remove in v6.1.  Functionality is now handled by lookup_autonomous_system()."
 	%{
 #ifdef USE_GEOIP
 	mmdb_check_asn();

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -4198,7 +4198,7 @@ static bool mmdb_try_open_asn ()
 ##
 ## Returns: A boolean indicating whether the db was successfully opened.
 ##
-## .. zeek:see:: lookup_asn
+## .. zeek:see:: lookup_asn lookup_autonomous_system
 function mmdb_open_location_db%(f: string%) : bool
 	%{
 #ifdef USE_GEOIP
@@ -4208,14 +4208,14 @@ function mmdb_open_location_db%(f: string%) : bool
 #endif
 	%}
 
-## Initializes MMDB for later use of lookup_asn.
+## Initializes MMDB for later use of lookup_asn or lookup_autonomous_system.
 ## Requires Zeek to be built with ``libmaxminddb``.
 ##
 ## f: The filename of the MaxMind ASN DB.
 ##
 ## Returns: A boolean indicating whether the db was successfully opened.
 ##
-## .. zeek:see:: lookup_asn
+## .. zeek:see:: lookup_asn lookup_autonomous_system
 function mmdb_open_asn_db%(f: string%) : bool
 	%{
 #ifdef USE_GEOIP
@@ -4232,7 +4232,7 @@ function mmdb_open_asn_db%(f: string%) : bool
 ##
 ## Returns: A record with country, region, city, latitude, and longitude.
 ##
-## .. zeek:see:: lookup_asn
+## .. zeek:see:: lookup_asn lookup_autonomous_system
 function lookup_location%(a: addr%) : geo_location
 	%{
 	static auto geo_location = zeek::id::find_type<zeek::RecordType>("geo_location");
@@ -4318,7 +4318,7 @@ function lookup_location%(a: addr%) : geo_location
 ##
 ## Returns: The number of the ASN that contains *a*.
 ##
-## .. zeek:see:: lookup_location
+## .. zeek:see:: lookup_location lookup_autonomous_system
 function lookup_asn%(a: addr%) : count
 	%{
 #ifdef USE_GEOIP
@@ -4365,6 +4365,74 @@ function lookup_asn%(a: addr%) : count
 	// able to initialize it or it didn't return any information for
 	// the address.
 	return zeek::val_mgr->Count(0);
+	%}
+
+## Performs an lookup of AS numbe & organization of an IP address.
+## Requires Zeek to be built with ``libmaxminddb``.
+##
+## a: The IP address to lookup.
+##
+## Returns: A record with autonomous system number and organization that
+## contains *a*.
+##
+## .. zeek:see:: lookup_location lookup_asn
+function lookup_autonomous_system%(a: addr%) : geo_autonomous_system
+	%{
+	static auto geo_autonomous_system = zeek::id::find_type<zeek::RecordType>("geo_autonomous_system");
+	auto autonomous_system = zeek::make_intrusive<zeek::RecordVal>(geo_autonomous_system);
+
+#ifdef USE_GEOIP
+	mmdb_check_asn();
+	if ( ! mmdb_asn )
+		{
+		if ( ! mmdb_try_open_asn() )
+			{
+			if ( ! did_mmdb_asn_db_error )
+				{
+				did_mmdb_asn_db_error = true;
+				zeek::emit_builtin_error("Failed to open GeoIP ASN database");
+				}
+
+			return autonomous_system;
+			}
+		}
+
+	MMDB_lookup_result_s result;
+
+	if ( mmdb_lookup_asn(a->AsAddr(), result) )
+		{
+		MMDB_entry_data_s entry_data;
+		int status;
+
+		// Get Autonomous System Number
+		status = MMDB_get_value(&result.entry, &entry_data,
+		                        "autonomous_system_number", nullptr);
+		autonomous_system->Assign(0, mmdb_getvalue(&entry_data, status,
+		                          MMDB_DATA_TYPE_UINT32));
+
+		// Get Autonomous System Organization
+		status = MMDB_get_value(&result.entry, &entry_data,
+		                        "autonomous_system_organization", nullptr);
+		autonomous_system->Assign(1, mmdb_getvalue(&entry_data, status,
+		                          MMDB_DATA_TYPE_UTF8_STRING));
+
+		return autonomous_system;
+		}
+
+#else // not USE_GEOIP
+	static int missing_geoip_reported = 0;
+
+	if ( ! missing_geoip_reported )
+		{
+		zeek::emit_builtin_error("Zeek was not configured for GeoIP ASN support");
+		missing_geoip_reported = 1;
+		}
+#endif
+
+	// We can get here even if we have GeoIP support, if we weren't
+	// able to initialize it or it didn't return any information for
+	// the address.
+	return autonomous_system;
 	%}
 
 ## Calculates distance between two geographic locations using the haversine


### PR DESCRIPTION
The existing BIF `lookup_asn()` only returns the autonomous system number. However, the ASN database from MaxMind includes the autonomous system organization as well. This PR adds a new BIF `lookup_autonomous_system()`  that returns a record containing both the ASN and the organization.

I took the approach of adding a new BIF rather than changing `lookup_asn()` since I figured users that might be depending on the existing BIF would not appreciate having to make changes to accommodate the different return type. With the approach taken here, users could switch over to the new BIF if that suits them and 
`lookup_asn()` could perhaps be deprecated in the future if desired.

I confess I'm not much of a C++ developer but was able to write this by following the pattern of `lookup_asn()` and `lookup_asn()`. To prove that it's working, I have a [branch of the geoip-conn Zeek package](https://github.com/philrz/geoip-conn/tree/as-org) that leverages this new BIF. Here's an example of the new AS org field being populated when Zeek processes the test pcap  [dns/loc-29-trunc.pcap](https://github.com/zeek/zeek/raw/master/testing/btest/Traces/dns/loc-29-trunc.pcap) from the Zeek repo.

```
$ zkg install https://github.com/philrz/geoip-conn --version fe0655225ed8b0f9eef1674fa21a25b14fc65fb9
The following packages will be INSTALLED:
  https://github.com/philrz/geoip-conn (fe0655225ed8b0f9eef1674fa21a25b14fc65fb9)

Proceed? [Y/n] y
Installing "https://github.com/philrz/geoip-conn".............................................................................................................................................................................................
Installed "https://github.com/philrz/geoip-conn" (fe0655225ed8b0f9eef1674fa21a25b14fc65fb9)
Loaded "https://github.com/philrz/geoip-conn"

$ zeek -C -r loc-29-trunc.pcap local
WARNING: No Site::local_nets have been defined.  It's usually a good idea to define your local networks.

$ zq -Z conn.log 
{
    _path: "conn",
    ts: 2020-11-09T00:02:02.851655Z,
    uid: "CHNGUcFixuswCrxsi",
    id: {
        orig_h: 79.141.82.250,
        orig_p: 57483 (port=uint16),
        resp_h: 192.188.22.52,
        resp_p: 53 (port)
    },
    proto: "udp" (=zenum),
    service: "dns",
    duration: 195us,
    orig_bytes: 72 (uint64),
    resp_bytes: 234 (uint64),
    conn_state: "SF",
    local_orig: null (bool),
    local_resp: null (bool),
    missed_bytes: 0 (uint64),
    history: "Dd",
    orig_pkts: 1 (uint64),
    orig_ip_bytes: 100 (uint64),
    resp_pkts: 1 (uint64),
    resp_ip_bytes: 262 (uint64),
    tunnel_parents: null (|[string]|),
    geo: {
        orig: {
            country_code: "CH",
            region: "GE",
            city: "Bernex",
            latitude: 46.1727,
            longitude: 6.0732,
            as_number: 44166 (uint64),
            as_org: "NTD SA"
        },
        resp: {
            country_code: "US",
            region: null (string),
            city: null (string),
            latitude: 37.751,
            longitude: -97.822,
            as_number: 3443 (uint64),
            as_org: "ESNET-AS"
        }
    }
}
```

Fixes #2141