### PR TITLE
Fix a -Wstringop-overflow memset size warning with GCC 12

### DIFF
--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -3113,7 +3113,7 @@ function hexstr_to_bytestring%(hexstr: string%): string
 		}
 
 	const char* bytes = hexstr->AsString()->CheckString();
-	int outlen = (len/2);
+	size_t outlen = (len/2);
 	auto bytestring_buf = std::make_unique<char[]>(outlen);
 	auto bytestring = bytestring_buf.get();
 	memset(bytestring, 0, outlen);


### PR DESCRIPTION
I think I haven't seen this one before, but I didn't check other compilers. I'll take a look at the CI runs.

```
In file included from /home/christian/devel/zeek/zeek/src/Func.cc:55:
zeek.bif: In function ‘zeek::detail::BifReturnVal zeek::BifFunc::hexstr_to_bytestring_bif(zeek::detail::Frame*, const zeek::Args*)’:
zeek.bif:3117:8: warning: ‘void* memset(void*, int, size_t)’ specified size between 18446744072635809792 and 18446744073709551615 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
``` 