### PR TITLE
Merge PQ_Timer into base TimerMgr class

### DIFF
--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -193,8 +193,7 @@ void ProfileLogger::Log()
 		                      run_state::network_time, stats.matchers, stats.nfa_states,
 		                      stats.dfa_states, stats.computed, stats.mem / 1024));
 		}
-
-	file->Write(util::fmt("%.06f Timers: current=%d max=%d lag=%.2fs\n", run_state::network_time,
+	file->Write(util::fmt("%.06f Timers: current=%zu max=%zu lag=%.2fs\n", run_state::network_time,
 	                      timer_mgr->Size(), timer_mgr->PeakSize(),
 	                      run_state::network_time - timer_mgr->LastTimestamp()));
 

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -72,11 +72,16 @@ TimerMgr::TimerMgr()
 	num_expired = 0;
 	last_advance = last_timestamp = 0;
 
+	q = std::make_unique<PriorityQueue>();
+
 	if ( iosource_mgr )
 		iosource_mgr->Register(this, true);
 	}
 
-TimerMgr::~TimerMgr() { }
+TimerMgr::~TimerMgr()
+	{
+	q.reset();
+	}
 
 int TimerMgr::Advance(double arg_t, int max_expire)
 	{
@@ -113,17 +118,7 @@ void TimerMgr::InitPostScript()
 		iosource_mgr->Register(this, true);
 	}
 
-PQ_TimerMgr::PQ_TimerMgr() : TimerMgr()
-	{
-	q = new PriorityQueue;
-	}
-
-PQ_TimerMgr::~PQ_TimerMgr()
-	{
-	delete q;
-	}
-
-void PQ_TimerMgr::Add(Timer* timer)
+void TimerMgr::Add(Timer* timer)
 	{
 	DBG_LOG(DBG_TM, "Adding timer %s (%p) at %.6f", timer_type_to_string(timer->Type()), timer,
 	        timer->Time());
@@ -137,7 +132,7 @@ void PQ_TimerMgr::Add(Timer* timer)
 	++current_timers[timer->Type()];
 	}
 
-void PQ_TimerMgr::Expire()
+void TimerMgr::Expire()
 	{
 	Timer* timer;
 	while ( (timer = Remove()) )
@@ -149,7 +144,7 @@ void PQ_TimerMgr::Expire()
 		}
 	}
 
-int PQ_TimerMgr::DoAdvance(double new_t, int max_expire)
+int TimerMgr::DoAdvance(double new_t, int max_expire)
 	{
 	Timer* timer = Top();
 	for ( num_expired = 0; (num_expired < max_expire) && timer && timer->Time() <= new_t;
@@ -173,7 +168,7 @@ int PQ_TimerMgr::DoAdvance(double new_t, int max_expire)
 	return num_expired;
 	}
 
-void PQ_TimerMgr::Remove(Timer* timer)
+void TimerMgr::Remove(Timer* timer)
 	{
 	if ( ! q->Remove(timer) )
 		reporter->InternalError("asked to remove a missing timer");
@@ -182,13 +177,23 @@ void PQ_TimerMgr::Remove(Timer* timer)
 	delete timer;
 	}
 
-double PQ_TimerMgr::GetNextTimeout()
+double TimerMgr::GetNextTimeout()
 	{
 	Timer* top = Top();
 	if ( top )
 		return std::max(0.0, top->Time() - run_state::network_time);
 
 	return -1;
+	}
+
+Timer* TimerMgr::Remove()
+	{
+	return (Timer*)q->Remove();
+	}
+
+Timer* TimerMgr::Top()
+	{
+	return (Timer*)q->Top();
 	}
 
 	} // namespace zeek::detail

--- a/src/Timer.h
+++ b/src/Timer.h
@@ -2,7 +2,8 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
+#include <memory>
 
 #include "zeek/PriorityQueue.h"
 #include "zeek/iosource/IOSource.h"
@@ -75,12 +76,14 @@ protected:
 	TimerType type{};
 	};
 
-class TimerMgr : public iosource::IOSource
+class TimerMgr final : public iosource::IOSource
 	{
 public:
+	TimerMgr();
+
 	virtual ~TimerMgr();
 
-	virtual void Add(Timer* timer) = 0;
+	void Add(Timer* timer);
 
 	/**
 	 * Advance the clock to time t, expiring at most max_expire timers.
@@ -100,7 +103,7 @@ public:
 	/**
 	 * Expire all timers.
 	 */
-	virtual void Expire() = 0;
+	void Expire();
 
 	/**
 	 * Removes a timer. Cancel() is a method separate from Remove()
@@ -115,9 +118,9 @@ public:
 
 	double Time() const { return t ? t : 1; } // 1 > 0
 
-	virtual int Size() const = 0;
-	virtual int PeakSize() const = 0;
-	virtual uint64_t CumulativeNum() const = 0;
+	size_t Size() const { return q->Size(); }
+	size_t PeakSize() const { return q->PeakSize(); }
+	size_t CumulativeNum() const { return q->CumulativeNum(); }
 
 	double LastTimestamp() const { return last_timestamp; }
 
@@ -129,7 +132,7 @@ public:
 	static unsigned int* CurrentTimers() { return current_timers; }
 
 	// IOSource API methods
-	virtual double GetNextTimeout() override { return -1; }
+	virtual double GetNextTimeout() override;
 	virtual void Process() override;
 	virtual const char* Tag() override { return "TimerMgr"; }
 
@@ -139,11 +142,12 @@ public:
 	 */
 	void InitPostScript();
 
-protected:
-	TimerMgr();
+private:
+	int DoAdvance(double t, int max_expire);
+	void Remove(Timer* timer);
 
-	virtual int DoAdvance(double t, int max_expire) = 0;
-	virtual void Remove(Timer* timer) = 0;
+	Timer* Remove();
+	Timer* Top();
 
 	double t;
 	double last_timestamp;
@@ -151,31 +155,11 @@ protected:
 
 	int num_expired;
 
+	size_t peak_size = 0;
+	size_t cumulative_num = 0;
+
 	static unsigned int current_timers[NUM_TIMER_TYPES];
-	};
-
-class PQ_TimerMgr : public TimerMgr
-	{
-public:
-	PQ_TimerMgr();
-	~PQ_TimerMgr() override;
-
-	void Add(Timer* timer) override;
-	void Expire() override;
-
-	int Size() const override { return q->Size(); }
-	int PeakSize() const override { return q->PeakSize(); }
-	uint64_t CumulativeNum() const override { return q->CumulativeNum(); }
-	double GetNextTimeout() override;
-
-protected:
-	int DoAdvance(double t, int max_expire) override;
-	void Remove(Timer* timer) override;
-
-	Timer* Remove() { return (Timer*)q->Remove(); }
-	Timer* Top() { return (Timer*)q->Top(); }
-
-	PriorityQueue* q;
+	std::unique_ptr<PriorityQueue> q;
 	};
 
 extern TimerMgr* timer_mgr;

--- a/src/stats.bif
+++ b/src/stats.bif
@@ -288,7 +288,7 @@ function get_timer_stats%(%): TimerStats
 
 	r->Assign(n++, static_cast<uint64_t>(zeek::detail::timer_mgr->Size()));
 	r->Assign(n++, static_cast<uint64_t>(zeek::detail::timer_mgr->PeakSize()));
-	r->Assign(n++, zeek::detail::timer_mgr->CumulativeNum());
+	r->Assign(n++, static_cast<uint64_t>(zeek::detail::timer_mgr->CumulativeNum()));
 
 	return r;
 	%}

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -641,7 +641,7 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 	if ( r != SQLITE_OK )
 		reporter->Error("Failed to initialize sqlite3: %s", sqlite3_errstr(r));
 
-	timer_mgr = new PQ_TimerMgr();
+	timer_mgr = new TimerMgr();
 
 	auto zeekygen_cfg = options.zeekygen_config_file.value_or("");
 	zeekygen_mgr = new zeekygen::detail::Manager(zeekygen_cfg, zeek_argv[0]);


### PR DESCRIPTION
This is a post-5.0-release PR.

We removed `CQ_TimerMgr` back in the 3.1 release, in favor of `PQ_TimerMgr`. I'm not sure of the details why we didn't merge these together back then, but this PR merges the `PQ_Timer` code into the base `TimerMgr` class. We've had 2.5 years to implement another timer manager, and no one's done it. It's under the `zeek::detail` namespace so `PQ_TimerMgr` doesn't need to be deprecated here.