### PR TITLE
Make broker.web-socket-events test require the Python websockets package

### DIFF
--- a/testing/btest/broker/web-socket-events.zeek
+++ b/testing/btest/broker/web-socket-events.zeek
@@ -1,5 +1,9 @@
 # @TEST-GROUP: broker
 #
+# This test requires the websockets module, available via
+# "pip install websockets".
+# @TEST-REQUIRES: python3 -c 'import websockets'
+#
 # @TEST-PORT: BROKER_PORT
 #
 # @TEST-EXEC: btest-bg-run server "zeek -b %INPUT >output"


### PR DESCRIPTION
Resolves #2152.