### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * 1,3,5'
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     if: github.repository == 'zeek/zeek'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,9 @@ env:
   IMAGE_FILE: /tmp/zeek-image.tar
   IMAGE_PATH: /tmp
 
+permissions:
+  contents: read
+
 jobs:
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -9,8 +9,13 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   generate:
+    permissions:
+      contents: write  # for Git to git push
     if: github.repository == 'zeek/zeek'
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
