### PR TITLE
Management framework: config validation

### DIFF
--- a/scripts/policy/frameworks/management/supervisor/config.zeek
+++ b/scripts/policy/frameworks/management/supervisor/config.zeek
@@ -7,6 +7,18 @@ export {
 	## Supervisor. The agent subscribes to this.
 	const topic_prefix = "zeek/management/supervisor" &redef;
 
+	## Whether to print the stdout sent up to the Supervisor by created
+	## nodes to the terminal. By default, this is disabled since this output
+	## already ends up in a node-specific stdout file, per
+	## :zeek:see:`Management::Node::stdout_file`.
+	const print_stdout = F &redef;
+
+	## Whether to print the stderr sent up to the Supervisor by created
+	## nodes to the terminal. By default, this is disabled since this output
+	## already ends up in a node-specific stderr file, per
+	## :zeek:see:`Management::Node::stderr_file`.
+	const print_stderr = F &redef;
+
 	## The maximum number of stdout/stderr output lines to convey in
 	## :zeek:see:`Management::Supervisor::API::notify_node_exit` events.
 	const output_max_lines: count = 100 &redef;

--- a/scripts/policy/frameworks/management/supervisor/main.zeek
+++ b/scripts/policy/frameworks/management/supervisor/main.zeek
@@ -70,8 +70,8 @@ hook Supervisor::stdout_hook(node: string, msg: string)
 	# Update the sliding window of recent output lines.
 	Queue::put(g_outputs[node]$stdout, msg);
 
-	# Don't print this message in the Supervisor's own stdout
-	break;
+	if ( ! print_stdout )
+		break;
 	}
 
 hook Supervisor::stderr_hook(node: string, msg: string)
@@ -87,8 +87,8 @@ hook Supervisor::stderr_hook(node: string, msg: string)
 
 	Queue::put(g_outputs[node]$stderr, msg);
 
-	# Don't print this message in the Supervisor's own stdout
-	break;
+	if ( ! print_stderr )
+		break;
 	}
 
 event Supervisor::node_status(node: string, pid: count)

--- a/testing/external/commit-hash.zeek-testing-cluster
+++ b/testing/external/commit-hash.zeek-testing-cluster
@@ -1,1 +1,1 @@
-fa91ac8b028034bbbf22acca00a059cbc6d90829
+4aaab045ca6b4c53a815faf45accc685cddbcd73


### PR DESCRIPTION
This adds a validation stage to the controller that looks for possible misconfigurations when the client uploads a configuration. 

Also I noticed that I overlooked possible collisions in node port auto-assignment, for which this includes a fix, as well as for the corner case of entirely empty configurations.

Finally, this adds two on/off knobs for allowing the stdout/stderr of output coming from nodes to appear on the Supervisor console despite redirection to files, since this allows "docker logs" to show all such output, simplifying test troubleshooting.