### PR TITLE
CI: Add Fedora 36, remove Fedora 34

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -136,10 +136,10 @@ fedora35_task:
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
-fedora34_task:
+fedora36_task:
   container:
-    # Fedora 34 EOL: Around May 2022
-    dockerfile: ci/fedora-34/Dockerfile
+    # Fedora 36 EOL: Around May 2023
+    dockerfile: ci/fedora-36/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 

--- a/ci/fedora-36/Dockerfile
+++ b/ci/fedora-36/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:34
+FROM fedora:36
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20220614
 
 RUN dnf -y install \
     bison \


### PR DESCRIPTION
This should optimally also make it into 5.0.