### PR TITLE
Use ccache on github for docs gen workflow

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -41,33 +41,39 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install \
-            git \
-            cmake \
-            make \
-            gcc \
-            g++ \
-            flex \
             bison \
-            libfl2 \
+            bsdmainutils \
+            ccache \
+            cmake \
+            flex \
+            g++ \
+            gcc \
+            git \
             libfl-dev \
+            libfl2 \
+            libkrb5-dev \
             libpcap-dev \
             libssl-dev \
+            make \
             python3 \
             python3-dev \
             python3-pip\
+            sqlite3 \
             swig \
-            zlib1g-dev \
-            libkrb5-dev \
-            bsdmainutils \
-            sqlite3
+            zlib1g-dev
           # Many distros adhere to PEP 394's recommendation for `python` =
           # `python2` so this is a simple workaround until we drop Python 2
           # support and explicitly use `python3` for all invocations.
           sudo ln -sf /usr/bin/python3 /usr/local/bin/python
           sudo pip3 install -r doc/requirements.txt
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: 'docs-gen-${{ github.job }}'
+
       - name: Configure
-        run: ./configure --disable-broker-tests --disable-cpp-tests --disable-spicy
+        run: ./configure --disable-broker-tests --disable-cpp-tests --disable-spicy --ccache
 
       - name: Build
         run: cd build && make -j $(nproc)


### PR DESCRIPTION
This doesn't affect the actual generation part, but the build runs about 10 minutes faster:
![Screen Shot 2022-06-15 at 12 41 19 PM](https://user-images.githubusercontent.com/2653616/173911615-4fff18b2-f8e1-49f9-a5e4-3c7d571b35ba.png)
![Screen Shot 2022-06-15 at 12 41 27 PM](https://user-images.githubusercontent.com/2653616/173911641-ac104d76-8e10-44d0-8306-10231fe350e5.png)

