### PR TITLE
Helpers for maintaining external-testsuite commit files

### DIFF
--- a/ci/init-external-repos.sh
+++ b/ci/init-external-repos.sh
@@ -13,7 +13,6 @@ set -e
 cd testing/external
 [[ ! -d zeek-testing ]] && make init
 cd zeek-testing
-git checkout -q $(cat ../commit-hash.zeek-testing)
 
 if [[ -n "${CIRRUS_CI}" ]]; then
     if [[ -d ../zeek-testing-traces ]]; then

--- a/testing/external/Makefile
+++ b/testing/external/Makefile
@@ -13,7 +13,7 @@ brief:
 	@for repo in $(REPOS); do ( cd $$repo && make -s brief ); done
 
 init:
-	git clone $(PUBLIC_REPO)
+	git clone $(PUBLIC_REPO) && ./scripts/sync-repo $$(basename $(PUBLIC_REPO))
 
 pull:
 	@for repo in $(REPOS); do ( cd $$repo && git pull ); done
@@ -29,5 +29,11 @@ coverage:
 
 update-timing:
 	@for repo in $(REPOS); do ( cd $$repo && echo "Updating timing for '$$repo' repo:" && make update-timing ); done
+
+sync-commits:
+	for repo in $(REPOS); do ./scripts/sync-commit $$repo; done
+
+sync-repos:
+	for repo in $(REPOS); do ./scripts/sync-repo $$repo; done
 
 .PHONY: all brief init pull push status coverage

--- a/testing/external/Makefile
+++ b/testing/external/Makefile
@@ -6,11 +6,11 @@ DIAG=diag.log
 
 all:
 	@rm -f $(DIAG)
-	@for repo in $(REPOS); do (cd $$repo && make -s ); done
+	@for repo in $(REPOS); do ( cd $$repo && make -s ); done
 
 brief:
 	@rm -f $(DIAG)
-	@for repo in $(REPOS); do (cd $$repo && make -s brief ); done
+	@for repo in $(REPOS); do ( cd $$repo && make -s brief ); done
 
 init:
 	git clone $(PUBLIC_REPO)
@@ -25,9 +25,9 @@ status:
 	@for repo in $(REPOS); do ( cd $$repo && echo '>>' $$repo && git status -bs && echo ); done
 
 coverage:
-	@for repo in $(REPOS); do (cd $$repo && echo "Coverage for '$$repo' repo:" && make coverage); done
+	@for repo in $(REPOS); do ( cd $$repo && echo "Coverage for '$$repo' repo:" && make coverage ); done
 
 update-timing:
-	@for repo in $(REPOS); do (cd $$repo && echo "Coverage for '$$repo' repo:" && make update-timing); done
+	@for repo in $(REPOS); do ( cd $$repo && echo "Updating timing for '$$repo' repo:" && make update-timing ); done
 
 .PHONY: all brief init pull push status coverage

--- a/testing/external/README
+++ b/testing/external/README
@@ -33,7 +33,6 @@ To later update to upstream changes:
 
 This updates the tests and the traces as necessary.
 
-
 Running Tests
 -------------
 
@@ -52,6 +51,18 @@ test repository:
 
 All the standard ``btest`` options can be used to run individual
 tests, get diagnostic output, etc.
+
+Versioning
+----------
+
+Since external testsuites live in separate repositories, we need a way to tie
+the local Zeek codebase to a particular version of the testsuites. Normally we'd
+use git submodules, but cloning the testsuites with the rest of the distribution
+isn't always desirable or feasible. We resort to "manual submodules": a file
+"commit-hash.<testsuite-name>" in this directory contains the commit hash to use
+for the respective testsuite. The Makefile target "sync-repos" brings the local
+repositories in line with commit files, while "sync-commits" updates the commit
+files for locally available testsuites to their HEAD commits.
 
 Updating Baseline
 -----------------

--- a/testing/external/scripts/sync-commit
+++ b/testing/external/scripts/sync-commit
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+#
+# This updates the requested test repo's commit file to the current HEAD commit
+# of that repo. If the repo isn't available, this does nothing. If the commit
+# file doesn't exist yet, this creates it. It doesn't stage or commit the
+# updated commit files.
+[[ -z "$1" ]] && {
+    echo "sync-commit needs a local testsuite repository path as argument"
+    exit 1
+}
+
+repo="$1"
+reponame=$(basename $repo)
+commitfile=commit-hash.$reponame
+
+[[ ! -d $repo || ! -d $repo/.git ]] && exit 0
+
+commit=$(cd $repo && git log -1 --pretty=format:%H)
+
+[[ -f $commitfile && $(cat $commitfile) == $commit ]] && exit 0
+
+if [[ -n $commit ]]; then
+    echo "Pinning '$reponame' to $commit"
+    echo $commit >$commitfile
+
+    # If git knows the commit file, show diff:
+    if git ls-files --error-unmatch $commitfile >/dev/null 2>&1; then
+        git diff $commitfile
+    fi
+fi

--- a/testing/external/scripts/sync-repo
+++ b/testing/external/scripts/sync-repo
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+#
+# This moves the requested test repo to the commit indicated in its commit file.
+# If repo or commit file do not exist, it does nothing.
+[[ -z "$1" ]] && {
+    echo "sync-repo needs a local testsuite repository path as argument"
+    exit 1
+}
+
+repo="$1"
+reponame=$(basename $repo)
+commitfile=commit-hash.$reponame
+
+[[ ! -d $repo || ! -f $commitfile ]] && exit 0
+
+commit=$(cat $commitfile)
+
+[[ $commit == $(cd $repo && git rev-parse HEAD) ]] && exit 0
+
+(
+    echo "Moving '$reponame' to $commit"
+    cd $repo && git -c advice.detachedHead=false checkout $commit
+)


### PR DESCRIPTION
I've been doing a lot of manual tweaking of the `commit-hash.<testsuite>` files lately and these come in handy. It seems intuitive for `make init` to also sync the clone to the present commit hash, so that now happens automatically. The CI setup still has an explicit `git checkout` to bring the private testsuite to its pinned commit. We could switch that to `./scripts/sync-repo zeek-testing-private`, but I felt the git invocation is clearer in this case.