### PR TITLE
Optimize 64 bit random number generation

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -544,8 +544,9 @@ uint64_t rand64bit()
 	uint64_t base = 0;
 	int i;
 
-	for ( i = 1; i <= 4; ++i )
-		base = (base << 16) | detail::random_number();
+	static_assert(RAND_MAX == 2147483647); // 2^32-1
+	for ( i = 1; i <= 2; ++i )
+		base = (base << 32) | detail::random_number();
 	return base;
 	}
 


### PR DESCRIPTION
rand64bit called random 4 times to generate one 64 bit number. There is
no reason to do this - random() is basically guaranteed to return a 32
bit number.

This also adds a static check to make sure that it does.