### PR TITLE
Add gulrak/filesystem to auxil

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 [submodule "auxil/spicy"]
 	path = auxil/spicy/spicy
 	url = https://github.com/zeek/spicy
+[submodule "auxil/filesystem"]
+	path = auxil/filesystem
+	url = https://github.com/gulrak/filesystem.git

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,6 +4,7 @@
 path_classifiers:
   library:
     - "auxil/broker/caf/"
+    - "auxil/filesystem/"
     - "auxil/libkqueue/"
     - "auxil/highwayhash/"
     - "auxil/rapidjson/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,17 @@ include_directories(BEFORE
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/auxil/rapidjson/include/rapidjson
         DESTINATION include/zeek/3rdparty/rapidjson/include)
 
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/auxil/filesystem/include/ghc
+        DESTINATION include/zeek/3rdparty/)
+
+# Create 3rdparty/ghc within the build directory so that the include for
+# "zeek/3rdparty/ghc/filesystem.hpp" works within the build tree.
+execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory
+                "${CMAKE_CURRENT_BINARY_DIR}/3rdparty/")
+execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink
+                "${CMAKE_CURRENT_SOURCE_DIR}/auxil/filesystem/include/ghc"
+                "${CMAKE_CURRENT_BINARY_DIR}/3rdparty/ghc")
+
 # Optional Dependencies
 
 set(USE_GEOIP false)

--- a/COPYING.3rdparty
+++ b/COPYING.3rdparty
@@ -533,6 +533,32 @@ POSSIBILITY OF SUCH DAMAGE.
 
 ==============================================================================
 
+%%% auxil/filesystem
+
+==============================================================================
+
+Copyright (c) 2018, Steffen Schümann <s.schuemann@pobox.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==============================================================================
+
 %%% auxil/highwayhash
 
 ==============================================================================

--- a/src/util.cc
+++ b/src/util.cc
@@ -2709,3 +2709,21 @@ extern "C" void out_of_memory(const char* where)
 
 	abort();
 	}
+
+TEST_CASE("util filesystem")
+	{
+	zeek::filesystem::path path1("/a/b");
+	CHECK(path1.is_absolute());
+	CHECK(! path1.is_relative());
+	CHECK(path1.filename() == "b");
+	CHECK(path1.parent_path() == "/a");
+
+	zeek::filesystem::path path2("/a//b//conn.log");
+	CHECK(path2.lexically_normal() == "/a/b/conn.log");
+
+	zeek::filesystem::path path3("a//b//");
+	CHECK(path3.lexically_normal() == "a/b/");
+
+	auto info = zeek::filesystem::space(".");
+	CHECK(info.capacity > 0);
+	}

--- a/src/util.h
+++ b/src/util.h
@@ -75,6 +75,8 @@ extern "C"
 #include "zeek/3rdparty/modp_numtoa.h"
 	}
 
+#include "zeek/3rdparty/ghc/filesystem.hpp"
+
 using bro_int_t = int64_t;
 using bro_uint_t = uint64_t;
 
@@ -90,6 +92,10 @@ namespace zeek
 
 class ODesc;
 class RecordVal;
+
+// Expose ghc::filesystem as zeek::filesystem until we can
+// switch to std::filesystem.
+namespace filesystem = ghc::filesystem;
 
 namespace util
 	{


### PR DESCRIPTION
This is adding https://github.com/gulrak/filesystem as a submodule
into auxil for use as a compiler-independent std::filesystem drop-in.