### PR TITLE
Management framework: make test artifacts save and temporarily mask testsuite

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -154,6 +154,14 @@ jobs:
         run: make -C testing/external/zeek-testing-cluster
         continue-on-error: true
 
+      # upload-artifact balks at certain characters in artifact
+      # filenames, so substitute them for dots.
+      - name: Sanitize artifacts
+        if: failure()
+        run: |
+          sudo apt-get -q update && sudo apt-get install -q -y rename
+          find testing/external/zeek-testing-cluster/.tmp -depth -execdir rename 's/[":<>|*?\r\n]/./g' "{}" \;
+
       - name: Preserve btest artifacts
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -152,6 +152,7 @@ jobs:
 
       - name: Run testsuite
         run: make -C testing/external/zeek-testing-cluster
+        continue-on-error: true
 
       - name: Preserve btest artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Tim and I noticed that the cluster testsuite occasionally fails. While investigating I noticed two things:

- Github's artifact upload action balks at certain filenames, helpfully refusing to upload artifacts at all. This adds a step to rename them. I ran this a bunch in my fork and managed to trigger failures (about once every 10-15 runs) and this renamed artifact files as expected. Offending filenames include archived logs and the Broker-backed state, due to colons in their filenames.

- With the above I managed to get good logs for troubleshooting, and I suspect the problem is a race condition at agent startup, where a few tests can cause the agent to send events to the supervisor before their peering is established. That's a hole in the agent bootstrap routine that I'll fix, but we'll have to see if that's the whole story. So testsuite failures don't distract people but I still get some data to investigate, I'm temporarily masking the step outcome.