### PR TITLE
Avoid calling safe_realloc unnecessarily from ODesc::Grow()

### DIFF
--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -373,10 +373,15 @@ void ODesc::AddBytesRaw(const void* bytes, unsigned int n)
 
 void ODesc::Grow(unsigned int n)
 	{
+	bool size_changed = false;
 	while ( offset + n + SLOP >= size )
+		{
 		size *= 2;
+		size_changed = true;
+		}
 
-	base = util::safe_realloc(base, size);
+	if ( size_changed )
+		base = util::safe_realloc(base, size);
 	}
 
 void ODesc::Clear()


### PR DESCRIPTION
This is a silly bug in `ODesc::Grow()`, where we call `safe_realloc` even if the buffer size doesn't change. This theoretically shouldn't cause a `realloc`, but on some extremely pathological cases I've seen significant performance improvements by avoiding calling it (think ~50x reductions in time spent).

On more normal-looking traffic, it's looking like up to 2% improvement in CPU used (tcpreplay of data-center-like traffic at 500mbps for 5 minutes) and up to 2.5% improvement in pcap read times (pcap file with a very large number of http sessions).