### PR TITLE
fix for script profiling of lambda functions

### DIFF
--- a/src/ScriptProfile.h
+++ b/src/ScriptProfile.h
@@ -93,7 +93,7 @@ public:
 	ScriptProfile(const Func* _func, const detail::StmtPtr& body)
 		: ScriptProfileStats(_func->Name())
 		{
-		func = _func;
+		func = {NewRef{}, const_cast<Func*>(_func)};
 		is_BiF = body == nullptr;
 
 		if ( is_BiF )
@@ -124,7 +124,9 @@ public:
 	void Report(FILE* f) const;
 
 private:
-	const Func* func;
+	// We store "func" as a FuncPtr to ensure it sticks around when
+	// it would otherwise be ephemeral (i.e., for lambdas).
+	FuncPtr func;
 	bool is_BiF;
 	detail::Location loc;
 


### PR DESCRIPTION
This simple PR addresses a crash when using `--profile-scripts` in the presence of the execution of lambda functions.  The problem was that the `Func` object associated with those objects would go away after the lambda went out of scope, so when the profiler accessed it during termination it would no longer be valid.  The fix is to hold not a `const Func*` pointer but instead a `FuncPtr`.