### PR TITLE
Fix for ZAM optimization of '?' conditional with vector-valued result

### DIFF
--- a/src/script_opt/ZAM/Expr.cc
+++ b/src/script_opt/ZAM/Expr.cc
@@ -227,7 +227,7 @@ const ZAMStmt ZAMCompiler::CompileAssignExpr(const AssignExpr* e)
 		return CondC2VVC(lhs, n1, c3);
 		}
 
-	if ( r1 && r2 )
+	if ( r1 && r2 && ! r3 )
 		{
 		auto v1 = IsVector(r1->GetType()->Tag());
 		auto v2 = IsVector(r2->GetType()->Tag());

--- a/testing/btest/Baseline/language.conditional-expression/out
+++ b/testing/btest/Baseline/language.conditional-expression/out
@@ -13,3 +13,4 @@ associativity (PASS)
 0, vector of string
 0, vector of string
 [1, 5, 3], vector of count
+[4, 5, 6], vector of count

--- a/testing/btest/language/conditional-expression.zeek
+++ b/testing/btest/language/conditional-expression.zeek
@@ -20,6 +20,11 @@ function f2(): bool
 	return F;
 	}
 
+# The following needs to be a global to test for a ZAM regression where
+# the ZAM optimizer will optimize away the problematic condition if the
+# value is constant.
+global false = F;
+
 event zeek_init()
 	{
 	local a: count;
@@ -86,4 +91,8 @@ event zeek_init()
 	local tvc = vector(T, F, T);
 	local tvr = tvc ? vector(1, 2, 3) : vector(4, 5, 6);
 	print tvr, type_name(tvr);
+
+	# Test for ternary results
+	local tvr2 = false ? vector(1, 2, 3) : vector(4, 5, 6);
+	print tvr2, type_name(tvr2);
 	}


### PR DESCRIPTION
ZAM would erroneously complain about (deprecated) mixing vectors with scalars when a `?` operator's conditional was a scalar but its first result value was a vector.  Includes a BTest update to catch any future regressions.