### PR TITLE
Fix usage of broker::convert(double,timespan)

### DIFF
--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -2050,9 +2050,9 @@ void Manager::PrepareForwarding(const std::string& name)
 
 void Manager::SetMetricsExportInterval(double value)
 	{
-	broker::timespan ts;
-	if ( broker::convert(value, ts) )
-		bstate->endpoint.metrics_exporter().set_interval(ts);
+	using dbl_seconds = std::chrono::duration<double>;
+	auto ts = std::chrono::duration_cast<broker::timespan>(dbl_seconds{value});
+	bstate->endpoint.metrics_exporter().set_interval(ts);
 	}
 
 void Manager::SetMetricsExportTopic(std::string value)


### PR DESCRIPTION
I'm pretty sure this is correct. `broker::convert(double,timespan)` simply calls [`std::chrono::duration_cast`](https://en.cppreference.com/w/cpp/chrono/duration/duration_cast) which doesn't have a failure case. In that case, we don't need to check anything anyways, hence why that version of `convert` returns `void` now.