### PR TITLE
Use the seed for Broker's ID in deterministic mode

### DIFF
--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -163,8 +163,21 @@ struct opt_mapping
 class BrokerState
 	{
 public:
+	static broker::endpoint_id make_id()
+		{
+		if ( ! util::detail::have_random_seed() )
+			{
+			return broker::endpoint_id::random();
+			}
+		else
+			{
+			auto useed = static_cast<unsigned>(util::detail::initial_seed());
+			return broker::endpoint_id::random(useed);
+			}
+		}
+
 	BrokerState(broker::configuration config, size_t congestion_queue_size)
-		: endpoint(std::move(config)),
+		: endpoint(std::move(config), make_id()),
 		  subscriber(endpoint.make_subscriber({broker::topic::statuses(), broker::topic::errors()},
 	                                          congestion_queue_size))
 		{


### PR DESCRIPTION
From @J-Gras (see https://github.com/zeek/broker/issues/253):

> For seeded Zeek runs (`zeek -G random.seed`), Node IDs will still vary as they seem to be based on process IDs. If this isn't too complicated or breaks other things, having deterministic node IDs in seeded runs would be handy for testing.

This PR uses the seed for generating Broker endpoint ID. Broker internally uses utilities from `<random>`, so as long as they behave the same on all platforms, the ID should be always the same when running with the same seed.

One note: when running a cluster, the broker IDs **must** differ for all nodes. So passing the same seed to two or more nodes in the cluster would break Broker.

@J-Gras is this change what you have been looking for? Mind testing it?