### PR TITLE
Avoid race conditions in broker.ssl-mismatch test

### DIFF
--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -582,6 +582,22 @@ void Manager::Peer(const string& addr, uint16_t port, double retry)
 		iosource_mgr->Register(this, false);
 	}
 
+void Manager::PeerNoRetry(const string& addr, uint16_t port)
+	{
+	if ( bstate->endpoint.is_shutdown() )
+		return;
+
+	DBG_LOG(DBG_BROKER, "Starting to peer with %s:%" PRIu16 " (no retry)", addr.c_str(), port);
+
+	bstate->endpoint.peer_nosync(addr, port, broker::timeout::seconds{0});
+
+	auto counts_as_iosource = get_option("Broker::peer_counts_as_iosource")->AsBool();
+
+	if ( counts_as_iosource )
+		// Register as a "does-count" source now.
+		iosource_mgr->Register(this, false);
+	}
+
 void Manager::Unpeer(const string& addr, uint16_t port)
 	{
 	if ( bstate->endpoint.is_shutdown() )

--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -144,6 +144,13 @@ public:
 	void Peer(const std::string& addr, uint16_t port, double retry = 10.0);
 
 	/**
+	 * Initiate a peering with a remote endpoint but tries only once.
+	 * @param addr an address to connect to, e.g. "localhost" or "127.0.0.1".
+	 * @param port the TCP port on which the remote side is listening.
+	 */
+	void PeerNoRetry(const std::string& addr, uint16_t port);
+
+	/**
 	 * Remove a remote peering.
 	 * @param addr the address used in bro_broker::Manager::Peer().
 	 * @param port the port used in bro_broker::Manager::Peer().

--- a/src/broker/comm.bif
+++ b/src/broker/comm.bif
@@ -104,6 +104,20 @@ function Broker::__peer%(a: string, p: port, retry: interval%): bool
 	return zeek::val_mgr->True();
 	%}
 
+function Broker::__peer_no_retry%(a: string, p: port%): bool
+	%{
+	zeek::Broker::Manager::ScriptScopeGuard ssg;
+
+	if ( ! p->IsTCP() )
+		{
+		zeek::emit_builtin_error("remote connection port must use tcp");
+		return zeek::val_mgr->False();
+		}
+
+	broker_mgr->PeerNoRetry(a->CheckString(), p->Port());
+	return zeek::val_mgr->True();
+	%}
+
 function Broker::__unpeer%(a: string, p: port%): bool
 	%{
 	zeek::Broker::Manager::ScriptScopeGuard ssg;


### PR DESCRIPTION
This PR adds a new `__peer_no_retry` BIF for Broker that's meant only for testing. Without this, some tests enter a retry loop that wastes time while running it and also introduces a race in tests (what happens first, the btest timeout of the loop completion?). I'm using it for a single test as of this PR, but there are more tests that could (or should) use the new function instead.

The `broker.ssl-mismatch` test itself was re-organized to make sure that the clients only try to connect after the listener is up and running to avoid a race where a client could observe an error if it tries to connect before the port has been opened.

Relates #2192. With this patch, I could no longer get the `broker.ssl-mismatch` test to fail locally (ran 100 times with no issues).