### PR TITLE
policy: Use literal dots for patterns used against content-type and h…

### DIFF
--- a/scripts/policy/frameworks/files/detect-MHR.zeek
+++ b/scripts/policy/frameworks/files/detect-MHR.zeek
@@ -16,7 +16,7 @@ export {
 
 	## File types to attempt matching against the Malware Hash Registry.
 	option match_file_types = /application\/x-dosexec/ |
-	                         /application\/vnd.ms-cab-compressed/ |
+	                         /application\/vnd\.ms-cab-compressed/ |
 	                         /application\/pdf/ |
 	                         /application\/x-shockwave-flash/ |
 	                         /application\/x-java-applet/ |

--- a/scripts/policy/frameworks/software/windows-version-detection.zeek
+++ b/scripts/policy/frameworks/software/windows-version-detection.zeek
@@ -54,7 +54,7 @@ export {
 
 event HTTP::log_http(rec: HTTP::Info) &priority=5
         {
-        if ( rec?$host && rec?$user_agent && /crl.microsoft.com/ in rec$host &&
+        if ( rec?$host && rec?$user_agent && /crl\.microsoft\.com/ in rec$host &&
              /Microsoft-CryptoAPI\// in rec$user_agent )
                 {
                 if ( rec$user_agent !in crypto_api_mapping )


### PR DESCRIPTION
…ostname

The following two patterns were identified while reviewing patterns that
match on any characters. The intention likely was to match actual
literal dots.