### PR TITLE
Run clang-format on all of our plugin test c++ files

### DIFF
--- a/testing/btest/plugins/binpac-flowbuffer-frame-length-plugin/src/FOO.cc
+++ b/testing/btest/plugins/binpac-flowbuffer-frame-length-plugin/src/FOO.cc
@@ -1,8 +1,7 @@
 #include "FOO.h"
 
-#include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
-
 #include "zeek/Reporter.h"
+#include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 #include "foo.bif.h"
 

--- a/testing/btest/plugins/binpac-flowbuffer-frame-length-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/binpac-flowbuffer-frame-length-plugin/src/Plugin.cc
@@ -1,16 +1,18 @@
 #include "plugin/Plugin.h"
-#include "analyzer/Component.h"
 
 #include "FOO.h"
+#include "analyzer/Component.h"
 
-namespace btest::plugin::Foo_FOO {
+namespace btest::plugin::Foo_FOO
+	{
 
-class Plugin : public zeek::plugin::Plugin {
+class Plugin : public zeek::plugin::Plugin
+	{
 public:
 	zeek::plugin::Configuration Configure()
 		{
-		AddComponent(new zeek::analyzer::Component("FOO",
-		             btest::analyzer::FOO::FOO_Analyzer::InstantiateAnalyzer));
+		AddComponent(new zeek::analyzer::Component(
+			"FOO", btest::analyzer::FOO::FOO_Analyzer::InstantiateAnalyzer));
 
 		zeek::plugin::Configuration config;
 		config.name = "FOO::Foo";
@@ -19,6 +21,6 @@ public:
 		config.version.minor = 0;
 		return config;
 		}
-} plugin;
+	} plugin;
 
-}
+	}

--- a/testing/btest/plugins/doctest-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/doctest-plugin/src/Plugin.cc
@@ -3,8 +3,10 @@
 
 #include <zeek/3rdparty/doctest.h>
 
-
-namespace btest::plugin::Demo_Doctest { Plugin plugin; }
+namespace btest::plugin::Demo_Doctest
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Demo_Doctest;
 
@@ -20,6 +22,6 @@ zeek::plugin::Configuration Plugin::Configure()
 	}
 
 TEST_CASE("doctest-plugin/demotest")
-        {
-        CHECK(true);
-        }
+	{
+	CHECK(true);
+	}

--- a/testing/btest/plugins/file-plugin/src/Foo.cc
+++ b/testing/btest/plugins/file-plugin/src/Foo.cc
@@ -1,9 +1,10 @@
 
 #include "Foo.h"
-#include "events.bif.h"
 
-#include <zeek/file_analysis/Manager.h>
 #include <zeek/file_analysis/File.h>
+#include <zeek/file_analysis/Manager.h>
+
+#include "events.bif.h"
 
 using namespace btest::plugin::Demo_Foo;
 
@@ -12,15 +13,15 @@ Foo::Foo(zeek::RecordValPtr args, zeek::file_analysis::File* file)
 	{
 	}
 
-zeek::file_analysis::Analyzer* Foo::Instantiate(zeek::RecordValPtr args, zeek::file_analysis::File* file)
+zeek::file_analysis::Analyzer* Foo::Instantiate(zeek::RecordValPtr args,
+                                                zeek::file_analysis::File* file)
 	{
 	return new Foo(std::move(args), file);
 	}
 
 bool Foo::DeliverStream(const u_char* data, uint64_t len)
 	{
-	zeek::event_mgr.Enqueue(foo_piece,
-	                        GetFile()->ToVal(),
+	zeek::event_mgr.Enqueue(foo_piece, GetFile()->ToVal(),
 	                        zeek::make_intrusive<zeek::StringVal>(new zeek::String(data, len, 0)));
-    return true;
-    }
+	return true;
+	}

--- a/testing/btest/plugins/file-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/file-plugin/src/Plugin.cc
@@ -1,16 +1,21 @@
 
-#include "Foo.h"
 #include "Plugin.h"
+
+#include "Foo.h"
 #include "file_analysis/Component.h"
 #include "file_analysis/File.h"
 
-namespace btest::plugin::Demo_Foo { Plugin plugin; }
+namespace btest::plugin::Demo_Foo
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Demo_Foo;
 
 zeek::plugin::Configuration Plugin::Configure()
 	{
-	AddComponent(new zeek::file_analysis::Component("Foo", btest::plugin::Demo_Foo::Foo::Instantiate));
+	AddComponent(
+		new zeek::file_analysis::Component("Foo", btest::plugin::Demo_Foo::Foo::Instantiate));
 
 	zeek::plugin::Configuration config;
 	config.name = "Demo::Foo";

--- a/testing/btest/plugins/func-hook-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/func-hook-plugin/src/Plugin.cc
@@ -1,14 +1,17 @@
 
 #include "Plugin.h"
 
-#include <zeek/Val.h>
-#include <zeek/Func.h>
-#include <zeek/Event.h>
 #include <zeek/Conn.h>
 #include <zeek/Desc.h>
+#include <zeek/Event.h>
+#include <zeek/Func.h>
+#include <zeek/Val.h>
 #include <zeek/threading/Formatter.h>
 
-namespace btest::plugin::Demo_Hooks { Plugin plugin; }
+namespace btest::plugin::Demo_Hooks
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Demo_Hooks;
 
@@ -41,8 +44,8 @@ static void describe_hook_args(const zeek::plugin::HookArgumentList& args, zeek:
 		}
 	}
 
-std::pair<bool, zeek::ValPtr> Plugin::HookFunctionCall(
-	const zeek::Func* func, zeek::detail::Frame* frame, zeek::Args* args)
+std::pair<bool, zeek::ValPtr> Plugin::HookFunctionCall(const zeek::Func* func,
+                                                       zeek::detail::Frame* frame, zeek::Args* args)
 	{
 	zeek::ODesc d;
 	d.SetShort();
@@ -69,8 +72,7 @@ void Plugin::MetaHookPre(zeek::plugin::HookType hook, const zeek::plugin::HookAr
 	        hook_name(hook), d.Description());
 	}
 
-void Plugin::MetaHookPost(zeek::plugin::HookType hook,
-	                      const zeek::plugin::HookArgumentList& args,
+void Plugin::MetaHookPost(zeek::plugin::HookType hook, const zeek::plugin::HookArgumentList& args,
                           zeek::plugin::HookArgument result)
 	{
 	zeek::ODesc d1;
@@ -82,6 +84,5 @@ void Plugin::MetaHookPost(zeek::plugin::HookType hook,
 	result.Describe(&d2);
 
 	fprintf(stderr, "%.6f %-15s %s(%s) -> %s\n", zeek::run_state::network_time, "  MetaHookPost",
-	        hook_name(hook), d1.Description(),
-	        d2.Description());
+	        hook_name(hook), d1.Description(), d2.Description());
 	}

--- a/testing/btest/plugins/hooks-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/hooks-plugin/src/Plugin.cc
@@ -1,16 +1,18 @@
 
 #include "Plugin.h"
 
-#include <cstring>
-
-#include <Func.h>
-#include <Event.h>
 #include <Conn.h>
 #include <Desc.h>
-#include <threading/Formatter.h>
+#include <Event.h>
+#include <Func.h>
 #include <RunState.h>
+#include <threading/Formatter.h>
+#include <cstring>
 
-namespace btest::plugin::Demo_Hooks { Plugin plugin; }
+namespace btest::plugin::Demo_Hooks
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Demo_Hooks;
 
@@ -55,11 +57,11 @@ static void describe_hook_args(const zeek::plugin::HookArgumentList& args, zeek:
 			// For function calls we remove args for unstable arguments
 			// from parsing the version in `base/misc/version`.
 			if ( i->GetType() == zeek::plugin::HookArgument::FUNC &&
-			    (::strcmp(d->Description(), "Version::parse") == 0 ||
-			     ::strcmp(d->Description(), "gsub") == 0 ||
-			     ::strcmp(d->Description(), "split_string1") == 0 ||
-			     ::strcmp(d->Description(), "lstrip") == 0 ||
-			     ::strcmp(d->Description(), "to_count") == 0))
+			     (::strcmp(d->Description(), "Version::parse") == 0 ||
+			      ::strcmp(d->Description(), "gsub") == 0 ||
+			      ::strcmp(d->Description(), "split_string1") == 0 ||
+			      ::strcmp(d->Description(), "lstrip") == 0 ||
+			      ::strcmp(d->Description(), "to_count") == 0) )
 				serialize_args = false;
 
 			continue;
@@ -79,19 +81,21 @@ static void describe_hook_args(const zeek::plugin::HookArgumentList& args, zeek:
 int Plugin::HookLoadFile(const LoadType type, const std::string& file, const std::string& resolved)
 	{
 	fprintf(stderr, "%.6f %-15s %s %s\n", zeek::run_state::network_time, "| HookLoadFile",
-		file.c_str(), resolved.c_str());
+	        file.c_str(), resolved.c_str());
 	return -1;
 	}
 
-std::pair<int, std::optional<std::string>> Plugin::HookLoadFileExtended(const LoadType type, const std::string& file, const std::string& resolved)
+std::pair<int, std::optional<std::string>> Plugin::HookLoadFileExtended(const LoadType type,
+                                                                        const std::string& file,
+                                                                        const std::string& resolved)
 	{
 	fprintf(stderr, "%.6f %-15s %s %s\n", zeek::run_state::network_time, "| HookLoadFileExtended",
-		file.c_str(), resolved.c_str());
+	        file.c_str(), resolved.c_str());
 	return std::make_pair(-1, std::nullopt);
 	}
 
-std::pair<bool, zeek::ValPtr> Plugin::HookFunctionCall(const zeek::Func* func, zeek::detail::Frame* frame,
-                                                       zeek::Args* args)
+std::pair<bool, zeek::ValPtr> Plugin::HookFunctionCall(const zeek::Func* func,
+                                                       zeek::detail::Frame* frame, zeek::Args* args)
 	{
 	zeek::ODesc d;
 	d.SetShort();
@@ -103,14 +107,13 @@ std::pair<bool, zeek::ValPtr> Plugin::HookFunctionCall(const zeek::Func* func, z
 	if ( ::strcmp(d.Description(), "Version::parse") == 0 ||
 	     ::strcmp(d.Description(), "gsub") == 0 ||
 	     ::strcmp(d.Description(), "split_string1") == 0 ||
-	     ::strcmp(d.Description(), "lstrip") == 0 ||
-	     ::strcmp(d.Description(), "to_count") == 0)
+	     ::strcmp(d.Description(), "lstrip") == 0 || ::strcmp(d.Description(), "to_count") == 0 )
 		d.Add("(...)");
 	else
 		zeek::plugin::HookArgument(args).Describe(&d);
 
 	fprintf(stderr, "%.6f %-15s %s\n", zeek::run_state::network_time, "| HookCallFunction",
-		d.Description());
+	        d.Description());
 
 	return {false, nullptr};
 	}
@@ -121,14 +124,14 @@ bool Plugin::HookQueueEvent(zeek::Event* event)
 	d.SetShort();
 	zeek::plugin::HookArgument(event).Describe(&d);
 	fprintf(stderr, "%.6f %-15s %s\n", zeek::run_state::network_time, "| HookQueueEvent",
-		d.Description());
+	        d.Description());
 
 	static int i = 0;
 
 	if ( zeek::run_state::network_time && i == 0 )
 		{
 		fprintf(stderr, "%.6f %-15s %s\n", zeek::run_state::network_time, "| RequestObjDtor",
-			d.Description());
+		        d.Description());
 
 		RequestBroObjDtor(event);
 		i = 1;
@@ -145,7 +148,7 @@ void Plugin::HookDrainEvents()
 void Plugin::HookUpdateNetworkTime(double network_time)
 	{
 	fprintf(stderr, "%.6f  %-15s %.6f\n", zeek::run_state::network_time, "| HookUpdateNetworkTime",
-		zeek::run_state::network_time);
+	        zeek::run_state::network_time);
 	}
 
 void Plugin::HookBroObjDtor(void* obj)
@@ -159,10 +162,11 @@ void Plugin::MetaHookPre(zeek::plugin::HookType hook, const zeek::plugin::HookAr
 	d.SetShort();
 	describe_hook_args(args, &d);
 	fprintf(stderr, "%.6f %-15s %s(%s)\n", zeek::run_state::network_time, "  MetaHookPre",
-		hook_name(hook), d.Description());
+	        hook_name(hook), d.Description());
 	}
 
-void Plugin::MetaHookPost(zeek::plugin::HookType hook, const zeek::plugin::HookArgumentList& args, zeek::plugin::HookArgument result)
+void Plugin::MetaHookPost(zeek::plugin::HookType hook, const zeek::plugin::HookArgumentList& args,
+                          zeek::plugin::HookArgument result)
 	{
 	zeek::ODesc d1;
 	d1.SetShort();
@@ -173,8 +177,7 @@ void Plugin::MetaHookPost(zeek::plugin::HookType hook, const zeek::plugin::HookA
 	result.Describe(&d2);
 
 	fprintf(stderr, "%.6f %-15s %s(%s) -> %s\n", zeek::run_state::network_time, "  MetaHookPost",
-		hook_name(hook), d1.Description(),
-		d2.Description());
+	        hook_name(hook), d1.Description(), d2.Description());
 	}
 
 void Plugin::HookSetupAnalyzerTree(zeek::Connection* conn)
@@ -183,17 +186,19 @@ void Plugin::HookSetupAnalyzerTree(zeek::Connection* conn)
 	d.SetShort();
 	conn->Describe(&d);
 
-	fprintf(stderr, "%.6f %-15s %s\n", zeek::run_state::network_time, "| HookSetupAnalyzerTree", d.Description());
+	fprintf(stderr, "%.6f %-15s %s\n", zeek::run_state::network_time, "| HookSetupAnalyzerTree",
+	        d.Description());
 	}
 
-void Plugin::HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local, bool remote,
+void Plugin::HookLogInit(const std::string& writer, const std::string& instantiating_filter,
+                         bool local, bool remote,
                          const zeek::logging::WriterBackend::WriterInfo& info, int num_fields,
                          const zeek::threading::Field* const* fields)
 	{
 	zeek::ODesc d;
 
 	d.Add("{");
-	for ( int i=0; i < num_fields; i++ )
+	for ( int i = 0; i < num_fields; i++ )
 		{
 		const zeek::threading::Field* f = fields[i];
 
@@ -207,92 +212,95 @@ void Plugin::HookLogInit(const std::string& writer, const std::string& instantia
 		}
 	d.Add("}");
 
-	fprintf(stderr, "%.6f %-15s %s %d/%d %s\n", zeek::run_state::network_time, "| HookLogInit", info.path, local, remote, d.Description());
+	fprintf(stderr, "%.6f %-15s %s %d/%d %s\n", zeek::run_state::network_time, "| HookLogInit",
+	        info.path, local, remote, d.Description());
 	}
 
-void Plugin::RenderVal(const zeek::threading::Value* val, zeek::ODesc &d) const
+void Plugin::RenderVal(const zeek::threading::Value* val, zeek::ODesc& d) const
 	{
-		if ( ! val->present )
-			{
-			d.Add("<uninitialized>");
-			return;
-			}
+	if ( ! val->present )
+		{
+		d.Add("<uninitialized>");
+		return;
+		}
 
-		switch ( val->type ) {
+	switch ( val->type )
+		{
 
-			case zeek::TYPE_BOOL:
-				d.Add(val->val.int_val ? "T" : "F");
-				break;
+		case zeek::TYPE_BOOL:
+			d.Add(val->val.int_val ? "T" : "F");
+			break;
 
-			case zeek::TYPE_INT:
-				d.Add(val->val.int_val);
-				break;
+		case zeek::TYPE_INT:
+			d.Add(val->val.int_val);
+			break;
 
-			case zeek::TYPE_COUNT:
-				d.Add(val->val.uint_val);
-				break;
+		case zeek::TYPE_COUNT:
+			d.Add(val->val.uint_val);
+			break;
 
-			case zeek::TYPE_PORT:
-				d.Add(val->val.port_val.port);
-				break;
+		case zeek::TYPE_PORT:
+			d.Add(val->val.port_val.port);
+			break;
 
-			case zeek::TYPE_SUBNET:
-				d.Add(zeek::threading::Formatter::Render(val->val.subnet_val));
-				break;
+		case zeek::TYPE_SUBNET:
+			d.Add(zeek::threading::Formatter::Render(val->val.subnet_val));
+			break;
 
-			case zeek::TYPE_ADDR:
-				d.Add(zeek::threading::Formatter::Render(val->val.addr_val));
-				break;
+		case zeek::TYPE_ADDR:
+			d.Add(zeek::threading::Formatter::Render(val->val.addr_val));
+			break;
 
-			case zeek::TYPE_DOUBLE:
-				d.Add(val->val.double_val, true);
-				break;
+		case zeek::TYPE_DOUBLE:
+			d.Add(val->val.double_val, true);
+			break;
 
-			case zeek::TYPE_INTERVAL:
-			case zeek::TYPE_TIME:
-				d.Add(zeek::threading::Formatter::Render(val->val.double_val));
-				break;
+		case zeek::TYPE_INTERVAL:
+		case zeek::TYPE_TIME:
+			d.Add(zeek::threading::Formatter::Render(val->val.double_val));
+			break;
 
-			case zeek::TYPE_ENUM:
-			case zeek::TYPE_STRING:
-			case zeek::TYPE_FILE:
-			case zeek::TYPE_FUNC:
-				d.AddN(val->val.string_val.data, val->val.string_val.length);
-				break;
+		case zeek::TYPE_ENUM:
+		case zeek::TYPE_STRING:
+		case zeek::TYPE_FILE:
+		case zeek::TYPE_FUNC:
+			d.AddN(val->val.string_val.data, val->val.string_val.length);
+			break;
 
-			case zeek::TYPE_TABLE:
-				for ( int j = 0; j < val->val.set_val.size; j++ )
-					{
-					if ( j > 0 )
-						d.Add(",");
+		case zeek::TYPE_TABLE:
+			for ( int j = 0; j < val->val.set_val.size; j++ )
+				{
+				if ( j > 0 )
+					d.Add(",");
 
-					RenderVal(val->val.set_val.vals[j], d);
-					}
-				break;
+				RenderVal(val->val.set_val.vals[j], d);
+				}
+			break;
 
-			case zeek::TYPE_VECTOR:
-				for ( int j = 0; j < val->val.vector_val.size; j++ )
-					{
-					if ( j > 0 )
-						d.Add(",");
+		case zeek::TYPE_VECTOR:
+			for ( int j = 0; j < val->val.vector_val.size; j++ )
+				{
+				if ( j > 0 )
+					d.Add(",");
 
-					RenderVal(val->val.vector_val.vals[j], d);
-					}
-				break;
+				RenderVal(val->val.vector_val.vals[j], d);
+				}
+			break;
 
-			default:
-				assert(false);
+		default:
+			assert(false);
 		}
 	}
 
 bool Plugin::HookLogWrite(const std::string& writer, const std::string& filter,
                           const zeek::logging::WriterBackend::WriterInfo& info, int num_fields,
-                          const zeek::threading::Field* const* fields, zeek::threading::Value** vals)
+                          const zeek::threading::Field* const* fields,
+                          zeek::threading::Value** vals)
 	{
 	zeek::ODesc d;
 
 	d.Add("[");
-	for ( int i=0; i < num_fields; i++ )
+	for ( int i = 0; i < num_fields; i++ )
 		{
 		const zeek::threading::Field* f = fields[i];
 		const zeek::threading::Value* val = vals[i];
@@ -307,7 +315,8 @@ bool Plugin::HookLogWrite(const std::string& writer, const std::string& filter,
 		}
 	d.Add("]");
 
-	fprintf(stderr, "%.6f %-15s %s %s\n", zeek::run_state::network_time, "| HookLogWrite", info.path, d.Description());
+	fprintf(stderr, "%.6f %-15s %s %s\n", zeek::run_state::network_time, "| HookLogWrite",
+	        info.path, d.Description());
 	return true;
 	}
 
@@ -321,5 +330,6 @@ void Plugin::HookUnprocessedPacket(const zeek::Packet* packet)
 	d.Add(packet->len);
 	d.Add("]");
 
-	fprintf(stderr, "%.6f %-23s %s\n", zeek::run_state::network_time, "| HookUnprocessedPacket", d.Description());
+	fprintf(stderr, "%.6f %-23s %s\n", zeek::run_state::network_time, "| HookUnprocessedPacket",
+	        d.Description());
 	}

--- a/testing/btest/plugins/logging-hooks-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/logging-hooks-plugin/src/Plugin.cc
@@ -1,14 +1,17 @@
 
 #include "Plugin.h"
 
-#include <Func.h>
-#include <Event.h>
 #include <Conn.h>
 #include <Desc.h>
-#include <threading/Formatter.h>
+#include <Event.h>
+#include <Func.h>
 #include <RunState.h>
+#include <threading/Formatter.h>
 
-namespace btest::plugin::Log_Hooks { Plugin plugin; }
+namespace btest::plugin::Log_Hooks
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Log_Hooks;
 
@@ -27,14 +30,15 @@ zeek::plugin::Configuration Plugin::Configure()
 	return config;
 	}
 
-void Plugin::HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local,
-                         bool remote, const zeek::logging::WriterBackend::WriterInfo& info,
-                         int num_fields, const zeek::threading::Field* const* fields)
+void Plugin::HookLogInit(const std::string& writer, const std::string& instantiating_filter,
+                         bool local, bool remote,
+                         const zeek::logging::WriterBackend::WriterInfo& info, int num_fields,
+                         const zeek::threading::Field* const* fields)
 	{
 	zeek::ODesc d;
 
 	d.Add("{");
-	for ( int i=0; i < num_fields; i++ )
+	for ( int i = 0; i < num_fields; i++ )
 		{
 		const zeek::threading::Field* f = fields[i];
 
@@ -48,13 +52,14 @@ void Plugin::HookLogInit(const std::string& writer, const std::string& instantia
 		}
 	d.Add("}");
 
-	fprintf(stderr, "%.6f %-15s %s %d/%d %s\n", zeek::run_state::network_time,
-	        "| HookLogInit", info.path, local, remote, d.Description());
+	fprintf(stderr, "%.6f %-15s %s %d/%d %s\n", zeek::run_state::network_time, "| HookLogInit",
+	        info.path, local, remote, d.Description());
 	}
 
 bool Plugin::HookLogWrite(const std::string& writer, const std::string& filter,
                           const zeek::logging::WriterBackend::WriterInfo& info, int num_fields,
-                          const zeek::threading::Field* const* fields, zeek::threading::Value** vals)
+                          const zeek::threading::Field* const* fields,
+                          zeek::threading::Value** vals)
 	{
 	round++;
 	if ( round == 1 ) // do not output line

--- a/testing/btest/plugins/packet-protocol-plugin/src/LLCDemo.cc
+++ b/testing/btest/plugins/packet-protocol-plugin/src/LLCDemo.cc
@@ -1,15 +1,14 @@
 #include "LLCDemo.h"
+
 #include "zeek/Event.h"
 #include "zeek/Val.h"
 #include "zeek/session/Manager.h"
+
 #include "events.bif.h"
 
 using namespace zeek::packet_analysis::PacketDemo;
 
-LLCDemo::LLCDemo()
-	: zeek::packet_analysis::Analyzer("LLC_Demo")
-	{
-	}
+LLCDemo::LLCDemo() : zeek::packet_analysis::Analyzer("LLC_Demo") { }
 
 bool LLCDemo::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet)
 	{
@@ -24,10 +23,8 @@ bool LLCDemo::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet)
 	auto ssap = data[15];
 	auto control = data[16];
 
-	event_mgr.Enqueue(llc_demo_message,
-		val_mgr->Count(dsap),
-		val_mgr->Count(ssap),
-		val_mgr->Count(control));
+	event_mgr.Enqueue(llc_demo_message, val_mgr->Count(dsap), val_mgr->Count(ssap),
+	                  val_mgr->Count(control));
 
 	return true;
 	}

--- a/testing/btest/plugins/packet-protocol-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/packet-protocol-plugin/src/Plugin.cc
@@ -1,19 +1,21 @@
 #include "Plugin.h"
+
+#include "LLCDemo.h"
+#include "RawLayer.h"
 #include "packet_analysis/Component.h"
 
-#include "RawLayer.h"
-#include "LLCDemo.h"
+namespace zeek::plugin::PacketDemo_Bar
+	{
 
-namespace zeek::plugin::PacketDemo_Bar {
-
-class Plugin : public zeek::plugin::Plugin {
+class Plugin : public zeek::plugin::Plugin
+	{
 public:
 	zeek::plugin::Configuration Configure()
 		{
-		AddComponent(new zeek::packet_analysis::Component("Raw_Layer",
-		                 zeek::packet_analysis::PacketDemo::RawLayer::Instantiate));
-		AddComponent(new zeek::packet_analysis::Component("LLC_Demo",
-		                 zeek::packet_analysis::PacketDemo::LLCDemo::Instantiate));
+		AddComponent(new zeek::packet_analysis::Component(
+			"Raw_Layer", zeek::packet_analysis::PacketDemo::RawLayer::Instantiate));
+		AddComponent(new zeek::packet_analysis::Component(
+			"LLC_Demo", zeek::packet_analysis::PacketDemo::LLCDemo::Instantiate));
 
 		zeek::plugin::Configuration config;
 		config.name = "PacketDemo::Bar";
@@ -24,6 +26,6 @@ public:
 		return config;
 		}
 
-} plugin;
+	} plugin;
 
-}
+	}

--- a/testing/btest/plugins/packet-protocol-plugin/src/RawLayer.cc
+++ b/testing/btest/plugins/packet-protocol-plugin/src/RawLayer.cc
@@ -1,4 +1,5 @@
 #include "RawLayer.h"
+
 #include "zeek/Event.h"
 #include "zeek/Val.h"
 #include "zeek/session/Manager.h"
@@ -7,10 +8,7 @@
 
 using namespace zeek::packet_analysis::PacketDemo;
 
-RawLayer::RawLayer()
-	: zeek::packet_analysis::Analyzer("Raw_Layer")
-	{
-	}
+RawLayer::RawLayer() : zeek::packet_analysis::Analyzer("Raw_Layer") { }
 
 bool RawLayer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet)
 	{
@@ -21,11 +19,11 @@ bool RawLayer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet)
 		return false;
 		}
 
-	uint16_t protocol = ntohs(*((const uint16_t*)(data + layer_size -2)));
+	uint16_t protocol = ntohs(*((const uint16_t*)(data + layer_size - 2)));
 
 	event_mgr.Enqueue(raw_layer_message,
-		make_intrusive<StringVal>(layer_size, reinterpret_cast<const char*>(data)),
-		val_mgr->Count(protocol));
+	                  make_intrusive<StringVal>(layer_size, reinterpret_cast<const char*>(data)),
+	                  val_mgr->Count(protocol));
 
 	return ForwardPacket(len - layer_size, data + layer_size, packet, protocol);
 	}

--- a/testing/btest/plugins/pktdumper-plugin/src/Foo.cc
+++ b/testing/btest/plugins/pktdumper-plugin/src/Foo.cc
@@ -1,10 +1,11 @@
 
 #include "Foo.h"
-#include "iosource/Packet.h"
-#include "RunState.h"
 
 #include <fcntl.h>
 #include <cstdio>
+
+#include "RunState.h"
+#include "iosource/Packet.h"
 
 using namespace btest::plugin::Demo_Foo;
 
@@ -13,9 +14,7 @@ Foo::Foo(const std::string& path, bool is_live)
 	props.path = path;
 	}
 
-Foo::~Foo()
-	{
-	}
+Foo::~Foo() { }
 
 void Foo::Open()
 	{

--- a/testing/btest/plugins/pktdumper-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/pktdumper-plugin/src/Plugin.cc
@@ -4,13 +4,17 @@
 #include "Foo.h"
 #include "iosource/Component.h"
 
-namespace btest::plugin::Demo_Foo { Plugin plugin; }
+namespace btest::plugin::Demo_Foo
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Demo_Foo;
 
 zeek::plugin::Configuration Plugin::Configure()
 	{
-	AddComponent(new zeek::iosource::PktDumperComponent("FooPktDumper", "foo", btest::plugin::Demo_Foo::Foo::Instantiate));
+	AddComponent(new zeek::iosource::PktDumperComponent("FooPktDumper", "foo",
+	                                                    btest::plugin::Demo_Foo::Foo::Instantiate));
 
 	zeek::plugin::Configuration config;
 	config.name = "Demo::Foo";

--- a/testing/btest/plugins/pktsrc-plugin/src/Foo.cc
+++ b/testing/btest/plugins/pktsrc-plugin/src/Foo.cc
@@ -1,9 +1,10 @@
 
 #include "Foo.h"
 
-extern "C" {
+extern "C"
+	{
 #include <pcap.h>
-}
+	}
 
 #include <fcntl.h>
 #include <cstdio>
@@ -12,11 +13,11 @@ using namespace btest::plugin::Demo_Foo;
 
 Foo::Foo(const std::string& path, bool is_live)
 	{
-	packet =
-		std::string("\x45\x00\x00\x40\x15\x55\x40\x00\x3e\x06\x25\x5b\x01\x02\x00\x02"
-			"\x01\x02\x00\x03\x09\xdf\x19\xf9\x5d\x8a\x36\x7c\x00\x00\x00\x00"
-			"\xb0\x02\x40\x00\x3c\x72\x00\x00\x02\x04\x05\x5c\x01\x03\x03\x00"
-			"\x01\x01\x08\x0a\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x04\x02", 64);
+	packet = std::string("\x45\x00\x00\x40\x15\x55\x40\x00\x3e\x06\x25\x5b\x01\x02\x00\x02"
+	                     "\x01\x02\x00\x03\x09\xdf\x19\xf9\x5d\x8a\x36\x7c\x00\x00\x00\x00"
+	                     "\xb0\x02\x40\x00\x3c\x72\x00\x00\x02\x04\x05\x5c\x01\x03\x03\x00"
+	                     "\x01\x01\x08\x0a\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x04\x02",
+	                     64);
 
 	props.path = path;
 	props.selectable_fd = open("/bin/sh", O_RDONLY); // any fd is fine.
@@ -48,9 +49,8 @@ bool Foo::ExtractNextPacket(zeek::Packet* pkt)
 		return false;
 		}
 
-	pkt_timeval ts = { 1409193037, 0 };
-	pkt->Init(props.link_type, &ts, packet.size(), packet.size(),
-		(const u_char *)packet.c_str());
+	pkt_timeval ts = {1409193037, 0};
+	pkt->Init(props.link_type, &ts, packet.size(), packet.size(), (const u_char*)packet.c_str());
 	return true;
 	}
 

--- a/testing/btest/plugins/pktsrc-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/pktsrc-plugin/src/Plugin.cc
@@ -4,13 +4,17 @@
 #include "Foo.h"
 #include "iosource/Component.h"
 
-namespace btest::plugin::Demo_Foo { Plugin plugin; }
+namespace btest::plugin::Demo_Foo
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Demo_Foo;
 
 zeek::plugin::Configuration Plugin::Configure()
 	{
-	AddComponent(new zeek::iosource::PktSrcComponent("FooPktSrc", "foo", zeek::iosource::PktSrcComponent::BOTH,
+	AddComponent(new zeek::iosource::PktSrcComponent("FooPktSrc", "foo",
+	                                                 zeek::iosource::PktSrcComponent::BOTH,
 	                                                 btest::plugin::Demo_Foo::Foo::Instantiate));
 
 	zeek::plugin::Configuration config;

--- a/testing/btest/plugins/plugin-load-dependency/1/src/Plugin.cc
+++ b/testing/btest/plugins/plugin-load-dependency/1/src/Plugin.cc
@@ -1,7 +1,10 @@
 
 #include "Plugin.h"
 
-namespace btest::plugin::Testing_Plugin1 { Plugin plugin; }
+namespace btest::plugin::Testing_Plugin1
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Testing_Plugin1;
 

--- a/testing/btest/plugins/plugin-load-dependency/2/src/Plugin.cc
+++ b/testing/btest/plugins/plugin-load-dependency/2/src/Plugin.cc
@@ -1,13 +1,17 @@
 
 #include "Plugin.h"
 
-namespace btest::plugin::Testing_Plugin2 { Plugin plugin; }
+namespace btest::plugin::Testing_Plugin2
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Testing_Plugin2;
 
-void Plugin2_foo() {
-    printf("in Plugin2\n");
-}
+void Plugin2_foo()
+	{
+	printf("in Plugin2\n");
+	}
 
 zeek::plugin::Configuration Plugin::Configure()
 	{

--- a/testing/btest/plugins/plugin-load-dependency/3/src/Plugin.cc
+++ b/testing/btest/plugins/plugin-load-dependency/3/src/Plugin.cc
@@ -1,7 +1,10 @@
 
 #include "Plugin.h"
 
-namespace btest::plugin::Testing_Plugin3 { Plugin plugin; }
+namespace btest::plugin::Testing_Plugin3
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Testing_Plugin3;
 

--- a/testing/btest/plugins/plugin-load-file-extended/src/Plugin.cc
+++ b/testing/btest/plugins/plugin-load-file-extended/src/Plugin.cc
@@ -34,7 +34,8 @@ std::pair<int, std::optional<std::string>> Plugin::HookLoadFileExtended(const Lo
 
 	if ( type == LoadType::SCRIPT && file == "xxx" )
 		{
-		printf("HookLoadExtended/script: file=|%s| resolved=|%s| srcloc=|%s|\n", file.c_str(), resolved.c_str(), src);
+		printf("HookLoadExtended/script: file=|%s| resolved=|%s| srcloc=|%s|\n", file.c_str(),
+		       resolved.c_str(), src);
 
 		return std::make_pair(1, R"(
 			event zeek_init() {
@@ -49,14 +50,16 @@ std::pair<int, std::optional<std::string>> Plugin::HookLoadFileExtended(const Lo
 
 	if ( type == LoadType::SCRIPT && file == "xxx3" )
 		{
-		printf("HookLoadExtended/script: file=|%s| resolved=|%s| srcloc=|%s|\n", file.c_str(), resolved.c_str(), src);
+		printf("HookLoadExtended/script: file=|%s| resolved=|%s| srcloc=|%s|\n", file.c_str(),
+		       resolved.c_str(), src);
 		// We don't replace this one.
 		return std::make_pair(-1, std::nullopt);
 		}
 
 	if ( type == LoadType::SCRIPT && file == "yyy" )
 		{
-		printf("HookLoadExtended/script: file=|%s| resolved=|%s| srcloc=|%s|\n", file.c_str(), resolved.c_str(), src);
+		printf("HookLoadExtended/script: file=|%s| resolved=|%s| srcloc=|%s|\n", file.c_str(),
+		       resolved.c_str(), src);
 
 		return std::make_pair(1, R"(
 			event zeek_init() {
@@ -67,7 +70,8 @@ std::pair<int, std::optional<std::string>> Plugin::HookLoadFileExtended(const Lo
 
 	if ( type == LoadType::SIGNATURES && file == "abc.sig" )
 		{
-		printf("HookLoadExtended/signature: file=|%s| resolved=|%s| srcloc=|%s|\n", file.c_str(), resolved.c_str(), src);
+		printf("HookLoadExtended/signature: file=|%s| resolved=|%s| srcloc=|%s|\n", file.c_str(),
+		       resolved.c_str(), src);
 
 		return std::make_pair(1, R"(
 		signature my-sig {
@@ -80,11 +84,11 @@ std::pair<int, std::optional<std::string>> Plugin::HookLoadFileExtended(const Lo
 
 	if ( type == LoadType::SIGNATURES && file == "def.sig" )
 		{
-		printf("HookLoadExtended/signature: file=|%s| resolved=|%s| srcloc=|%s|\n", file.c_str(), resolved.c_str(), src);
+		printf("HookLoadExtended/signature: file=|%s| resolved=|%s| srcloc=|%s|\n", file.c_str(),
+		       resolved.c_str(), src);
 		// We don't replace this one.
 		return std::make_pair(-1, std::nullopt);
 		}
 
 	return std::make_pair(-1, std::nullopt);
 	}
-

--- a/testing/btest/plugins/plugin-nopatchversion-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/plugin-nopatchversion-plugin/src/Plugin.cc
@@ -1,7 +1,10 @@
 
 #include "Plugin.h"
 
-namespace btest::plugin::Testing_NoPatchVersion { Plugin plugin; }
+namespace btest::plugin::Testing_NoPatchVersion
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Testing_NoPatchVersion;
 

--- a/testing/btest/plugins/plugin-withpatchversion-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/plugin-withpatchversion-plugin/src/Plugin.cc
@@ -1,7 +1,10 @@
 
 #include "Plugin.h"
 
-namespace btest::plugin::Testing_WithPatchVersion { Plugin plugin; }
+namespace btest::plugin::Testing_WithPatchVersion
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Testing_WithPatchVersion;
 

--- a/testing/btest/plugins/protocol-plugin/src/Foo.cc
+++ b/testing/btest/plugins/protocol-plugin/src/Foo.cc
@@ -1,14 +1,14 @@
 
 #include "Foo.h"
-#include "foo_pac.h"
-#include "events.bif.h"
 
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
+#include "events.bif.h"
+#include "foo_pac.h"
+
 using namespace btest::plugin::Demo_Foo;
 
-Foo::Foo(zeek::Connection* conn)
-	: zeek::analyzer::tcp::TCP_ApplicationAnalyzer("Foo", conn)
+Foo::Foo(zeek::Connection* conn) : zeek::analyzer::tcp::TCP_ApplicationAnalyzer("Foo", conn)
 	{
 	interp = new binpac::Foo::Foo_Conn(this);
 	}

--- a/testing/btest/plugins/protocol-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/protocol-plugin/src/Plugin.cc
@@ -1,17 +1,21 @@
 
 #include "Plugin.h"
+
+#include "Foo.h"
 #include "analyzer/Component.h"
 #include "analyzer/Manager.h"
 
-#include "Foo.h"
-
-namespace btest::plugin::Demo_Foo { Plugin plugin; }
+namespace btest::plugin::Demo_Foo
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Demo_Foo;
 
 zeek::plugin::Configuration Plugin::Configure()
 	{
-	AddComponent(new zeek::analyzer::Component("Foo", btest::plugin::Demo_Foo::Foo::Instantiate, 1));
+	AddComponent(
+		new zeek::analyzer::Component("Foo", btest::plugin::Demo_Foo::Foo::Instantiate, 1));
 
 	zeek::plugin::Configuration config;
 	config.name = "Demo::Foo";
@@ -22,12 +26,11 @@ zeek::plugin::Configuration Plugin::Configure()
 	return config;
 	}
 
-
 void Plugin::InitPostScript()
 	{
-		auto tag = ::zeek::analyzer_mgr->GetAnalyzerTag("Foo");
-		if ( ! tag )
-			::zeek::reporter->FatalError("cannot get analyzer Tag");
+	auto tag = ::zeek::analyzer_mgr->GetAnalyzerTag("Foo");
+	if ( ! tag )
+		::zeek::reporter->FatalError("cannot get analyzer Tag");
 
-		zeek::analyzer_mgr->RegisterAnalyzerForPort(tag, TransportProto::TRANSPORT_TCP, 4243);
+	zeek::analyzer_mgr->RegisterAnalyzerForPort(tag, TransportProto::TRANSPORT_TCP, 4243);
 	}

--- a/testing/btest/plugins/reader-plugin/src/Foo.cc
+++ b/testing/btest/plugins/reader-plugin/src/Foo.cc
@@ -1,22 +1,23 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include <sys/types.h>
+#include "Foo.h"
+
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 #include <cerrno>
 
-#include "Foo.h"
-
-#include "threading/SerialTypes.h"
 #include "threading/Manager.h"
+#include "threading/SerialTypes.h"
 
 using namespace btest::input::reader;
-using zeek::threading::Value;
 using zeek::threading::Field;
+using zeek::threading::Value;
 
-Foo::Foo(zeek::input::ReaderFrontend *frontend) : zeek::input::ReaderBackend(frontend)
+Foo::Foo(zeek::input::ReaderFrontend* frontend) : zeek::input::ReaderBackend(frontend)
 	{
-	ascii = new zeek::threading::formatter::Ascii(this, zeek::threading::formatter::Ascii::SeparatorInfo());
+	ascii = new zeek::threading::formatter::Ascii(
+		this, zeek::threading::formatter::Ascii::SeparatorInfo());
 	}
 
 Foo::~Foo()
@@ -25,11 +26,10 @@ Foo::~Foo()
 	delete ascii;
 	}
 
-void Foo::DoClose()
-	{
-	}
+void Foo::DoClose() { }
 
-bool Foo::DoInit(const zeek::input::ReaderBackend::ReaderInfo& info, int num_fields, const Field* const* fields)
+bool Foo::DoInit(const zeek::input::ReaderBackend::ReaderInfo& info, int num_fields,
+                 const Field* const* fields)
 	{
 	DoUpdate();
 	return true;
@@ -39,16 +39,16 @@ std::string Foo::RandomString(const int len)
 	{
 	std::string s(len, ' ');
 
-	static const char values[] =
-	"0123456789!@#$%^&*()-_=+{}[]\\|"
-	"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	"abcdefghijklmnopqrstuvwxyz";
+	static const char values[] = "0123456789!@#$%^&*()-_=+{}[]\\|"
+								 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+								 "abcdefghijklmnopqrstuvwxyz";
 
-	for (int i = 0; i < len; ++i)
+	for ( int i = 0; i < len; ++i )
 		// zeek::random_number() is not thread-safe; as we are only using one simultaneous thread
 		// here, this should not matter in this case. If this test ever starts showing
 		// random errors, this might be the culprit.
-		s[i] = values[zeek::util::detail::random_number() / (zeek::util::detail::max_random() / sizeof(values))];
+		s[i] = values[zeek::util::detail::random_number() /
+		              (zeek::util::detail::max_random() / sizeof(values))];
 
 	return s;
 	}
@@ -60,16 +60,16 @@ bool Foo::DoUpdate()
 	for ( int i = 0; i < linestosend; i++ )
 		{
 		Value** field = new Value*[NumFields()];
-		for  (int j = 0; j < NumFields(); j++ )
+		for ( int j = 0; j < NumFields(); j++ )
 			field[j] = EntryToVal(Fields()[j]->type, Fields()[j]->subtype);
 
 		SendEntry(field);
-	}
+		}
 
 	EndCurrentSend();
 
 	return true;
-}
+	}
 
 zeek::threading::Value* Foo::EntryToVal(zeek::TypeTag type, zeek::TypeTag subtype)
 	{
@@ -77,111 +77,109 @@ zeek::threading::Value* Foo::EntryToVal(zeek::TypeTag type, zeek::TypeTag subtyp
 
 	// basically construct something random from the fields that we want.
 
-	switch ( type ) {
-	case zeek::TYPE_ENUM:
-		assert(false); // no enums, please.
-
-	case zeek::TYPE_STRING:
+	switch ( type )
 		{
-		std::string rnd = RandomString(10);
-		val->val.string_val.data = zeek::util::copy_string(rnd.c_str());
-		val->val.string_val.length = rnd.size();
-		break;
-		}
+		case zeek::TYPE_ENUM:
+			assert(false); // no enums, please.
 
-	case zeek::TYPE_BOOL:
-		val->val.int_val = 1; // we never lie.
-		break;
-
-	case zeek::TYPE_INT:
-		val->val.int_val = random();
-		break;
-
-	case zeek::TYPE_TIME:
-		val->val.double_val = 0;
-		break;
-
-	case zeek::TYPE_DOUBLE:
-	case zeek::TYPE_INTERVAL:
-		val->val.double_val = random();
-		break;
-
-	case zeek::TYPE_COUNT:
-		val->val.uint_val = random();
-		break;
-
-	case zeek::TYPE_PORT:
-		val->val.port_val.port = random() / (RAND_MAX / 60000);
-		val->val.port_val.proto = TRANSPORT_UNKNOWN;
-		break;
-
-	case zeek::TYPE_SUBNET:
-		{
-		val->val.subnet_val.prefix = ascii->ParseAddr("192.168.17.1");
-		val->val.subnet_val.length = 16;
-		}
-		break;
-
-	case zeek::TYPE_ADDR:
-		val->val.addr_val = ascii->ParseAddr("192.168.17.1");
-		break;
-
-	case zeek::TYPE_TABLE:
-	case zeek::TYPE_VECTOR:
-		// First - common initialization
-		// Then - initialization for table.
-		// Then - initialization for vector.
-		// Then - common stuff
-		{
-		// how many entries do we have...
-		unsigned int length = random() / (RAND_MAX / 15);
-
-		Value** lvals = new Value* [length];
-
-		if ( type == zeek::TYPE_TABLE )
+		case zeek::TYPE_STRING:
 			{
-			val->val.set_val.vals = lvals;
-			val->val.set_val.size = length;
+			std::string rnd = RandomString(10);
+			val->val.string_val.data = zeek::util::copy_string(rnd.c_str());
+			val->val.string_val.length = rnd.size();
+			break;
 			}
-		else if ( type == zeek::TYPE_VECTOR )
+
+		case zeek::TYPE_BOOL:
+			val->val.int_val = 1; // we never lie.
+			break;
+
+		case zeek::TYPE_INT:
+			val->val.int_val = random();
+			break;
+
+		case zeek::TYPE_TIME:
+			val->val.double_val = 0;
+			break;
+
+		case zeek::TYPE_DOUBLE:
+		case zeek::TYPE_INTERVAL:
+			val->val.double_val = random();
+			break;
+
+		case zeek::TYPE_COUNT:
+			val->val.uint_val = random();
+			break;
+
+		case zeek::TYPE_PORT:
+			val->val.port_val.port = random() / (RAND_MAX / 60000);
+			val->val.port_val.proto = TRANSPORT_UNKNOWN;
+			break;
+
+		case zeek::TYPE_SUBNET:
 			{
-			val->val.vector_val.vals = lvals;
-			val->val.vector_val.size = length;
+			val->val.subnet_val.prefix = ascii->ParseAddr("192.168.17.1");
+			val->val.subnet_val.length = 16;
 			}
-		else
-			assert(false);
+			break;
 
-		if ( length == 0 )
-			break; //empty
+		case zeek::TYPE_ADDR:
+			val->val.addr_val = ascii->ParseAddr("192.168.17.1");
+			break;
 
-		for ( unsigned int pos = 0; pos < length; pos++ )
-			{
-			Value* newval = EntryToVal(subtype, zeek::TYPE_ENUM);
-			if ( newval == 0 )
+		case zeek::TYPE_TABLE:
+		case zeek::TYPE_VECTOR:
+				// First - common initialization
+				// Then - initialization for table.
+				// Then - initialization for vector.
+				// Then - common stuff
 				{
-				Error("Error while reading set");
-				delete val;
-				return 0;
+				// how many entries do we have...
+				unsigned int length = random() / (RAND_MAX / 15);
+
+				Value** lvals = new Value*[length];
+
+				if ( type == zeek::TYPE_TABLE )
+					{
+					val->val.set_val.vals = lvals;
+					val->val.set_val.size = length;
+					}
+				else if ( type == zeek::TYPE_VECTOR )
+					{
+					val->val.vector_val.vals = lvals;
+					val->val.vector_val.size = length;
+					}
+				else
+					assert(false);
+
+				if ( length == 0 )
+					break; // empty
+
+				for ( unsigned int pos = 0; pos < length; pos++ )
+					{
+					Value* newval = EntryToVal(subtype, zeek::TYPE_ENUM);
+					if ( newval == 0 )
+						{
+						Error("Error while reading set");
+						delete val;
+						return 0;
+						}
+					lvals[pos] = newval;
+					}
+
+				break;
 				}
-			lvals[pos] = newval;
-			}
 
-		break;
+		default:
+			Error(Fmt("unsupported field format %d", type));
+			delete val;
+			return 0;
 		}
-
-
-	default:
-		Error(Fmt("unsupported field format %d", type));
-		delete val;
-		return 0;
-	}
 
 	return val;
-
 	}
 
-
 bool Foo::DoHeartbeat(double network_time, double current_time)
-{
+	{
 	return true;
-}
+	}

--- a/testing/btest/plugins/reader-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/reader-plugin/src/Plugin.cc
@@ -2,7 +2,10 @@
 
 #include "Foo.h"
 
-namespace btest::plugin::Demo_Foo { Plugin plugin; }
+namespace btest::plugin::Demo_Foo
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Demo_Foo;
 

--- a/testing/btest/plugins/reporter-hook-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/reporter-hook-plugin/src/Plugin.cc
@@ -1,13 +1,16 @@
 
 #include "Plugin.h"
 
-#include <Func.h>
-#include <Event.h>
 #include <Conn.h>
 #include <Desc.h>
+#include <Event.h>
+#include <Func.h>
 #include <threading/Formatter.h>
 
-namespace btest::plugin::Reporter_Hook { Plugin plugin; }
+namespace btest::plugin::Reporter_Hook
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Reporter_Hook;
 
@@ -26,8 +29,9 @@ zeek::plugin::Configuration Plugin::Configure()
 
 bool Plugin::HookReporter(const std::string& prefix, const zeek::EventHandlerPtr event,
                           const zeek::Connection* conn, const zeek::ValPList* addl, bool location,
-                          const zeek::detail::Location* location1, const zeek::detail::Location* location2,
-                          bool time, const std::string& message)
+                          const zeek::detail::Location* location1,
+                          const zeek::detail::Location* location2, bool time,
+                          const std::string& message)
 	{
 	zeek::ODesc d;
 	if ( location1 )

--- a/testing/btest/plugins/unprocessed-packet-hook-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/unprocessed-packet-hook-plugin/src/Plugin.cc
@@ -1,14 +1,17 @@
 
 #include "Plugin.h"
 
-#include <Func.h>
-#include <Event.h>
 #include <Conn.h>
 #include <Desc.h>
-#include <threading/Formatter.h>
+#include <Event.h>
+#include <Func.h>
 #include <RunState.h>
+#include <threading/Formatter.h>
 
-namespace btest::plugin::Demo_Unprocessed_Packet { Plugin plugin; }
+namespace btest::plugin::Demo_Unprocessed_Packet
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Demo_Unprocessed_Packet;
 
@@ -35,5 +38,6 @@ void Plugin::HookUnprocessedPacket(const zeek::Packet* packet)
 	d.Add(packet->len);
 	d.Add("]");
 
-	fprintf(stdout, "%.6f %-23s %s\n", zeek::run_state::network_time, "| HookUnprocessedPacket", d.Description());
+	fprintf(stdout, "%.6f %-23s %s\n", zeek::run_state::network_time, "| HookUnprocessedPacket",
+	        d.Description());
 	}

--- a/testing/btest/plugins/writer-plugin/src/Foo.cc
+++ b/testing/btest/plugins/writer-plugin/src/Foo.cc
@@ -9,13 +9,13 @@ Foo::~Foo()
 	}
 
 bool Foo::DoInit(const zeek::logging::WriterBackend::WriterInfo& info, int num_fields,
-                 const zeek::threading::Field* const * fields)
+                 const zeek::threading::Field* const* fields)
 	{
 	desc.EnableEscaping();
 	desc.AddEscapeSequence("|");
 	zeek::threading::formatter::Ascii::SeparatorInfo sep_info("|", ",", "-", "");
-    formatter = new zeek::threading::formatter::Ascii(this, sep_info);
-    path = info.path;
+	formatter = new zeek::threading::formatter::Ascii(this, sep_info);
+	path = info.path;
 
 	return true;
 	}
@@ -28,7 +28,7 @@ bool Foo::DoWrite(int num_fields, const zeek::threading::Field* const* fields,
 	if ( ! formatter->Describe(&desc, num_fields, fields, vals) )
 		return false;
 
-    printf("[%s] %s\n", path.c_str(), desc.Description());
+	printf("[%s] %s\n", path.c_str(), desc.Description());
 
-    return true;
+	return true;
 	}

--- a/testing/btest/plugins/writer-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/writer-plugin/src/Plugin.cc
@@ -2,7 +2,10 @@
 
 #include "Foo.h"
 
-namespace btest::plugin::Demo_Foo { Plugin plugin; }
+namespace btest::plugin::Demo_Foo
+	{
+Plugin plugin;
+	}
 
 using namespace btest::plugin::Demo_Foo;
 


### PR DESCRIPTION
This is a general cleanup thing I've had sitting around for a while now.