### PR TITLE
Use clang-format for all files in `testing/btest/plugins`.

### DIFF
--- a/testing/btest/plugins/.clang-format
+++ b/testing/btest/plugins/.clang-format
@@ -1,2 +1,0 @@
-DisableFormat: true
-SortIncludes: false

--- a/testing/btest/plugins/binpac-flowbuffer-frame-length-plugin/src/FOO.h
+++ b/testing/btest/plugins/binpac-flowbuffer-frame-length-plugin/src/FOO.h
@@ -1,15 +1,16 @@
 #ifndef ANALYZER_PROTOCOL_FOO_FOO_H
 #define ANALYZER_PROTOCOL_FOO_FOO_H
 
-#include "foo.bif.h"
-
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 
+#include "foo.bif.h"
 #include "foo_pac.h"
 
-namespace btest::analyzer::FOO {
+namespace btest::analyzer::FOO
+	{
 
-class FOO_Analyzer : public zeek::analyzer::tcp::TCP_ApplicationAnalyzer {
+class FOO_Analyzer : public zeek::analyzer::tcp::TCP_ApplicationAnalyzer
+	{
 public:
 	FOO_Analyzer(zeek::Connection* conn);
 	virtual ~FOO_Analyzer();
@@ -24,14 +25,15 @@ public:
 	virtual void EndpointEOF(bool is_orig);
 
 	static zeek::analyzer::Analyzer* InstantiateAnalyzer(zeek::Connection* conn)
-		{ return new FOO_Analyzer(conn); }
+		{
+		return new FOO_Analyzer(conn);
+		}
 
 protected:
 	binpac::FOO::FOO_Conn* interp;
 	bool had_gap;
+	};
 
-};
-
-} // namespace btest::analyzer::FOO
+	} // namespace btest::analyzer::FOO
 
 #endif

--- a/testing/btest/plugins/doctest-plugin/src/Plugin.h
+++ b/testing/btest/plugins/doctest-plugin/src/Plugin.h
@@ -3,15 +3,16 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Demo_Doctest {
+namespace btest::plugin::Demo_Doctest
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/file-plugin/src/Foo.h
+++ b/testing/btest/plugins/file-plugin/src/Foo.h
@@ -4,16 +4,19 @@
 #include <Val.h>
 #include <file_analysis/Analyzer.h>
 
-namespace btest::plugin::Demo_Foo {
+namespace btest::plugin::Demo_Foo
+	{
 
-class Foo : public zeek::file_analysis::Analyzer {
+class Foo : public zeek::file_analysis::Analyzer
+	{
 public:
 	virtual bool DeliverStream(const u_char* data, uint64_t len);
 
-	static zeek::file_analysis::Analyzer* Instantiate(zeek::RecordValPtr args, zeek::file_analysis::File* file);
+	static zeek::file_analysis::Analyzer* Instantiate(zeek::RecordValPtr args,
+	                                                  zeek::file_analysis::File* file);
 
 protected:
 	Foo(zeek::RecordValPtr args, zeek::file_analysis::File* file);
-};
+	};
 
-}
+	}

--- a/testing/btest/plugins/file-plugin/src/Plugin.h
+++ b/testing/btest/plugins/file-plugin/src/Plugin.h
@@ -2,15 +2,16 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Demo_Foo {
+namespace btest::plugin::Demo_Foo
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/func-hook-plugin/src/Plugin.h
+++ b/testing/btest/plugins/func-hook-plugin/src/Plugin.h
@@ -3,25 +3,24 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Demo_Hooks {
+namespace btest::plugin::Demo_Hooks
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
-
-	std::pair<bool, zeek::ValPtr> HookFunctionCall(
-		const zeek::Func* func, zeek::detail::Frame* frame, zeek::Args* args) override;
+	std::pair<bool, zeek::ValPtr>
+	HookFunctionCall(const zeek::Func* func, zeek::detail::Frame* frame, zeek::Args* args) override;
 
 	void MetaHookPre(zeek::plugin::HookType hook,
 	                 const zeek::plugin::HookArgumentList& args) override;
-	void MetaHookPost(zeek::plugin::HookType hook,
-	                  const zeek::plugin::HookArgumentList& args,
+	void MetaHookPost(zeek::plugin::HookType hook, const zeek::plugin::HookArgumentList& args,
 	                  zeek::plugin::HookArgument result) override;
 
 	// Overridden from plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/hooks-plugin/src/Plugin.h
+++ b/testing/btest/plugins/hooks-plugin/src/Plugin.h
@@ -3,39 +3,45 @@
 
 #include <plugin/Plugin.h>
 
-namespace btest::plugin::Demo_Hooks {
+namespace btest::plugin::Demo_Hooks
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
-	int HookLoadFile(const LoadType type, const std::string& file, const std::string& resolved) override;
-	std::pair<int, std::optional<std::string>> HookLoadFileExtended(const LoadType type, const std::string& file, const std::string& resolved) override;
-	std::pair<bool, zeek::ValPtr> HookFunctionCall(const zeek::Func* func, zeek::detail::Frame* parent,
+	int HookLoadFile(const LoadType type, const std::string& file,
+	                 const std::string& resolved) override;
+	std::pair<int, std::optional<std::string>>
+	HookLoadFileExtended(const LoadType type, const std::string& file,
+	                     const std::string& resolved) override;
+	std::pair<bool, zeek::ValPtr> HookFunctionCall(const zeek::Func* func,
+	                                               zeek::detail::Frame* parent,
 	                                               zeek::Args* args) override;
 	bool HookQueueEvent(zeek::Event* event) override;
 	void HookDrainEvents() override;
 	void HookUpdateNetworkTime(double network_time) override;
 	void HookBroObjDtor(void* obj) override;
 	void HookObjDtor(void* obj) override;
-	void HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local, bool remote,
-	                 const zeek::logging::WriterBackend::WriterInfo& info, int num_fields,
-	                 const zeek::threading::Field* const* fields) override;
+	void HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local,
+	                 bool remote, const zeek::logging::WriterBackend::WriterInfo& info,
+	                 int num_fields, const zeek::threading::Field* const* fields) override;
 	bool HookLogWrite(const std::string& writer, const std::string& filter,
-	                  const zeek::logging::WriterBackend::WriterInfo& info,
-	                  int num_fields, const zeek::threading::Field* const* fields,
+	                  const zeek::logging::WriterBackend::WriterInfo& info, int num_fields,
+	                  const zeek::threading::Field* const* fields,
 	                  zeek::threading::Value** vals) override;
-	void HookSetupAnalyzerTree(zeek::Connection *conn) override;
+	void HookSetupAnalyzerTree(zeek::Connection* conn) override;
 	void HookUnprocessedPacket(const zeek::Packet* packet) override;
-	void MetaHookPre(zeek::plugin::HookType hook, const zeek::plugin::HookArgumentList& args) override;
+	void MetaHookPre(zeek::plugin::HookType hook,
+	                 const zeek::plugin::HookArgumentList& args) override;
 	void MetaHookPost(zeek::plugin::HookType hook, const zeek::plugin::HookArgumentList& args,
 	                  zeek::plugin::HookArgument result) override;
 
-	void RenderVal(const zeek::threading::Value* val, zeek::ODesc &d) const;
+	void RenderVal(const zeek::threading::Value* val, zeek::ODesc& d) const;
 
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/logging-hooks-plugin/src/Plugin.h
+++ b/testing/btest/plugins/logging-hooks-plugin/src/Plugin.h
@@ -3,25 +3,27 @@
 
 #include <plugin/Plugin.h>
 
-namespace btest::plugin::Log_Hooks {
+namespace btest::plugin::Log_Hooks
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	void HookLogInit(const std::string& writer, const std::string& instantiating_filter, bool local,
-	                 bool remote, const zeek::logging::WriterBackend::WriterInfo& info, int num_fields,
-	                 const zeek::threading::Field* const* fields) override;
+	                 bool remote, const zeek::logging::WriterBackend::WriterInfo& info,
+	                 int num_fields, const zeek::threading::Field* const* fields) override;
 	bool HookLogWrite(const std::string& writer, const std::string& filter,
 	                  const zeek::logging::WriterBackend::WriterInfo& info, int num_fields,
-	                  const zeek::threading::Field* const* fields, zeek::threading::Value** vals) override;
+	                  const zeek::threading::Field* const* fields,
+	                  zeek::threading::Value** vals) override;
 
 	// Overridden from plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
 
 private:
 	int round;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/packet-protocol-plugin/src/LLCDemo.h
+++ b/testing/btest/plugins/packet-protocol-plugin/src/LLCDemo.h
@@ -3,19 +3,18 @@
 #include "zeek/packet_analysis/Analyzer.h"
 #include "zeek/packet_analysis/Component.h"
 
-namespace zeek::packet_analysis::PacketDemo {
+namespace zeek::packet_analysis::PacketDemo
+	{
 
-class LLCDemo : public Analyzer {
+class LLCDemo : public Analyzer
+	{
 public:
 	LLCDemo();
 	~LLCDemo() override = default;
 
 	bool AnalyzePacket(size_t len, const uint8_t* data, Packet* packet) override;
 
-	static AnalyzerPtr Instantiate()
-		{
-		return std::make_shared<LLCDemo>();
-		}
-};
+	static AnalyzerPtr Instantiate() { return std::make_shared<LLCDemo>(); }
+	};
 
-}
+	}

--- a/testing/btest/plugins/packet-protocol-plugin/src/RawLayer.h
+++ b/testing/btest/plugins/packet-protocol-plugin/src/RawLayer.h
@@ -3,19 +3,18 @@
 #include "zeek/packet_analysis/Analyzer.h"
 #include "zeek/packet_analysis/Component.h"
 
-namespace zeek::packet_analysis::PacketDemo {
+namespace zeek::packet_analysis::PacketDemo
+	{
 
-class RawLayer : public Analyzer {
+class RawLayer : public Analyzer
+	{
 public:
 	RawLayer();
 	~RawLayer() override = default;
 
 	bool AnalyzePacket(size_t len, const uint8_t* data, Packet* packet) override;
 
-	static AnalyzerPtr Instantiate()
-		{
-		return std::make_shared<RawLayer>();
-		}
-};
+	static AnalyzerPtr Instantiate() { return std::make_shared<RawLayer>(); }
+	};
 
-}
+	}

--- a/testing/btest/plugins/pktdumper-plugin/src/Foo.h
+++ b/testing/btest/plugins/pktdumper-plugin/src/Foo.h
@@ -3,9 +3,11 @@
 #include <Val.h>
 #include <iosource/PktDumper.h>
 
-namespace btest::plugin::Demo_Foo {
+namespace btest::plugin::Demo_Foo
+	{
 
-class Foo : public zeek::iosource::PktDumper {
+class Foo : public zeek::iosource::PktDumper
+	{
 public:
 	Foo(const std::string& path, bool is_live);
 	virtual ~Foo();
@@ -19,6 +21,6 @@ protected:
 
 private:
 	Properties props;
-};
+	};
 
-}
+	}

--- a/testing/btest/plugins/pktdumper-plugin/src/Plugin.h
+++ b/testing/btest/plugins/pktdumper-plugin/src/Plugin.h
@@ -3,15 +3,16 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Demo_Foo {
+namespace btest::plugin::Demo_Foo
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/pktsrc-plugin/src/Foo.h
+++ b/testing/btest/plugins/pktsrc-plugin/src/Foo.h
@@ -4,9 +4,11 @@
 #include <Val.h>
 #include <iosource/PktSrc.h>
 
-namespace btest::plugin::Demo_Foo {
+namespace btest::plugin::Demo_Foo
+	{
 
-class Foo : public zeek::iosource::PktSrc {
+class Foo : public zeek::iosource::PktSrc
+	{
 public:
 	Foo(const std::string& path, bool is_live);
 
@@ -24,6 +26,6 @@ protected:
 private:
 	Properties props;
 	std::string packet;
-};
+	};
 
-}
+	}

--- a/testing/btest/plugins/pktsrc-plugin/src/Plugin.h
+++ b/testing/btest/plugins/pktsrc-plugin/src/Plugin.h
@@ -3,15 +3,16 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Demo_Foo {
+namespace btest::plugin::Demo_Foo
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/plugin-load-dependency/1/src/Plugin.h
+++ b/testing/btest/plugins/plugin-load-dependency/1/src/Plugin.h
@@ -3,15 +3,16 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Testing_Plugin1 {
+namespace btest::plugin::Testing_Plugin1
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/plugin-load-dependency/2/src/Plugin.h
+++ b/testing/btest/plugins/plugin-load-dependency/2/src/Plugin.h
@@ -3,15 +3,16 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Testing_Plugin2 {
+namespace btest::plugin::Testing_Plugin2
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/plugin-load-dependency/3/src/Plugin.h
+++ b/testing/btest/plugins/plugin-load-dependency/3/src/Plugin.h
@@ -3,15 +3,16 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Testing_Plugin3 {
+namespace btest::plugin::Testing_Plugin3
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/plugin-load-file-extended/src/Plugin.h
+++ b/testing/btest/plugins/plugin-load-file-extended/src/Plugin.h
@@ -3,16 +3,19 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Testing_LoadFileExtended {
+namespace btest::plugin::Testing_LoadFileExtended
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-    std::pair<int, std::optional<std::string>> HookLoadFileExtended(const Plugin::LoadType type, const std::string& file, const std::string& resolved) override;
-};
+	std::pair<int, std::optional<std::string>>
+	HookLoadFileExtended(const Plugin::LoadType type, const std::string& file,
+	                     const std::string& resolved) override;
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/plugin-nopatchversion-plugin/src/Plugin.h
+++ b/testing/btest/plugins/plugin-nopatchversion-plugin/src/Plugin.h
@@ -3,15 +3,16 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Testing_NoPatchVersion {
+namespace btest::plugin::Testing_NoPatchVersion
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/plugin-withpatchversion-plugin/src/Plugin.h
+++ b/testing/btest/plugins/plugin-withpatchversion-plugin/src/Plugin.h
@@ -3,15 +3,16 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Testing_WithPatchVersion {
+namespace btest::plugin::Testing_WithPatchVersion
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/protocol-plugin/src/Foo.h
+++ b/testing/btest/plugins/protocol-plugin/src/Foo.h
@@ -1,14 +1,22 @@
 
 #pragma once
 
-#include "analyzer/protocol/tcp/TCP.h"
 #include "analyzer/protocol/pia/PIA.h"
+#include "analyzer/protocol/tcp/TCP.h"
 
-namespace binpac  { namespace Foo { class Foo_Conn; } }
+namespace binpac
+	{
+namespace Foo
+	{
+class Foo_Conn;
+	}
+	}
 
-namespace btest::plugin::Demo_Foo {
+namespace btest::plugin::Demo_Foo
+	{
 
-class Foo : public zeek::analyzer::tcp::TCP_ApplicationAnalyzer {
+class Foo : public zeek::analyzer::tcp::TCP_ApplicationAnalyzer
+	{
 public:
 	Foo(zeek::Connection* conn);
 	~Foo();
@@ -18,11 +26,10 @@ public:
 	virtual void Undelivered(uint64_t seq, int len, bool orig);
 	virtual void EndpointEOF(bool is_orig);
 
-	static zeek::analyzer::Analyzer* Instantiate(zeek::Connection* conn)
-		{ return new Foo(conn); }
+	static zeek::analyzer::Analyzer* Instantiate(zeek::Connection* conn) { return new Foo(conn); }
 
 protected:
 	binpac::Foo::Foo_Conn* interp;
-};
+	};
 
-}
+	}

--- a/testing/btest/plugins/protocol-plugin/src/Plugin.h
+++ b/testing/btest/plugins/protocol-plugin/src/Plugin.h
@@ -3,17 +3,18 @@
 
 #include <zeek/plugin/Plugin.h>
 
-namespace btest::plugin::Demo_Foo {
+namespace btest::plugin::Demo_Foo
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
 
 	void InitPostScript() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/reader-plugin/src/Foo.h
+++ b/testing/btest/plugins/reader-plugin/src/Foo.h
@@ -4,17 +4,22 @@
 #include "input/ReaderBackend.h"
 #include "threading/formatters/Ascii.h"
 
-namespace btest::input::reader {
+namespace btest::input::reader
+	{
 
 /**
  * A Foo reader to measure performance of the input framework.
  */
-class Foo : public zeek::input::ReaderBackend {
+class Foo : public zeek::input::ReaderBackend
+	{
 public:
 	Foo(zeek::input::ReaderFrontend* frontend);
 	~Foo();
 
-	static zeek::input::ReaderBackend* Instantiate(zeek::input::ReaderFrontend* frontend) { return new Foo(frontend); }
+	static zeek::input::ReaderBackend* Instantiate(zeek::input::ReaderFrontend* frontend)
+		{
+		return new Foo(frontend);
+		}
 
 protected:
 	virtual bool DoInit(const zeek::input::ReaderBackend::ReaderInfo& info, int arg_num_fields,
@@ -27,6 +32,6 @@ private:
 	std::string RandomString(const int len);
 	zeek::threading::Value* EntryToVal(zeek::TypeTag Type, zeek::TypeTag subtype);
 	zeek::threading::formatter::Ascii* ascii;
-};
+	};
 
-}
+	}

--- a/testing/btest/plugins/reader-plugin/src/Plugin.h
+++ b/testing/btest/plugins/reader-plugin/src/Plugin.h
@@ -3,15 +3,16 @@
 
 #include <plugin/Plugin.h>
 
-namespace btest::plugin::Demo_Foo {
+namespace btest::plugin::Demo_Foo
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from plugin::Plugin.
 	virtual zeek::plugin::Configuration Configure();
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/reporter-hook-plugin/src/Plugin.h
+++ b/testing/btest/plugins/reporter-hook-plugin/src/Plugin.h
@@ -3,20 +3,22 @@
 
 #include <plugin/Plugin.h>
 
-namespace btest::plugin::Reporter_Hook {
+namespace btest::plugin::Reporter_Hook
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	bool HookReporter(const std::string& prefix, const zeek::EventHandlerPtr event,
 	                  const zeek::Connection* conn, const zeek::ValPList* addl, bool location,
-	                  const zeek::detail::Location* location1, const zeek::detail::Location* location2,
-	                  bool time, const std::string& buffer) override;
+	                  const zeek::detail::Location* location1,
+	                  const zeek::detail::Location* location2, bool time,
+	                  const std::string& buffer) override;
 
 	// Overridden from plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/unprocessed-packet-hook-plugin/src/Plugin.h
+++ b/testing/btest/plugins/unprocessed-packet-hook-plugin/src/Plugin.h
@@ -3,17 +3,18 @@
 
 #include <plugin/Plugin.h>
 
-namespace btest::plugin::Demo_Unprocessed_Packet {
+namespace btest::plugin::Demo_Unprocessed_Packet
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	void HookUnprocessedPacket(const zeek::Packet* packet) override;
 
 	// Overridden from zeek::plugin::Plugin.
 	zeek::plugin::Configuration Configure() override;
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}

--- a/testing/btest/plugins/writer-plugin/src/Foo.h
+++ b/testing/btest/plugins/writer-plugin/src/Foo.h
@@ -1,37 +1,43 @@
 
 #pragma once
 
+#include "Desc.h"
 #include "logging/WriterBackend.h"
 #include "threading/formatters/Ascii.h"
-#include "Desc.h"
 
-namespace btest::logging::writer {
+namespace btest::logging::writer
+	{
 
-class Foo : public zeek::logging::WriterBackend {
+class Foo : public zeek::logging::WriterBackend
+	{
 public:
-	Foo(zeek::logging::WriterFrontend* frontend) : zeek::logging::WriterBackend(frontend)	{}
+	Foo(zeek::logging::WriterFrontend* frontend) : zeek::logging::WriterBackend(frontend) { }
 	~Foo();
 
 	static zeek::logging::WriterBackend* Instantiate(zeek::logging::WriterFrontend* frontend)
-		{ return new Foo(frontend); }
+		{
+		return new Foo(frontend);
+		}
 
 protected:
 	virtual bool DoInit(const zeek::logging::WriterBackend::WriterInfo& info, int num_fields,
-	                    const zeek::threading::Field* const * fields);
+	                    const zeek::threading::Field* const* fields);
 
 	virtual bool DoWrite(int num_fields, const zeek::threading::Field* const* fields,
 	                     zeek::threading::Value** vals);
-	virtual bool DoSetBuf(bool enabled)	{ return true; }
-	virtual bool DoRotate(const char* rotated_path, double open,
-	                      double close, bool terminating) { return true; }
-	virtual bool DoFlush(double network_time)	{ return true; }
-	virtual bool DoFinish(double network_time)	{ return true; }
-	virtual bool DoHeartbeat(double network_time, double current_time)	{ return true; }
+	virtual bool DoSetBuf(bool enabled) { return true; }
+	virtual bool DoRotate(const char* rotated_path, double open, double close, bool terminating)
+		{
+		return true;
+		}
+	virtual bool DoFlush(double network_time) { return true; }
+	virtual bool DoFinish(double network_time) { return true; }
+	virtual bool DoHeartbeat(double network_time, double current_time) { return true; }
 
 private:
 	std::string path;
 	zeek::ODesc desc;
 	zeek::threading::Formatter* formatter;
-};
+	};
 
-}
+	}

--- a/testing/btest/plugins/writer-plugin/src/Plugin.h
+++ b/testing/btest/plugins/writer-plugin/src/Plugin.h
@@ -3,15 +3,16 @@
 
 #include <plugin/Plugin.h>
 
-namespace btest::plugin::Demo_Foo {
+namespace btest::plugin::Demo_Foo
+	{
 
 class Plugin : public zeek::plugin::Plugin
-{
+	{
 protected:
 	// Overridden from plugin::Plugin.
 	virtual zeek::plugin::Configuration Configure();
-};
+	};
 
 extern Plugin plugin;
 
-}
+	}


### PR DESCRIPTION
This is a fixup commit for dc65b6248c017b947e60afa4992decab04772111.