### PR TITLE
Fix requirement check in a logging framework / sqlite btest

### DIFF
--- a/testing/btest/scripts/base/frameworks/logging/sqlite/simultaneous-writes.zeek
+++ b/testing/btest/scripts/base/frameworks/logging/sqlite/simultaneous-writes.zeek
@@ -5,7 +5,7 @@
 
 # Don't run this test if we build with '--sanitizers=thread' because we
 # disable the shared cache in that case due to a SQLite bug.
-# @TEST-REQUIRES: grep -q "#define ZEEK_TSAN" zeek-config.h || test $? == 0
+# @TEST-REQUIRES: ! grep -q "#define ZEEK_TSAN" $BUILD/zeek-config.h
 # @TEST-GROUP: sqlite
 #
 # @TEST-EXEC: zeek -b %INPUT


### PR DESCRIPTION
Just a tweak here after I noticed that this test always got skipped in my runs.