### PR TITLE
Remove use of fallible `get_conn_transport_proto` in `analyzer_violation`.

### DIFF
--- a/scripts/base/frameworks/dpd/main.zeek
+++ b/scripts/base/frameworks/dpd/main.zeek
@@ -79,7 +79,7 @@ event analyzer_violation(c: connection, atype: AllAnalyzers::Tag, aid: count,
 	info$ts=network_time();
 	info$uid=c$uid;
 	info$id=c$id;
-	info$proto=get_conn_transport_proto(c$id);
+	info$proto=get_port_transport_proto(c$id$orig_p);
 	info$analyzer=analyzer;
 	info$failure_reason=reason;
 	c$dpd = info;


### PR DESCRIPTION
When setting up the DPD info we previously would get the
`transport_proto` for the connection with `get_conn_transport_proto`.
This function takes a `conn_id` and would fail fatally if the connection
for the given ID was unknown. It seems it was possible to run into such
scenarios when the `analyzer_violation` event was processed after the
connection had been cleaned up.

We now get the `transport_proto` directly from the ports in the
`connection` passed into `analyzer_violation` via
`get_port_transport_proto` which cannot fail.