### PR TITLE
Re-enable sending coverage data to Coveralls via Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -316,6 +316,7 @@ asan_sanitizer_task:
 
   << : *CI_TEMPLATE
   test_fuzzers_script: ./ci/test-fuzzers.sh
+  coverage_script: ./ci/upload-coverage.sh
   env:
     CXXFLAGS: -DZEEK_DICT_DEBUG
     ZEEK_CI_CONFIGURE_FLAGS: *ASAN_SANITIZER_CONFIG


### PR DESCRIPTION
This was lost in 903f4bcc8ea2bc260f7ca9bf8d9fff445cb22f26