### PR TITLE
Use ID name (including module name) to create EventExpr when possible

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -1936,9 +1936,13 @@ event:
 
 				if ( id->IsDeprecated() )
 					reporter->Warning("%s", id->GetDeprecationWarning().c_str());
-				}
 
-			$$ = new EventExpr($1, {AdoptRef{}, $3});
+				$$ = new EventExpr(id->Name(), {AdoptRef{}, $3});
+				}
+			else
+				{
+				$$ = new EventExpr($1, {AdoptRef{}, $3});
+				}
 			}
 	;
 

--- a/testing/btest/Baseline/scripts.policy.misc.capture-loss/capture_loss.log
+++ b/testing/btest/Baseline/scripts.policy.misc.capture-loss/capture_loss.log
@@ -8,4 +8,5 @@
 #fields	ts	ts_delta	peer	gaps	acks	percent_lost
 #types	time	interval	string	count	count	double
 XXXXXXXXXX.XXXXXX	0.000000	zeek	0	0	0.0
+XXXXXXXXXX.XXXXXX	0.000000	zeek	0	0	0.0
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/btest/Baseline/scripts.policy.misc.capture-loss/notice.log
+++ b/testing/btest/Baseline/scripts.policy.misc.capture-loss/notice.log
@@ -8,4 +8,5 @@
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	fuid	file_mime_type	file_desc	proto	note	msg	sub	src	dst	p	n	peer_descr	actions	email_dest	suppress_for	remote_location.country_code	remote_location.region	remote_location.city	remote_location.latitude	remote_location.longitude
 #types	time	string	addr	port	addr	port	string	string	string	enum	enum	string	string	addr	addr	port	count	string	set[enum]	set[string]	interval	string	string	string	double	double
 XXXXXXXXXX.XXXXXX	-	-	-	-	-	-	-	-	-	CaptureLoss::Too_Little_Traffic	Only observed 0 TCP ACKs and was expecting at least 1.	-	-	-	-	-	-	Notice::ACTION_LOG	(empty)	3600.000000	-	-	-	-	-
+XXXXXXXXXX.XXXXXX	-	-	-	-	-	-	-	-	-	CaptureLoss::Too_Little_Traffic	Only observed 0 TCP ACKs and was expecting at least 1.	-	-	-	-	-	-	Notice::ACTION_LOG	(empty)	3600.000000	-	-	-	-	-
 #close XXXX-XX-XX-XX-XX-XX


### PR DESCRIPTION
I'm not entirely sure about this one, but it fixes the problem reported in #163. The problem was that we're passing just unscoped event name into the `EventExpr` constructor, so if the event doesn't exist with just that name, it fails to find it. If you were to change the call to the event to include the module name (so `Foo::Bar` instead of `bar`) it worked fine. This does essentially the same thing. If we were able to find the event ID with the module name attached, use that. Otherwise, fall back to just using the event name by itself.

Fixes #163