### PR TITLE
Alignment tweak in help output

### DIFF
--- a/src/Options.cc
+++ b/src/Options.cc
@@ -107,7 +107,7 @@ void usage(const char* prog, int code)
 	fprintf(stderr, "    -s|--rulefile <rulefile>        | read rules from given file\n");
 	fprintf(stderr, "    -t|--tracefile <tracefile>      | activate execution tracing\n");
 	fprintf(stderr, "    -u|--usage-issues               | find variable usage issues and exit\n");
-	fprintf(stderr, "       --no-unused-warnings          | suppress warnings of unused "
+	fprintf(stderr, "       --no-unused-warnings         | suppress warnings of unused "
 	                "functions/hooks/events\n");
 	fprintf(stderr, "    -v|--version                    | print version and exit\n");
 	fprintf(stderr, "    -w|--writefile <writefile>      | write to given tcpdump file\n");


### PR DESCRIPTION
Fixes this:

```
    -t|--tracefile <tracefile>      | activate execution tracing
    -u|--usage-issues               | find variable usage issues and exit
       --no-unused-warnings          | suppress warnings of unused functions/hooks/events
    -v|--version                    | print version and exit
    -w|--writefile <writefile>      | write to given tcpdump file
 
```
:-)