### PR TITLE
Truncate Docker image artifact at end of Docker CI workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -168,3 +168,16 @@ jobs:
           name: cluster-btest
           path: testing/external/zeek-testing-cluster/.tmp
           if-no-files-found: ignore
+
+      # To save storage space, truncate the Docker image artifact
+      # when this run was successful.
+      - name: Truncate Docker image
+        run: |
+          truncate -s0 ${{ env.IMAGE_FILE }}
+
+      - name: Store truncated image artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.IMAGE_NAME }}
+          path: ${{ env.IMAGE_FILE }}
+          retention-days: 1


### PR DESCRIPTION
In the (private) zeek-security repo we currently hit the 2GB storage limit
whenever CI runs happen multiple times in one day, because our Docker Github
workflow preserves the output of the first job (the image build) for the second
job (the cluster tests).

For successful runs, there's no use for the Docker image to survive as a CI
artifact. (For failures, it might help to grab the image for local testing.)

There's no Github-official way to delete an attachment within a workflow, so
this simply truncates the artifact if the workflow succeeds.