### PR TITLE
Zeekygen: add Sphinx labels to each plugin's generated documentation

### DIFF
--- a/src/zeekygen/Target.cc
+++ b/src/zeekygen/Target.cc
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <regex>
 
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/Component.h"
@@ -27,6 +28,16 @@ namespace zeek::zeekygen::detail
 static void write_plugin_section_heading(FILE* f, const plugin::Plugin* p)
 	{
 	const string& name = p->Name();
+
+	// A label-safe version of the plugin name: replace _ and : with -, turn
+	// sequences of - into single ones, and make lower-case. Example:
+	// "Zeek::IEEE802_11" -> "zeek-ieee802-11".
+	auto flags = std::regex_constants::match_any;
+	string label_name = std::regex_replace(name, std::regex("[_:]"), "-", flags);
+	label_name = std::regex_replace(label_name, std::regex("-+"), "-", flags);
+	label_name = zeek::util::strtolower(label_name);
+
+	fprintf(f, ".. _plugin-%s:\n\n", label_name.c_str());
 
 	fprintf(f, "%s\n", name.c_str());
 	for ( size_t i = 0; i < name.size(); ++i )

--- a/testing/btest/doc/zeekygen/command_line.zeek
+++ b/testing/btest/doc/zeekygen/command_line.zeek
@@ -4,9 +4,9 @@
 # Shouldn't emit any warnings about not being able to document something
 # that's supplied via command line script.
 
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek %INPUT -e 'redef myvar=10; print myvar' >output 2>&1
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -e '@load %INPUT print myvar' >>output 2>&1
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek %INPUT -e 'module mymodule; print myvar' >>output 2>&1
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek %INPUT -e 'redef myvar=10; print myvar' >output 2>&1
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -e '@load %INPUT print myvar' >>output 2>&1
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek %INPUT -e 'module mymodule; print myvar' >>output 2>&1
 # @TEST-EXEC: btest-diff output
 
 const myvar = 5 &redef;

--- a/testing/btest/doc/zeekygen/comment_retrieval_bifs.zeek
+++ b/testing/btest/doc/zeekygen/comment_retrieval_bifs.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b %INPUT >out
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b %INPUT >out
 # @TEST-EXEC: btest-diff out
 
 ##! This is a test script.

--- a/testing/btest/doc/zeekygen/enums.zeek
+++ b/testing/btest/doc/zeekygen/enums.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff autogen-reST-enums.rst
 
 @TEST-START-FILE zeekygen.config

--- a/testing/btest/doc/zeekygen/example.zeek
+++ b/testing/btest/doc/zeekygen/example.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT
 # @TEST-EXEC: btest-diff example.rst
 
 @TEST-START-FILE zeekygen.config

--- a/testing/btest/doc/zeekygen/func-params.zeek
+++ b/testing/btest/doc/zeekygen/func-params.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff autogen-reST-func-params.rst
 
 @TEST-START-FILE zeekygen.config

--- a/testing/btest/doc/zeekygen/identifier.zeek
+++ b/testing/btest/doc/zeekygen/identifier.zeek
@@ -1,5 +1,5 @@
 # @TEST-PORT: BROKER_PORT
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT Broker::default_port=$BROKER_PORT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT Broker::default_port=$BROKER_PORT
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff test.rst
 
 @TEST-START-FILE zeekygen.config

--- a/testing/btest/doc/zeekygen/package.zeek
+++ b/testing/btest/doc/zeekygen/package.zeek
@@ -1,5 +1,5 @@
 # @TEST-PORT: BROKER_PORT
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT Broker::default_port=$BROKER_PORT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT Broker::default_port=$BROKER_PORT
 # @TEST-EXEC: btest-diff test.rst
 
 @TEST-START-FILE zeekygen.config

--- a/testing/btest/doc/zeekygen/package_index.zeek
+++ b/testing/btest/doc/zeekygen/package_index.zeek
@@ -1,5 +1,5 @@
 # @TEST-PORT: BROKER_PORT
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT Broker::default_port=$BROKER_PORT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT Broker::default_port=$BROKER_PORT
 # @TEST-EXEC: btest-diff test.rst
 
 @TEST-START-FILE zeekygen.config

--- a/testing/btest/doc/zeekygen/records.zeek
+++ b/testing/btest/doc/zeekygen/records.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff autogen-reST-records.rst
 
 @TEST-START-FILE zeekygen.config

--- a/testing/btest/doc/zeekygen/script_index.zeek
+++ b/testing/btest/doc/zeekygen/script_index.zeek
@@ -1,5 +1,5 @@
 # @TEST-PORT: BROKER_PORT
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT Broker::default_port=$BROKER_PORT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT Broker::default_port=$BROKER_PORT
 # @TEST-EXEC: btest-diff test.rst
 
 @TEST-START-FILE zeekygen.config

--- a/testing/btest/doc/zeekygen/script_summary.zeek
+++ b/testing/btest/doc/zeekygen/script_summary.zeek
@@ -1,5 +1,5 @@
 # @TEST-PORT: BROKER_PORT
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT Broker::default_port=$BROKER_PORT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT Broker::default_port=$BROKER_PORT
 # @TEST-EXEC: btest-diff test.rst
 
 @TEST-START-FILE zeekygen.config

--- a/testing/btest/doc/zeekygen/type-aliases.zeek
+++ b/testing/btest/doc/zeekygen/type-aliases.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff autogen-reST-type-aliases.rst
 
 @TEST-START-FILE zeekygen.config

--- a/testing/btest/doc/zeekygen/vectors.zeek
+++ b/testing/btest/doc/zeekygen/vectors.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; unset BRO_DISABLE_BROXYGEN; zeek -b -X zeekygen.config %INPUT
+# @TEST-EXEC: unset ZEEK_DISABLE_ZEEKYGEN; zeek -b -X zeekygen.config %INPUT
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff autogen-reST-vectors.rst
 
 @TEST-START-FILE zeekygen.config


### PR DESCRIPTION
For packet/protocol/file analyzers, Zeekygen runs similar content generation code driven by the plugin manager's registered plugins. It's currently not possible to link to a specific plugin's documentation from anywhere within the documentation — Sphinx is picky about linking directly to (sub)sections elsewhere.

This tweak adds a Sphinx label derived from the plugin name, allowing simple references via `:ref:`. For example, the HTTP analyzer at

https://docs.zeek.org/en/master/script-reference/proto-analyzers.html#zeek-http

becomes linkable from anywhere via:

    :ref:`plugin-zeek-http`

I considered adding a btest but I'm not sure how — if I add a test for the `proto_analyzer` index, for example, the output is the full protocol analyzer documentation, and too sensitive for baselining. I'm about to use this in our docs, so it'll at least be covered that way, but suggestions are welcome.

Also includes removal of the outdated `BRO_DISABLE_BROXYGEN` in the btests.