### PR TITLE
Use correct variable to pass existing Spicy root to spicy-plugin.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,7 @@ else ()
 endif ()
 
 if ( NOT DISABLE_SPICY )
-    if ( NOT Spicy_ROOT )
+    if ( NOT SPICY_ROOT_DIR )
         add_subdirectory(auxil/spicy)
 
         # Set variables used by the spicy-plugin build since we are building Spicy
@@ -703,7 +703,7 @@ CheckOptionalBuildSources(auxil/zeek-archiver ZeekArchiver INSTALL_ZEEK_ARCHIVER
 CheckOptionalBuildSources(auxil/zeek-client ZeekClient INSTALL_ZEEK_CLIENT)
 
 if ( NOT DISABLE_SPICY )
-    if ( NOT Spicy_ROOT )
+    if ( NOT SPICY_ROOT_DIR )
         list(APPEND _spicy_rt_libs spicy-rt hilti-rt)
 
         # Use the debug runtime libraries if we are building a debug Zeek.

--- a/configure
+++ b/configure
@@ -379,7 +379,7 @@ while [ $# -ne 0 ]; do
             append_cache_entry PYTHON_LIBRARY PATH $optarg
             ;;
         --with-spicy=*)
-            append_cache_entry SPICY_ROOT PATH $optarg
+            append_cache_entry SPICY_ROOT_DIR PATH $optarg
             ;;
         --with-spicy-plugin=*)
             append_cache_entry SPICY_PLUGIN_PATH PATH $optarg


### PR DESCRIPTION
spicy-plugin can find Spicy in paths given by `SPICY_ROOT_DIR` while
`./configure` instead set `SPICY_ROOT`. With this patch we now set the
correct variable.

We also adjust variations of the previous variable name with different
capitalization which caused us to not properly configure spicy-plugin
(which triggers finding Spicy in its given prefix).

Closes #2363.