### PR TITLE
Switch macOS Monterey build to new m1-based VM

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -242,7 +242,7 @@ alpine_task:
 # We aim to support both the current and previous macOS release.
 macos_monterey_task:
   macos_instance:
-    image: monterey-xcode-13.1
+    image: ghcr.io/cirruslabs/macos-monterey-base:latest
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_ENVIRONMENT

--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -9,3 +9,11 @@ brew update
 brew upgrade cmake openssl@1.1
 brew install swig bison flex ccache
 python3 -m pip install --user websockets
+
+# Brew doesn't create the /opt/homebrew/opt/openssl symlink if you install
+# openssl@1.1, only with 3.0. Create the symlink if it doesn't exist.
+if [ ! -e /opt/homebrew/opt/openssl ]; then
+    if [ -d /opt/homebrew/opt/openssl@1.1 ]; then
+        ln -s /opt/homebrew/opt/openssl@1.1 /opt/homebrew/opt/openssl
+    fi
+fi


### PR DESCRIPTION
Fedor from Cirrus recently mentioned that they have new M1-based macOS VMs for use, which are apparently quite a bit more efficient than the existing macOS images. They're only available for Monterey and Ventura (due to being M1-based). This PR switches over our Monty build to use that image.