### PR TITLE
Revert to regular peering fn for ssl_auth_failure

### DIFF
--- a/testing/btest/broker/ssl_auth_failure.zeek
+++ b/testing/btest/broker/ssl_auth_failure.zeek
@@ -100,7 +100,7 @@ BTdqMbieumB/zL97iK5baHUFEJ4VRtLQhh/SOXgew/BF8ccpilI=
 
 event zeek_init()
 	{
-	Broker::__peer_no_retry("127.0.0.1", to_port(getenv("BROKER_PORT")));
+	Broker::peer("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 
 event Broker::peer_added(endpoint: Broker::EndpointInfo, msg: string)
@@ -121,7 +121,7 @@ redef Broker::ssl_certificate = "../cert.1.pem";
 
 event zeek_init()
 	{
-	Broker::__peer_no_retry("127.0.0.1", to_port(getenv("BROKER_PORT")));
+	Broker::peer("127.0.0.1", to_port(getenv("BROKER_PORT")));
 	}
 
 event Broker::peer_added(endpoint: Broker::EndpointInfo, msg: string)


### PR DESCRIPTION
Pulls in https://github.com/zeek/broker/pull/273 to verify that the patch fixes the btest error for `ssl_auth_failure` and revert a change to the test to use the regular `peer` function again.