### PR TITLE
plugins: Reject dynamic plugins matching names of built-in ones

### DIFF
--- a/testing/btest/Baseline/plugins.conflict-plugin/output
+++ b/testing/btest/Baseline/plugins.conflict-plugin/output
@@ -1,0 +1,2 @@
+error in <...>/init-bare.zeek, line 1: dynamic plugin zeek::asciireader from directory <...>/build/ conflicts with built-in plugin Zeek::AsciiReader (-1.-1.0)
+fatal error in <...>/init-bare.zeek, line 1: aborting after plugin errors

--- a/testing/btest/plugins/conflict-plugin.zeek
+++ b/testing/btest/plugins/conflict-plugin.zeek
@@ -1,0 +1,5 @@
+# @TEST-EXEC: ${DIST}/auxil/zeek-aux/plugin-support/init-plugin  -u . Zeek AsciiReader 2>&1 > /dev/null
+# @TEST-EXEC: cp -r %DIR/conflict-plugin/* .
+# @TEST-EXEC: ./configure --zeek-dist=${DIST} && make
+# @TEST-EXEC-FAIL: ZEEK_PLUGIN_PATH=`pwd` zeek -NN >> output 2>&1
+# @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff output

--- a/testing/btest/plugins/conflict-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/conflict-plugin/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+project(Zeek-Plugin-Conflict-Plugin)
+
+cmake_minimum_required(VERSION 3.5)
+
+if ( NOT ZEEK_DIST )
+    message(FATAL_ERROR "ZEEK_DIST not set")
+endif ()
+
+set(CMAKE_MODULE_PATH ${ZEEK_DIST}/cmake)
+
+include(ZeekPlugin)
+
+zeek_plugin_begin(Zeek AsciiReader)
+zeek_plugin_cc(src/Plugin.cc)
+zeek_plugin_end()

--- a/testing/btest/plugins/conflict-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/conflict-plugin/src/Plugin.cc
@@ -1,0 +1,19 @@
+#include "Plugin.h"
+
+namespace btest::plugin::Demo_Foo
+	{
+Plugin plugin;
+	}
+
+using namespace btest::plugin::Demo_Foo;
+
+zeek::plugin::Configuration Plugin::Configure()
+	{
+	zeek::plugin::Configuration config;
+	config.name = "Zeek::AsciiReader";
+	config.description = "Conflicts with the built-in AsciiReader";
+	config.version.major = 1;
+	config.version.minor = 0;
+	config.version.patch = 0;
+	return config;
+	}

--- a/testing/btest/plugins/conflict-plugin/src/Plugin.h
+++ b/testing/btest/plugins/conflict-plugin/src/Plugin.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <plugin/Plugin.h>
+
+namespace btest::plugin::Demo_Foo
+	{
+
+class Plugin : public zeek::plugin::Plugin
+	{
+protected:
+	// Overridden from plugin::Plugin.
+	virtual zeek::plugin::Configuration Configure();
+	};
+
+extern Plugin plugin;
+
+	}


### PR DESCRIPTION
This goes the hard-exit on conflicts route as IMO it provides better messaging that something is wrong, rather than defaulting to something the user may not expect.

Fixes #2403