### PR TITLE
Skip darwin builds on zeek-security repo

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,14 +52,19 @@ sanitizers_resource_template: &SANITIZERS_RESOURCE_TEMPLATE
   greedy: true
 
 ci_template: &CI_TEMPLATE
+  # Rules for skipping builds:
+  # - Don't do darwin builds on zeek-security repo because they use up a ton of compute credits.
+  # - Always build PRs, but not if they come from dependabot
+  # - Always build master and release/* builds from the main repo
   only_if: >
-    ( $CIRRUS_PR != '' && $CIRRUS_BRANCH !=~ 'dependabot/.*' ) ||
+    ( $CIRRUS_REPO_NAME != 'zeek-security' || $CIRRUS_OS != "darwin" ) &&
+    ( ( $CIRRUS_PR != '' && $CIRRUS_BRANCH !=~ 'dependabot/.*' ) ||
     ( $CIRRUS_REPO_NAME == 'zeek' &&
       (
       $CIRRUS_BRANCH == 'master' ||
       $CIRRUS_BRANCH =~ 'release/.*'
       )
-    )
+    ) )
 
   # Default timeout is 60 minutes, Cirrus hard limit is 120 minutes for free
   # tasks, so may as well ask for full time.


### PR DESCRIPTION
The private zeek-security repo uses compute credits from Cirrus in order to run builds, since it's not a public repository. According to Fedor from Cirrus, the darwin builds eat a large number of the credits leading us to have to ask for more quite frequently. This PR adds some extra conditions to the `only_if` in the cirrus configuration to skip darwin builds on that repository but not others so that we still have normal coverage on the public repos.

I have some concerns about Darwin builds not being handled automatically for security PRs, but I think there's enough of us doing development on macOS that we'd encounter any problems early. Otherwise we would catch the failures once the issues are merged back into the public Zeek repo.

I tested this on a separate repo called `zeek-build-skip`. You can see the build that skipped the macOS builds at https://cirrus-ci.com/build/4697397258354688 (ignore the fact that they all failed, just note that the macOS builds are missing).