### PR TITLE
fix for deprecated when's where the inner frame is larger than the outer frame

### DIFF
--- a/src/Scope.cc
+++ b/src/Scope.cc
@@ -190,6 +190,20 @@ ScopePtr pop_scope()
 	return old_top;
 	}
 
+void merge_top_scope()
+	{
+	if ( scopes.size() < 2 )
+		reporter->InternalError("scope merge underflow");
+
+	auto t = pop_scope();
+
+	for ( auto v : t->OrderedVars() )
+		{
+		v->SetOffset(top_scope->Length());
+		top_scope->Insert(v->Name(), v);
+		}
+	}
+
 ScopePtr current_scope()
 	{
 	return top_scope;

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -92,6 +92,11 @@ extern void push_existing_scope(ScopePtr scope);
 
 // Returns the one popped off.
 extern ScopePtr pop_scope();
+
+// Merges the elements of the current scope with the one surrounding it,
+// popping it in the process.
+extern void merge_top_scope();
+
 extern ScopePtr current_scope();
 extern ScopePtr global_scope();
 

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -1893,7 +1893,7 @@ void WhenInfo::Build(StmtPtr ws)
 	{
 	if ( IsDeprecatedSemantics(ws) )
 		{
-		pop_scope();
+		merge_top_scope();
 		return;
 		}
 


### PR DESCRIPTION
This fixes https://github.com/zeek/zeek/issues/2377, which arises from recent `when` changes incorrectly introducing (and then discarding) an inner scope for the `when` body & timeout.  The fix is to merge that scope with its surrounding scope.