### PR TITLE
fixes for compiling "standalone" C++ scripts

### DIFF
--- a/src/Type.cc
+++ b/src/Type.cc
@@ -278,6 +278,15 @@ detail::TraversalCode Type::Traverse(detail::TraversalCallback* cb) const
 	HANDLE_TC_TYPE_POST(tc);
 	}
 
+void TypeList::CheckPure()
+	{
+	if ( pure_type )
+		return;
+
+	if ( ! types.empty() && AllMatch(types[0], false) )
+		pure_type = types[0];
+	}
+
 bool TypeList::AllMatch(const Type* t, bool is_init) const
 	{
 	for ( const auto& type : types )

--- a/src/Type.h
+++ b/src/Type.h
@@ -339,6 +339,10 @@ public:
 	// is not pure or is empty.
 	const TypePtr& GetPureType() const { return pure_type; }
 
+	// Retrospectively instantiates an underlying pure type, if in
+	// fact each element has the same type.
+	void CheckPure();
+
 	// True if all of the types match t, false otherwise.  If
 	// is_init is true, then the matching is done in the context
 	// of an initialization.

--- a/src/script_opt/CPP/RuntimeInits.cc
+++ b/src/script_opt/CPP/RuntimeInits.cc
@@ -377,6 +377,8 @@ TypePtr CPP_TypeInits::BuildTypeList(InitsManager* im, ValElemVec& init_vals, in
 	while ( iv_it != iv_end )
 		tl->Append(im->Types(*(iv_it++)));
 
+	tl->CheckPure();
+
 	return tl;
 	}
 

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -412,7 +412,7 @@ static void use_CPP()
 			}
 		}
 
-	if ( num_used == 0 )
+	if ( num_used == 0 && standalone_activations.empty() )
 		reporter->FatalError("no C++ functions found to use");
 
 	// Now that we've loaded all of the compiled scripts


### PR DESCRIPTION
These are maintenance fixes for `-O gen-standalone-C++`, which doesn't get exercised as much as `-O gen-C++` because it's not feasible to run the test suite for standalone compilation.