### PR TITLE
Dynamics initialization of globals for -O gen-C++

### DIFF
--- a/src/ID.cc
+++ b/src/ID.cc
@@ -680,11 +680,6 @@ std::vector<Func*> ID::GetOptionHandlers() const
 	return v;
 	}
 
-void IDOptInfo::AddInitExpr(ExprPtr init_expr)
-	{
-	init_exprs.emplace_back(std::move(init_expr));
-	}
-
 	} // namespace detail
 
 	} // namespace zeek

--- a/src/parse.y
+++ b/src/parse.y
@@ -102,7 +102,6 @@
 #include "zeek/zeekygen/Manager.h"
 #include "zeek/module_util.h"
 #include "zeek/IntrusivePtr.h"
-#include "zeek/script_opt/IDOptInfo.h"
 
 extern const char* filename;  // Absolute path of file currently being parsed.
 extern const char* last_filename; // Absolute path of last file parsed.
@@ -321,8 +320,6 @@ static void build_global(ID* id, Type* t, InitClass ic, Expr* e,
 
 	add_global(id_ptr, std::move(t_ptr), ic, e_ptr, std::move(attrs_ptr), dt);
 
-	id->GetOptInfo()->AddInitExpr(e_ptr);
-
 	if ( dt == VAR_REDEF )
 		zeekygen_mgr->Redef(id, ::filename, ic, std::move(e_ptr));
 	else
@@ -341,8 +338,6 @@ static StmtPtr build_local(ID* id, Type* t, InitClass ic, Expr* e,
 
 	auto init = add_local(std::move(id_ptr), std::move(t_ptr), ic,
 	                      e_ptr, std::move(attrs_ptr), dt);
-
-	id->GetOptInfo()->AddInitExpr(std::move(e_ptr));
 
 	if ( do_coverage )
 		script_coverage_mgr.AddStmt(init.get());

--- a/src/script_opt/CPP/Attrs.cc
+++ b/src/script_opt/CPP/Attrs.cc
@@ -18,7 +18,7 @@ shared_ptr<CPP_InitInfo> CPPCompile::RegisterAttributes(const AttributesPtr& att
 	if ( pa != processed_attrs.end() )
 		return pa->second;
 
-	attributes.AddKey(attrs);
+	attributes.AddKey(attrs, pfs.HashAttrs(attrs));
 
 	// The cast is just so we can make an IntrusivePtr.
 	auto a_rep = const_cast<Attributes*>(attributes.GetRep(attrs));
@@ -49,7 +49,7 @@ shared_ptr<CPP_InitInfo> CPPCompile::RegisterAttr(const AttrPtr& attr)
 
 	const auto& e = a->GetExpr();
 	if ( e && ! IsSimpleInitExpr(e) )
-		init_exprs.AddKey(e);
+		init_exprs.AddKey(e, p_hash(e));
 
 	auto gi = make_shared<AttrInfo>(this, attr);
 	attr_info->AddInstance(gi);

--- a/src/script_opt/CPP/Compile.h
+++ b/src/script_opt/CPP/Compile.h
@@ -1015,6 +1015,10 @@ private:
 	// Generate code to initialize indirect references to constants.
 	void InitializeConsts();
 
+	// Generate code to initialize globals (using dynamic statements
+	// rather than constants).
+	void InitializeGlobals();
+
 	// Generate the initialization hook for this set of compiled code.
 	void GenInitHook();
 

--- a/src/script_opt/CPP/Driver.cc
+++ b/src/script_opt/CPP/Driver.cc
@@ -5,6 +5,7 @@
 #include <cerrno>
 
 #include "zeek/script_opt/CPP/Compile.h"
+#include "zeek/script_opt/IDOptInfo.h"
 
 extern std::unordered_set<std::string> files_with_conditionals;
 
@@ -311,6 +312,9 @@ void CPPCompile::RegisterCompiledBody(const string& f)
 void CPPCompile::GenEpilog()
 	{
 	NL();
+	InitializeGlobals();
+
+	NL();
 	for ( const auto& ii : init_infos )
 		GenInitExpr(ii.second);
 
@@ -467,6 +471,9 @@ void CPPCompile::GenFinishInit()
 
 	NL();
 	Emit("load_BiFs__CPP();");
+
+	NL();
+	Emit("init_globals__CPP();");
 
 	EndBlock();
 	}

--- a/src/script_opt/CPP/InitsInfo.cc
+++ b/src/script_opt/CPP/InitsInfo.cc
@@ -439,6 +439,9 @@ ListTypeInfo::ListTypeInfo(CPPCompile* _c, TypePtr _t)
 		if ( gi )
 			init_cohort = max(init_cohort, gi->InitCohort());
 		}
+
+	if ( ! types.empty() )
+		++init_cohort;
 	}
 
 void ListTypeInfo::AddInitializerVals(std::vector<std::string>& ivs) const

--- a/src/script_opt/CPP/InitsInfo.cc
+++ b/src/script_opt/CPP/InitsInfo.cc
@@ -339,16 +339,7 @@ GlobalInitInfo::GlobalInitInfo(CPPCompile* c, const ID* g, string _CPP_name)
 		attrs = -1;
 
 	exported = g->IsExport();
-
-	auto v = g->GetVal();
-	if ( v && gt->Tag() == TYPE_OPAQUE )
-		{
-		reporter->Error("cannot compile to C++ global \"%s\" initialized to opaque value",
-		                g->Name());
-		v = nullptr;
-		}
-
-	val = ValElem(c, v);
+	val = ValElem(c, nullptr); // empty because we initialize dynamically
 	}
 
 void GlobalInitInfo::InitializerVals(std::vector<std::string>& ivs) const

--- a/src/script_opt/CPP/README.md
+++ b/src/script_opt/CPP/README.md
@@ -173,9 +173,6 @@ as currently done, to instead be in a pseudo-event handler.
 code requires initializing a global variable that specifies extend fields in
 an extensible record (i.e., fields added using `redef`).
 
-* The compiler will not compile bodies that include "when" statements
-This is fairly involved to fix.
-
 * If a lambda generates an event that is not otherwise referred to, that
 event will not be registered upon instantiating the lambda.  This is not
 particularly difficult to fix.

--- a/src/script_opt/CPP/RuntimeInits.cc
+++ b/src/script_opt/CPP/RuntimeInits.cc
@@ -485,11 +485,10 @@ void CPP_GlobalInit::Generate(InitsManager* im, std::vector<void*>& /* inits_vec
 	global = lookup_global__CPP(name, im->Types(type), exported);
 
 	if ( ! global->HasVal() && val >= 0 )
-		{
 		global->SetVal(im->ConstVals(val));
-		if ( attrs >= 0 )
-			global->SetAttrs(im->Attributes(attrs));
-		}
+
+	if ( attrs >= 0 )
+		global->SetAttrs(im->Attributes(attrs));
 	}
 
 void generate_indices_set(int* inits, std::vector<std::vector<int>>& indices_set)

--- a/src/script_opt/CPP/RuntimeInits.h
+++ b/src/script_opt/CPP/RuntimeInits.h
@@ -66,12 +66,41 @@ public:
 	// Accessors for the sundry initialization vectors, each retrieving
 	// a specific element identified by an index/offset.
 	const std::vector<int>& Indices(int offset) const { return indices[offset]; }
-	const char* Strings(int offset) const { return strings[offset]; }
-	const p_hash_type Hashes(int offset) const { return hashes[offset]; }
-	const TypePtr& Types(int offset) const { return types[offset]; }
-	const AttributesPtr& Attributes(int offset) const { return attributes[offset]; }
-	const AttrPtr& Attrs(int offset) const { return attrs[offset]; }
-	const CallExprPtr& CallExprs(int offset) const { return call_exprs[offset]; }
+	const char* Strings(int offset) const
+		{
+		ASSERT(offset >= 0 && offset < strings.size());
+		ASSERT(strings[offset]);
+		return strings[offset];
+		}
+	const p_hash_type Hashes(int offset) const
+		{
+		ASSERT(offset >= 0 && offset < hashes.size());
+		return hashes[offset];
+		}
+	const TypePtr& Types(int offset) const
+		{
+		ASSERT(offset >= 0 && offset < types.size());
+		ASSERT(types[offset]);
+		return types[offset];
+		}
+	const AttributesPtr& Attributes(int offset) const
+		{
+		ASSERT(offset >= 0 && offset < attributes.size());
+		ASSERT(attributes[offset]);
+		return attributes[offset];
+		}
+	const AttrPtr& Attrs(int offset) const
+		{
+		ASSERT(offset >= 0 && offset < attrs.size());
+		ASSERT(attrs[offset]);
+		return attrs[offset];
+		}
+	const CallExprPtr& CallExprs(int offset) const
+		{
+		ASSERT(offset >= 0 && offset < call_exprs.size());
+		ASSERT(call_exprs[offset]);
+		return call_exprs[offset];
+		}
 
 private:
 	std::vector<CPP_ValElem>& const_vals;

--- a/src/script_opt/CPP/maint/README
+++ b/src/script_opt/CPP/maint/README
@@ -15,7 +15,7 @@ The maintenance workflow:
     to check in updates to the list of how the compiler currently fares
     on various btests (see end of this doc):
 
-	Fri Sep 16 16:13:49 PDT 2022
+	Thu Sep 29 14:49:49 PDT 2022
 
 2.  Run "find-test-files.sh" to generate a list (to stdout) of all of the
     possible Zeek source files found in the test suite.
@@ -74,18 +74,11 @@ These BTests won't successfully run due to the indicated issue:
 Database Of Known Issues (keep sorted)
 
 ../testing/btest/bifs/table_values.zeek bad-constructor
-../testing/btest/core/global_opaque_val.zeek opaque
 ../testing/btest/language/alternate-event-hook-prototypes.zeek deprecated
-../testing/btest/language/global-init-calls-bif.zeek opaque
 ../testing/btest/language/redef-same-prefixtable-idx.zeek deprecated
 ../testing/btest/language/table-redef.zeek deprecated
 ../testing/btest/language/when-aggregates.zeek bad-when
 ../testing/btest/scripts/base/protocols/krb/smb2_krb.test skipped
 ../testing/btest/scripts/base/protocols/krb/smb2_krb_nokeytab.test skipped
 ../testing/btest/scripts/base/utils/active-http.test test-glitch
-../testing/btest/scripts/policy/frameworks/telemetry/log-prefixes.zeek opaque
-../testing/btest/scripts/policy/frameworks/telemetry/log.zeek opaque
 ../testing/btest/scripts/policy/misc/dump-events.zeek skipped
-../testing/btest/telemetry/counter.zeek opaque
-../testing/btest/telemetry/gauge.zeek opaque
-../testing/btest/telemetry/histogram.zeek opaque

--- a/src/script_opt/IDOptInfo.cc
+++ b/src/script_opt/IDOptInfo.cc
@@ -51,6 +51,8 @@ void IDDefRegion::Dump() const
 	printf("\n");
 	}
 
+std::vector<IDInitInfo> IDOptInfo::global_init_exprs;
+
 void IDOptInfo::Clear()
 	{
 	static bool did_init = false;
@@ -67,6 +69,17 @@ void IDOptInfo::Clear()
 	confluence_stmts.clear();
 
 	tracing = trace_ID && util::streq(trace_ID, my_id->Name());
+	}
+
+void IDOptInfo::AddInitExpr(ExprPtr init_expr, InitClass ic)
+	{
+	if ( ! init_expr )
+		return;
+
+	if ( my_id->IsGlobal() )
+		global_init_exprs.emplace_back(IDInitInfo(my_id, init_expr, ic));
+
+	init_exprs.emplace_back(std::move(init_expr));
 	}
 
 void IDOptInfo::DefinedAfter(const Stmt* s, const ExprPtr& e,

--- a/src/script_opt/ProfileFunc.cc
+++ b/src/script_opt/ProfileFunc.cc
@@ -917,7 +917,10 @@ p_hash_type ProfileFuncs::HashAttrs(const AttributesPtr& Attrs)
 		// can vary in structure due to compilation of elements.  We
 		// do though enforce consistency for their types.
 		if ( e )
+			{
 			h = merge_p_hashes(h, HashType(e->GetType()));
+			h = merge_p_hashes(h, p_hash(e.get()));
+			}
 		}
 
 	return h;


### PR DESCRIPTION
Previously, `-O gen-C++` generated C++ code that statically initialized Zeek globals to whatever value they finally had after parsing/interpreter initialization.  This had two problems: (1) incorrect behavior when an initialization value depends on other globals whose values might change during a new run (or BiFs like `current_time()` that return different values), and (2) no ability to deal with globals initialized to `opaque` values, since these can't be represented as constants.  This second has become particularly thorny since the recently introduced Telemetry framework includes some of these.

This PR changes initialization to instead occur via a series of run-time assignments, conducted in the same order as for the original script.  Along the way I fixed some `-O gen-C++` problems arising from inconsistent hashing & initialization ordering, added some safety checks during the execution of compiled scripts, and updated the user and maintenance documentation.