### PR TITLE
analyzer: Add file_analyzer support to enable_analyzer()/disable_analyzer()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,11 +22,11 @@ New Functionality
 - File analyzers can now raise analyzer violations to the script-layer via
   the new ``AnalyzerViolation()`` method.
 
-- Packet analyzers can now be disabled and enabled at runtime using
+- Packet and file analyzers can now be disabled and enabled at runtime using
   the ``Analyzer::enable_analyzer()`` and ``Analyzer::disable_analyzer()``
   wrappers. While initially for protocol analyzers only, these have
-  been extended to work for packet analyzers, too. Packet analyzers can
-  be added to ``Analyzer::disabled_analyzers``, too.
+  been extended to work for packet and file analyzers. This now allows to
+  leverage ``Analyzer::disabled_analyzers`` for these kinds of analyzers.
 
 Changed Functionality
 ---------------------

--- a/scripts/base/frameworks/analyzer/main.zeek
+++ b/scripts/base/frameworks/analyzer/main.zeek
@@ -142,6 +142,8 @@ export {
 }
 
 @load base/bif/analyzer.bif
+@load base/bif/file_analysis.bif
+@load base/bif/packet_analysis.bif
 
 event zeek_init() &priority=5
 	{
@@ -157,6 +159,9 @@ function enable_analyzer(tag: AllAnalyzers::Tag) : bool
 	if ( is_packet_analyzer(tag) )
 		return PacketAnalyzer::__enable_analyzer(tag);
 
+	if ( is_file_analyzer(tag) )
+		return Files::__enable_analyzer(tag);
+
 	return __enable_analyzer(tag);
 	}
 
@@ -164,6 +169,9 @@ function disable_analyzer(tag: AllAnalyzers::Tag) : bool
 	{
 	if ( is_packet_analyzer(tag) )
 		return PacketAnalyzer::__disable_analyzer(tag);
+
+	if ( is_file_analyzer(tag) )
+		return Files::__disable_analyzer(tag);
 
 	return __disable_analyzer(tag);
 	}

--- a/testing/btest/Baseline/coverage.bare-load-baseline/canonified_loaded_scripts.log
+++ b/testing/btest/Baseline/coverage.bare-load-baseline/canonified_loaded_scripts.log
@@ -27,6 +27,7 @@ scripts/base/init-bare.zeek
       scripts/base/frameworks/analyzer/main.zeek
         scripts/base/frameworks/packet-filter/utils.zeek
         build/scripts/base/bif/analyzer.bif.zeek
+        build/scripts/base/bif/file_analysis.bif.zeek
     scripts/base/packet-protocols/root/__load__.zeek
       scripts/base/packet-protocols/root/main.zeek
     scripts/base/packet-protocols/ip/__load__.zeek
@@ -115,7 +116,6 @@ scripts/base/init-frameworks-and-bifs.zeek
     scripts/base/frameworks/analyzer/dpd.zeek
   scripts/base/frameworks/files/__load__.zeek
     scripts/base/frameworks/files/main.zeek
-      build/scripts/base/bif/file_analysis.bif.zeek
       scripts/base/utils/site.zeek
         scripts/base/utils/patterns.zeek
     scripts/base/frameworks/files/magic/__load__.zeek

--- a/testing/btest/Baseline/coverage.default-load-baseline/canonified_loaded_scripts.log
+++ b/testing/btest/Baseline/coverage.default-load-baseline/canonified_loaded_scripts.log
@@ -27,6 +27,7 @@ scripts/base/init-bare.zeek
       scripts/base/frameworks/analyzer/main.zeek
         scripts/base/frameworks/packet-filter/utils.zeek
         build/scripts/base/bif/analyzer.bif.zeek
+        build/scripts/base/bif/file_analysis.bif.zeek
     scripts/base/packet-protocols/root/__load__.zeek
       scripts/base/packet-protocols/root/main.zeek
     scripts/base/packet-protocols/ip/__load__.zeek
@@ -115,7 +116,6 @@ scripts/base/init-frameworks-and-bifs.zeek
     scripts/base/frameworks/analyzer/dpd.zeek
   scripts/base/frameworks/files/__load__.zeek
     scripts/base/frameworks/files/main.zeek
-      build/scripts/base/bif/file_analysis.bif.zeek
       scripts/base/utils/site.zeek
         scripts/base/utils/patterns.zeek
     scripts/base/frameworks/files/magic/__load__.zeek

--- a/testing/btest/Baseline/plugins.hooks/output
+++ b/testing/btest/Baseline/plugins.hooks/output
@@ -716,6 +716,7 @@
 0.000000   MetaHookPost  CallFunction(getenv, <null>, (ZEEK_DEFAULT_LISTEN_ADDRESS)) -> <no result>
 0.000000   MetaHookPost  CallFunction(global_options, <frame>, ()) -> <no result>
 0.000000   MetaHookPost  CallFunction(gsub, ..., ...) -> <no result>
+0.000000   MetaHookPost  CallFunction(is_file_analyzer, <frame>, (AllAnalyzers::ANALYZER_ANALYZER_TCPSTATS)) -> <no result>
 0.000000   MetaHookPost  CallFunction(is_packet_analyzer, <frame>, (AllAnalyzers::ANALYZER_ANALYZER_TCPSTATS)) -> <no result>
 0.000000   MetaHookPost  CallFunction(lstrip, ..., ...) -> <no result>
 0.000000   MetaHookPost  CallFunction(network_time, <frame>, ()) -> <no result>
@@ -2230,6 +2231,7 @@
 0.000000   MetaHookPre   CallFunction(getenv, <null>, (ZEEK_DEFAULT_LISTEN_ADDRESS))
 0.000000   MetaHookPre   CallFunction(global_options, <frame>, ())
 0.000000   MetaHookPre   CallFunction(gsub, ..., ...)
+0.000000   MetaHookPre   CallFunction(is_file_analyzer, <frame>, (AllAnalyzers::ANALYZER_ANALYZER_TCPSTATS))
 0.000000   MetaHookPre   CallFunction(is_packet_analyzer, <frame>, (AllAnalyzers::ANALYZER_ANALYZER_TCPSTATS))
 0.000000   MetaHookPre   CallFunction(lstrip, ..., ...)
 0.000000   MetaHookPre   CallFunction(network_time, <frame>, ())
@@ -3743,6 +3745,7 @@
 0.000000 | HookCallFunction getenv(ZEEK_DEFAULT_LISTEN_ADDRESS)
 0.000000 | HookCallFunction global_options()
 0.000000 | HookCallFunction gsub(...)
+0.000000 | HookCallFunction is_file_analyzer(AllAnalyzers::ANALYZER_ANALYZER_TCPSTATS)
 0.000000 | HookCallFunction is_packet_analyzer(AllAnalyzers::ANALYZER_ANALYZER_TCPSTATS)
 0.000000 | HookCallFunction lstrip(...)
 0.000000 | HookCallFunction network_time()

--- a/testing/btest/scripts/base/frameworks/analyzer/disabled-file-analyzers.zeek
+++ b/testing/btest/scripts/base/frameworks/analyzer/disabled-file-analyzers.zeek
@@ -1,0 +1,20 @@
+# @TEST-DOC: Add the PE analyzer to Analyzer::disabled_analyzers and ensure no pe.log is created.
+
+# First, cross-check that pe.log is indeed generated.
+# @TEST-EXEC: zeek -b -r $TRACES/pe/pe.trace %INPUT
+# @TEST-EXEC: test -f pe.log
+# @TEST-EXEC: rm *log
+
+# @TEST-EXEC: zeek -b -r $TRACES/pe/pe.trace %INPUT 'Analyzer::disabled_analyzers += { Files::ANALYZER_PE }'
+# @TEST-EXEC: test ! -f pe.log
+# @TEST-EXEC: test -f conn.log
+# @TEST-EXEC: rm *log
+
+# Finally, explicitly enable the analyzer via Analyzer::enable_analyzer() during zeek_init() and expect pe.log to be generated.
+# @TEST-EXEC: zeek -b -r $TRACES/pe/pe.trace %INPUT 'Analyzer::disabled_analyzers += { Files::ANALYZER_PE }' -e 'event zeek_init() { Analyzer::enable_analyzer(Files::ANALYZER_PE); }'
+# @TEST-EXEC: test -f pe.log
+# @TEST-EXEC: test -f conn.log
+
+@load base/protocols/conn
+@load base/protocols/ftp
+@load base/files/pe


### PR DESCRIPTION
This allows to enable/disable file analyzers through the same interfaces as packet and protocol analyzers, specifically Analyzer::disable_analyzer could be interesting.