### PR TITLE
Switch to bundled CAF for Coverity build

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -42,11 +42,8 @@ jobs:
             curl \
             wget
 
-      - name: Install CAF
-        run: cd auxil/broker/caf && ./configure --prefix=`pwd`/build/install-root && cd build && make -j $(nproc) install
-
       - name: Configure
-        run: ./configure --build-type=debug --with-caf=`pwd`/auxil/broker/caf/build/install-root --disable-broker-tests --disable-spicy
+        run: ./configure --build-type=debug --disable-broker-tests --disable-spicy
 
       - name: Fetch Coverity Tools
         env:


### PR DESCRIPTION
zeek/broker#285 prevents use of an external CAF without also using an external incubator, which isn't currently tweakable at the `configure` level. This fails the Coverity build: https://github.com/zeek/zeek/actions/runs/3293864275/jobs/5442294447

The reason for using an external CAF are historic and may no longer hold, so this is a check to see whether we can now use a normal build.