### PR TITLE
bifs/record_fields: Include actual enum name in type_name

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -101,6 +101,9 @@ Changed Functionality
 - The parameter given to ``enum_names()`` can now be a string naming the
   enum type, rather than the type itself.
 
+- The ``type_name`` of enum types produced by ``record_fields()`` now
+  includes the actual type name rather than just ``"enum"``.
+
 Deprecated Functionality
 ------------------------
 

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1235,6 +1235,8 @@ static string container_type_name(const Type* ft)
 			s += container_type_name(ft->Yield().get());
 			}
 		}
+	else if ( ft->Tag() == TYPE_ENUM )
+		s = "enum " + ft->GetName();
 	else
 		s = type_name(ft->Tag());
 	return s;

--- a/testing/btest/Baseline/bifs.records_fields/out
+++ b/testing/btest/Baseline/bifs.records_fields/out
@@ -11,16 +11,20 @@ F
 {
 [a] = [type_name=bool, log=F, value=<uninitialized>, default_val=<uninitialized>],
 [d] = [type_name=string, log=T, value=<uninitialized>, default_val=<uninitialized>],
+[f] = [type_name=enum Monochrome::color, log=T, value=<uninitialized>, default_val=<uninitialized>],
 [b] = [type_name=string, log=F, value=<uninitialized>, default_val=Bar],
+[c] = [type_name=double, log=F, value=<uninitialized>, default_val=<uninitialized>],
 [m] = [type_name=record myrec, log=F, value=<uninitialized>, default_val=<uninitialized>],
-[c] = [type_name=double, log=F, value=<uninitialized>, default_val=<uninitialized>]
+[e] = [type_name=enum color, log=F, value=<uninitialized>, default_val=BLUE]
 }
 {
 [a] = [type_name=bool, log=F, value=<uninitialized>, default_val=<uninitialized>],
 [d] = [type_name=string, log=T, value=<uninitialized>, default_val=<uninitialized>],
+[f] = [type_name=enum Monochrome::color, log=T, value=<uninitialized>, default_val=<uninitialized>],
 [b] = [type_name=string, log=F, value=<uninitialized>, default_val=Bar],
+[c] = [type_name=double, log=F, value=<uninitialized>, default_val=<uninitialized>],
 [m] = [type_name=record myrec, log=F, value=<uninitialized>, default_val=<uninitialized>],
-[c] = [type_name=double, log=F, value=<uninitialized>, default_val=<uninitialized>]
+[e] = [type_name=enum color, log=F, value=<uninitialized>, default_val=BLUE]
 }
 {
 [a] = [type_name=count, log=F, value=42, default_val=<uninitialized>],
@@ -38,9 +42,11 @@ F
 {
 [a] = [type_name=bool, log=F, value=<uninitialized>, default_val=<uninitialized>],
 [d] = [type_name=string, log=T, value=<uninitialized>, default_val=<uninitialized>],
+[f] = [type_name=enum Monochrome::color, log=T, value=<uninitialized>, default_val=<uninitialized>],
 [b] = [type_name=string, log=F, value=<uninitialized>, default_val=Bar],
+[c] = [type_name=double, log=F, value=<uninitialized>, default_val=<uninitialized>],
 [m] = [type_name=record myrec, log=F, value=<uninitialized>, default_val=<uninitialized>],
-[c] = [type_name=double, log=F, value=<uninitialized>, default_val=<uninitialized>]
+[e] = [type_name=enum color, log=F, value=<uninitialized>, default_val=BLUE]
 }
 {
 [a] = [type_name=count, log=F, value=<uninitialized>, default_val=<uninitialized>],
@@ -52,7 +58,9 @@ F
 {
 [a] = [type_name=set[double], log=F, value=<uninitialized>, default_val=<uninitialized>],
 [d] = [type_name=table[double,string] of table[string] of vector of string, log=F, value=<uninitialized>, default_val=<uninitialized>],
+[f] = [type_name=vector of enum color, log=F, value=<uninitialized>, default_val=<uninitialized>],
 [b] = [type_name=set[double,string], log=F, value=<uninitialized>, default_val=<uninitialized>],
 [c] = [type_name=set[double,record tt], log=F, value=<uninitialized>, default_val=<uninitialized>],
+[g] = [type_name=table[string] of enum color, log=F, value=<uninitialized>, default_val=<uninitialized>],
 [e] = [type_name=vector of vector of string, log=F, value=<uninitialized>, default_val=<uninitialized>]
 }

--- a/testing/btest/bifs/records_fields.zeek
+++ b/testing/btest/bifs/records_fields.zeek
@@ -2,6 +2,15 @@
 # @TEST-EXEC: zeek -b %INPUT >out
 # @TEST-EXEC: btest-diff out
 
+module Monochrome;
+export {
+	type color: enum { BLACK, WHITE };
+}
+
+module GLOBAL;
+
+type color: enum { RED, BLUE };
+
 type myrec: record {
 	myfield: bool;
 };
@@ -11,6 +20,8 @@ type tt: record {
 	b: string &default="Bar";
 	c: double &optional;
 	d: string &log;
+	e: color &default=BLUE;
+	f: Monochrome::color &log;
 	m: myrec;
 };
 
@@ -30,6 +41,8 @@ type cr: record {
      c: set[double, tt];
      d: table[double, string] of table[string] of vector of string;
      e: vector of vector of string;
+     f: vector of color;
+     g: table[string] of color;
 };
 
 event zeek_init()


### PR DESCRIPTION
One more from @stevesmoot. The record_fields() BIF produced "enum" as type_name for fields of type enum.

Extend container_type_name() to append the actual name of the enum.

This is changing the format and may break consumers, but those are likely in a category that are happy to adapt. Not having the actual enum name available wasn't very helpful.

We could alternatively render only the actual type_name without the prefixed "enum", but that isn't how it's done for record types currently and it would make it more difficult to decide which subsequent BIFs to use for further introspection, like enum_names().