### PR TITLE
egrep reported as obsolete by opensuse-tumbleweed builds

### DIFF
--- a/ci/opensuse-tumbleweed/Dockerfile
+++ b/ci/opensuse-tumbleweed/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/tumbleweed
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220705
+ENV DOCKERFILE_VERSION 20221027
 
 RUN zypper refresh \
  && zypper in -y \

--- a/src/script_opt/CPP/maint/find-test-files.sh
+++ b/src/script_opt/CPP/maint/find-test-files.sh
@@ -1,10 +1,10 @@
 #! /bin/sh
 
 find ../testing/btest -type f |
-    egrep -v 'Baseline|\.tmp' |
-    egrep '\.(zeek|test)$' |
+    grep -E -v 'Baseline|\.tmp' |
+    grep -E '\.(zeek|test)$' |
     sort |
-    xargs egrep -l '^[ 	]*(event|print)' |
-    xargs egrep -lc 'REQUIRES.*CPP.*((!=.*1)|(==.*0))' |
+    xargs grep -E -l '^[ 	]*(event|print)' |
+    xargs grep -E -lc 'REQUIRES.*CPP.*((!=.*1)|(==.*0))' |
     grep ':0$' |
     sed 's,:0,,'

--- a/testing/btest/coverage/bare-load-baseline.test
+++ b/testing/btest/coverage/bare-load-baseline.test
@@ -11,7 +11,7 @@
 # @TEST-REQUIRES: $SCRIPTS/have-spicy  # This test logs loaded scripts, so disable it if Spicy and it associated plugin is unavailable.
 # @TEST-EXEC: zeek -b misc/loaded-scripts
 # @TEST-EXEC: test -e loaded_scripts.log
-# @TEST-EXEC: cat loaded_scripts.log | egrep -v '#' | awk 'NR>0{print $1}' | sed -e ':a' -e '$!N' -e 's/^\(.*\).*\n\1.*/\1/' -e 'ta' >prefix
+# @TEST-EXEC: cat loaded_scripts.log | grep -E -v '#' | awk 'NR>0{print $1}' | sed -e ':a' -e '$!N' -e 's/^\(.*\).*\n\1.*/\1/' -e 'ta' >prefix
 # @TEST-EXEC: (test -L $BUILD && basename $(readlink $BUILD) || basename $BUILD) >buildprefix
 # @TEST-EXEC: cat loaded_scripts.log | sed "s#`cat buildprefix`#build#g" | sed "s#`cat prefix`##g" >prefix_canonified_loaded_scripts.log
 # @TEST-EXEC: grep -v 'Zeek_AF_Packet' prefix_canonified_loaded_scripts.log > canonified_loaded_scripts.log

--- a/testing/btest/coverage/default-load-baseline.test
+++ b/testing/btest/coverage/default-load-baseline.test
@@ -10,7 +10,7 @@
 # @TEST-REQUIRES: test -x ${BUILD}/auxil/spicy/spicy/bin/spicy-config
 # @TEST-EXEC: zeek misc/loaded-scripts
 # @TEST-EXEC: test -e loaded_scripts.log
-# @TEST-EXEC: cat loaded_scripts.log | egrep -v '#' | sed 's/ //g' | sed -e ':a' -e '$!N' -e 's/^\(.*\).*\n\1.*/\1/' -e 'ta' >prefix
+# @TEST-EXEC: cat loaded_scripts.log | grep -E -v '#' | sed 's/ //g' | sed -e ':a' -e '$!N' -e 's/^\(.*\).*\n\1.*/\1/' -e 'ta' >prefix
 # @TEST-EXEC: (test -L $BUILD && basename $(readlink $BUILD) || basename $BUILD) >buildprefix
 # @TEST-EXEC: cat loaded_scripts.log | sed "s#`cat buildprefix`#build#g" | sed "s#`cat prefix`##g" >prefix_canonified_loaded_scripts.log
 # @TEST-EXEC: grep -v 'Zeek_AF_Packet' prefix_canonified_loaded_scripts.log > canonified_loaded_scripts.log

--- a/testing/btest/coverage/init-default.test
+++ b/testing/btest/coverage/init-default.test
@@ -12,8 +12,8 @@
 #@TEST-EXEC: ( cd $DIST/scripts/base && find . -name '*.zeek' ) | sort >"all scripts found"
 #@TEST-EXEC: zeek misc/loaded-scripts
 #@TEST-EXEC: (test -L $BUILD && basename $(readlink $BUILD) || basename $BUILD) >buildprefix
-#@TEST-EXEC: cat loaded_scripts.log | egrep -v "/build/scripts/|$(cat buildprefix)/scripts/|/loaded-scripts.zeek|#" | sed 's#/./#/#g'  >loaded_scripts.log.tmp
+#@TEST-EXEC: cat loaded_scripts.log | grep -E -v "/build/scripts/|$(cat buildprefix)/scripts/|/loaded-scripts.zeek|#" | sed 's#/./#/#g'  >loaded_scripts.log.tmp
 #@TEST-EXEC: cat loaded_scripts.log.tmp | sed 's/ //g' | sed -e ':a' -e '$!N' -e 's/^\(.*\).*\n\1.*/\1/' -e 'ta' >prefix
 #@TEST-EXEC: cat loaded_scripts.log.tmp | sed 's/ //g' | sed "s#`cat prefix`#./#g" | sort >init-default.zeek
-#@TEST-EXEC: diff -u "all scripts found" init-default.zeek | egrep "^-[^-]" > missing_loads
+#@TEST-EXEC: diff -u "all scripts found" init-default.zeek | grep -E "^-[^-]" > missing_loads
 #@TEST-EXEC: btest-diff missing_loads

--- a/testing/btest/coverage/zeekygen.sh
+++ b/testing/btest/coverage/zeekygen.sh
@@ -20,8 +20,8 @@ if [ $# -ne 2 ]; then
     exit 1
 fi
 
-all_loads=$(egrep "#[[:space:]]*@load.*" $1 | sed 's/#[[:space:]]*@load[[:space:]]*//g')
-zeekygen_loads=$(egrep "@load.*" $2 | sed 's/@load[[:space:]]*//g')
+all_loads=$(grep -E "#[[:space:]]*@load.*" $1 | sed 's/#[[:space:]]*@load[[:space:]]*//g')
+zeekygen_loads=$(grep -E "@load.*" $2 | sed 's/@load[[:space:]]*//g')
 
 for f in $all_loads; do
     echo "$zeekygen_loads" | grep -q $f || error_msg "$f not loaded in zeekygen/__load__.zeek"

--- a/testing/btest/scripts/base/frameworks/logging/ascii-escape.zeek
+++ b/testing/btest/scripts/base/frameworks/logging/ascii-escape.zeek
@@ -1,6 +1,6 @@
 #
-# @TEST-EXEC: zeek -b %INPUT 
-# @TEST-EXEC: cat ssh.log | egrep -v '#open|#close' >ssh.log.tmp && mv ssh.log.tmp ssh.log
+# @TEST-EXEC: zeek -b %INPUT
+# @TEST-EXEC: cat ssh.log | grep -E -v '#open|#close' >ssh.log.tmp && mv ssh.log.tmp ssh.log
 # @TEST-EXEC: btest-diff ssh.log
 
 redef LogAscii::separator = "||";
@@ -28,6 +28,5 @@ event zeek_init()
 	Log::write(SSH::LOG, [$t=network_time(), $id=cid, $status="failure", $country="US"]);
 	Log::write(SSH::LOG, [$t=network_time(), $id=cid, $status="fa||ure", $country="UK"]);
 	Log::write(SSH::LOG, [$t=network_time(), $id=cid, $status="su||ess", $country="BR"]);
-	Log::write(SSH::LOG, [$t=network_time(), $id=cid, $status="failure", $country="MX"]);	
+	Log::write(SSH::LOG, [$t=network_time(), $id=cid, $status="failure", $country="MX"]);
 }
-

--- a/testing/btest/scripts/base/frameworks/logging/rotate-custom-fmt-func.zeek
+++ b/testing/btest/scripts/base/frameworks/logging/rotate-custom-fmt-func.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: zeek -b -r ${TRACES}/rotation.trace %INPUT | egrep "test|test2" | sort >out.tmp
+# @TEST-EXEC: zeek -b -r ${TRACES}/rotation.trace %INPUT | grep -E "test|test2" | sort >out.tmp
 # @TEST-EXEC: cat out.tmp pp.log | sort >out
 # @TEST-EXEC: for i in `ls test*.log | sort`; do printf '> %s\n' $i; cat $i; done | sort | $SCRIPTS/diff-remove-timestamps | uniq >>out
 # @TEST-EXEC: btest-diff out

--- a/testing/btest/scripts/base/frameworks/logging/rotate-custom.zeek
+++ b/testing/btest/scripts/base/frameworks/logging/rotate-custom.zeek
@@ -1,5 +1,5 @@
 #
-# @TEST-EXEC: zeek -b -r ${TRACES}/rotation.trace %INPUT | egrep "test|test2" | sort >out.tmp
+# @TEST-EXEC: zeek -b -r ${TRACES}/rotation.trace %INPUT | grep -E "test|test2" | sort >out.tmp
 # @TEST-EXEC: cat out.tmp pp.log | sort >out
 # @TEST-EXEC: for i in `ls test*.log | sort`; do printf '> %s\n' $i; cat $i; done | sort | $SCRIPTS/diff-remove-timestamps | uniq >>out
 # @TEST-EXEC: btest-diff out

--- a/testing/external/scripts/diff-all
+++ b/testing/external/scripts/diff-all
@@ -27,7 +27,7 @@ for i in $(echo $files_cwd $files_baseline | sort | uniq); do
         if [[ "$i" == "reporter.log" ]]; then
             # Do not diff the reporter.log if it only complains about missing
             # GeoIP support or database.
-            if ! egrep -v "^#|Zeek was not configured for GeoIP support|Failed to open GeoIP" $i; then
+            if ! grep -E -v "^#|Zeek was not configured for GeoIP support|Failed to open GeoIP" $i; then
                 continue
             fi
         fi


### PR DESCRIPTION
One of the CI builds from the Microsoft work started reporting the following error:

```
  == File ===============================
  egrep: warning: egrep is obsolescent; using grep -E
```

This only happens on the opensuse-tumbleweed build, but the `-E` flag for grep should exist on every supported platform at this point. There's some other usages in submodules but this fixes the btest failures inside of the main repo, so those are less important.