### PR TITLE
fuzzer-setup: Update ZEEKPATH to align with DEFAULT_ZEEKPATH

### DIFF
--- a/src/fuzzers/fuzzer-setup.h
+++ b/src/fuzzers/fuzzer-setup.h
@@ -22,7 +22,8 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
 		auto fuzzer_dir = zeek::util::SafeDirname(fuzzer_path).result;
 		std::string fs = zeek::util::fmt("%s/%s", fuzzer_dir.data(), oss_fuzz_scripts);
 		auto p = fs.data();
-		auto oss_fuzz_zeekpath = zeek::util::fmt(".:%s:%s/policy:%s/site", p, p, p);
+		auto oss_fuzz_zeekpath = zeek::util::fmt(".:%s:%s/policy:%s/site:%s/builtin-plugins", p, p,
+		                                         p, p);
 
 		if ( setenv("ZEEKPATH", oss_fuzz_zeekpath, true) == -1 )
 			abort();


### PR DESCRIPTION
The util-config.h file uses @DEFAULT_ZEEKPATH@ which includes the builtin-plugins directory. Do the same change for the fuzzers so that scripts from builtin plugins can be found.

Fixes #2540