### PR TITLE
zeekygen/normalize_script_path: Special case plugin dirnames without _

### DIFF
--- a/src/zeekygen/utils.cc
+++ b/src/zeekygen/utils.cc
@@ -146,6 +146,16 @@ std::string normalize_script_path(std::string_view path)
 		{
 		auto rval = util::detail::normalize_path(path);
 		auto prefix = util::SafeBasename(p->PluginDirectory()).result;
+
+		// Collision avoidance when there's no _ in the plugin basename such
+		// as when using ./build within a plugin checkout for testing. Include
+		// the parent in the normalized path assuming it's unique.
+		if ( prefix.find('_') == std::string::npos )
+			{
+			auto parent = util::SafeBasename(util::SafeDirname(p->PluginDirectory()).result).result;
+			prefix = parent + "/" + prefix;
+			}
+
 		return prefix + "/" + rval.substr(p->PluginDirectory().size() + 1);
 		}
 


### PR DESCRIPTION
In normal installations, a plugin's basename has an underscore in it to separate the namespace from the plugin name. E.g Zeek_Spicy. When there is no underscore, this is most likely due to ./build being picked up when using ZEEK_PLUGIN_PATH. The basename ends-up "build" and is susceptible to collisions.

Prepend one parent directory as a heuristic to make this scenario less likely, assuming ./build is usually below a repository checkout that uniquely identifies the plugin.

Fixes #2577