### PR TITLE
Make dependency of `zeek` on spicy-plugin's driver object file explicit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -863,6 +863,10 @@ CheckOptionalBuildSources(auxil/zeek-archiver ZeekArchiver INSTALL_ZEEK_ARCHIVER
 CheckOptionalBuildSources(auxil/zeek-client ZeekClient INSTALL_ZEEK_CLIENT)
 
 if ( NOT DISABLE_SPICY )
+    # The `zeek` binary implicitly depends on the driver object file built
+    # as part of `spicy`; make that dependency explicit.
+    add_dependencies(zeek spicyz)
+
     if ( NOT SPICY_ROOT_DIR )
         list(APPEND _spicy_rt_libs spicy-rt hilti-rt)
 


### PR DESCRIPTION
For generators like Makefile the implicit dependency would not have been apparent to `make` which could have lead to build failures (depending on the way targets were scheduled). This patch makes the dependency explicit so it can be enforced.

Closes #2586.