### PR TITLE
ssh: Test for c$ssh$analyzer_id existence

### DIFF
--- a/scripts/base/protocols/ssh/main.zeek
+++ b/scripts/base/protocols/ssh/main.zeek
@@ -249,7 +249,7 @@ event ssh_auth_attempted(c: connection, authenticated: bool) &priority=5
 	c$ssh$auth_success = authenticated;
 	c$ssh$auth_attempts += 1;
 
-	if ( authenticated && disable_analyzer_after_detection )
+	if ( authenticated && disable_analyzer_after_detection && c$ssh?$analyzer_id )
 		disable_analyzer(c$id, c$ssh$analyzer_id);
 	}
 


### PR DESCRIPTION
While unusual, analyzer_confirmation() may never be called for the SSH analyzer, but still ssh_auth_attempted is invoked later indicating successful authentication. I haven't checked how that is actually possible, but seems prudent to check for the existence of c$ssh$analyzer_id before referencing it (also in light of runtime enable/disabling of events).

This was found testing Tim's all-the-fuzzing branch on large system, merging this should avoid oss-fuzz telling us about it right away.

    $ zeek -C -r ./e83db.pcap 'DPD::ignore_violations+={ Analyzer::ANALYZER_SSH }'
    1668610572.429058 expression error in scripts/base/protocols/ssh/./main.zeek, line 260: field value missing (SSH::c$ssh$analyzer_id)