### PR TITLE
smb1: Ensure existence of dialect_index in offered dialects

### DIFF
--- a/scripts/base/protocols/smb/smb1-main.zeek
+++ b/scripts/base/protocols/smb/smb1-main.zeek
@@ -89,9 +89,10 @@ event smb1_negotiate_response(c: connection, hdr: SMB1::Header, response: SMB1::
 	{
 	if ( c$smb_state$current_cmd?$smb1_offered_dialects )
 		{
-		if ( response?$ntlm )
+		local offered_dialects = c$smb_state$current_cmd$smb1_offered_dialects;
+		if ( response?$ntlm && response$ntlm$dialect_index < |offered_dialects| )
 			{
-			c$smb_state$current_cmd$argument = c$smb_state$current_cmd$smb1_offered_dialects[response$ntlm$dialect_index];
+			c$smb_state$current_cmd$argument = offered_dialects[response$ntlm$dialect_index];
 			}
 
 		delete c$smb_state$current_cmd$smb1_offered_dialects;


### PR DESCRIPTION
When a negotiate request offers no dialects, but the response contains an ntlm record which selects a dialect, a script error is triggered.

    $ zeek -C -r ./f2b0e.pcap 'DPD::ignore_violations+={ Analyzer::ANALYZER_SMB }'
    1668615340.837882 expression error in /home/awelzel/corelight-oss/zeek/scripts/base/protocols/smb/./smb1-main.zeek, line 96: no such index (SMB1::c$smb_state$current_cmd$smb1_offered_dialects[SMB1::response$ntlm$dialect_index])

Script error triggered by fuzzing when testing Tim's all-the-fuzzing branch.