### PR TITLE
Fix warning in broker.web-socket-events btest

### DIFF
--- a/testing/btest/broker/web-socket-events.zeek
+++ b/testing/btest/broker/web-socket-events.zeek
@@ -45,7 +45,7 @@ event Broker::peer_lost(endpoint: Broker::EndpointInfo, msg: string)
     terminate();
     }
 
-event pong(msg: string, n: count)
+event pong(msg: string, n: count) &is_used
     {
     print fmt("sender got pong: %s, %s", msg, n);
     send_event();


### PR DESCRIPTION
Running the `broker.web-socket-events` btest currently emits a warning that "pong" never emits, but that's only because we trigger it via a Broker message (by sending JSON over WebSocket) that the usage checker cannot see.