### PR TITLE
Fix the strcasestr unit test

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1375,14 +1375,14 @@ char* strcasestr(const char* s, const char* find)
 TEST_CASE("util strcasestr")
 	{
 	const char* s = "this is a string";
-	const char* out = strcasestr(s, "is");
+	const char* out = strcasestr(s, "is a");
 	CHECK(strcmp(out, "is a string") == 0);
 
-	const char* out2 = strcasestr(s, "IS");
+	const char* out2 = strcasestr(s, "Is A");
 	CHECK(strcmp(out2, "is a string") == 0);
 
 	const char* out3 = strcasestr(s, "not there");
-	CHECK(strcmp(out2, s) == 0);
+	CHECK(out3 == nullptr);
 	}
 
 #endif


### PR DESCRIPTION
We apparently don't have a platform that runs this unit test other than Windows, so we never noticed that the tests were actually wrong. This fixes the values we pass in to strcasestr to make them more worthwhile tests, plus fixes one check for null.