### PR TITLE
Fix logic error in vfmt() when growing the buffer

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1630,7 +1630,7 @@ const char* vfmt(const char* format, va_list al)
 	va_copy(alc, al);
 	int n = vsnprintf(buf, buf_len, format, al);
 
-	if ( n > 0 && buf_len < n )
+	if ( n > 0 && buf_len <= n )
 		{ // Not enough room, grow the buffer.
 		buf_len = n + 32;
 		buf = (char*)safe_realloc(buf, buf_len);


### PR DESCRIPTION
This was changed in a8fc63e (the merge of microsoft/master) introducing a logic error and not growing the buffer when n==buf_len.  We hit this when compiling very large regexs, but vfmt() is used in a couple other places too I think.