### PR TITLE
docker/ecr: Push into zeek/zeek, not zeekurity/zeek

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,7 +106,7 @@ jobs:
             CONFFLAGS=${{ env.CONFFLAGS }}
           push: true
           tags: |
-            public.ecr.aws/zeekurity/${{ steps.target.outputs.tag }}
+            public.ecr.aws/zeek/${{ steps.target.outputs.tag }}
             docker.io/zeekurity/${{ steps.target.outputs.tag }}
 
       - name: Preserve image artifact


### PR DESCRIPTION
As discussed on #2248. Also aligns with what Spicy does.
