### PR TITLE
Additional script optimization fixes

### DIFF
--- a/src/script_opt/CPP/Attrs.cc
+++ b/src/script_opt/CPP/Attrs.cc
@@ -49,7 +49,15 @@ shared_ptr<CPP_InitInfo> CPPCompile::RegisterAttr(const AttrPtr& attr)
 
 	const auto& e = a->GetExpr();
 	if ( e && ! IsSimpleInitExpr(e) )
-		init_exprs.AddKey(e, p_hash(e));
+		{
+		auto h = p_hash(e);
+
+		// Include the type in the hash, otherwise expressions
+		// like "vector()" are ambiguous.
+		h = merge_p_hashes(h, p_hash(e->GetType()));
+
+		init_exprs.AddKey(e, h);
+		}
 
 	auto gi = make_shared<AttrInfo>(this, attr);
 	attr_info->AddInstance(gi);

--- a/src/script_opt/CPP/CPP-load.bif
+++ b/src/script_opt/CPP/CPP-load.bif
@@ -29,15 +29,7 @@ function load_CPP%(h: count%): bool
 		return zeek::val_mgr->False();
 		}
 
-	// Ensure that any compiled scripts are used.  If instead
-	// the AST is used, then when we activate the standalone
-	// scripts, they won't be able to avoid installing redundant
-	// event handlers.
-	detail::analysis_options.use_CPP = true;
-
-	// Mark this script as one we should activate after loading
-	// compiled scripts.
-	detail::standalone_activations.push_back(cb->second);
+	(*cb->second)();
 
 	return zeek::val_mgr->True();
 	%}

--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -869,7 +869,13 @@ string CPPCompile::GenUnary(const Expr* e, GenType gt, const char* op, const cha
 	if ( e->GetType()->Tag() == TYPE_VECTOR )
 		return GenVectorOp(e, GenExpr(e->GetOp1(), GEN_NATIVE), vec_op);
 
-	return NativeToGT(string(op) + "(" + GenExpr(e->GetOp1(), GEN_NATIVE) + ")", e->GetType(), gt);
+	// Look for coercions that the interpreter does implicitly.
+	auto op1 = e->GetOp1();
+	if ( op1->GetType()->Tag() == TYPE_COUNT &&
+	     (e->Tag() == EXPR_POSITIVE || e->Tag() == EXPR_NEGATE) )
+		op1 = make_intrusive<ArithCoerceExpr>(op1, TYPE_INT);
+
+	return NativeToGT(string(op) + "(" + GenExpr(op1, GEN_NATIVE) + ")", e->GetType(), gt);
 	}
 
 string CPPCompile::GenBinary(const Expr* e, GenType gt, const char* op, const char* vec_op)

--- a/src/script_opt/CPP/Func.cc
+++ b/src/script_opt/CPP/Func.cc
@@ -15,7 +15,7 @@ using namespace std;
 unordered_map<p_hash_type, CompiledScript> compiled_scripts;
 unordered_map<string, unordered_set<p_hash_type>> added_bodies;
 unordered_map<p_hash_type, void (*)()> standalone_callbacks;
-vector<void (*)()> standalone_activations;
+vector<void (*)()> standalone_finalizations;
 
 void CPPFunc::Describe(ODesc* d) const
 	{

--- a/src/script_opt/CPP/Func.h
+++ b/src/script_opt/CPP/Func.h
@@ -119,9 +119,8 @@ extern std::unordered_map<std::string, std::unordered_set<p_hash_type>> added_bo
 // Maps hashes to standalone script initialization callbacks.
 extern std::unordered_map<p_hash_type, void (*)()> standalone_callbacks;
 
-// Standalone callbacks marked for activation by calls to the
-// load_CPP() BiF.
-extern std::vector<void (*)()> standalone_activations;
+// Callbacks to finalize initialization of standalone compiled scripts.
+extern std::vector<void (*)()> standalone_finalizations;
 
 	} // namespace detail
 

--- a/src/script_opt/CPP/Inits.cc
+++ b/src/script_opt/CPP/Inits.cc
@@ -331,8 +331,8 @@ void CPPCompile::GenStandaloneActivation()
 	Emit("void standalone_init__CPP()");
 	StartBlock();
 	Emit("init__CPP();");
-	Emit("CPP_activation_funcs.push_back(standalone_activation__CPP);");
-	Emit("CPP_activation_hook = activate__CPPs;");
+	Emit("standalone_activation__CPP();");
+	Emit("standalone_finalizations.push_back(load_BiFs__CPP);");
 	EndBlock();
 	}
 

--- a/src/script_opt/CPP/RuntimeInitSupport.h
+++ b/src/script_opt/CPP/RuntimeInitSupport.h
@@ -23,12 +23,6 @@ using CPP_init_func = void (*)();
 // Tracks the initialization hooks for different compilation runs.
 extern std::vector<CPP_init_func> CPP_init_funcs;
 
-// Tracks the activation hooks for different "standalone" compilations.
-extern std::vector<CPP_init_func> CPP_activation_funcs;
-
-// Activates all previously registered standalone code.
-extern void activate__CPPs();
-
 // Registers the given global type, if not already present.
 extern void register_type__CPP(TypePtr t, const std::string& name);
 
@@ -38,6 +32,10 @@ extern void register_type__CPP(TypePtr t, const std::string& name);
 // function body is going to be used.
 extern void register_body__CPP(CPPStmtPtr body, int priority, p_hash_type hash,
                                std::vector<std::string> events, void (*finish_init)());
+
+// Same but for standalone function bodies.
+extern void register_standalone_body__CPP(CPPStmtPtr body, int priority, p_hash_type hash,
+                                          std::vector<std::string> events, void (*finish_init)());
 
 // Registers a lambda body as associated with the given hash.  Includes
 // the name of the lambda (so it can be made available as a quasi-global

--- a/src/script_opt/CPP/Stmts.cc
+++ b/src/script_opt/CPP/Stmts.cc
@@ -11,6 +11,10 @@ using namespace std;
 
 void CPPCompile::GenStmt(const Stmt* s)
 	{
+	auto loc = s->GetLocationInfo();
+	if ( loc != &detail::no_location && s->Tag() != STMT_LIST )
+		Emit("// %s:%s", loc->filename, to_string(loc->first_line));
+
 	switch ( s->Tag() )
 		{
 		case STMT_INIT:

--- a/src/script_opt/CPP/Tracker.cc
+++ b/src/script_opt/CPP/Tracker.cc
@@ -16,9 +16,6 @@ template <class T> void CPPTracker<T>::AddKey(IntrusivePtr<T> key, p_hash_type h
 	if ( HasKey(key) )
 		return;
 
-	if ( h == 0 )
-		h = Hash(key);
-
 	if ( map2.count(h) == 0 )
 		{
 		auto index = keys.size();
@@ -55,16 +52,6 @@ template <class T> string CPPTracker<T>::KeyName(const T* key)
 		full_name = base_name + "_" + ind + "__CPP";
 
 	return full_name;
-	}
-
-template <class T> p_hash_type CPPTracker<T>::Hash(IntrusivePtr<T> key) const
-	{
-	ODesc d;
-	d.SetDeterminism(true);
-	key->Describe(&d);
-	string desc = d.Description();
-	auto h = hash<string>{}(base_name + desc);
-	return p_hash_type(h);
 	}
 
 // Instantiate the templates we'll need.

--- a/src/script_opt/CPP/Tracker.h
+++ b/src/script_opt/CPP/Tracker.h
@@ -35,9 +35,8 @@ public:
 	bool HasKey(const T* key) const { return map.count(key) > 0; }
 	bool HasKey(IntrusivePtr<T> key) const { return HasKey(key.get()); }
 
-	// Only adds the key if it's not already present.  If a hash
-	// is provided, then refrains from computing it.
-	void AddKey(IntrusivePtr<T> key, p_hash_type h = 0);
+	// Only adds the key if it's not already present.
+	void AddKey(IntrusivePtr<T> key, p_hash_type h);
 
 	void AddInitInfo(const T* rep, std::shared_ptr<CPP_InitInfo> gi) { gi_s[rep] = std::move(gi); }
 
@@ -58,9 +57,6 @@ public:
 	const T* GetRep(IntrusivePtr<T> key) { return GetRep(key.get()); }
 
 private:
-	// Compute a hash for the given key.
-	p_hash_type Hash(IntrusivePtr<T> key) const;
-
 	// Maps keys to internal representations (i.e., hashes).
 	std::unordered_map<const T*, p_hash_type> map;
 

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -418,13 +418,8 @@ static void use_CPP()
 			}
 		}
 
-	if ( num_used == 0 && standalone_activations.empty() )
+	if ( num_used == 0 )
 		reporter->FatalError("no C++ functions found to use");
-
-	// Now that we've loaded all of the compiled scripts
-	// relevant for the AST, activate standalone ones.
-	for ( auto cb : standalone_activations )
-		(*cb)();
 	}
 
 static void generate_CPP(std::unique_ptr<ProfileFuncs>& pfs)
@@ -528,13 +523,12 @@ static void analyze_scripts_for_ZAM(std::unique_ptr<ProfileFuncs>& pfs)
 
 void analyze_scripts(bool no_unused_warnings)
 	{
-	static bool did_init = false;
+	init_options();
 
-	if ( ! did_init )
-		{
-		init_options();
-		did_init = true;
-		}
+	// Any standalone compiled scripts have already been instantiated
+	// at this point, but may require post-loading-of-scripts finalization.
+	for ( auto cb : standalone_finalizations )
+		(*cb)();
 
 	std::unique_ptr<UsageAnalyzer> ua;
 	if ( ! no_unused_warnings )

--- a/src/script_opt/ZAM/Low-Level.cc
+++ b/src/script_opt/ZAM/Low-Level.cc
@@ -72,11 +72,16 @@ int ZAMCompiler::InternalAddVal(ZInstAux* zi, int i, Expr* e)
 		auto& indices = e->GetOp1()->AsListExpr()->Exprs();
 		auto val = e->GetOp2();
 		int width = indices.length();
+		int num_vals;
 
 		for ( int j = 0; j < width; ++j )
-			ASSERT(InternalAddVal(zi, i + j, indices[j]) == 1);
+			{
+			num_vals = InternalAddVal(zi, i + j, indices[j]);
+			ASSERT(num_vals == 1);
+			}
 
-		ASSERT(InternalAddVal(zi, i + width, val.get()) == 1);
+		num_vals = InternalAddVal(zi, i + width, val.get());
+		ASSERT(num_vals == 1);
 
 		return width + 1;
 		}
@@ -87,7 +92,10 @@ int ZAMCompiler::InternalAddVal(ZInstAux* zi, int i, Expr* e)
 		int width = indices.length();
 
 		for ( int j = 0; j < width; ++j )
-			ASSERT(InternalAddVal(zi, i + j, indices[j]) == 1);
+			{
+			int num_vals = InternalAddVal(zi, i + j, indices[j]);
+			ASSERT(num_vals == 1);
+			}
 
 		return width;
 		}


### PR DESCRIPTION
 This is a collection of tweaks for script optimization.  The fixes are mainly for `-O gen-C++`: a new initialization model for `-O gen-standalone-C++`, a fix for converting `count` values to `int`, and disambiguation for empty constructors that return different types.  There's also a ZAM fix for C++ optimizers that discard the entire contents of `ASSERT`s.
