### PR TITLE
tighten type equivalence for vector constructors

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -3977,7 +3977,7 @@ VectorConstructorExpr::VectorConstructorExpr(ListExprPtr constructor_list, TypeP
 			return;
 			}
 
-		if ( auto t = merge_type_list(op->AsListExpr()) )
+		if ( auto t = maximal_type(op->AsListExpr()) )
 			SetType(make_intrusive<VectorType>(std::move(t)));
 		else
 			{

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -2673,6 +2673,31 @@ TypePtr merge_types(const TypePtr& arg_t1, const TypePtr& arg_t2)
 		}
 	}
 
+TypePtr merge_type_list(detail::ListExpr* elements)
+	{
+	TypeList* tl_type = elements->GetType()->AsTypeList();
+	const auto& tl = tl_type->GetTypes();
+
+	if ( tl.size() < 1 )
+		{
+		reporter->Error("no type can be inferred for empty list");
+		return nullptr;
+		}
+
+	auto t = tl[0];
+
+	if ( tl.size() == 1 )
+		return t;
+
+	for ( size_t i = 1; t && i < tl.size(); ++i )
+		t = merge_types(t, tl[i]);
+
+	if ( ! t )
+		reporter->Error("inconsistent types in list");
+
+	return t;
+	}
+
 TypePtr maximal_type(detail::ListExpr* elements)
 	{
 	TypeList* tl_type = elements->GetType()->AsTypeList();

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -63,11 +63,6 @@ const char* type_name(TypeTag t)
 	return type_names[int(t)];
 	}
 
-// Given two types, returns the "merge", in which promotable types
-// are promoted to the maximum of the two.  Returns nil (and generates
-// an error message) if the types are incompatible.
-static TypePtr merge_types(const TypePtr& t1, const TypePtr& t2);
-
 Type::Type(TypeTag t, bool arg_base_type)
 	: tag(t), internal_tag(to_internal_type_tag(tag)), is_network_order(zeek::is_network_order(t)),
 	  base_type(arg_base_type)
@@ -2696,7 +2691,7 @@ TypePtr maximal_type(detail::ListExpr* elements)
 
 	for ( size_t i = 1; t && i < tl.size(); ++i )
 		{
-		auto& tl_i = tl[i];
+		const auto& tl_i = tl[i];
 
 		if ( t == tl_i )
 			continue;

--- a/src/Type.h
+++ b/src/Type.h
@@ -923,15 +923,10 @@ extern Type* flatten_type(Type* t);
 // Returns the "maximum" of two type tags, in a type-promotion sense.
 extern TypeTag max_type(TypeTag t1, TypeTag t2);
 
-// Given two types, returns the "merge", in which promotable types
-// are promoted to the maximum of the two.  Returns nil (and generates
-// an error message) if the types are incompatible.
-TypePtr merge_types(const TypePtr& t1, const TypePtr& t2);
-
-// Given a list of expressions, returns a (ref'd) type reflecting
-// a merged type consistent across all of them, or nil if this
-// cannot be done.
-TypePtr merge_type_list(detail::ListExpr* elements);
+// Given a list of expressions, returns the maximal type consistent across
+// all of them, or nil if this cannot be done.  "Maximal" incorporates
+// notions of arithmetic coercion, but otherwise requires type-equivalence.
+TypePtr maximal_type(detail::ListExpr* elements);
 
 // Given an expression, infer its type when used for an initialization.
 TypePtr init_type(const detail::ExprPtr& init);

--- a/src/Type.h
+++ b/src/Type.h
@@ -928,6 +928,12 @@ extern TypeTag max_type(TypeTag t1, TypeTag t2);
 // an error message) if the types are incompatible.
 TypePtr merge_types(const TypePtr& t1, const TypePtr& t2);
 
+// Given a list of expressions, returns a (ref'd) type reflecting
+// a merged type consistent across all of them, or nil if this
+// cannot be done.
+[[deprecated("Remove in v6.1. Use maximal_type() if possible. See GH-2604.")]] TypePtr
+merge_type_list(detail::ListExpr* elements);
+
 // Given a list of expressions, returns the maximal type consistent across
 // all of them, or nil if this cannot be done.  "Maximal" incorporates
 // notions of arithmetic coercion, but otherwise requires type-equivalence.

--- a/src/Type.h
+++ b/src/Type.h
@@ -923,6 +923,11 @@ extern Type* flatten_type(Type* t);
 // Returns the "maximum" of two type tags, in a type-promotion sense.
 extern TypeTag max_type(TypeTag t1, TypeTag t2);
 
+// Given two types, returns the "merge", in which promotable types
+// are promoted to the maximum of the two.  Returns nil (and generates
+// an error message) if the types are incompatible.
+TypePtr merge_types(const TypePtr& t1, const TypePtr& t2);
+
 // Given a list of expressions, returns the maximal type consistent across
 // all of them, or nil if this cannot be done.  "Maximal" incorporates
 // notions of arithmetic coercion, but otherwise requires type-equivalence.

--- a/testing/btest/Baseline/language.vector-coerce-expr2/output
+++ b/testing/btest/Baseline/language.vector-coerce-expr2/output
@@ -3,3 +3,13 @@
 [11, 5, , 107, , , 1046]
 [-2, -4, , -7, , -18, -999]
 [, -1, 11, 15]
+[connT
+{ 
+return (T);
+}, connF
+{ 
+return (F);
+}, connMaybe
+{ 
+return (c$id$orig_p < c$id$resp_p);
+}]

--- a/testing/btest/language/vector-coerce-expr2.zeek
+++ b/testing/btest/language/vector-coerce-expr2.zeek
@@ -51,3 +51,30 @@ event zeek_init()
 
 	print d;
 	}
+
+type recursive: record {
+	placeholder: bool;
+};
+
+redef record recursive += { rec: table[count] of recursive &optional; };
+
+function connT(c: connection, r: recursive): bool
+	{
+	return T;
+	}
+
+function connF(c: connection, r: recursive): bool
+	{
+	return F;
+	}
+
+function connMaybe(c: connection, r: recursive): bool
+	{
+	return c$id$orig_p < c$id$resp_p;
+	}
+
+event zeek_init()
+	{
+	local v = vector(connT, connF, connMaybe);
+	print v;
+	}


### PR DESCRIPTION
The impetus behind this PR was discovering that using recursive types in vector constructors resulted in crashes due to infinite recursion while trying to "merge" the types to come up with the final type to associate with the constructed vector.  (FYI, this comes up in a practical context when constructing a vector of functions that take `connection` records, as those are recursive unless using `-b` bare mode due to connection `RemovalHook`s.)

Rather than changing the merge code to catch such recursion - which is conceptually tricky, as the merge needs to create a new type, rather than just returning a verdict as in the somewhat similar situation for `same_type()` - this change only allows type variation in vector constructors for arithmetic types directly present.  Use of any other type must match directly, which seems like a reasonable enough restriction.

The PR includes a new BTest test case that crashes earlier versions of Zeek.