### PR TITLE
ci/alpine: Use musl-fts-dev rather than fts-dev

### DIFF
--- a/ci/alpine/Dockerfile
+++ b/ci/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20221201
 
 RUN apk add --no-cache \
   bash \
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
   cmake \
   curl \
   flex-dev \
-  fts-dev \
+  musl-fts-dev \
   g++ \
   git \
   libpcap-dev \


### PR DESCRIPTION
With the release of alpine 3.17 (2022-11-22), the fts-dev package was renamed to musl-fts-dev. Change it accordingly.

This is currently breaking CI in a fork of zeek/zeek. Suspect some caching prevents it from breaking here currently.

Alpine 3.16 is still supported till 2024-05-23, but we're essentially not doing CI testing for it anymore. Appears to be in line with the comment in .cirrus.yml