### PR TITLE
CMakeLists: Disable gold detection for bundled spicy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,6 +548,7 @@ endif ()
 
 if ( NOT DISABLE_SPICY )
     if ( NOT SPICY_ROOT_DIR )
+        set(USE_GOLD OFF)
         add_subdirectory(auxil/spicy)
 
         # Set variables used by the spicy-plugin build since we are building Spicy


### PR DESCRIPTION
Two reasons. First, it is surprising that built-in Spicy is using a different linker than the Zeek build. Second, when the gold linker is installed, Spicy will ignore any -fuse-ld= option provided in LDFLAGS due to always appending -fuse-ld=gold to its linker flags. This avoids both scenarios.

See also zeek/spicy#1308