### PR TITLE
dfa: Remove transition_counter

### DIFF
--- a/src/DFA.cc
+++ b/src/DFA.cc
@@ -11,8 +11,6 @@
 namespace zeek::detail
 	{
 
-unsigned int DFA_State::transition_counter = 0;
-
 DFA_State::DFA_State(int arg_state_num, const EquivClass* ec, NFA_state_list* arg_nfa_states,
                      AcceptingSet* arg_accept)
 	{

--- a/src/DFA.h
+++ b/src/DFA.h
@@ -68,8 +68,6 @@ protected:
 	NFA_state_list* nfa_states;
 	EquivClass* meta_ec; // which ec's make same transition
 	DFA_State* mark;
-
-	static unsigned int transition_counter; // see Xtion()
 	};
 
 using DigestStr = std::basic_string<u_char>;


### PR DESCRIPTION
I believe that's unused since 2011 (8eb241fde76f5d817b96a6179aa32b7e7a0055e3).
