### PR TITLE
Docker Hub: Push images to zeek/zeek and zeek/zeek-dev

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,6 +108,7 @@ jobs:
           tags: |
             public.ecr.aws/zeek/${{ steps.target.outputs.tag }}
             docker.io/zeekurity/${{ steps.target.outputs.tag }}
+            docker.io/zeek/${{ steps.target.outputs.tag }}
 
       - name: Preserve image artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
We may want to copy some of the current feature and lts releases over to zeek/zeek by hand, but for now see if pushing works out for zeek/zeek-dev, mainly.