### PR TITLE
Fix sprintf warnings on macOS

### DIFF
--- a/src/DFA.cc
+++ b/src/DFA.cc
@@ -231,16 +231,17 @@ void DFA_State::Dump(FILE* f, DFA_Machine* m)
 			if ( xtions[i] != s )
 				break;
 
-		char xbuf[512];
+		constexpr int xbuf_size = 512;
+		char* xbuf = new char[xbuf_size];
 
 		int r = m->Rep(sym);
 		if ( ! r )
 			r = '.';
 
 		if ( i == sym + 1 )
-			sprintf(xbuf, "'%c'", r);
+			snprintf(xbuf, xbuf_size, "'%c'", r);
 		else
-			sprintf(xbuf, "'%c'-'%c'", r, m->Rep(i - 1));
+			snprintf(xbuf, xbuf_size, "'%c'-'%c'", r, m->Rep(i - 1));
 
 		if ( s == DFA_UNCOMPUTED_STATE_PTR )
 			fprintf(f, "%stransition on %s to <uncomputed>", ++num_trans == 1 ? "\t" : "\n\t",
@@ -248,6 +249,8 @@ void DFA_State::Dump(FILE* f, DFA_Machine* m)
 		else
 			fprintf(f, "%stransition on %s to state %d", ++num_trans == 1 ? "\t" : "\n\t", xbuf,
 			        s->StateNum());
+
+		delete[] xbuf;
 
 		sym = i - 1;
 		}

--- a/src/Dict.h
+++ b/src/Dict.h
@@ -992,7 +992,7 @@ public:
 		if ( binary )
 			{
 			char key = char(random() % 26) + 'A';
-			sprintf(key_file, "%d.%d-%c.key", Length(), max_distance, key);
+			snprintf(key_file, 100, "%d.%d-%c.key", Length(), max_distance, key);
 			std::ofstream f(key_file, std::ios::binary | std::ios::out | std::ios::trunc);
 			for ( int idx = 0; idx < Capacity(); idx++ )
 				if ( ! table[idx].Empty() )
@@ -1005,7 +1005,7 @@ public:
 		else
 			{
 			char key = char(random() % 26) + 'A';
-			sprintf(key_file, "%d.%d-%d.ckey", Length(), max_distance, key);
+			snprintf(key_file, 100, "%d.%d-%d.ckey", Length(), max_distance, key);
 			std::ofstream f(key_file, std::ios::out | std::ios::trunc);
 			for ( int idx = 0; idx < Capacity(); idx++ )
 				if ( ! table[idx].Empty() )

--- a/src/ZeekString.cc
+++ b/src/ZeekString.cc
@@ -215,7 +215,7 @@ char* String::Render(int format, int* len) const
 
 			*sp++ = '\\';
 			*sp++ = 'x';
-			sprintf(hex_fmt, "%02x", b[i]);
+			snprintf(hex_fmt, 16, "%02x", b[i]);
 			*sp++ = hex_fmt[0];
 			*sp++ = hex_fmt[1];
 			}

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -733,7 +733,7 @@ function string_to_ascii_hex%(s: string%): string
 	const u_char* sp = s->Bytes();
 
 	for ( int i = 0; i < s->Len(); ++i )
-		sprintf(x + i * 2, "%02x", sp[i]);
+		snprintf(x + i * 2, 3, "%02x", sp[i]);
 
 	return zeek::make_intrusive<zeek::StringVal>(new zeek::String(1, (u_char*) x, s->Len() * 2));
 	%}

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -452,9 +452,10 @@ static bool prepare_environment(zeek::TableVal* tbl, bool set)
 static int do_system(const char* s)
 	{
 	const char* system_fmt = "(%s) 1>&2 &";	// output to stderr
-	char* cmd = new char[strlen(system_fmt) + strlen(s) + 1];
+	auto cmd_len = strlen(system_fmt) + strlen(s) + 1;
+	char* cmd = new char[cmd_len];
 
-	sprintf(cmd, system_fmt, s);
+	snprintf(cmd, cmd_len, system_fmt, s);
 	int status = system(cmd);
 	delete [] cmd;
 


### PR DESCRIPTION
The most recent compiler update for macOS marked sprintf as deprecated, so we started getting warnings from all of the places that use it. @vpax recently fixed a few of these in binpac (see https://github.com/zeek/binpac/pull/24). This PR fixes the ones in Zeek itself.