### PR TITLE
Fixes to support the Npcap library on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,10 +71,13 @@ if ( MSVC )
     endif()
 
     # Set LibPCAP to point to libpcap binaries.
-    find_package(libpcap)
-    set(PCAP_ROOT_DIR "${libpcap_LIB_DIRS}/../")
-    set(PCAP_INCLUDE_DIR ${libpcap_INCLUDES})
-    set(PCAP_LIBRARY ${libpcap_LIBS})
+    if ( NOT PCAP_ROOT_DIR )
+        find_package(libpcap)
+        set(PCAP_ROOT_DIR "${libpcap_LIB_DIRS}/../")
+        set(PCAP_INCLUDE_DIR ${libpcap_INCLUDES})
+        set(PCAP_LIBRARY ${libpcap_LIBS})
+    endif()
+
     set(LIBPCAP_PCAP_COMPILE_NOPCAP_HAS_ERROR_PARAMETER false)
 
     # Set ZLib to point at the right variable.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -543,6 +543,15 @@ if (ZEEK_STANDALONE)
                 ${bro_SUBDIR_LIBS}
                 ${bro_PLUGIN_LIBS}
     )
+
+    # npcap/winpcap need to be loaded in delayed mode so that we can set the load path
+    # correctly at runtime. See https://npcap.com/guide/npcap-devguide.html#npcap-feature-native
+    # for why this is necessary.
+    if ( MSVC AND HAVE_WPCAP )
+        set(zeekdeps ${zeekdeps} delayimp.lib)
+        set_target_properties(zeek PROPERTIES LINK_FLAGS "/DELAYLOAD:wpcap.dll")
+    endif()
+
     target_link_libraries(zeek ${bro_PLUGIN_LINK_LIBS} ${zeekdeps} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 
     # Export symbols from zeek executable for use by plugins

--- a/zeek-config.h.in
+++ b/zeek-config.h.in
@@ -54,6 +54,9 @@
 /* Define if libpcap supports pcap_dump_open_append(). */
 #cmakedefine HAVE_PCAP_DUMP_OPEN_APPEND
 
+/* Define if the pcap library is winpcap or npcap */
+#cmakedefine HAVE_WPCAP
+
 /* line editing & history powers */
 #cmakedefine HAVE_READLINE
 


### PR DESCRIPTION
This is part of the fixes for #2575. This adds support for linking against Npcap, which lets Zeek actually find network interfaces and capture packets briefly. There are some outstanding problems starting from that point, but we'll fix them separately.

- Ignore conan libpcap if PCAP_ROOT_DIR is passed
- Update the cmake submodule to pick up changes for finding the right paths to npcap
- Add lazy-loading of npcap so the library path gets set correctly at startup