### PR TITLE
fix for GH-2645

### DIFF
--- a/src/ScriptProfile.cc
+++ b/src/ScriptProfile.cc
@@ -177,7 +177,10 @@ void activate_script_profiling(const char* fn)
 		{
 		f = fopen(fn, "w");
 		if ( ! f )
-			reporter->FatalError("can't open %s to record scripting profile", fn);
+			{
+			fprintf(stderr, "ERROR: Can't open %s to record scripting profile\n", fn);
+			exit(1);
+			}
 		}
 	else
 		f = stdout;


### PR DESCRIPTION
This fixes https://github.com/zeek/zeek/issues/2645, a crash that's due to reporting an error using `reporter` when that global hasn't yet been initialized.