### PR TITLE
CI updates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -136,13 +136,6 @@ env:
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
-fedora35_task:
-  container:
-    # Fedora 35 EOL: Around Dec 2022
-    dockerfile: ci/fedora-35/Dockerfile
-    << : *RESOURCES_TEMPLATE
-  << : *CI_TEMPLATE
-
 fedora36_task:
   container:
     # Fedora 36 EOL: Around May 2023

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
         with:
           submodules: "recursive"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "::set-output name=RELEASE_VERSION::$(cat VERSION)"
+        run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
 
       - name: Compute target tag
         id: target
@@ -69,11 +69,11 @@ jobs:
           #
           # Any other refs are not published below.
           if [ "${GITHUB_REF}" = "refs/tags/release" ]; then
-            echo "::set-output name=tag::zeek:latest"
+            echo "tag=zeek:latest" >> $GITHUB_OUTPUT
           elif [ "${GITHUB_REF}" = "refs/heads/master" ]; then
-            echo "::set-output name=tag::zeek-dev:latest"
+            echo "tag=zeek-dev:latest" >> $GITHUB_OUTPUT
           elif [[ "${GITHUB_REF}" = refs/tags/v* ]] && [[ "${GITHUB_REF}" != refs/tags/v*-dev ]]; then
-            echo "::set-output name=tag::zeek:${RELEASE_VERSION}"
+            echo "tag=zeek:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
           fi
 
       - name: Login to ECR

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
       TEST_TAG: zeek:latest
       CONFFLAGS: --generator=Ninja --build-type=Release
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
         with:
           submodules: "recursive"
 
@@ -134,7 +134,7 @@ jobs:
       # Grab the sources so we have access to btest. Could also use pip, but it
       # seems appealing to be using the in-tree version of btest. btest is in a
       # submodule; we check it out selectively to save time.
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
       - name: Check out btest
         run: git submodule update --init ./auxil/btest
 
@@ -156,7 +156,7 @@ jobs:
           echo "TESTSUITE_COMMIT=$(cat ./testing/external/commit-hash.zeek-testing-cluster)" >> $GITHUB_ENV
 
       - name: Retrieve cluster testsuite
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
         with:
           repository: zeek/zeek-testing-cluster
           path: testing/external/zeek-testing-cluster

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -24,12 +24,12 @@ jobs:
       # event, so we only need to authenticate in that case. Use
       # unauthenticated access otherwise so this action can e.g., also run from
       # clones.
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
         if: github.event_name == 'schedule'
         with:
           submodules: "recursive"
           token: ${{ secrets.ZEEK_BOT_TOKEN }}
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
         if: github.event_name != 'schedule'
         with:
           submodules: "recursive"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
     - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Minor tweaks: switch `actions/checkout` to the more future-proof `v3` and avoid deprecated use of `::set-output`.