### PR TITLE
Move container image build to Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -133,6 +133,8 @@ env:
   CCACHE_DIR: /tmp/ccache
   CCACHE_COMPRESS: 1
 
+  ZEEK_IMAGE_REPO: zeek
+
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 
@@ -381,3 +383,86 @@ windows_task:
     # Give verbose error output on a test failure.
     CTEST_OUTPUT_ON_FAILURE: 1
   << : *BRANCH_WHITELIST
+
+
+# General idea: Build container images for amd64 and arm64 in separate
+# docker_builder tasks, then use a third docker_builder task to collect
+# the produced images (through CIRRUS_HTTP_CACHE), push them into
+# zeek/zeek-multiarch on Docker Hub and create a manifest in zeek/zeek
+# tagged as latest or a tag.
+#
+# We've previously tried docker buildx with qemu, but at least within
+# a GitHub action the emulated arm64 build on the amd64 VMs would take
+# > 6 hours. Using separate builders on Cirrus allows us build natively
+# and much faster.
+docker_build_script_template: &DOCKER_BUILD_SCRIPT_TEMPLATE
+    - git submodule update --init --recursive
+    - set -x; cd docker && docker build -f Dockerfile --tag ${IMAGE_TAG} ..
+    - set -x; docker save $IMAGE_TAG | zstd > image.zst
+    - curl -v -X POST --data-binary @image.zst http://$CIRRUS_HTTP_CACHE_HOST/${CIRRUS_BUILD_ID}-image-${CIRRUS_ARCH}
+arm64_docker_builder:
+  env:
+    CIRRUS_ARCH: arm64
+    CIRRUS_LOG_TIMESTAMP: true
+    CONFFLAGS: --generator=Ninja --build-type=Release
+  set_image_tag_script: echo "IMAGE_TAG=${ZEEK_IMAGE_REPO}/zeek-multiarch:${CIRRUS_ARCH}" >> $CIRRUS_ENV
+  build_script:
+    << : *DOCKER_BUILD_SCRIPT_TEMPLATE
+
+amd64_docker_builder:
+  env:
+    CIRRUS_LOG_TIMESTAMP: true
+    CONFFLAGS: --generator=Ninja --build-type=Release
+  set_image_tag_script: echo "IMAGE_TAG=${ZEEK_IMAGE_REPO}/zeek-multiarch:${CIRRUS_ARCH}" >> $CIRRUS_ENV
+  build_script:
+    << : *DOCKER_BUILD_SCRIPT_TEMPLATE
+
+
+create_manifest_docker_builder:
+  # Only push master builds or when on a release branch and tagged.
+  only_if: >
+    ( $CIRRUS_REPO_NAME == 'zeek' &&
+      (
+        $CIRRUS_BRANCH == 'master' ||
+        $CIRRUS_BRANCH == 'topic/awelzel/2675-arm64-containers-on-cirrus' ||
+        ( $CIRRUS_BRANCH =~ 'release/.*' && $CIRRUS_TAG != '')
+      )
+    )
+  env:
+    CIRRUS_LOG_TIMESTAMP: true
+    DOCKER_USERNAME: ENCRYPTED[7ecd9c29dafa6200b715dbff116a7d169ef3b19f0587c8dd8abf7be346b431424a824468532198cbdf97c86a0ffd4df0]
+    DOCKER_PASSWORD: ENCRYPTED[dcd1eb93c1b974951a3b5303e64d257522ecac367dc7b73eb8104652d51d24cbdd020e793a0fa6f41ce5dc6a245ef310]
+  login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+  set_image_tag_script: |
+    # If we have a CIRRUS_TAG, use that for the tags to push the architectures,
+    # otherwise use latest. Basically we push the arch images as zeek/zeek-multiarch:<arch>-<latest|v1.2.3>
+    # and then create a manifest of the form zeek/zeek:$(cat VERSION).
+    if [ -n "${CIRRUS_TAG}" ]; then
+      echo "IMAGE_NAME=zeek" >> $CIRRUS_ENV
+      echo "IMAGE_TAG=${CIRRUS_TAG}" >> $CIRRUS_ENV
+      # TODO: Remove this hunk - here for testing
+    elif [ "$${CIRRUS_BRANCH}" = "topic/awelzel/2675-arm64-containers-on-cirrus"; then
+      echo "IMAGE_NAME=zeek-next" >> $CIRRUS_ENV
+      echo "IMAGE_TAG=latest" >> $CIRRUS_ENV
+    else
+      echo "IMAGE_NAME=zeek-dev" >> $CIRRUS_ENV
+      echo "IMAGE_TAG=latest" >> $CIRRUS_ENV
+    fi
+    echo "MANIFEST_TAG=$(cat VERSION)" >> $CIRRUS_ENV
+  build_script:
+    # Fetch and load the images
+    - set -x; curl -v -O http://$CIRRUS_HTTP_CACHE_HOST/${CIRRUS_BUILD_ID}-image-arm64
+    - set -x; curl -v -O http://$CIRRUS_HTTP_CACHE_HOST/${CIRRUS_BUILD_ID}-image-amd64
+    - set -x; zstd -d < ${CIRRUS_BUILD_ID}-image-arm64 | docker load
+    - set -x; zstd -d < ${CIRRUS_BUILD_ID}-image-amd64 | docker load
+
+    - set -x; docker tag ${ZEEK_IMAGE_REPO}/zeek-multiarch:arm64 ${ZEEK_IMAGE_REPO}/zeek-multiarch:arm64-${IMAGE_TAG}
+    - set -x; docker tag ${ZEEK_IMAGE_REPO}/zeek-multiarch:amd64 ${ZEEK_IMAGE_REPO}/zeek-multiarch:amd64-${IMAGE_TAG}
+    - set -x; docker push ${ZEEK_IMAGE_REPO}/zeek-multiarch:arm64-${IMAGE_TAG}
+    - set -x; docker push ${ZEEK_IMAGE_REPO}/zeek-multiarch:amd64-${IMAGE_TAG}
+
+    - set -x; docker manifest create ${ZEEK_IMAGE_REPO}/$IMAGE_NAME:${MANIFEST_TAG} ${ZEEK_IMAGE_REPO}/zeek-multiarch:arm64-${IMAGE_TAG} ${ZEEK_IMAGE_REPO}/zeek-multiarch:amd64-${IMAGE_TAG}
+    - set -x; docker manifest push ${ZEEK_IMAGE_REPO}/$IMAGE_NAME:${MANIFEST_TAG}
+  depends_on:
+    - arm64_docker_builder
+    - amd64_docker_builder

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,63 +52,63 @@ jobs:
       - name: Save image tarball
         run: docker save -o ${{ env.IMAGE_FILE }} ${{ env.TEST_TAG }}
 
-      - name: Get version
-        id: version
-        run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
-
-      - name: Compute target tag
-        id: target
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.RELEASE_VERSION }}
-        run: |
-          # Translate the GitHub reference into a tag name.
-          #
-          # - `release` tag maps to `zeek:latest`
-          # - `v*` tag (excluding `v*-dev` tags) maps to `zeek:RELEASE_VERSION`
-          # - `master` branch maps to `zeek-dev:latest`
-          #
-          # Any other refs are not published below.
-          if [ "${GITHUB_REF}" = "refs/tags/release" ]; then
-            echo "tag=zeek:latest" >> $GITHUB_OUTPUT
-          elif [ "${GITHUB_REF}" = "refs/heads/master" ]; then
-            echo "tag=zeek-dev:latest" >> $GITHUB_OUTPUT
-          elif [[ "${GITHUB_REF}" = refs/tags/v* ]] && [[ "${GITHUB_REF}" != refs/tags/v*-dev ]]; then
-            echo "tag=zeek:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Login to ECR
-        # Don't publish on forks. Also note that secrets for the login are not
-        # available for pull requests, so trigger on pushes only.
-        if: github.repository == 'zeek/zeek' && github.event_name == 'push'
-        uses: docker/login-action@v1
-        with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        # Don't publish on forks. Also note that secrets for the login are not
-        # available for pull requests, so trigger on pushes only.
-        if: github.repository == 'zeek/zeek' && github.event_name == 'push'
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push image
-        # Only publish if we did compute a tag.
-        if: github.repository == 'zeek/zeek' && github.event_name == 'push' && steps.target.outputs.tag != ''
-        uses: docker/build-push-action@v3
-        with:
-          context: ./
-          file: docker/Dockerfile
-          build-args: |
-            CONFFLAGS=${{ env.CONFFLAGS }}
-          push: true
-          tags: |
-            public.ecr.aws/zeek/${{ steps.target.outputs.tag }}
-            docker.io/zeekurity/${{ steps.target.outputs.tag }}
-            docker.io/zeek/${{ steps.target.outputs.tag }}
+#      - name: Get version
+#        id: version
+#        run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
+#
+#      - name: Compute target tag
+#        id: target
+#        env:
+#          RELEASE_VERSION: ${{ steps.version.outputs.RELEASE_VERSION }}
+#        run: |
+#          # Translate the GitHub reference into a tag name.
+#          #
+#          # - `release` tag maps to `zeek:latest`
+#          # - `v*` tag (excluding `v*-dev` tags) maps to `zeek:RELEASE_VERSION`
+#          # - `master` branch maps to `zeek-dev:latest`
+#          #
+#          # Any other refs are not published below.
+#          if [ "${GITHUB_REF}" = "refs/tags/release" ]; then
+#            echo "tag=zeek:latest" >> $GITHUB_OUTPUT
+#          elif [ "${GITHUB_REF}" = "refs/heads/master" ]; then
+#            echo "tag=zeek-dev:latest" >> $GITHUB_OUTPUT
+#          elif [[ "${GITHUB_REF}" = refs/tags/v* ]] && [[ "${GITHUB_REF}" != refs/tags/v*-dev ]]; then
+#            echo "tag=zeek:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+#          fi
+#
+#      - name: Login to ECR
+#        # Don't publish on forks. Also note that secrets for the login are not
+#        # available for pull requests, so trigger on pushes only.
+#        if: github.repository == 'zeek/zeek' && github.event_name == 'push'
+#        uses: docker/login-action@v1
+#        with:
+#          registry: public.ecr.aws
+#          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v2
+#        # Don't publish on forks. Also note that secrets for the login are not
+#        # available for pull requests, so trigger on pushes only.
+#        if: github.repository == 'zeek/zeek' && github.event_name == 'push'
+#        with:
+#          username: ${{ secrets.DOCKER_USERNAME }}
+#          password: ${{ secrets.DOCKER_PASSWORD }}
+#
+#      - name: Push image
+#        # Only publish if we did compute a tag.
+#        if: github.repository == 'zeek/zeek' && github.event_name == 'push' && steps.target.outputs.tag != ''
+#        uses: docker/build-push-action@v3
+#        with:
+#          context: ./
+#          file: docker/Dockerfile
+#          build-args: |
+#            CONFFLAGS=${{ env.CONFFLAGS }}
+#          push: true
+#          tags: |
+#            public.ecr.aws/zeek/${{ steps.target.outputs.tag }}
+#            docker.io/zeekurity/${{ steps.target.outputs.tag }}
+#            docker.io/zeek/${{ steps.target.outputs.tag }}
 
       - name: Preserve image artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
After trying to build ARM images within a GitHub action using buildx in #2692, it was found that the job times out after 6 hours. Cirrus offers docker_builder tasks for amd64 and arm64 natively and builds are faster.

TODO:
 * Add AWS ECR
 * Drop the GitHub action container image build completely?