### PR TITLE
removed -O add-C++ option and updated documentation

### DIFF
--- a/src/Options.cc
+++ b/src/Options.cc
@@ -205,7 +205,6 @@ static void print_analysis_help()
 	fprintf(stderr, "    xform	transform scripts to \"reduced\" form\n");
 
 	fprintf(stderr, "\n--optimize options when generating C++:\n");
-	fprintf(stderr, "    add-C++	add C++ script bodies to existing generated code\n");
 	fprintf(
 		stderr,
 		"    allow-cond	allow standalone compilation of functions influenced by conditionals\n");
@@ -240,8 +239,6 @@ static void set_analysis_option(const char* opt, Options& opts)
 		a_o.activate = a_o.dump_xform = true;
 	else if ( util::streq(opt, "dump-ZAM") )
 		a_o.activate = a_o.dump_ZAM = true;
-	else if ( util::streq(opt, "add-C++") )
-		a_o.add_CPP = true;
 	else if ( util::streq(opt, "allow-cond") )
 		a_o.allow_cond = true;
 	else if ( util::streq(opt, "gen-C++") )

--- a/src/script_opt/CPP/Compile.h
+++ b/src/script_opt/CPP/Compile.h
@@ -127,7 +127,7 @@ class CPPCompile
 	{
 public:
 	CPPCompile(std::vector<FuncInfo>& _funcs, ProfileFuncs& pfs, const std::string& gen_name,
-	           bool add, bool _standalone, bool report_uncompilable);
+	           bool _standalone, bool report_uncompilable);
 	~CPPCompile();
 
 	// Constructing a CPPCompile object does all of the compilation.
@@ -345,10 +345,6 @@ private:
 	// Maps functions (not hooks or events) to upstream compiled names.
 	std::unordered_map<std::string, std::string> hashed_funcs;
 
-	// If non-zero, provides a tag used for auxiliary/additional
-	// compilation units.
-	int addl_tag = 0;
-
 	// If true, the generated code should run "standalone".
 	bool standalone = false;
 
@@ -358,10 +354,6 @@ private:
 	// compilation time, which is why these are "seatbelts" and
 	// likely not important to make distinct).
 	p_hash_type total_hash = 0;
-
-	// Working directory in which we're compiling.  Used to quasi-locate
-	// error messages when doing test-suite "add-C++" crunches.
-	std::string working_dir;
 
 	//
 	// End of methods related to script/C++ variables.

--- a/src/script_opt/CPP/README.md
+++ b/src/script_opt/CPP/README.md
@@ -108,40 +108,8 @@ On the other hand, it's possible (not yet established) that code created
 using `gen-C++` can be made to compile significantly faster than
 standalone code.
 
-Another option, `-O add-C++`, instead _appends_ the generated code to existing C++ in `CPP-gen.cc`.
-You can use this option repeatedly for different scripts and then
-compile the collection _en masse_.
-
-There are additional workflows relating to running the test suite, which
-we document only briefly here as they're likely going to change or go away
-, as it's not clear they're actually needed.
-
-* `non-embedded-build`  
-Builds `zeek` without any embedded compiled-to-C++ scripts.
-* `bare-embedded-build`  
-Builds `zeek` with the `-b` "bare-mode" scripts compiled in.
-* `full-embedded-build`  
-Builds `zeek` with the default scripts compiled in.
-
-<br>
-
-* `eval-test-suite`  
-Runs the test suite using the `cpp` alternative over the given set of tests.
-* `test-suite-build`  
-Incrementally compiles to `CPP-gen-addl.h` code for the given test suite elements.
-
-<br>
-
-* `single-test.sh`  
-Builds the given btest test as a single `add-C++` add-on and then runs it.
-* `single-full-test.sh`  
-Builds the given btest test from scratch as a self-contained `zeek`, and runs it.
-* `update-single-test.sh`  
-Given an already-compiled `zeek` for the given test, updates its `cpp` test suite alternative.
-
-Some of these scripts could be made less messy if `btest` supported
-a "dry run" option that reported the executions it would do for a given
-test without actually undertaking them.
+There are additional workflows relating to running the test suite: see
+`src/script_opt/CPP/maint/README`.
 
 <br>
 

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -272,7 +272,6 @@ static void init_options()
 	check_env_opt("ZEEK_PROFILE", analysis_options.profile_ZAM);
 
 	// Compile-to-C++-related options.
-	check_env_opt("ZEEK_ADD_CPP", analysis_options.add_CPP);
 	check_env_opt("ZEEK_GEN_CPP", analysis_options.gen_CPP);
 	check_env_opt("ZEEK_GEN_STANDALONE_CPP", analysis_options.gen_standalone_CPP);
 	check_env_opt("ZEEK_COMPILE_ALL", analysis_options.compile_all);
@@ -280,7 +279,7 @@ static void init_options()
 	check_env_opt("ZEEK_USE_CPP", analysis_options.use_CPP);
 	check_env_opt("ZEEK_ALLOW_COND", analysis_options.allow_cond);
 
-	if ( analysis_options.gen_standalone_CPP || analysis_options.add_CPP )
+	if ( analysis_options.gen_standalone_CPP )
 		analysis_options.gen_CPP = true;
 
 	if ( analysis_options.gen_CPP )
@@ -426,11 +425,10 @@ static void generate_CPP(std::unique_ptr<ProfileFuncs>& pfs)
 	{
 	const auto gen_name = CPP_dir + "CPP-gen.cc";
 
-	const bool add = analysis_options.add_CPP;
 	const bool standalone = analysis_options.gen_standalone_CPP;
 	const bool report = analysis_options.report_uncompilable;
 
-	CPPCompile cpp(funcs, *pfs, gen_name, add, standalone, report);
+	CPPCompile cpp(funcs, *pfs, gen_name, standalone, report);
 	}
 
 static void analyze_scripts_for_ZAM(std::unique_ptr<ProfileFuncs>& pfs)

--- a/src/script_opt/ScriptOpt.h
+++ b/src/script_opt/ScriptOpt.h
@@ -102,9 +102,6 @@ struct AnalyOpt
 	// of the corresponding script, and not activated by default).
 	bool gen_standalone_CPP = false;
 
-	// Generate C++ that's added to existing generated code.
-	bool add_CPP = false;
-
 	// If true, use C++ bodies if available.
 	bool use_CPP = false;
 


### PR DESCRIPTION
The `-O add-C++` option was meant to support incremental compilation of scripts to C++.  It wound up not being a useful workflow, and stopped working a while ago (which no one complained about :-P).  This PR removes the last vestiges of it, and updates the documentation accordingly.

BTW, in the process of making this change I accidentally recreated the `topic/vern/Jan23-C++-maint` branch (deleted recently), and have not figured out the right way to delete it, so if someone can enlighten me (or just go ahead and re-delete it), I'd appreciate it.