### PR TITLE
github: Send emails for success conclusion, too

### DIFF
--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -11,7 +11,8 @@ jobs:
         uses: zeek/ci-email-action@master
         env:
           CI_APP_NAME: "Cirrus CI"
-          BRANCH_WHITELIST: "master|release/.*"
+          BRANCH_REGEX: "master|release/.*"
+          SKIP_CONCLUSIONS: 'cancelled,neutral'
           SMTP_HOST: ${{ secrets.SMTP_HOST }}
           SMTP_PORT: ${{ secrets.SMTP_PORT }}
           SMTP_USER: ${{ secrets.SMTP_USER }}

--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -7,6 +7,9 @@ jobs:
     if: github.repository == 'zeek/zeek'
     runs-on: ubuntu-latest
     steps:
+      - name: Show the event
+        run: cat "$GITHUB_EVENT_PATH" || true
+
       - name: Send CI Email Notification
         uses: zeek/ci-email-action@master
         env:


### PR DESCRIPTION
Default behavior of the ci-email-action is to filter
cancelled,neutral,success. We're interested in
success for the time being.
