### PR TITLE
Enable Debian 10 builds for PRs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -204,7 +204,6 @@ debian10_task:
     dockerfile: ci/debian-10/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
-  << : *SKIP_TASK_ON_PR
 
 opensuse_leap_15_4_task:
   container:


### PR DESCRIPTION
Not having this build happen on every PR has bitten me a couple of times recently, especially around testing pcaps that are based on OSS-Fuzz test cases. I'd like to re-enable this build to always happen so we can catch those failures earlier.