### PR TITLE
cirrus: No container images builds or cluster testing on branches

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -444,6 +444,7 @@ docker_build_template: &DOCKER_BUILD_TEMPLATE
   test_script:
     - docker tag ${IMAGE_TAG} zeek:latest
     - make -C docker/btest
+  << : *BRANCH_WHITELIST
 
 arm64_container_image_docker_builder:
   env:
@@ -533,7 +534,6 @@ container_image_manifest_docker_builder:
 cluster_testing_docker_builder:
   cpu: *CPUS
   memory: *MEMORY
-  only_if: $CIRRUS_REPO_FULL_NAME == 'zeek/zeek'
   env:
     CIRRUS_LOG_TIMESTAMP: true
     # At this point, zeek-testing-cluster checks for "GITHUB_ACTION" to
@@ -558,3 +558,4 @@ cluster_testing_docker_builder:
       path: "testing/external/zeek-testing-cluster/.tmp/**"
   depends_on:
     - amd64_container_image
+  << : *BRANCH_WHITELIST


### PR DESCRIPTION
Tim mentioned he saw those tasks running when pushing without opening a PR. Fix that, too.

![Screenshot-20230202-170611](https://user-images.githubusercontent.com/2100509/216377511-08a2ab8e-f55d-42a5-9cd9-fe4b94219d8a.png)
