### PR TITLE
Fix git tag handling in the Docker image uploads workflows, for 5.0.x and 5.1.x.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,9 @@ env:
   IMAGE_FILE: /tmp/zeek-image.tar
   IMAGE_PATH: /tmp
 
+permissions:
+  contents: read
+
 jobs:
   docker-build:
     runs-on: ubuntu-latest
@@ -26,16 +29,16 @@ jobs:
       TEST_TAG: zeek:latest
       CONFFLAGS: --generator=Ninja --build-type=Release
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: "recursive"
 
       # Create and boot a loader. This will e.g., provide caching
       # so we avoid rebuilds of the same image after this step.
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v2
 
       - name: Build image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./
           file: docker/Dockerfile
@@ -52,14 +55,14 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "::set-output name=RELEASE_VERSION::$(cat VERSION)"
+        run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
 
       - name: Compute target tag
         id: target
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.RELEASE_VERSION }}
         run: |
-          # Translate the Github reference into a tag name.
+          # Translate the GitHub reference into a tag name.
           #
           # - `release` tag maps to `zeek:latest`
           # - `v*` tag (excluding `v*-dev` tags) maps to `zeek:RELEASE_VERSION`
@@ -67,15 +70,25 @@ jobs:
           #
           # Any other refs are not published below.
           if [ "${GITHUB_REF}" = "refs/tags/release" ]; then
-            echo "::set-output name=tag::zeek:latest"
+            echo "tag=zeek:latest" >> $GITHUB_OUTPUT
           elif [ "${GITHUB_REF}" = "refs/heads/master" ]; then
-            echo "::set-output name=tag::zeek-dev:latest"
+            echo "tag=zeek-dev:latest" >> $GITHUB_OUTPUT
           elif [[ "${GITHUB_REF}" = refs/tags/v* ]] && [[ "${GITHUB_REF}" != refs/tags/v*-dev ]]; then
-            echo "::set-output name=tag::zeek:${RELEASE_VERSION}"
+            echo "tag=zeek:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Login to ECR
+        # Don't publish on forks. Also note that secrets for the login are not
+        # available for pull requests, so trigger on pushes only.
+        if: github.repository == 'zeek/zeek' && github.event_name == 'push'
+        uses: docker/login-action@v2
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         # Don't publish on forks. Also note that secrets for the login are not
         # available for pull requests, so trigger on pushes only.
         if: github.repository == 'zeek/zeek' && github.event_name == 'push'
@@ -86,7 +99,7 @@ jobs:
       - name: Push image
         # Only publish if we did compute a tag.
         if: github.repository == 'zeek/zeek' && github.event_name == 'push' && steps.target.outputs.tag != ''
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./
           file: docker/Dockerfile
@@ -94,18 +107,19 @@ jobs:
             CONFFLAGS=${{ env.CONFFLAGS }}
           push: true
           tags: |
+            public.ecr.aws/zeek/${{ steps.target.outputs.tag }}
             docker.io/zeekurity/${{ steps.target.outputs.tag }}
             docker.io/zeek/${{ steps.target.outputs.tag }}
 
       - name: Preserve image artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.IMAGE_NAME }}
           path: ${{ env.IMAGE_FILE }}
           retention-days: 1
 
       - name: Preserve btest artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: docker-btest
@@ -121,12 +135,12 @@ jobs:
       # Grab the sources so we have access to btest. Could also use pip, but it
       # seems appealing to be using the in-tree version of btest. btest is in a
       # submodule; we check it out selectively to save time.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check out btest
         run: git submodule update --init ./auxil/btest
 
       - name: Download Docker image artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ env.IMAGE_NAME }}
           path: ${{ env.IMAGE_PATH }}
@@ -143,7 +157,7 @@ jobs:
           echo "TESTSUITE_COMMIT=$(cat ./testing/external/commit-hash.zeek-testing-cluster)" >> $GITHUB_ENV
 
       - name: Retrieve cluster testsuite
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: zeek/zeek-testing-cluster
           path: testing/external/zeek-testing-cluster
@@ -152,8 +166,16 @@ jobs:
       - name: Run testsuite
         run: make -C testing/external/zeek-testing-cluster
 
+      # upload-artifact balks at certain characters in artifact
+      # filenames, so substitute them for dots.
+      - name: Sanitize artifacts
+        if: failure()
+        run: |
+          sudo apt-get -q update && sudo apt-get install -q -y rename
+          find testing/external/zeek-testing-cluster/.tmp -depth -execdir rename 's/[":<>|*?\r\n]/./g' "{}" \;
+
       - name: Preserve btest artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cluster-btest
@@ -167,7 +189,7 @@ jobs:
           truncate -s0 ${{ env.IMAGE_FILE }}
 
       - name: Store truncated image artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.IMAGE_NAME }}
           path: ${{ env.IMAGE_FILE }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,8 @@ on:
     tags:
       - 'v*'
       - '!v*-dev'
+      - 'latest'
       - 'lts'
-      - 'release'
 
 defaults:
   run:
@@ -64,13 +64,16 @@ jobs:
         run: |
           # Translate the GitHub reference into a tag name.
           #
-          # - `release` tag maps to `zeek:latest`
+          # - `latest` tag maps to `zeek:latest`
+          # - `lts` tag maps to `zeek:lts`
           # - `v*` tag (excluding `v*-dev` tags) maps to `zeek:RELEASE_VERSION`
           # - `master` branch maps to `zeek-dev:latest`
           #
           # Any other refs are not published below.
-          if [ "${GITHUB_REF}" = "refs/tags/release" ]; then
+          if [ "${GITHUB_REF}" = "refs/tags/latest" ]; then
             echo "tag=zeek:latest" >> $GITHUB_OUTPUT
+          elif [ "${GITHUB_REF}" = "refs/tags/lts" ]; then
+            echo "tag=zeek:lts" >> $GITHUB_OUTPUT
           elif [ "${GITHUB_REF}" = "refs/heads/master" ]; then
             echo "tag=zeek-dev:latest" >> $GITHUB_OUTPUT
           elif [[ "${GITHUB_REF}" = refs/tags/v* ]] && [[ "${GITHUB_REF}" != refs/tags/v*-dev ]]; then


### PR DESCRIPTION
This brings the docker.yml version in the `release/5.0` branch up to where it was before we nuked it from master, and modernizes the git tag handling to `lts` and `latest`, away from `release`, which we no longer use.

This is untested, and we'd need to do the same for `release/5.1`. This is all transient until the new Cirrus setup trickles into release branches (like `release/5.2` now has, though I'm not sure it'll handle these tags correctly yet).