### PR TITLE
Fix missing get_file_handle and new_event overhead

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,13 @@ release. For an exhaustive list of changes, see the ``CHANGES`` file
 Zeek 6.0.0
 ==========
 
+Changed Functionality
+---------------------
+
+- When ``get_file_handle()`` is invoked for an analyzer that did not register
+  an appropriate callback function, log a warning and return a generic handle
+  value based on the analyzer and connection information.
+
 Zeek 5.2.0
 ==========
 

--- a/scripts/base/frameworks/files/main.zeek
+++ b/scripts/base/frameworks/files/main.zeek
@@ -513,7 +513,11 @@ function describe(f: fa_file): string
 event get_file_handle(tag: Files::Tag, c: connection, is_orig: bool) &priority=5
 	{
 	if ( tag !in registered_protocols )
+		{
+		Reporter::warning(fmt("get_file_handle() invoked for %s", tag));
+		set_file_handle(fmt("%s-fallback-%s-%s-%s", tag, c$uid, is_orig, network_time()));
 		return;
+		}
 
 	local handler = registered_protocols[tag];
 	set_file_handle(handler$get_file_handle(c, is_orig));

--- a/src/EventHandler.h
+++ b/src/EventHandler.h
@@ -49,7 +49,10 @@ public:
 
 	// Flags the event as interesting even if there is no body defined. In
 	// particular, this will then still pass the event on to plugins.
-	void SetGenerateAlways() { generate_always = true; }
+	void SetGenerateAlways(bool arg_generate_always = true)
+		{
+		generate_always = arg_generate_always;
+		}
 	bool GenerateAlways() const { return generate_always; }
 
 	uint64_t CallCount() const { return call_count; }

--- a/src/fuzzers/fuzzer-setup.h
+++ b/src/fuzzers/fuzzer-setup.h
@@ -47,6 +47,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
 	// even if they don't, because otherwise we lose a bit of coverage where if
 	// statements return false that would otherwise not.
 	zeek::event_registry->ActivateAllHandlers();
+	zeek::event_registry->Lookup("new_event")->SetGenerateAlways(false);
 
 	return 0;
 	}

--- a/testing/btest/scripts/base/protocols/krb/smb2_krb_nokeytab.test
+++ b/testing/btest/scripts/base/protocols/krb/smb2_krb_nokeytab.test
@@ -8,13 +8,37 @@
 # @TEST-EXEC: btest-diff .stdout
 # @TEST-EXEC: btest-diff .stderr
 
+module SMB;
+
+export {
+	global get_file_handle: function(c: connection, is_orig: bool): string;
+	global describe_file: function(f: fa_file): string;
+}
+
 global monitor_ports: set[port] = { 445/tcp, 139/tcp } &redef;
 
-event zeek_init() &priority=5{
+
+# Stubs for testing so that we don't produce a warning due
+# to missing get_file_handle() handlers for SMB.
+function get_file_handle(c: connection, is_orig: bool): string
+	{
+	return cat(c$uid);
+	}
+
+function describe_file(f: fa_file): string
+	{
+	return "";
+	}
+
+event zeek_init() &priority=5
+	{
 	Analyzer::register_for_ports(Analyzer::ANALYZER_SMB, monitor_ports);
-}
+	Files::register_protocol(Analyzer::ANALYZER_SMB,
+	                         [$get_file_handle = SMB::get_file_handle,
+	                          $describe        = SMB::describe_file]);
+	}
 
-event krb_ap_request(c: connection, ticket: KRB::Ticket, opts:  KRB::AP_Options){
-   print ticket?$authenticationinfo;
-}
-
+event krb_ap_request(c: connection, ticket: KRB::Ticket, opts:  KRB::AP_Options)
+	{
+	print ticket?$authenticationinfo;
+	}


### PR DESCRIPTION
Prevent overhead when fuzzing due to:
* non-implemented `get_file_handle()` method for POP3 calling `get_file_handle()` repeatedly for every `DataIn()` call.
* `new_event` invocation requiring expensive argument construction (fueled by the previous issue)