### PR TITLE
HashKey: Do not call Describe() unconditionally in DEBUG mode

### DIFF
--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -213,9 +213,12 @@ hash_t HashKey::Hash() const
 	if ( hash == 0 )
 		hash = HashBytes(key, size);
 #ifdef DEBUG
-	ODesc d;
-	Describe(&d);
-	DBG_LOG(DBG_HASHKEY, "HashKey %p %s", this, d.Description());
+	if ( zeek::detail::debug_logger.IsEnabled(DBG_HASHKEY) )
+		{
+		ODesc d;
+		Describe(&d);
+		DBG_LOG(DBG_HASHKEY, "HashKey %p %s", this, d.Description());
+		}
 #endif
 	return hash;
 	}


### PR DESCRIPTION
An unnecessary overhead of the Hash() method was uncovered for DEBUG builds due to computing a description of every HashKey() even when the DBG_HASHKEY stream is not enabled. Squelch it.