### PR TITLE
zeek-setup: Ensure telemetry_mgr is created before other managers

### DIFF
--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -705,6 +705,7 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 	// policy, but we can't parse policy without DNS resolution.
 	dns_mgr->SetDir(".state");
 
+	telemetry_mgr = new telemetry::Manager;
 	iosource_mgr = new iosource::Manager();
 	event_registry = new EventRegistry();
 	packet_mgr = new packet_analysis::Manager();
@@ -714,7 +715,6 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 	file_mgr = new file_analysis::Manager();
 	auto broker_real_time = ! options.pcap_file && ! options.deterministic_mode;
 	broker_mgr = new Broker::Manager(broker_real_time);
-	telemetry_mgr = new telemetry::Manager;
 	trigger_mgr = new trigger::Manager();
 
 	plugin_mgr->InitPreScript();
@@ -839,12 +839,12 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 		if ( reporter->Errors() > 0 )
 			exit(1);
 
+		telemetry_mgr->InitPostScript();
 		iosource_mgr->InitPostScript();
 		log_mgr->InitPostScript();
 		plugin_mgr->InitPostScript();
 		zeekygen_mgr->InitPostScript();
 		broker_mgr->InitPostScript();
-		telemetry_mgr->InitPostScript();
 		timer_mgr->InitPostScript();
 		event_mgr.InitPostScript();
 


### PR DESCRIPTION
It's difficult to initialize metrics families in the constructor
of other Managers if the telemetry_mgr isn't around yet.

Splitting this out in a separate PR as I ran into this sektching #2572.
