### PR TITLE
Move get_relative_seq and get_segment_len to public static methods

### DIFF
--- a/src/packet_analysis/protocol/tcp/TCPSessionAdapter.cc
+++ b/src/packet_analysis/protocol/tcp/TCPSessionAdapter.cc
@@ -77,7 +77,7 @@ void TCPSessionAdapter::Done()
 	finished = 1;
 	}
 
-static int get_segment_len(int payload_len, analyzer::tcp::TCP_Flags flags)
+int TCPSessionAdapter::get_segment_len(int payload_len, analyzer::tcp::TCP_Flags flags)
 	{
 	int seg_len = payload_len;
 
@@ -175,8 +175,9 @@ static void init_endpoint(analyzer::tcp::TCP_Endpoint* endpoint, analyzer::tcp::
 		}
 	}
 
-static uint64_t get_relative_seq(const analyzer::tcp::TCP_Endpoint* endpoint, uint32_t cur_base,
-                                 uint32_t last, uint32_t wraps, bool* underflow)
+uint64_t TCPSessionAdapter::get_relative_seq(const analyzer::tcp::TCP_Endpoint* endpoint,
+                                             uint32_t cur_base, uint32_t last, uint32_t wraps,
+                                             bool* underflow)
 	{
 	int32_t delta = seq_delta(cur_base, last);
 

--- a/src/packet_analysis/protocol/tcp/TCPSessionAdapter.h
+++ b/src/packet_analysis/protocol/tcp/TCPSessionAdapter.h
@@ -78,6 +78,10 @@ public:
 
 	void AddExtraAnalyzers(Connection* conn) override;
 
+	static int get_segment_len(int payload_len, analyzer::tcp::TCP_Flags flags);
+	static uint64_t get_relative_seq(const analyzer::tcp::TCP_Endpoint* endpoint, uint32_t cur_base,
+	                                 uint32_t last, uint32_t wraps, bool* underflow);
+
 protected:
 	friend class analyzer::tcp::TCP_ApplicationAnalyzer;
 	friend class analyzer::tcp::TCP_Endpoint;


### PR DESCRIPTION
These functions got moved to be private file-level static methods during the work to make the TCP and UDP analyzers as packet analyzers. This PR restores them as public class-level static methods in the TCP session adapter.

Fixes #2788