### PR TITLE
Use ensurepip to install pip on FreeBSD

### DIFF
--- a/ci/freebsd/prepare.sh
+++ b/ci/freebsd/prepare.sh
@@ -9,7 +9,8 @@ env ASSUME_ALWAYS_YES=YES pkg bootstrap
 pkg install -y bash git cmake swig bison python3 base64 flex ccache
 pkg upgrade -y curl
 pyver=$(python3 -c 'import sys; print(f"py{sys.version_info[0]}{sys.version_info[1]}")')
-pkg install -y $pyver-sqlite3 $pyver-pip
+pkg install -y $pyver-sqlite3
+python -m ensurepip --upgrade
 
 python -m pip install websockets junit2html
 


### PR DESCRIPTION
The py39-pip package is sometimes not available on FreeBSD, and using ensurepip is the recommended way to install pip according to the pip documentation. ensurepip should be available in every python installation.