### PR TITLE
ci/collect-repo-info: No hard dependency on git, take two

### DIFF
--- a/ci/collect-repo-info.py
+++ b/ci/collect-repo-info.py
@@ -129,7 +129,7 @@ def collect_plugin_info(plugin_dir: pathlib.Path):
     except FileNotFoundError:
         logger.warning("No VERSION found in %s", plugin_dir)
 
-    if git_is_repo(plugin_dir):
+    if git_available() and git_is_repo(plugin_dir):
         result.update(git_generic_info(plugin_dir))
 
     return result


### PR DESCRIPTION
Collecting information about builtin external plugins also tried to use `git` unconditionally.