### PR TITLE
Force usage of a different debian mirror for Docker image builds

### DIFF
--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -3,6 +3,8 @@
 # Layer to build Zeek.
 FROM debian:bullseye-slim
 
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+
 # Configure system for build.
 RUN apt-get -q update \
  && apt-get install -q -y --no-install-recommends \

--- a/docker/final.Dockerfile
+++ b/docker/final.Dockerfile
@@ -3,6 +3,8 @@
 # Final layer containing all artifacts.
 FROM debian:bullseye-slim
 
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get -q update \
  && apt-get install -q -y --no-install-recommends \
      ca-certificates \


### PR DESCRIPTION
Debian by default uses the deb.debian.org host to automatically determine the best mirror to connect to for packages. Recently our CI setup has been fighting a ton of timeouts from that host which building the images for and executing the cluster tests. This PR switches the host for apt to use the mirror at OSUOSL. I opted for that one specifically because the Zeek project already has a relationship with that group in case anything else comes up.