### PR TITLE
Add build status, slack, and discourse badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ traffic analysis and security monitoring.
 Follow us on Twitter at [@zeekurity](https://twitter.com/zeekurity).
 
 [![Coverage Status](https://coveralls.io/repos/github/zeek/zeek/badge.svg?branch=master)](https://coveralls.io/github/zeek/zeek?branch=master)
+[![Build Status](https://img.shields.io/cirrus/github/zeek/zeek)](https://cirrus-ci.com/github/zeek/zeek)
+
+[![Slack](https://img.shields.io/badge/slack-@zeek-brightgreen.svg?logo=slack)](https://join.slack.com/t/zeekorg/shared_invite/zt-1ev1nr7z4-rEVSsaIzYzFWpdgh2I6ZOg)
+[![Discourse](https://img.shields.io/discourse/status?server=https%3A%2F%2Fcommunity.zeek.org)](https://community.zeek.org)
 
 </h4>
 


### PR DESCRIPTION
Adds a few extra badges to the readme, mostly for discoverability of the social stuff outside of the website:

![Screenshot 2023-02-27 at 3 27 15 PM](https://user-images.githubusercontent.com/2653616/221700304-833741e7-05f9-459d-ad6c-432c795a0eb1.png)
