### PR TITLE
Allow offline packet sources to register FDs.

### DIFF
--- a/src/iosource/PktSrc.cc
+++ b/src/iosource/PktSrc.cc
@@ -83,17 +83,11 @@ void PktSrc::Opened(const Properties& arg_props)
 		}
 
 	if ( props.is_live )
-		{
 		Info(util::fmt("listening on %s\n", props.path.c_str()));
 
-		// We only register the file descriptor if we're in live
-		// mode because libpcap's file descriptor for trace files
-		// isn't a reliable way to know whether we actually have
-		// data to read.
-		if ( props.selectable_fd != -1 )
-			if ( ! iosource_mgr->RegisterFd(props.selectable_fd, this) )
-				reporter->FatalError("Failed to register pktsrc fd with iosource_mgr");
-		}
+	if ( props.selectable_fd != -1 )
+		if ( ! iosource_mgr->RegisterFd(props.selectable_fd, this) )
+			reporter->FatalError("Failed to register pktsrc fd with iosource_mgr");
 
 	DBG_LOG(DBG_PKTIO, "Opened source %s", props.path.c_str());
 	}

--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -182,10 +182,11 @@ void PcapSource::OpenOffline()
 		return;
 		}
 
-	props.selectable_fd = fileno(pcap_file(pd));
-
-	if ( props.selectable_fd < 0 )
-		InternalError("OS does not support selectable pcap fd");
+	// We don't register the file descriptor if we're in offline mode,
+	// because libpcap's file descriptor for trace files isn't a reliable
+	// way to know whether we actually have data to read.
+	// See https://github.com/the-tcpdump-group/libpcap/issues/870
+	props.selectable_fd = -1;
 
 	props.link_type = pcap_datalink(pd);
 	props.is_live = false;


### PR DESCRIPTION
This just removes a check that prevents any offline packet source from registering a file descriptor. If provided, Zeek could use the descriptor to determine whether the source is ready.

```
// We only register the file descriptor if we're in live
// mode because libpcap's file descriptor for trace files
// isn't a reliable way to know whether we actually have
// data to read.
```
Given the above comment, the check was introduced for a good reason. However, it seems strange that the PCAP source sets the FD in the first place:

https://github.com/zeek/zeek/blob/8cf9e5b3741956901b9bc0ce5ad249570c39c549/src/iosource/pcap/Source.cc#L185-L188

If the original comment was about `fileno` failing we should already be good. If there are cases where `fileno` returns a valid descriptor but using the descriptor does not work as expected, it might make sense to set `selectable_fd = -1` in the PCAP source itself. @timwoj, can you remember?

So far, I have done some basic performance tests on my local machine and did not spot any issues. Nevertheless, I guess the change should probably be tested on all supported platforms.