### PR TITLE
Add trigger_mgr to iosource_mgr later during startup

### DIFF
--- a/src/Trigger.cc
+++ b/src/Trigger.cc
@@ -504,12 +504,16 @@ void Trigger::Modified(notifier::detail::Modifiable* m)
 Manager::Manager() : iosource::IOSource()
 	{
 	pending = new TriggerList();
-	iosource_mgr->Register(this, true);
 	}
 
 Manager::~Manager()
 	{
 	delete pending;
+	}
+
+void Manager::InitPostScript()
+	{
+	iosource_mgr->Register(this, true);
 	}
 
 double Manager::GetNextTimeout()

--- a/src/Trigger.h
+++ b/src/Trigger.h
@@ -162,6 +162,8 @@ public:
 	Manager();
 	~Manager();
 
+	void InitPostScript();
+
 	double GetNextTimeout() override;
 	void Process() override;
 	const char* Tag() override { return "TriggerMgr"; }

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -884,8 +884,7 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 		analyzer_mgr->InitPostScript();
 		file_mgr->InitPostScript();
 		dns_mgr->InitPostScript();
-
-		//		dns_mgr->LookupAddr("17.253.144.10");
+		trigger_mgr->InitPostScript();
 
 #ifdef USE_PERFTOOLS_DEBUG
 		}


### PR DESCRIPTION
This fixes a potential crash due to trigger_mgr getting shutdown earlier than dns_mgr, and dns_mgr then trying to use it after it's been deleted. This change forces the order of initialization/destruction in iosource_mgr to cause dns_mgr to be deleted first.

Fixes #2846 