### PR TITLE
Allow offline packet sources to register FDs.

### DIFF
--- a/src/iosource/PktSrc.cc
+++ b/src/iosource/PktSrc.cc
@@ -83,17 +83,11 @@ void PktSrc::Opened(const Properties& arg_props)
 		}
 
 	if ( props.is_live )
-		{
 		Info(util::fmt("listening on %s\n", props.path.c_str()));
 
-		// We only register the file descriptor if we're in live
-		// mode because libpcap's file descriptor for trace files
-		// isn't a reliable way to know whether we actually have
-		// data to read.
-		if ( props.selectable_fd != -1 )
-			if ( ! iosource_mgr->RegisterFd(props.selectable_fd, this) )
-				reporter->FatalError("Failed to register pktsrc fd with iosource_mgr");
-		}
+	if ( props.selectable_fd != -1 )
+		if ( ! iosource_mgr->RegisterFd(props.selectable_fd, this) )
+			reporter->FatalError("Failed to register pktsrc fd with iosource_mgr");
 
 	DBG_LOG(DBG_PKTIO, "Opened source %s", props.path.c_str());
 	}
@@ -102,7 +96,7 @@ void PktSrc::Closed()
 	{
 	SetClosed(true);
 
-	if ( props.is_live && props.selectable_fd != -1 )
+	if ( props.selectable_fd != -1 )
 		iosource_mgr->UnregisterFd(props.selectable_fd, this);
 
 	DBG_LOG(DBG_PKTIO, "Closed source %s", props.path.c_str());

--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -182,10 +182,11 @@ void PcapSource::OpenOffline()
 		return;
 		}
 
-	props.selectable_fd = fileno(pcap_file(pd));
-
-	if ( props.selectable_fd < 0 )
-		InternalError("OS does not support selectable pcap fd");
+	// We don't register the file descriptor if we're in offline mode,
+	// because libpcap's file descriptor for trace files isn't a reliable
+	// way to know whether we actually have data to read.
+	// See https://github.com/the-tcpdump-group/libpcap/issues/870
+	props.selectable_fd = -1;
 
 	props.link_type = pcap_datalink(pd);
 	props.is_live = false;


### PR DESCRIPTION
Unfortunately, #2842 turned out to have some unexpected side-effects and had to be reverted. This is just a re-open to keep it on the radar. The logic related to `selectable_fd` in `GetNextTimeout()` might be part of the puzzle:
https://github.com/zeek/zeek/blob/b73dda5cff7a939444e646508cc796584982017e/src/iosource/PktSrc.cc#L277-L312