### PR TITLE
PktSrc: Avoid calling ExtractNextPacketInternal() in GetNextTimeout()

### DIFF
--- a/src/iosource/PktSrc.cc
+++ b/src/iosource/PktSrc.cc
@@ -85,17 +85,11 @@ void PktSrc::Opened(const Properties& arg_props)
 		}
 
 	if ( props.is_live )
-		{
 		Info(util::fmt("listening on %s\n", props.path.c_str()));
 
-		// We only register the file descriptor if we're in live
-		// mode because libpcap's file descriptor for trace files
-		// isn't a reliable way to know whether we actually have
-		// data to read.
-		if ( props.selectable_fd != -1 )
-			if ( ! iosource_mgr->RegisterFd(props.selectable_fd, this) )
-				reporter->FatalError("Failed to register pktsrc fd with iosource_mgr");
-		}
+	if ( props.selectable_fd != -1 )
+		if ( ! iosource_mgr->RegisterFd(props.selectable_fd, this) )
+			reporter->FatalError("Failed to register pktsrc fd with iosource_mgr");
 
 	DBG_LOG(DBG_PKTIO, "Opened source %s", props.path.c_str());
 	}
@@ -104,7 +98,7 @@ void PktSrc::Closed()
 	{
 	SetClosed(true);
 
-	if ( props.is_live && props.selectable_fd != -1 )
+	if ( props.selectable_fd != -1 )
 		iosource_mgr->UnregisterFd(props.selectable_fd, this);
 
 	DBG_LOG(DBG_PKTIO, "Closed source %s", props.path.c_str());

--- a/src/iosource/PktSrc.h
+++ b/src/iosource/PktSrc.h
@@ -362,6 +362,8 @@ private:
 
 	bool have_packet;
 	Packet current_packet;
+	// Did the previous call to ExtractNextPacket() yield a packet.
+	bool had_packet;
 
 	// For BPF filtering support.
 	std::vector<detail::BPF_Program*> filters;

--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -182,10 +182,11 @@ void PcapSource::OpenOffline()
 		return;
 		}
 
-	props.selectable_fd = fileno(pcap_file(pd));
-
-	if ( props.selectable_fd < 0 )
-		InternalError("OS does not support selectable pcap fd");
+	// We don't register the file descriptor if we're in offline mode,
+	// because libpcap's file descriptor for trace files isn't a reliable
+	// way to know whether we actually have data to read.
+	// See https://github.com/the-tcpdump-group/libpcap/issues/870
+	props.selectable_fd = -1;
 
 	props.link_type = pcap_datalink(pd);
 	props.is_live = false;


### PR DESCRIPTION
This reworks 2aec7640dd60c3ea3cffd82461588567e406db34 (zeek/zeek#2039) to
avoid calling ExtractNextPacketInternal() within GetNextTimeout() for
the non-pseudo-realtime case. Also relates to zeek/zeek#2842.

The intention of the referenced change was to avoid a 0.00002 timeout when
a non-selectable packet source has more packets queued. This was implemented
by checking for a new packet within GetNextTimeout().

The proposed change switches to an predictive approach: Use the result of
the previous ExtractNextPacket() call (stored as had_packet) as an indication
whether more packets are to be expected.

Calling ExtractNextPacketInternal() within GetNextTimeout() may cause
surprising behavior as some packet source may block [1] or spent a significant
amount of time (e.g. applying BPF filters [2]) within ExtractNextPacket().
The result of GetNextTimeout() should be available immediately as guidance
for the main-loop and the actual work should happen within the ->Process()
method.

This change also attempts to separate the pseudo-realtime logic from the
non-pseudo-realtime.

[1] https://github.com/hosom/bro-napatech/blob/00c4d657e034927301d5f8d9bc03eca81e619699/src/Napatech.cc#L116
[2] https://github.com/sethhall/bro-myricom/blob/58b25c8ebac6d184ff8ff0c27f8da2b603694dab/src/Myricom.cc#L250


---

Addition: This change needs @J-Gras proposal to set libpcap's unreliable FD to -1 when in offline mode, because GetNextTimeout() now assumes that a set selectable_fd is properly usable and doesn't distingush between the Live/Offline case anymore. I think this is for the better, actually.