### PR TITLE
Install git as part of the centos-7 CI image

### DIFF
--- a/ci/centos-7/Dockerfile
+++ b/ci/centos-7/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20230312
 
 ENV FLEX_VERSION=2.6.4
 ENV FLEX_DIR=/opt/flex


### PR DESCRIPTION
I have no idea if this was part of the base image that Cirrus uses and was removed recently, but it's missing right now and builds are failing because of it.