### PR TITLE
Fix some recent Coverity findings

### DIFF
--- a/src/Conn.h
+++ b/src/Conn.h
@@ -64,10 +64,10 @@ struct ConnTuple
 	{
 	IPAddr src_addr;
 	IPAddr dst_addr;
-	uint32_t src_port;
-	uint32_t dst_port;
-	bool is_one_way; // if true, don't canonicalize order
-	TransportProto proto;
+	uint32_t src_port = 0;
+	uint32_t dst_port = 0;
+	bool is_one_way = false; // if true, don't canonicalize order
+	TransportProto proto = TRANSPORT_UNKNOWN;
 	};
 
 static inline int addr_port_canon_lt(const IPAddr& addr1, uint32_t p1, const IPAddr& addr2,

--- a/src/Scope.cc
+++ b/src/Scope.cc
@@ -22,7 +22,7 @@ Scope::Scope(IDPtr id, std::unique_ptr<std::vector<AttrPtr>> al)
 	{
 	return_type = nullptr;
 
-	if ( id )
+	if ( scope_id )
 		{
 		const auto& id_type = scope_id->GetType();
 
@@ -31,7 +31,7 @@ Scope::Scope(IDPtr id, std::unique_ptr<std::vector<AttrPtr>> al)
 		else if ( id_type->Tag() != TYPE_FUNC )
 			reporter->InternalError("bad scope id");
 
-		FuncType* ft = id->GetType()->AsFuncType();
+		FuncType* ft = scope_id->GetType()->AsFuncType();
 		return_type = ft->Yield();
 		}
 	}

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -930,13 +930,13 @@ TEST_SUITE("Analyzer management")
 		auto b1 = zeek::analyzer_mgr->InstantiateAnalyzer("IMAP", a->Conn());
 		REQUIRE(b1);
 
-		tcp->AddChildAnalyzer(a);
-		a->AddChildAnalyzer(b1);
+		CHECK(tcp->AddChildAnalyzer(a));
+		CHECK(a->AddChildAnalyzer(b1));
 
 		CHECK(conn->FindAnalyzer("SSH"));
 		CHECK(conn->FindAnalyzer("IMAP"));
 
-		a->RemoveChildAnalyzer(b1);
+		CHECK(a->RemoveChildAnalyzer(b1));
 
 		CHECK(! conn->FindAnalyzer("IMAP"));
 

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -70,13 +70,13 @@ struct LeftoverLog
 	 * The time at which the shadow file was created.  This is used
 	 * as the log file's "opening time" for rotation purposes.
 	 */
-	time_t open_time;
+	time_t open_time = 0;
 
 	/**
 	 * Time of the log file's last modification.  This is used
 	 * as the log file's "closing time" for rotation purposes.
 	 */
-	time_t close_time;
+	time_t close_time = 0;
 
 	/**
 	 * Set the an error message explaining any error that happened while
@@ -123,7 +123,7 @@ static std::optional<LeftoverLog> parse_shadow_log(const std::string& fname)
 	{
 	auto sfname = prefix_basename_with(fname, shadow_file_prefix);
 
-	LeftoverLog rval;
+	LeftoverLog rval = {};
 	rval.filename = fname;
 	rval.shadow_filename = std::move(sfname);
 

--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -254,6 +254,7 @@ bool Manager::ActivateDynamicPluginInternal(const std::string& name, bool ok_if_
 				{
 				errors->push_back(
 					util::fmt("load plugin library %s did not instantiate a plugin", path));
+				dlclose(hdl);
 				continue;
 				}
 


### PR DESCRIPTION
The only one of these I have concerns about is 54d92045c1fda88936e958427ceaea5170701c00. The code in that if statement isn't covered by testing anywhere, but it makes sense that we should close the library handle if we're not actually using it.

The rest are pretty straight-forward fixes.