### PR TITLE
PktSrc: Move termination pseudo_realtime special case to RunState

### DIFF
--- a/src/RunState.cc
+++ b/src/RunState.cc
@@ -352,17 +352,13 @@ void run_loop()
 			// the future on which we need to wait.
 			have_pending_timers = zeek::detail::timer_mgr->Size() > 0;
 
+		// Terminate if we're running pseudo_realtime and
+		// the interface has been closed.
 		if ( pseudo_realtime && communication_enabled )
 			{
-			auto have_active_packet_source = false;
-
 			iosource::PktSrc* ps = iosource_mgr->GetPktSrc();
-			if ( ps && ps->IsOpen() )
-				have_active_packet_source = true;
-
-			if ( ! have_active_packet_source )
-				// Can turn off pseudo realtime now
-				pseudo_realtime = 0.0;
+			if ( ps && ! ps->IsOpen() )
+				iosource_mgr->Terminate();
 			}
 		}
 

--- a/src/iosource/PktSrc.cc
+++ b/src/iosource/PktSrc.cc
@@ -194,12 +194,6 @@ bool PktSrc::ExtractNextPacketInternal()
 		had_packet = false;
 		}
 
-	if ( run_state::pseudo_realtime && ! IsOpen() )
-		{
-		if ( broker_mgr->Active() )
-			iosource_mgr->Terminate();
-		}
-
 	return false;
 	}
 


### PR DESCRIPTION
This also removes setting pseduo_realtime to 0.0 in the main loop when the packet source has been closed. I had tried to understand the implications and it actually seems if we shutdown the iosource::Manager anyway, it shouldn't have any and it's confusing to update it.