### PR TITLE
Add configure option for preallocating PortVal objects

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -80,6 +80,17 @@ Changed Functionality
 
 - The ``&on_change`` attribute of set and tables is propagated through ``copy()``.
 
+- Revert back to old method of preallocting ``PortVal`` objects for all valid
+  port numbers, as it was implemented prior to the Windows port. Not
+  preallocating these objects saves a minor amount of memory for short runs of
+  Zeek, but comes at a performance cost for having to allocate the objects every
+  time a new port is seen plus do map lookups for each port. This memory savings
+  is mostly lost for long runs of Zeek, since all of the ports will likely end
+  up allocated in time.
+
+  If the version from the Windows port is desired, a new configure option
+  ``--disable-port-prealloc`` will disable the preallocation and enable the map
+  lookup version.
 
 Zeek 5.2.0
 ==========

--- a/configure
+++ b/configure
@@ -68,6 +68,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --disable-btest        don't install BTest
     --disable-btest-pcaps  don't install Zeek's BTest input pcaps
     --disable-cpp-tests    don't build Zeek's C++ unit tests
+    --disable-port-prealloc disable pre-allocating the PortVal array in ValManager
     --disable-python       don't try to build python bindings for Broker
     --disable-spicy        don't include Spicy
     --disable-zeek-client  don't install Zeek cluster management client
@@ -183,6 +184,7 @@ append_cache_entry INSTALL_ZKG BOOL true
 append_cache_entry CPACK_SOURCE_IGNORE_FILES STRING
 append_cache_entry ZEEK_SANITIZERS STRING ""
 append_cache_entry ZEEK_INCLUDE_PLUGINS STRING ""
+append_cache_entry PREALLOCATE_PORT_ARRAY BOOL true
 
 # parse arguments
 while [ $# -ne 0 ]; do
@@ -322,6 +324,9 @@ while [ $# -ne 0 ]; do
             ;;
         --disable-cpp-tests)
             append_cache_entry ENABLE_ZEEK_UNIT_TESTS BOOL false
+            ;;
+        --disable-port-prealloc)
+            append_cache_entry PREALLOCATE_PORT_ARRAY BOOL false
             ;;
         --disable-python)
             append_cache_entry DISABLE_PYTHON_BINDINGS BOOL true

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -3977,6 +3977,17 @@ ValManager::ValManager()
 
 	for ( auto i = 0u; i < PREALLOCATED_INTS; ++i )
 		ints[i] = Val::MakeInt(PREALLOCATED_INT_LOWEST + i);
+
+#ifdef PREALLOCATE_PORT_ARRAY
+	for ( auto i = 0u; i < ports.size(); ++i )
+		{
+		auto& arr = ports[i];
+		auto port_type = static_cast<TransportProto>(i);
+
+		for ( auto j = 0u; j < arr.size(); ++j )
+			arr[j] = make_intrusive<PortVal>(PortVal::Mask(j, port_type));
+		}
+#endif
 	}
 
 const PortValPtr& ValManager::Port(uint32_t port_num, TransportProto port_type)
@@ -3988,10 +3999,14 @@ const PortValPtr& ValManager::Port(uint32_t port_num, TransportProto port_type)
 		}
 
 	auto port_masked = PortVal::Mask(port_num, port_type);
+#ifdef PREALLOCATE_PORT_ARRAY
+	return ports[port_type][port_num];
+#else
 	if ( ports.count(port_masked) == 0 )
 		ports.insert({port_masked, make_intrusive<PortVal>(port_masked)});
 
 	return ports[port_masked];
+#endif
 	}
 
 const PortValPtr& ValManager::Port(uint32_t port_num)

--- a/src/Val.h
+++ b/src/Val.h
@@ -339,7 +339,12 @@ public:
 	const PortValPtr& Port(uint32_t port_num);
 
 private:
+#ifdef PREALLOCATE_PORT_ARRAY
+	std::array<std::array<PortValPtr, 65536>, NUM_PORT_SPACES> ports;
+#else
 	std::unordered_map<uint32_t, PortValPtr> ports;
+#endif
+
 	std::array<ValPtr, PREALLOCATED_COUNTS> counts;
 	std::array<ValPtr, PREALLOCATED_INTS> ints;
 	StringValPtr empty_string;

--- a/zeek-config.h.in
+++ b/zeek-config.h.in
@@ -147,6 +147,11 @@
 /* whether htonll/ntohll is defined in <arpa/inet.h> */
 #cmakedefine HAVE_BYTEORDER_64
 
+/* whether to preallocate the array of PortVal objects in ValManager. Doing
+   so is typically a performance increase, at the cost of a small amount of
+   memory. */
+#cmakedefine PREALLOCATE_PORT_ARRAY
+
 /* ultrix can't hack const */
 #cmakedefine NEED_ULTRIX_CONST_HACK
 #ifdef NEED_ULTRIX_CONST_HACK


### PR DESCRIPTION
This PR restores the old model of pre-allocating all of the `PortVal` objects at startup, but adds an option to `configure` that allows usage of the new model of not pre-allocating them.

I considered making this a script-level option but ValManager gets initialized before script parsing starts and the PortVals should exist prior to that as well. I also considered making it a runtime option, but the code ends up cleaner by making it compile-time. There's a question of whether a runtime option would be more useful for things like btests though.

Fixes #2571 