### PR TITLE
Fix the x509-invalid-extension test on OpenSSL 3.1

### DIFF
--- a/testing/btest/scripts/base/protocols/ssl/x509-invalid-extension.test
+++ b/testing/btest/scripts/base/protocols/ssl/x509-invalid-extension.test
@@ -8,6 +8,9 @@ event x509_extension(f: fa_file, ext: X509::Extension)
 	if ( ext$oid != "1.3.6.1.5.5.7.1.12" )
 		return;
 
-	print ext$short_name;
+	if ( ext?$short_name )
+		print ext$short_name;
+	else
+		print "UNDEF";
 	print ext$value;
 	}


### PR DESCRIPTION
OpenSSL 3.1 switched from outputting UNDEF to not giving a short name in this case. Luckily this only requires a tiny test change.

We might consider pulling this into older versions, for ease of CI testing.

Fixes GH-2869