### PR TITLE
Fix integer signedness comparison warning with GCC 12.2

### DIFF
--- a/src/packet_analysis/protocol/teredo/Teredo.cc
+++ b/src/packet_analysis/protocol/teredo/Teredo.cc
@@ -291,7 +291,7 @@ bool TeredoAnalyzer::DetectProtocol(size_t len, const uint8_t* data, Packet* pac
 		uint8_t client_id_length = data[2];
 		uint8_t auth_length = data[3];
 
-		if ( len < (13 + client_id_length + auth_length) )
+		if ( len < (static_cast<size_t>(13) + client_id_length + auth_length) )
 			return false;
 
 		// There's 9 bytes at the end of the header for a nonce value and a


### PR DESCRIPTION
We're so close to a warning-free build again ... this fixes:
```
/home/christian/devel/zeek/zeek/src/packet_analysis/protocol/teredo/Teredo.cc: In member function ‘virtual bool zeek::packet_analysis::teredo::TeredoAnalyzer::DetectProtocol(size_t, const uint8_t*, zeek::Packet*)’:
/home/christian/devel/zeek/zeek/src/packet_analysis/protocol/teredo/Teredo.cc:294:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
  294 |                 if ( len < (13 + client_id_length + auth_length) )
```