### PR TITLE
Ensure master/release builds run for zeek-security

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -61,7 +61,7 @@ builds_only_if_template: &BUILDS_ONLY_IF_TEMPLATE
     ( $CIRRUS_CRON == '' ) &&
     ( $CIRRUS_REPO_NAME != 'zeek-security' || $CIRRUS_OS != "darwin" ) &&
     ( ( $CIRRUS_PR != '' && $CIRRUS_BRANCH !=~ 'dependabot/.*' ) ||
-    ( $CIRRUS_REPO_NAME == 'zeek' &&
+    ( ( $CIRRUS_REPO_NAME == 'zeek' || $CIRRUS_REPO_NAME == 'zeek-security' ) &&
       (
       $CIRRUS_BRANCH == 'master' ||
       $CIRRUS_BRANCH =~ 'release/.*'


### PR DESCRIPTION
At some point we broke master/release builds running on the zeek-security repo. This PR fixes it so those always run.