### PR TITLE
Fix a bunch of -Wunqualified-std-cast-call warnings from clang 15

### DIFF
--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -86,7 +86,7 @@ void Reporter::InitOptions()
 			auto k = wle.GetHashKey();
 			auto index = wl_val->RecreateIndex(*k);
 			std::string key = index->Idx(0)->AsString()->CheckString();
-			set->emplace(move(key));
+			set->emplace(std::move(key));
 			}
 	};
 

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -237,14 +237,14 @@ struct val_converter
 					if ( disambiguate )
 						{
 						// Disambiguate from composite key w/ multiple vals.
-						composite_key.emplace_back(move(item));
+						composite_key.emplace_back(std::move(item));
 						indices = &composite_key;
 						}
 					}
 				}
 			else
 				{
-				composite_key.emplace_back(move(item));
+				composite_key.emplace_back(std::move(item));
 				indices = &composite_key;
 				}
 
@@ -255,7 +255,8 @@ struct val_converter
 
 			for ( size_t i = 0; i < indices->size(); ++i )
 				{
-				auto index_val = data_to_val(move((*indices)[i]), expected_index_types[i].get());
+				auto index_val = data_to_val(std::move((*indices)[i]),
+				                             expected_index_types[i].get());
 
 				if ( ! index_val )
 					return nullptr;
@@ -292,14 +293,14 @@ struct val_converter
 					if ( disambiguate )
 						{
 						// Disambiguate from composite key w/ multiple vals.
-						composite_key.emplace_back(move(item.first));
+						composite_key.emplace_back(std::move(item.first));
 						indices = &composite_key;
 						}
 					}
 				}
 			else
 				{
-				composite_key.emplace_back(move(item.first));
+				composite_key.emplace_back(std::move(item.first));
 				indices = &composite_key;
 				}
 
@@ -310,7 +311,8 @@ struct val_converter
 
 			for ( size_t i = 0; i < indices->size(); ++i )
 				{
-				auto index_val = data_to_val(move((*indices)[i]), expected_index_types[i].get());
+				auto index_val = data_to_val(std::move((*indices)[i]),
+				                             expected_index_types[i].get());
 
 				if ( ! index_val )
 					return nullptr;
@@ -318,7 +320,7 @@ struct val_converter
 				list_val->Append(std::move(index_val));
 				}
 
-			auto value_val = data_to_val(move(item.second), tt->Yield().get());
+			auto value_val = data_to_val(std::move(item.second), tt->Yield().get());
 
 			if ( ! value_val )
 				return nullptr;
@@ -338,7 +340,7 @@ struct val_converter
 
 			for ( auto& item : a )
 				{
-				auto item_val = data_to_val(move(item), vt->Yield().get());
+				auto item_val = data_to_val(std::move(item), vt->Yield().get());
 
 				if ( ! item_val )
 					return nullptr;
@@ -364,7 +366,7 @@ struct val_converter
 			unsigned int pos = 0;
 			for ( auto& item : a )
 				{
-				auto item_val = data_to_val(move(item),
+				auto item_val = data_to_val(std::move(item),
 				                            pure ? lt->GetPureType().get() : types[pos].get());
 				pos++;
 
@@ -441,7 +443,7 @@ struct val_converter
 					continue;
 					}
 
-				auto item_val = data_to_val(move(a[idx]), rt->GetFieldType(i).get());
+				auto item_val = data_to_val(std::move(a[idx]), rt->GetFieldType(i).get());
 
 				if ( ! item_val )
 					return nullptr;
@@ -814,7 +816,7 @@ static bool data_type_check(const broker::data& d, Type* t)
 ValPtr data_to_val(broker::data d, Type* type)
 	{
 	if ( type->Tag() == TYPE_ANY )
-		return make_data_val(move(d));
+		return make_data_val(std::move(d));
 
 	return visit(val_converter{type}, d);
 	}
@@ -936,18 +938,18 @@ broker::expected<broker::data> val_to_data(const Val* v)
 					if ( ! key_part )
 						return broker::ec::invalid_data;
 
-					composite_key.emplace_back(move(*key_part));
+					composite_key.emplace_back(std::move(*key_part));
 					}
 
 				broker::data key;
 
 				if ( composite_key.size() == 1 )
-					key = move(composite_key[0]);
+					key = std::move(composite_key[0]);
 				else
-					key = move(composite_key);
+					key = std::move(composite_key);
 
 				if ( is_set )
-					get<broker::set>(rval).emplace(move(key));
+					get<broker::set>(rval).emplace(std::move(key));
 				else
 					{
 					auto val = val_to_data(te.value->GetVal().get());
@@ -955,7 +957,7 @@ broker::expected<broker::data> val_to_data(const Val* v)
 					if ( ! val )
 						return broker::ec::invalid_data;
 
-					get<broker::table>(rval).emplace(move(key), move(*val));
+					get<broker::table>(rval).emplace(std::move(key), std::move(*val));
 					}
 				}
 
@@ -979,7 +981,7 @@ broker::expected<broker::data> val_to_data(const Val* v)
 				if ( ! item )
 					return broker::ec::invalid_data;
 
-				rval.emplace_back(move(*item));
+				rval.emplace_back(std::move(*item));
 				}
 
 			return {std::move(rval)};
@@ -1004,7 +1006,7 @@ broker::expected<broker::data> val_to_data(const Val* v)
 				if ( ! item )
 					return broker::ec::invalid_data;
 
-				rval.emplace_back(move(*item));
+				rval.emplace_back(std::move(*item));
 				}
 
 			return {std::move(rval)};
@@ -1031,7 +1033,7 @@ broker::expected<broker::data> val_to_data(const Val* v)
 				if ( ! item )
 					return broker::ec::invalid_data;
 
-				rval.emplace_back(move(*item));
+				rval.emplace_back(std::move(*item));
 				}
 
 			return {std::move(rval)};
@@ -1067,7 +1069,7 @@ RecordValPtr make_data_val(Val* v)
 	auto data = val_to_data(v);
 
 	if ( data )
-		rval->Assign(0, make_intrusive<DataVal>(move(*data)));
+		rval->Assign(0, make_intrusive<DataVal>(std::move(*data)));
 	else
 		reporter->Warning("did not get a value from val_to_data");
 
@@ -1077,7 +1079,7 @@ RecordValPtr make_data_val(Val* v)
 RecordValPtr make_data_val(broker::data d)
 	{
 	auto rval = make_intrusive<RecordVal>(BifType::Record::Broker::Data);
-	rval->Assign(0, make_intrusive<DataVal>(move(d)));
+	rval->Assign(0, make_intrusive<DataVal>(std::move(d)));
 	return rval;
 	}
 

--- a/src/broker/data.bif
+++ b/src/broker/data.bif
@@ -218,7 +218,7 @@ function Broker::__table_insert%(t: Broker::Data, key: any, val: any%): Broker::
 	try
 		{
 		auto& prev = table.at(*k);
-		auto rval = zeek::Broker::detail::make_data_val(move(prev));
+		auto rval = zeek::Broker::detail::make_data_val(std::move(prev));
 		prev = std::move(*v);
 		return rval;
 		}
@@ -248,7 +248,7 @@ function Broker::__table_remove%(t: Broker::Data, key: any%): Broker::Data
 		return zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::Broker::Data);
 	else
 		{
-		auto rval = zeek::Broker::detail::make_data_val(move(it->second));
+		auto rval = zeek::Broker::detail::make_data_val(std::move(it->second));
 		table.erase(it);
 		return rval;
 		}
@@ -369,7 +369,7 @@ function Broker::__vector_replace%(v: Broker::Data, idx: count, d: any%): Broker
 	if ( idx >= vec.size() )
 		return zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::Broker::Data);
 
-	auto rval = zeek::Broker::detail::make_data_val(move(vec[idx]));
+	auto rval = zeek::Broker::detail::make_data_val(std::move(vec[idx]));
 	vec[idx] = std::move(*item);
 	return rval;
 	%}
@@ -382,7 +382,7 @@ function Broker::__vector_remove%(v: Broker::Data, idx: count%): Broker::Data
 	if ( idx >= vec.size() )
 		return zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::Broker::Data);
 
-	auto rval = zeek::Broker::detail::make_data_val(move(vec[idx]));
+	auto rval = zeek::Broker::detail::make_data_val(std::move(vec[idx]));
 	vec.erase(vec.begin() + idx);
 	return rval;
 	%}

--- a/src/reporter.bif
+++ b/src/reporter.bif
@@ -189,7 +189,7 @@ function Reporter::set_weird_sampling_whitelist%(weird_sampling_whitelist: strin
 
 		auto index = wl_val->RecreateIndex(*k);
 		string key = index->Idx(0)->AsString()->CheckString();
-		whitelist_set.emplace(move(key));
+		whitelist_set.emplace(std::move(key));
 		}
 	reporter->SetWeirdSamplingWhitelist(std::move(whitelist_set));
 	return zeek::val_mgr->True();
@@ -225,7 +225,7 @@ function Reporter::set_weird_sampling_global_list%(weird_sampling_global_list: s
 		auto k = tble.GetHashKey();
 		auto index = wl_val->RecreateIndex(*k);
 		string key = index->Idx(0)->AsString()->CheckString();
-		global_list_set.emplace(move(key));
+		global_list_set.emplace(std::move(key));
 		}
 	reporter->SetWeirdSamplingGlobalList(std::move(global_list_set));
 	return zeek::val_mgr->True();

--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -1352,7 +1352,7 @@ string CPPCompile::GenEnum(const TypePtr& t, const ValPtr& ev)
 		mapping_slot = num_ev_mappings++;
 
 		string enum_name = et->Lookup(v);
-		enum_names.emplace_back(pair(TypeOffset(t), move(enum_name)));
+		enum_names.emplace_back(pair(TypeOffset(t), std::move(enum_name)));
 
 		if ( evm != enum_val_mappings.end() )
 			{

--- a/src/script_opt/CPP/Func.cc
+++ b/src/script_opt/CPP/Func.cc
@@ -46,9 +46,9 @@ CPPStmt::CPPStmt(const char* _name, const char* filename, int line_num)
 	}
 
 CPPLambdaFunc::CPPLambdaFunc(string _name, FuncTypePtr ft, CPPStmtPtr _l_body)
-	: ScriptFunc(move(_name), move(ft), {_l_body}, {0})
+	: ScriptFunc(std::move(_name), std::move(ft), {_l_body}, {0})
 	{
-	l_body = move(_l_body);
+	l_body = std::move(_l_body);
 	}
 
 broker::expected<broker::data> CPPLambdaFunc::SerializeCaptures() const
@@ -67,13 +67,13 @@ broker::expected<broker::data> CPPLambdaFunc::SerializeCaptures() const
 			return broker::ec::invalid_data;
 
 		TypeTag tag = val->GetType()->Tag();
-		broker::vector val_tuple{move(*expected), static_cast<broker::integer>(tag)};
-		body.emplace_back(move(val_tuple));
+		broker::vector val_tuple{std::move(*expected), static_cast<broker::integer>(tag)};
+		body.emplace_back(std::move(val_tuple));
 		}
 
-	rval.emplace_back(move(body));
+	rval.emplace_back(std::move(body));
 
-	return {move(rval)};
+	return {std::move(rval)};
 	}
 
 void CPPLambdaFunc::SetCaptures(Frame* f)

--- a/src/script_opt/CPP/InitsInfo.cc
+++ b/src/script_opt/CPP/InitsInfo.cc
@@ -27,7 +27,7 @@ void CPP_InitsInfo::AddInstance(shared_ptr<CPP_InitInfo> g)
 
 	g->SetOffset(this, size++);
 
-	instances[final_init_cohort].push_back(move(g));
+	instances[final_init_cohort].push_back(std::move(g));
 	}
 
 string CPP_InitsInfo::Declare() const
@@ -353,7 +353,7 @@ AttrsInfo::AttrsInfo(CPPCompile* _c, const AttributesPtr& _attrs) : CompoundItem
 	}
 
 GlobalInitInfo::GlobalInitInfo(CPPCompile* c, const ID* g, string _CPP_name)
-	: CPP_InitInfo(g), CPP_name(move(_CPP_name))
+	: CPP_InitInfo(g), CPP_name(std::move(_CPP_name))
 	{
 	Zeek_name = g->Name();
 
@@ -392,7 +392,8 @@ void GlobalInitInfo::InitializerVals(std::vector<std::string>& ivs) const
 	}
 
 CallExprInitInfo::CallExprInitInfo(CPPCompile* c, ExprPtr _e, string _e_name, string _wrapper_class)
-	: CPP_InitInfo(_e), e(move(_e)), e_name(move(_e_name)), wrapper_class(move(_wrapper_class))
+	: CPP_InitInfo(_e), e(std::move(_e)), e_name(std::move(_e_name)),
+	  wrapper_class(std::move(_wrapper_class))
 	{
 	auto gi = c->RegisterType(e->GetType());
 	if ( gi )
@@ -402,7 +403,7 @@ CallExprInitInfo::CallExprInitInfo(CPPCompile* c, ExprPtr _e, string _e_name, st
 LambdaRegistrationInfo::LambdaRegistrationInfo(CPPCompile* c, string _name, FuncTypePtr ft,
                                                string _wrapper_class, p_hash_type _h,
                                                bool _has_captures)
-	: CPP_InitInfo(ft), name(move(_name)), wrapper_class(move(_wrapper_class)), h(_h),
+	: CPP_InitInfo(ft), name(std::move(_name)), wrapper_class(std::move(_wrapper_class)), h(_h),
 	  has_captures(_has_captures)
 	{
 	auto gi = c->RegisterType(ft);
@@ -436,7 +437,7 @@ void OpaqueTypeInfo::AddInitializerVals(std::vector<std::string>& ivs) const
 	ivs.emplace_back(Fmt(c->TrackString(t->AsOpaqueType()->Name())));
 	}
 
-TypeTypeInfo::TypeTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, move(_t))
+TypeTypeInfo::TypeTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, std::move(_t))
 	{
 	tt = t->AsTypeType()->GetType();
 	auto gi = c->RegisterType(tt);
@@ -449,7 +450,7 @@ void TypeTypeInfo::AddInitializerVals(std::vector<std::string>& ivs) const
 	ivs.emplace_back(to_string(c->TypeOffset(tt)));
 	}
 
-VectorTypeInfo::VectorTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, move(_t))
+VectorTypeInfo::VectorTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, std::move(_t))
 	{
 	yield = t->Yield();
 	auto gi = c->RegisterType(yield);
@@ -463,7 +464,7 @@ void VectorTypeInfo::AddInitializerVals(std::vector<std::string>& ivs) const
 	}
 
 ListTypeInfo::ListTypeInfo(CPPCompile* _c, TypePtr _t)
-	: AbstractTypeInfo(_c, move(_t)), types(t->AsTypeList()->GetTypes())
+	: AbstractTypeInfo(_c, std::move(_t)), types(t->AsTypeList()->GetTypes())
 	{
 	// Note, we leave init_cohort at 0 because the skeleton of this type
 	// is built in the first cohort.
@@ -488,7 +489,7 @@ void ListTypeInfo::AddInitializerVals(std::vector<std::string>& ivs) const
 		}
 	}
 
-TableTypeInfo::TableTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, move(_t))
+TableTypeInfo::TableTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, std::move(_t))
 	{
 	// Note, we leave init_cohort at 0 because the skeleton of this type
 	// is built in the first cohort.
@@ -516,7 +517,7 @@ void TableTypeInfo::AddInitializerVals(std::vector<std::string>& ivs) const
 	ivs.emplace_back(Fmt(yield ? c->TypeOffset(yield) : -1));
 	}
 
-FuncTypeInfo::FuncTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, move(_t))
+FuncTypeInfo::FuncTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, std::move(_t))
 	{
 	auto f = t->AsFuncType();
 
@@ -543,7 +544,7 @@ void FuncTypeInfo::AddInitializerVals(std::vector<std::string>& ivs) const
 	ivs.emplace_back(Fmt(static_cast<int>(flavor)));
 	}
 
-RecordTypeInfo::RecordTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, move(_t))
+RecordTypeInfo::RecordTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, std::move(_t))
 	{
 	// Note, we leave init_cohort at 0 because the skeleton of this type
 	// is built in the first cohort.

--- a/src/script_opt/CPP/RuntimeInitSupport.cc
+++ b/src/script_opt/CPP/RuntimeInitSupport.cc
@@ -52,7 +52,7 @@ void register_type__CPP(TypePtr t, const string& name)
 void register_body__CPP(CPPStmtPtr body, int priority, p_hash_type hash, vector<string> events,
                         void (*finish_init)())
 	{
-	compiled_scripts[hash] = {move(body), priority, move(events), finish_init};
+	compiled_scripts[hash] = {std::move(body), priority, std::move(events), finish_init};
 	}
 
 static unordered_map<p_hash_type, CompiledScript> compiled_standalone_scripts;
@@ -62,7 +62,7 @@ void register_standalone_body__CPP(CPPStmtPtr body, int priority, p_hash_type ha
 	{
 	// For standalone scripts we don't actually need finish_init, but
 	// we keep it for symmetry with compiled_scripts.
-	compiled_standalone_scripts[hash] = {move(body), priority, move(events), finish_init};
+	compiled_standalone_scripts[hash] = {std::move(body), priority, std::move(events), finish_init};
 	}
 
 void register_lambda__CPP(CPPStmtPtr body, p_hash_type hash, const char* name, TypePtr t,
@@ -75,8 +75,8 @@ void register_lambda__CPP(CPPStmtPtr body, p_hash_type hash, const char* name, T
 	auto func = make_intrusive<CPPLambdaFunc>(name, ft, body);
 	func->SetName(name);
 
-	auto v = make_intrusive<FuncVal>(move(func));
-	id->SetVal(move(v));
+	auto v = make_intrusive<FuncVal>(std::move(func));
+	id->SetVal(std::move(v));
 	id->SetType(ft);
 
 	// Lambdas used in initializing global functions need to
@@ -118,7 +118,7 @@ void activate_bodies__CPP(const char* fn, const char* module, bool exported, Typ
 		vector<int> no_priorities;
 		auto sf = make_intrusive<ScriptFunc>(fn, ft, no_bodies, no_priorities);
 
-		v = make_intrusive<FuncVal>(move(sf));
+		v = make_intrusive<FuncVal>(std::move(sf));
 		fg->SetVal(v);
 		}
 
@@ -221,9 +221,10 @@ FuncValPtr lookup_func__CPP(string name, int num_bodies, vector<p_hash_type> has
 			}
 		}
 
-	auto sf = make_intrusive<ScriptFunc>(move(name), move(ft), move(bodies), move(priorities));
+	auto sf = make_intrusive<ScriptFunc>(std::move(name), std::move(ft), std::move(bodies),
+	                                     std::move(priorities));
 
-	return make_intrusive<FuncVal>(move(sf));
+	return make_intrusive<FuncVal>(std::move(sf));
 	}
 
 IDPtr find_global__CPP(const char* g)
@@ -259,7 +260,7 @@ EnumTypePtr get_enum_type__CPP(const string& enum_type_name)
 
 EnumValPtr make_enum__CPP(TypePtr t, zeek_int_t i)
 	{
-	auto et = cast_intrusive<EnumType>(move(t));
+	auto et = cast_intrusive<EnumType>(std::move(t));
 	return make_intrusive<EnumVal>(et, i);
 	}
 

--- a/src/script_opt/CPP/RuntimeInits.cc
+++ b/src/script_opt/CPP/RuntimeInits.cc
@@ -526,7 +526,7 @@ void CPP_GlobalInit::Generate(InitsManager* im, std::vector<void*>& /* inits_vec
 
 			auto sf = make_intrusive<ScriptFunc>(fn, ft, no_bodies, no_priorities);
 
-			auto v = make_intrusive<FuncVal>(move(sf));
+			auto v = make_intrusive<FuncVal>(std::move(sf));
 			global->SetVal(v);
 			}
 		}
@@ -561,7 +561,7 @@ void generate_indices_set(int* inits, std::vector<std::vector<int>>& indices_set
 			indices.push_back(i_ptr[i]);
 		i_ptr += n;
 
-		indices_set.emplace_back(move(indices));
+		indices_set.emplace_back(std::move(indices));
 		}
 	}
 

--- a/src/script_opt/CPP/RuntimeOps.cc
+++ b/src/script_opt/CPP/RuntimeOps.cc
@@ -43,7 +43,7 @@ ListValPtr index_val__CPP(vector<ValPtr> indices)
 
 ValPtr index_table__CPP(const TableValPtr& t, vector<ValPtr> indices)
 	{
-	auto v = t->FindOrDefault(index_val__CPP(move(indices)));
+	auto v = t->FindOrDefault(index_val__CPP(std::move(indices)));
 	if ( ! v )
 		reporter->CPPRuntimeError("no such index");
 	return v;
@@ -59,7 +59,7 @@ ValPtr index_vec__CPP(const VectorValPtr& vec, int index)
 
 ValPtr index_string__CPP(const StringValPtr& svp, vector<ValPtr> indices)
 	{
-	return index_string(svp->AsString(), index_val__CPP(move(indices)).get());
+	return index_string(svp->AsString(), index_val__CPP(std::move(indices)).get());
 	}
 
 ValPtr when_index_table__CPP(const TableValPtr& t, vector<ValPtr> indices)
@@ -168,7 +168,7 @@ static void check_iterators__CPP(bool invalid)
 template <typename T> ValPtr assign_to_index__CPP(T v1, ValPtr v2, ValPtr v3)
 	{
 	bool iterators_invalidated = false;
-	auto err_msg = assign_to_index(move(v1), move(v2), v3, iterators_invalidated);
+	auto err_msg = assign_to_index(std::move(v1), std::move(v2), v3, iterators_invalidated);
 
 	check_iterators__CPP(iterators_invalidated);
 
@@ -180,15 +180,15 @@ template <typename T> ValPtr assign_to_index__CPP(T v1, ValPtr v2, ValPtr v3)
 
 ValPtr assign_to_index__CPP(TableValPtr v1, ValPtr v2, ValPtr v3)
 	{
-	return assign_to_index__CPP<TableValPtr>(move(v1), move(v2), move(v3));
+	return assign_to_index__CPP<TableValPtr>(std::move(v1), std::move(v2), std::move(v3));
 	}
 ValPtr assign_to_index__CPP(VectorValPtr v1, ValPtr v2, ValPtr v3)
 	{
-	return assign_to_index__CPP<VectorValPtr>(move(v1), move(v2), move(v3));
+	return assign_to_index__CPP<VectorValPtr>(std::move(v1), std::move(v2), std::move(v3));
 	}
 ValPtr assign_to_index__CPP(StringValPtr v1, ValPtr v2, ValPtr v3)
 	{
-	return assign_to_index__CPP<StringValPtr>(move(v1), move(v2), move(v3));
+	return assign_to_index__CPP<StringValPtr>(std::move(v1), std::move(v2), std::move(v3));
 	}
 
 void add_element__CPP(TableValPtr aggr, ListValPtr indices)
@@ -225,17 +225,17 @@ static AttributesPtr build_attrs__CPP(vector<int> attr_tags, vector<ValPtr> attr
 		attrs.emplace_back(make_intrusive<Attr>(t_i, e));
 		}
 
-	return make_intrusive<Attributes>(move(attrs), nullptr, false, false);
+	return make_intrusive<Attributes>(std::move(attrs), nullptr, false, false);
 	}
 
 TableValPtr set_constructor__CPP(vector<ValPtr> elements, TableTypePtr t, vector<int> attr_tags,
                                  vector<ValPtr> attr_vals)
 	{
-	auto attrs = build_attrs__CPP(move(attr_tags), move(attr_vals));
-	auto aggr = make_intrusive<TableVal>(move(t), move(attrs));
+	auto attrs = build_attrs__CPP(std::move(attr_tags), std::move(attr_vals));
+	auto aggr = make_intrusive<TableVal>(std::move(t), std::move(attrs));
 
 	for ( auto& elem : elements )
-		aggr->Assign(move(elem), nullptr);
+		aggr->Assign(std::move(elem), nullptr);
 
 	return aggr;
 	}
@@ -246,14 +246,14 @@ TableValPtr table_constructor__CPP(vector<ValPtr> indices, vector<ValPtr> vals, 
 	const auto& yt = t->Yield();
 	auto n = indices.size();
 
-	auto attrs = build_attrs__CPP(move(attr_tags), move(attr_vals));
-	auto aggr = make_intrusive<TableVal>(move(t), move(attrs));
+	auto attrs = build_attrs__CPP(std::move(attr_tags), std::move(attr_vals));
+	auto aggr = make_intrusive<TableVal>(std::move(t), std::move(attrs));
 
 	for ( auto i = 0u; i < n; ++i )
 		{
 		auto v = check_and_promote(vals[i], yt, true);
 		if ( v )
-			aggr->Assign(move(indices[i]), move(v));
+			aggr->Assign(std::move(indices[i]), std::move(v));
 		}
 
 	return aggr;
@@ -261,7 +261,7 @@ TableValPtr table_constructor__CPP(vector<ValPtr> indices, vector<ValPtr> vals, 
 
 void assign_attrs__CPP(IDPtr id, std::vector<int> attr_tags, std::vector<ValPtr> attr_vals)
 	{
-	id->SetAttrs(build_attrs__CPP(move(attr_tags), move(attr_vals)));
+	id->SetAttrs(build_attrs__CPP(std::move(attr_tags), std::move(attr_vals)));
 	}
 
 RecordValPtr record_constructor__CPP(vector<ValPtr> vals, RecordTypePtr t)
@@ -309,7 +309,7 @@ RecordValPtr record_constructor_map__CPP(vector<ValPtr> vals, vector<int> map, R
 
 VectorValPtr vector_constructor__CPP(vector<ValPtr> vals, VectorTypePtr t)
 	{
-	auto vv = make_intrusive<VectorVal>(move(t));
+	auto vv = make_intrusive<VectorVal>(std::move(t));
 	auto n = vals.size();
 
 	for ( auto i = 0u; i < n; ++i )
@@ -321,7 +321,7 @@ VectorValPtr vector_constructor__CPP(vector<ValPtr> vals, VectorTypePtr t)
 ValPtr schedule__CPP(double dt, EventHandlerPtr event, vector<ValPtr> args)
 	{
 	if ( ! run_state::terminating )
-		timer_mgr->Add(new ScheduleTimer(event, move(args), dt));
+		timer_mgr->Add(new ScheduleTimer(event, std::move(args), dt));
 
 	return nullptr;
 	}

--- a/src/script_opt/CPP/RuntimeVec.cc
+++ b/src/script_opt/CPP/RuntimeVec.cc
@@ -251,7 +251,7 @@ VectorValPtr vec_op_add__CPP(VectorValPtr v, int incr)
 
 VectorValPtr vec_op_sub__CPP(VectorValPtr v, int i)
 	{
-	return vec_op_add__CPP(move(v), -i);
+	return vec_op_add__CPP(std::move(v), -i);
 	}
 
 // This function provides the core functionality.  The arguments
@@ -381,7 +381,7 @@ VectorValPtr vector_select__CPP(const VectorValPtr& v1, VectorValPtr v2, VectorV
 	for ( unsigned int i = 0; i < n; ++i )
 		{
 		auto vr_i = v1->BoolAt(i) ? v2->ValAt(i) : v3->ValAt(i);
-		v_result->Assign(i, move(vr_i));
+		v_result->Assign(i, std::move(vr_i));
 		}
 
 	return v_result;
@@ -390,7 +390,7 @@ VectorValPtr vector_select__CPP(const VectorValPtr& v1, VectorValPtr v2, VectorV
 VectorValPtr vector_coerce_to__CPP(const VectorValPtr& v, const TypePtr& targ)
 	{
 	auto res_t = cast_intrusive<VectorType>(targ);
-	auto v_result = make_intrusive<VectorVal>(move(res_t));
+	auto v_result = make_intrusive<VectorVal>(std::move(res_t));
 	auto n = v->Size();
 	auto yt = targ->Yield();
 	auto ytag = yt->Tag();
@@ -455,7 +455,7 @@ VectorValPtr vector_coerce_to__CPP(const VectorValPtr& v, const TypePtr& targ)
 				reporter->InternalError("bad vector type in vector_coerce_to__CPP");
 			}
 
-		v_result->Assign(i, move(r_i));
+		v_result->Assign(i, std::move(r_i));
 		}
 
 	return v_result;

--- a/src/script_opt/CPP/Vars.cc
+++ b/src/script_opt/CPP/Vars.cc
@@ -104,7 +104,7 @@ bool CPPCompile::AddGlobal(const string& g, const char* suffix)
 
 void CPPCompile::RegisterEvent(string ev_name)
 	{
-	body_events[body_name].emplace_back(move(ev_name));
+	body_events[body_name].emplace_back(std::move(ev_name));
 	}
 
 const string& CPPCompile::IDNameStr(const ID* id)


### PR DESCRIPTION
I started using clang 15 on my local Ubuntu installation and it's spitting out a bunch of warnings from unqualified calls to `std::move()`. This PR fixes all of the finding in Zeek itself. There's some other findings in CAF that trickle down to reports via the Broker build, as well as a few in Gen-Zam.