### PR TITLE
Replace deprecated Conan generators with new ones

### DIFF
--- a/ci/windows/build.cmd
+++ b/ci/windows/build.cmd
@@ -7,5 +7,6 @@ call "c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliar
 mkdir build
 cd build
 
-cmake.exe .. -DCMAKE_BUILD_TYPE=release -DENABLE_ZEEK_UNIT_TESTS=yes -G Ninja
+cmake.exe --version
+cmake.exe .. -DCMAKE_BUILD_TYPE=release -DENABLE_ZEEK_UNIT_TESTS=yes -G Ninja -DCMAKE_TOOLCHAIN_FILE=C:\zeek\build\conan_toolchain.cmake -DCMAKE_POLICY_DEFAULT_CMP0091=NEW
 cmake.exe --build .

--- a/ci/windows/conanfile_windows.txt
+++ b/ci/windows/conanfile_windows.txt
@@ -3,6 +3,9 @@ zlib/1.2.11
 libpcap/1.10.1
 c-ares/1.18.1
 
+[options]
+pr:b=default
+
 [generators]
 CMakeDeps
 CMakeToolchain


### PR DESCRIPTION
The `conan` and `conan_find_package` generators were deprecated in Conan 1.58. This PR replaces them with the recommended `CMakeDeps` and `CMakeToolchain` generators that are fully-released in Conan 2.0. I tested these with Conan 1.54 on my local machine and they work there as well.