### PR TITLE
Consider cap len when forwarding into packet analysis.

### DIFF
--- a/src/packet_analysis/Analyzer.h
+++ b/src/packet_analysis/Analyzer.h
@@ -237,8 +237,9 @@ protected:
 	 * Triggers analysis of the encapsulated packet. The encapsulated protocol
 	 * is determined using the given identifier.
 	 *
+	 * @param len The length of the data left to analyze.
+	 * @param data Pointer to the payload in the raw packet left to analyze.
 	 * @param packet The packet to analyze.
-	 * @param data Reference to the payload pointer into the raw packet.
 	 * @param identifier The identifier of the encapsulated protocol.
 	 *
 	 * @return false if the analysis failed, else true.
@@ -249,8 +250,9 @@ protected:
 	 * Triggers default analysis of the encapsulated packet if the default analyzer
 	 * is set.
 	 *
+	 * @param len The length of the data left to analyze.
+	 * @param data Pointer to the payload in the raw packet left to analyze.
 	 * @param packet The packet to analyze.
-	 * @param data Reference to the payload pointer into the raw packet.
 	 *
 	 * @return false if the analysis failed, else true.
 	 */

--- a/src/packet_analysis/protocol/tcp/TCP.cc
+++ b/src/packet_analysis/protocol/tcp/TCP.cc
@@ -125,7 +125,7 @@ void TCPAnalyzer::DeliverPacket(Connection* c, double t, bool is_orig, int remai
 	pkt->session = c;
 
 	// Send the packet back into the packet analysis framework.
-	ForwardPacket(len, data, pkt);
+	ForwardPacket(std::min(len, remaining), data, pkt);
 
 	// Call DeliverPacket on the adapter directly here. Normally we'd call ForwardPacket
 	// but this adapter does some other things in its DeliverPacket with the packet children

--- a/src/packet_analysis/protocol/udp/UDP.cc
+++ b/src/packet_analysis/protocol/udp/UDP.cc
@@ -223,7 +223,7 @@ void UDPAnalyzer::DeliverPacket(Connection* c, double t, bool is_orig, int remai
 	// port here because the orig/resp should have already swapped around based on
 	// likely_server_ports. This also prevents us from processing things twice if protocol
 	// detection has to be used.
-	ForwardPacket(len, data, pkt, ntohs(c->RespPort()));
+	ForwardPacket(std::min(len, remaining), data, pkt, ntohs(c->RespPort()));
 
 	// Also try sending it into session analysis.
 	if ( remaining >= len )


### PR DESCRIPTION
When forwarding into packet analysis from TCP or UDP, the protocol's length fields were trusted. This might be dangerous in case of truncated packets.