### PR TITLE
Fixes for building on GCC 13

### DIFF
--- a/auxil/spicy/CMakeLists.txt
+++ b/auxil/spicy/CMakeLists.txt
@@ -24,7 +24,7 @@ endif ()
 # set these flags we do need a customizable subdirectory above the Spicy
 # sources.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-braces")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-vla")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-vla -Wno-changes-meaning")
 
 # The script generating precompiled headers for Spicy expects a different build
 # system layout than provided for a bundled Spicy, disable it.

--- a/ci/opensuse-tumbleweed/Dockerfile
+++ b/ci/opensuse-tumbleweed/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/tumbleweed
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20221027
+ENV DOCKERFILE_VERSION 20230330
 
 RUN zypper refresh \
  && zypper in -y \

--- a/src/WeirdState.h
+++ b/src/WeirdState.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
While running test builds on OBS for https://github.com/zeek/zeek/pull/2799, we ran into a problem where the OpenSUSE Tumbleweed VM updated to GCC 13. This causes a few different build failures in Zeek:

- The [recently-merged flow scopes](https://github.com/zeek/broker/pull/307) feature in Broker had a use-after-free bug that didn't show up in testing. This PR updates the broker submodule to pull in that plus a few other changes.
- Spicy fails to build due to a new warning in one of their dependencies. This PR adds a new flag to the Zeek build to avoid that error.
- `WeirdState.h` needs `<cstdint>` included to find uint64_t correctly.