### PR TITLE
Add reporter framework to core.packet-analyzer-override btest

### DIFF
--- a/testing/btest/core/packet-analyzer-override.zeek
+++ b/testing/btest/core/packet-analyzer-override.zeek
@@ -1,6 +1,8 @@
 # @TEST-EXEC: zeek -b %INPUT
 # @TEST-EXEC: btest-diff reporter.log
 
+@load base/frameworks/reporter
+
 redef PacketAnalyzer::SKIP::skip_bytes: count = 0;
 
 event zeek_init()


### PR DESCRIPTION
I'm not sure how this works on some platforms but not on others, but on the sanitizer builds it's required to load the reporter framework or else reporter.log isn't created.