### PR TITLE
Compile-to-C++ monthly maintenance - April 2023

### DIFF
--- a/src/script_opt/CPP/InitsInfo.cc
+++ b/src/script_opt/CPP/InitsInfo.cc
@@ -329,6 +329,7 @@ AttrInfo::AttrInfo(CPPCompile* _c, const AttrPtr& attr) : CompoundItemInfo(_c)
 		else
 			{
 			ASSERT(a_e->Tag() == EXPR_RECORD_COERCE);
+			ASSERT(gi);
 			vals.emplace_back(Fmt(static_cast<int>(AE_RECORD)));
 			vals.emplace_back(Fmt(gi->Offset()));
 			}

--- a/testing/btest/language/at-if-lambda.zeek
+++ b/testing/btest/language/at-if-lambda.zeek
@@ -9,11 +9,7 @@ event zeek_init()
 	{
 	local make_epoch_result = function(pass_name: string): function(ts: time): time
 		{
-@if ( Version::at_least("4.1") )
 		return function [pass_name] (ts: time): time
-@else
-		return function (ts: time)
-@endif
 			{
 			print pass_name;
 			return ts;
@@ -35,11 +31,7 @@ event zeek_init()
 	{
 	local make_epoch_result = function(pass_name: string): function(ts: time): time
 		{
-@if ( Version::at_least("4.1") )
 		return function [pass_name] (ts: time): time {
-@else
-		return function (ts: time) {
-@endif
 			print pass_name;
 			return ts;
 			};

--- a/testing/btest/scripts/policy/frameworks/dpd/packet-segment-logging.zeek
+++ b/testing/btest/scripts/policy/frameworks/dpd/packet-segment-logging.zeek
@@ -9,10 +9,8 @@ event analyzer_violation(c: connection, atype: AllAnalyzers::Tag, aid: count, re
 	print "analyzer_violation", c$id, atype, aid, reason;
 	}
 
-@if ( Version::at_least("5.1") )
 event analyzer_violation_info(tag: AllAnalyzers::Tag, info: AnalyzerViolationInfo)
 	{
 	print "reason", info$reason;
 	print "data", fmt("%s", info$data);
 	}
-@endif

--- a/testing/btest/supervisor/config-cluster-pcap.zeek
+++ b/testing/btest/supervisor/config-cluster-pcap.zeek
@@ -1,4 +1,5 @@
 # @TEST-DOC: Test support for pcap_file on Supervisor::ClusterEndpoint and Supervisor::NodeConfig
+# @TEST-REQUIRES: test "${ZEEK_USE_CPP}" != "1"
 #
 # @TEST-PORT: MANAGER_PORT
 # @TEST-PORT: WORKER_PORT


### PR DESCRIPTION
The only maintenance for `-O gen-C++` this month concerns BTests with conditional code.  For one of these, the fix is add a `# @TEST-REQUIRES` to skip it for C++ compilation.  The other have conditional code that can now be removed, as it's testing for old Zeek versions.

UPDATE: I'd forgotten about a static analysis concern regarding a possible null pointer de-ref.  I don't believe it can happen in practice, but I've now added an `ASSERT` which should let the analyzer determine that it's not an issue.