### PR TITLE
iosource/Manager: Make packet sources readiness heuristic configurable

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -173,6 +173,17 @@ type PacketSource: record {
 ## by this many milliseconds after the last packet has been received.
 const packet_source_inactivity_timeout = 100msec &redef;
 
+## Setting to relax aggressive packet source processing.
+##
+## A packet source that has not yielded packets after this many processing
+## attempts is elected for processing less often in order to save CPU time.
+##
+## Set this value to 0 in order to disable the relaxing mechanism.
+##
+## .. zeek:see:: io_poll_interval_live Pcap::non_fd_timeout
+##
+const packet_source_inactivity_count = 4 &redef;
+
 ## Whether Zeek will forward network_time to the current time upon
 ## observing an idle packet source (or no configured packet source).
 ##

--- a/src/const.bif
+++ b/src/const.bif
@@ -3,6 +3,7 @@
 ##! variables themselves are found in :doc:`/scripts/base/init-bare.zeek`.
 
 const packet_source_inactivity_timeout: interval;
+const packet_source_inactivity_count: count;
 const allow_network_time_forward: bool;
 const ignore_keep_alive_rexmit: bool;
 const skip_http_data: bool;

--- a/src/iosource/PktSrc.h
+++ b/src/iosource/PktSrc.h
@@ -107,6 +107,13 @@ public:
 	virtual bool HasBeenIdleFor(double interval) const;
 
 	/**
+	 * Return the number of times ExtractNextPacket() has not yielded a packet.
+	 *
+	 * @return The idle counter.
+	 */
+	uint64_t GetIdleCounter() const { return idle_counter; }
+
+	/**
 	 * If the source encountered an error, returns a corresponding error
 	 * message. Returns an empty string otherwise.
 	 */
@@ -379,8 +386,7 @@ private:
 
 	bool have_packet;
 	Packet current_packet;
-	// Did the previous call to ExtractNextPacket() yield a packet.
-	bool had_packet;
+	uint64_t idle_counter;
 
 	double idle_at_wallclock = 0.0;
 


### PR DESCRIPTION
...and relax the current logic by default.

In a zero-packet scenario, we're currently polling non-selectable packet
sources 10 times in a row, then relax for 20usec. Roughly, this may result
in 500000  pkt_src->Process() calls per second (possibly somewhat less)
when there are no packets available. This is a lot.

Further, in low packet rate scenarios, e.g. 500kpps over 8 workers, an
individual workers should only see 62 kpps. Asking the packet source
much more often isn't very useful (and in fact queueing up packets may
be more efficient).

Add a heuristic to stop calling Process() poll interval times in a row
when a packet source has not yielded packets over the past
packet_source_inactivity_count times. This setting, together with
Pcap::non_fd_timeout, should allow to fine tune for better idle CPU
usage, but also behave better out-of-the box.

Relates to #2296.