### PR TITLE
ci: Add debian-12 / bookworm

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -201,6 +201,14 @@ centos7_task:
   << : *CI_TEMPLATE
   << : *SKIP_TASK_ON_PR
 
+debian12_task:
+  container:
+    # Debian 12 (bookworm) EOL: (not yet released)
+    dockerfile: ci/debian-12/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+
 debian11_task:
   container:
     # Debian 11 EOL: June 2026

--- a/ci/debian-12/Dockerfile
+++ b/ci/debian-12/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:bookworm
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20230405
+
+RUN apt-get update && apt-get -y install \
+    bison \
+    bsdmainutils \
+    ccache \
+    cmake \
+    curl \
+    flex \
+    g++ \
+    gcc \
+    git \
+    libkrb5-dev \
+    libpcap-dev \
+    libssl-dev \
+    make \
+    python3 \
+    python3-dev \
+    python3-pip\
+    python3-websockets \
+    sqlite3 \
+    swig \
+    wget \
+    xz-utils \
+    zlib1g-dev \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Debian bookworm really doesn't like using pip to install system wide stuff, but
+# doesn't seem there's a python3-junit2html package, so not sure what we'd break.
+RUN pip3 install --break-system-packages junit2html


### PR DESCRIPTION
The next version of Debian (bookworm) had a hard-freeze on
2023-03-16. Seems reasonable to have it in CI now.

https://lists.debian.org/debian-devel-announce/2023/03/msg00004.html