### PR TITLE
iosource/Manager: Fix poll_interval updating using not-yet valid IsLive()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -180,6 +180,10 @@ Changed Functionality
   processing input. Specifically in zeek -r scenarios, that is not the wanted
   behaviour.
 
+- The IO loop's poll interval is now correctly reduced from 100 to 10 for
+  live packet sources. This should lower CPU usage for deployments with
+  non-selectable packet sources.
+
 Removed Functionality
 ---------------------
 

--- a/src/iosource/Manager.cc
+++ b/src/iosource/Manager.cc
@@ -402,12 +402,16 @@ void Manager::Register(PktSrc* src)
 	{
 	pkt_src = src;
 
+	Register(src, false);
+
+	// Once we know if the source is live or not, adapt the
+	// poll_interval accordingly.
+	//
+	// Note that src->IsLive() is only valid after calling Register().
 	if ( src->IsLive() )
 		poll_interval = BifConst::io_poll_interval_live;
 	else if ( run_state::pseudo_realtime )
 		poll_interval = 1;
-
-	Register(src, false);
 	}
 
 static std::pair<std::string, std::string> split_prefix(std::string path)


### PR DESCRIPTION
Testing io_poll_interval_live tweaks with @dopheide-esnet on a Myricom based system to reduce CPU usage showed no visible effect.

It turns out, the pkt_src->IsLive() call used to update poll_interval is only valid *after* calling ->Register() with the source. The conditional updating of the poll_interval introduced in 4fa3e4b9b4d78e6f20f42b9dbd85216403be07db never worked out how it was intended to.

The fix ensures that

* we actually use a poll_interval of 10 in the live case
* changing io_poll_interval_live does have an effect

This is a bit of a major change due to lowering the default poll_interval by a magnitude, but that seemed to have been the intention always. It's also tunable via redef, so worst case it can be adapted via configuration.

As reference, with the default a Pcap::non_fd_timeout of 20usec *and* a poll_interval of 100, theoretically we'd be trying to ask a non-selectable packet source 500000 per second for a new packet. This is not a likely packet rate that a single worker would currently observe or manage to process.