### PR TITLE
ListVal::Append: Fix memory leak after re-using TypeList instances

### DIFF
--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1988,12 +1988,16 @@ TypeManager::TypeManager()
 		TypeTag tag = static_cast<TypeTag>(i);
 		TypePtr pure_type = tag == TYPE_ANY ? nullptr : base_type(tag);
 		base_list_types[tag] = make_intrusive<zeek::TypeList>(pure_type);
+		base_list_types[tag]->Append(pure_type);
 		}
 	}
 
 const TypeListPtr& TypeManager::TypeList(TypeTag t) const
 	{
 	assert(t >= 0 && t < NUM_TYPES);
+	// This assert is to catch type lists mutation due to
+	// AsTypeList() removal of const being a dangerous trap.
+	assert(base_list_types[t]->GetTypes().size() == 1);
 	return base_list_types[t];
 	}
 

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1220,9 +1220,7 @@ void ListVal::Append(ValPtr v)
 			Internal("heterogeneous list in ListVal::Append");
 		}
 
-	const auto& vt = v->GetType();
 	vals.emplace_back(std::move(v));
-	type->AsTypeList()->Append(vt);
 	}
 
 TableValPtr ListVal::ToSetVal() const

--- a/testing/btest/core/list-val-eval-leak.zeek
+++ b/testing/btest/core/list-val-eval-leak.zeek
@@ -1,0 +1,64 @@
+# @TEST-DOC: Test that ListVal::Eval() does not end-up leaking memory by exercising IndexExpr and comparing memory before/after a long running loop. This test is sensitive to the sanitizers. It fails with ASAN enabled even after the fix that motivated the test, so we skip running there.
+# @TEST-REQUIRES: ! grep -E 'ZEEK_SANITIZERS:STRING=.+$' ${BUILD}/CMakeCache.txt >&2
+# @TEST-EXEC: zeek -b %INPUT >&2
+
+event zeek_done()
+	{
+	local ctbl: table[count] of count;
+	local stbl: table[string] of string;
+	local tbl: table[string, count, string, addr, string] of set[string, count];
+	local s0 = "s0";
+	local c0 = 42;
+	local s1 = "s1";
+	local a0 = 127.0.0.1;
+	local s2 = "s2";
+	local c1 = 43;
+
+	local i = 0;
+
+	# Priming
+	ctbl[c0] = c0;
+	ctbl[c1] = c1;
+	stbl[s0] = s0;
+	stbl[s1] = s1;
+	tbl[s0, c0, s1, a0, s2] = set([s0, c0]);
+	tbl[s2, c0, s0, a0, s1] = tbl[s0, c0, s1, a0, s2];
+	if ( [s0, c0, s1, a0, s2] !in tbl )
+		exit(1);
+	if ( [s2, c0, s0, a0, s1] !in tbl )
+		exit(1);
+
+	# This loop caused ~16MB of memory growth after c1215ca47 while none
+	# is expected. Below is a poor man's approach to capturing the
+	# increase via get_proc_stats(). It may cause false negatives, but
+	# if something is really off, it probably captures that.
+	local start_stats = get_proc_stats();
+	while (++i < 50000 )
+		{
+		ctbl[c0] = c0;
+		ctbl[c1] = c1;
+		stbl[s0] = s0;
+		stbl[s1] = s1;
+		tbl[s0, c0, s1, a0, s2] = tbl[s2, c0, s0, a0, s1];
+		tbl[s2, c0, s0, a0, s1] = tbl[s0, c0, s1, a0, s2];
+		if ( [s0, c0, s1, a0, s2] !in tbl )
+			exit(1);
+		if ( [s2, c0, s0, a0, s1] !in tbl )
+			exit(1);
+		}
+	local end_stats = get_proc_stats();
+
+	local mb_diff = (end_stats$mem - start_stats$mem) / (1024.0 * 1024.0);
+	if ( mb_diff > 0.1 )
+		{
+		print "start_stats", start_stats;
+		print "end_stats", start_stats;
+		print fmt("MEMORY GROWTH %.3f MB", mb_diff);
+		exit(1);
+		}
+
+	# Output in case it's interesting.
+	print "start_stats", start_stats;
+	print "end_stats", start_stats;
+	print "mb_diff", mb_diff;
+	}


### PR DESCRIPTION
Commit 24c606b4df92f9871964c5bcb2fe90e43a177b1f added a TypeManager to re-use TypeList instances of the same type (particularly TYPE_ANY) and thereby caused a pretty bad memory leak. It missed that for non-pure ListVals, appending a Val would also append that element's type to the type list of the Val. This resulted in the pre-allocated TYPE_ANY to bloat whenever a ListExpr was eval'ed.

Due to the above error not causing any other apparent issues in the test suite (other than the memory leak) and neither causing any test failures with the type removed, I'm unclear why the logic was there to begin with.