### PR TITLE
Revert "Type: Add TypeManager->TypeList() and use for ListVal()"

### DIFF
--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1981,22 +1981,6 @@ detail::TraversalCode VectorType::Traverse(detail::TraversalCallback* cb) const
 	HANDLE_TC_TYPE_POST(tc);
 	}
 
-TypeManager::TypeManager()
-	{
-	for ( auto i = 0u; i < base_list_types.size(); ++i )
-		{
-		TypeTag tag = static_cast<TypeTag>(i);
-		TypePtr pure_type = tag == TYPE_ANY ? nullptr : base_type(tag);
-		base_list_types[tag] = make_intrusive<zeek::TypeList>(pure_type);
-		}
-	}
-
-const TypeListPtr& TypeManager::TypeList(TypeTag t) const
-	{
-	assert(t >= 0 && t < NUM_TYPES);
-	return base_list_types[t];
-	}
-
 // Returns true if t1 is initialization-compatible with t2 (i.e., if an
 // initializer with type t1 can be used to initialize a value with type t2),
 // false otherwise.  Assumes that t1's tag is different from t2's.  Note

--- a/src/Type.h
+++ b/src/Type.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <array>
 #include <list>
 #include <map>
 #include <optional>
@@ -866,21 +865,6 @@ protected:
 
 	TypePtr yield_type;
 	};
-
-// Holds pre-allocated Type objects.
-class TypeManager
-	{
-public:
-	TypeManager();
-
-	// Get a Typelist instance with the given type tag.
-	const TypeListPtr& TypeList(TypeTag t) const;
-
-private:
-	std::array<TypeListPtr, NUM_TYPES> base_list_types;
-	};
-
-extern TypeManager* type_mgr;
 
 // True if the two types are equivalent.  If is_init is true then the test is
 // done in the context of an initialization. If match_record_field_names is

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1188,7 +1188,10 @@ ValPtr PatternVal::DoClone(CloneState* state)
 	return state->NewClone(this, make_intrusive<PatternVal>(re));
 	}
 
-ListVal::ListVal(TypeTag t) : Val(type_mgr->TypeList(t)), tag(t) { }
+ListVal::ListVal(TypeTag t) : Val(make_intrusive<TypeList>(t == TYPE_ANY ? nullptr : base_type(t)))
+	{
+	tag = t;
+	}
 
 ListVal::~ListVal() { }
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -172,7 +172,6 @@ void do_ssl_deinit()
 	} // namespace
 #endif
 
-zeek::TypeManager* zeek::type_mgr = nullptr;
 zeek::ValManager* zeek::val_mgr = nullptr;
 zeek::packet_analysis::Manager* zeek::packet_mgr = nullptr;
 zeek::analyzer::Manager* zeek::analyzer_mgr = nullptr;
@@ -438,7 +437,6 @@ static void terminate_zeek()
 	delete session_mgr;
 	delete fragment_mgr;
 	delete telemetry_mgr;
-	delete type_mgr;
 
 	// free the global scope
 	pop_scope();
@@ -595,7 +593,6 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 
 	run_state::zeek_start_time = util::current_time(true);
 
-	type_mgr = new TypeManager();
 	val_mgr = new ValManager();
 	reporter = new Reporter(options.abort_on_scripting_errors);
 	thread_mgr = new threading::Manager();


### PR DESCRIPTION
This reverts commit 24c606b4df92f9871964c5bcb2fe90e43a177b1f.

This commit introduced a memory leak ListVal::Append() modifying the cached TYPE_ANY type list.

This supersedes #2936 as a revert seems safer due to the ListVal / TypeList management become less clear the longer I look at.