### PR TITLE
log-caching-cluster: Wait for X509::known_log_certs to populate

### DIFF
--- a/testing/btest/scripts/base/files/x509/log-caching-cluster.test
+++ b/testing/btest/scripts/base/files/x509/log-caching-cluster.test
@@ -41,7 +41,20 @@ event zeek_init()
 
 event Broker::peer_added(endpoint: Broker::EndpointInfo, msg: string)
 	{
-	continue_processing();
+	if ( /worker-2/ in Cluster::node )
+	       {
+	       when ( |X509::known_log_certs| >= 3 )
+			{
+			continue_processing();
+			}
+		timeout 3sec
+			{
+			Reporter::error("Timeout waiting for X509::known_log_certs to be populated!");
+			terminate();
+			}
+	       }
+	else
+	       continue_processing();
 	}
 @endif
 


### PR DESCRIPTION
The known_log_certs table is populated asynchronously via broker after a Broker::peer_added. It may take a variable amount of time depending on where we run this test and it has been observed flaky specifically for the arm_debian11 task. Instead of racing, give worker-2 3 seconds for receiving the expected table content before continuing.

Fixes #2885