### PR TITLE
file_analysis/Manager: Remove RunState.h include

### DIFF
--- a/src/file_analysis/Manager.h
+++ b/src/file_analysis/Manager.h
@@ -7,7 +7,6 @@
 #include <string>
 
 #include "zeek/RuleMatcher.h"
-#include "zeek/RunState.h"
 #include "zeek/Tag.h"
 #include "zeek/file_analysis/Component.h"
 #include "zeek/file_analysis/FileTimer.h"
@@ -18,6 +17,13 @@ namespace zeek
 
 class TableVal;
 class VectorVal;
+
+namespace run_state
+	{
+
+extern bool terminating;
+
+	} // namespace run_state
 
 namespace analyzer
 	{

--- a/src/script_opt/ZAM/ZBody.cc
+++ b/src/script_opt/ZAM/ZBody.cc
@@ -23,6 +23,9 @@
 #include "zeek/logging/Manager.h"
 #include "zeek/packet_analysis/Manager.h"
 
+// For reading_live and reading_traces
+#include "zeek/RunState.h"
+
 namespace zeek::detail
 	{
 


### PR DESCRIPTION
The file_analysis/Manager.h header only needs run_state::terminating, so declare just that similar to what Val.h does. This breaks ZBody compilation due to OP_READING_LIVE_TRAFFIC_V and OP_READING_TRACES_V accessing run-state::reading_live and run_state::reading_traces. Add the include to ZBody.cc as a fix.

This may break external plugins, too, but then they didn't have the right includes setup to begin with.