### PR TITLE
Update AF-Packet submodule

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -277,6 +277,10 @@ Changed Functionality
 - The IRC base script now use ``file_sniff()`` instead of ``file_new()`` for
   DCC file transfers to capture ``fuid`` and inferred MIME type in irc.log.
 
+- The vlan field reported by the AF_PACKET packet source is now properly
+  masked to exclude PCP and DEI bits. Previously, these bits were included
+  and could cause invalid vlan values > 4095 to be reported.
+
 Removed Functionality
 ---------------------
 

--- a/testing/btest/btest.cfg
+++ b/testing/btest/btest.cfg
@@ -4,7 +4,7 @@
 build_dir = build
 
 [btest]
-TestDirs    = doc bifs language core scripts coverage signatures plugins broker spicy supervisor telemetry javascript
+TestDirs    = af_packet doc bifs language core scripts coverage signatures plugins broker spicy supervisor telemetry javascript
 TmpDir      = %(testbase)s/.tmp
 BaselineDir = %(testbase)s/Baseline
 IgnoreDirs  = .svn CVS .tmp


### PR DESCRIPTION
* Mask VLAN ID from tp_vlan_tci field to fix vlan > 4095 reported by Zeek when PCP and/or DEI bits are set.
* Descriptive error message when interface is down. Instead of "Invalid argument", Zeek now reports "interface is down".