### PR TITLE
Run unit tests as part of Windows CI build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,10 @@ set(cmake_install_prefix "${CMAKE_INSTALL_PREFIX}")
 set(cmake_source_dir "${CMAKE_SOURCE_DIR}")
 set(zeek_script_install_path "${ZEEK_SCRIPT_INSTALL_PATH}")
 if ( MSVC )
+    # This has to happen before we modify the paths below so that
+    # the pure Windows paths are stored in the output file.
+    configure_file(zeek-path-dev.bat.in ${CMAKE_CURRENT_BINARY_DIR}/zeek-path-dev.bat)
+
     string(REGEX REPLACE "^([A-Za-z]):/(.*)" "/\\1/\\2" cmake_binary_dir "${cmake_binary_dir}")
     string(REGEX REPLACE "^([A-Za-z]):/(.*)" "/\\1/\\2" cmake_current_binary_dir "${cmake_current_binary_dir}")
     string(REGEX REPLACE "^([A-Za-z]):/(.*)" "/\\1/\\2" cmake_install_prefix "${cmake_install_prefix}")

--- a/ci/windows/test.cmd
+++ b/ci/windows/test.cmd
@@ -1,7 +1,11 @@
 :: See build.cmd for documentation on this call.
 call "c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 
-:: We currently don't have any tests to run on Windows, so this is just commented out.
-:: We'll expand on this later.
-:: cd build
-:: ctest -C release || exit \b 1
+cd build
+
+:: This sets up ZEEKPATH and ZEEK_PLUGIN_PATH
+call zeek-path-dev.bat
+
+:: Only run the unit tests for now. Btest is supported on Windows but a ton
+:: of tests are still failing so it's not worth trying to run it.
+src\zeek --test

--- a/zeek-path-dev.bat.in
+++ b/zeek-path-dev.bat.in
@@ -4,5 +4,5 @@
 :: The ZEEKPATH line here should be kept in sync with the zeek-path-dev.in file.
 ::
 
-set ZEEKPATH=.;${cmake_source_dir}/scripts;${cmake_source_dir}/scripts/policy;${cmake_source_dir}/scripts/site;${cmake_binary_dir}/scripts;${cmake_binary_dir}/scripts/builtin-plugins
-set ZEEK_PLUGIN_PATH=${cmake_binary_dir}/src}
+@set ZEEKPATH=.;${cmake_source_dir}/scripts;${cmake_source_dir}/scripts/policy;${cmake_source_dir}/scripts/site;${cmake_binary_dir}/scripts;${cmake_binary_dir}/scripts/builtin-plugins
+@set ZEEK_PLUGIN_PATH=${cmake_binary_dir}/src}

--- a/zeek-path-dev.bat.in
+++ b/zeek-path-dev.bat.in
@@ -1,0 +1,8 @@
+:: Sets up the basic environment needed to run Zeek from a Windows command prompt (not bash!).
+:: This is needed in order to run unit tests on Cirrus.
+::
+:: The ZEEKPATH line here should be kept in sync with the zeek-path-dev.in file.
+::
+
+set ZEEKPATH=.;${cmake_source_dir}/scripts;${cmake_source_dir}/scripts/policy;${cmake_source_dir}/scripts/site;${cmake_binary_dir}/scripts;${cmake_binary_dir}/scripts/builtin-plugins
+set ZEEK_PLUGIN_PATH=${cmake_binary_dir}/src}

--- a/zeek-path-dev.in
+++ b/zeek-path-dev.in
@@ -9,5 +9,6 @@
 #
 #     ZEEKPATH=`./zeek-path-dev` ./src/zeek
 #
+# This file should be kept in sync with the ZEEKPATH line in zeek-path-dev.bat.in.
 
 echo .:${cmake_source_dir}/scripts:${cmake_source_dir}/scripts/policy:${cmake_source_dir}/scripts/site:${cmake_binary_dir}/scripts:${cmake_binary_dir}/scripts/builtin-plugins


### PR DESCRIPTION
This PR adds running the unit tests on Windows during CI builds, as a first step to running the full test suite. I needed to add a zeek-path-dev file that could be sourced from the Windows command line, but other than that is pretty straight forward. It tested that a failing test causes the build to fail as well here: https://cirrus-ci.com/task/6257900302106624