### PR TITLE
Broker: Make GetNextTimeout() readiness configurable

### DIFF
--- a/ci/update-zeekygen-docs.sh
+++ b/ci/update-zeekygen-docs.sh
@@ -33,7 +33,8 @@ function run_zeek {
 
     if [ $? -ne 0 ]; then
         echo "Failed running zeek with zeekygen config file $conf_file"
-        echo "See stderr in $zeek_error_file"
+        echo "Content of $zeek_error_file follows"
+        cat $zeek_error_file
         exit 1
     fi
 }

--- a/scripts/base/frameworks/broker/main.zeek
+++ b/scripts/base/frameworks/broker/main.zeek
@@ -135,6 +135,15 @@ export {
 	## done reading the pcap.
 	option peer_counts_as_iosource = T;
 
+	## Configure the Broker manager to use zero-timeouts to indicate readiness.
+	##
+	## By default, Zeek's IO loop will process the Broker manager's IO source
+	## only every :zeek:see:`io_poll_interval_live` or :zeek:see:`io_poll_interval_default`
+	## iterations. In certain circumstances, this results in significant Broker
+	## message processing delays. Setting this value to T causes the Broker
+	## manager to be processed immediately in the next IO loop iteration.
+	const iosource_use_zero_timeout = F &redef;
+
 	## Port for Broker's metric exporter. Setting this to a valid TCP port causes
 	## Broker to make metrics available to Prometheus scrapers via HTTP. Zeek
 	## overrides any value provided in zeek_init or earlier at startup if the

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -252,6 +252,7 @@ void Manager::InitPostScript()
 	{
 	DBG_LOG(DBG_BROKER, "Initializing");
 
+	iosource_use_zero_timeout = get_option("Broker::iosource_use_zero_timeout")->AsBool();
 	log_batch_size = get_option("Broker::log_batch_size")->AsCount();
 	default_log_topic_prefix =
 		get_option("Broker::default_log_topic_prefix")->AsString()->CheckString();
@@ -1219,6 +1220,14 @@ void Manager::Process()
 				ProcessStoreResponse(s.second, std::move(r));
 			}
 		}
+	}
+
+double Manager::GetNextTimeout()
+	{
+	if ( ! iosource_use_zero_timeout )
+		return -1;
+
+	return bstate->subscriber.available() > 0 ? 0 : -1;
 	}
 
 void Manager::ProcessStoreEventInsertUpdate(const TableValPtr& table, const std::string& store_id,

--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -444,7 +444,7 @@ private:
 	// IOSource interface overrides:
 	void Process() override;
 	const char* Tag() override { return "Broker::Manager"; }
-	double GetNextTimeout() override { return -1; }
+	double GetNextTimeout() override;
 
 	struct LogBuffer
 		{
@@ -481,6 +481,7 @@ private:
 
 	uint16_t bound_port;
 	bool use_real_time;
+	bool iosource_use_zero_timeout;
 	int peer_count;
 
 	size_t log_batch_size;


### PR DESCRIPTION
Introduce a new const &redef Broker::use_zero_timeout_iosource to allow Broker's IO source be processed before the poll interval would pick it. This should reduce message processing latency significantly at the cost of less batching up of Broker messages. Not enabled by default due to potential subtleness of the change.