### PR TITLE
pcap/Source: Allow more than 32bit for link and dropped stats

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -297,6 +297,9 @@ Changed Functionality
   masked to exclude PCP and DEI bits. Previously, these bits were included
   and could cause invalid vlan values > 4095 to be reported.
 
+- Libpcap based packet source now avoids the 32bit wraparound of link and
+  dropped packet counters as reported by users.
+
 Removed Functionality
 ---------------------
 

--- a/src/iosource/pcap/Source.h
+++ b/src/iosource/pcap/Source.h
@@ -43,6 +43,7 @@ private:
 	Stats stats;
 
 	pcap_t* pd;
+	struct pcap_stat prev_pstat = {0};
 	};
 
 	} // namespace zeek::iosource::pcap


### PR DESCRIPTION
The PktSrc::Stats object works with 64bit unsigned integers. Unfortunately, libpcap's struct pcap_stat is using 32bit values and users have reported the wrapping of these values being visible in their stats.log roughly every 7.5 hours (~160kpps).

This change moves tracking of link and drop counters into the PktSrc::Stats object (like is done for received and bytes_received) and updates them on a call to PcapSource::Statistics() with the difference to the previous stats values to prevent the wrap from becoming visible to script land.

This doesn't cover the case of the stats counters wrapping around multiple times between two invocations of PktSrc::Statistics(). With the default interval of 5 minutes for the stats script, this seems acceptable.

Closes #2791.