### PR TITLE
unload: Fix unloading of packages

### DIFF
--- a/src/scan.l
+++ b/src/scan.l
@@ -489,6 +489,16 @@ when	return TOK_WHEN;
 	const char* file = zeek::util::skip_whitespace(yytext + 7);
 	std::string path = find_relative_script_file(file);
 
+	if ( ! path.empty() && zeek::util::is_dir(path.c_str()) )
+		{
+		// open_package() appends __load__.zeek to path and verifies existence
+		FILE *f = zeek::util::detail::open_package(path);
+		if (f)
+			fclose(f);
+		else
+			path = "";
+		}
+
 	if ( path.empty() )
 		zeek::reporter->Error("failed find file associated with @unload %s", file);
 	else

--- a/testing/btest/core/load-unload.zeek
+++ b/testing/btest/core/load-unload.zeek
@@ -1,13 +1,18 @@
 # This tests the @unload directive
 #
-# @TEST-EXEC: zeek -b unload misc/loaded-scripts dontloadme > output
+# @TEST-EXEC: zeek -b unload misc/loaded-scripts dontloadme pkg-dontloadme > output
 # @TEST-EXEC: btest-diff output
 # @TEST-EXEC: grep dontloadme loaded_scripts.log && exit 1 || exit 0
 
 @TEST-START-FILE unload.zeek
 @unload dontloadme
+@unload pkg-dontloadme
 @TEST-END-FILE
 
 @TEST-START-FILE dontloadme.zeek
 print "Loaded: dontloadme.zeek";
+@TEST-END-FILE
+
+@TEST-START-FILE pkg-dontloadme/__load__.zeek
+print "Loaded: pkg-dontloadme/__load__.zeek";
 @TEST-END-FILE


### PR DESCRIPTION
@ynadji found that unloading packages doesn't work due to @unload not resolving the __load__.zeek file within a directory like @load does.

Fixes #2991