### PR TITLE
Use workaround for setvbuf on Windows in DebugLogger/Extract file analyzer

### DIFF
--- a/src/DebugLogger.cc
+++ b/src/DebugLogger.cc
@@ -56,7 +56,7 @@ void DebugLogger::OpenDebugLog(const char* filename)
 				}
 			}
 
-		setvbuf(file, NULL, _IOLBF, 0);
+		util::detail::setvbuf(file, NULL, _IOLBF, 0);
 		}
 	else
 		file = stderr;

--- a/src/File.cc
+++ b/src/File.cc
@@ -202,16 +202,8 @@ void File::SetBuf(bool arg_buffered)
 	if ( ! f )
 		return;
 
-#ifndef _MSC_VER
-	if ( setvbuf(f, NULL, arg_buffered ? _IOFBF : _IOLBF, 0) != 0 )
+	if ( util::detail::setvbuf(f, NULL, arg_buffered ? _IOFBF : _IOLBF, 0) != 0 )
 		reporter->Error("setvbuf failed");
-#else
-	// TODO: this turns off buffering altogether because Windows wants us to pass a valid
-	// buffer and length if we're going to pass one of the other modes. We need to
-	// investigate the performance ramifications of this.
-	if ( setvbuf(f, NULL, _IONBF, 0) != 0 )
-		reporter->Error("setvbuf failed");
-#endif
 
 	buffered = arg_buffered;
 	}

--- a/src/file_analysis/analyzer/extract/Extract.cc
+++ b/src/file_analysis/analyzer/extract/Extract.cc
@@ -23,7 +23,7 @@ Extract::Extract(RecordValPtr args, file_analysis::File* file, const std::string
 	if ( file_stream )
 		{
 		// Try to ensure full buffering.
-		if ( setvbuf(file_stream, nullptr, _IOFBF, BUFSIZ) )
+		if ( util::detail::setvbuf(file_stream, nullptr, _IOFBF, BUFSIZ) )
 			{
 			util::zeek_strerror_r(errno, buf, sizeof(buf));
 			reporter->Warning("cannot set buffering mode for %s: %s", filename.data(), buf);

--- a/src/util.cc
+++ b/src/util.cc
@@ -996,6 +996,18 @@ void set_thread_name(const char* name, pthread_t tid)
 #endif
 	}
 
+int setvbuf(FILE* stream, char* buf, int type, size_t size)
+	{
+#ifndef _MSC_VER
+	return ::setvbuf(stream, NULL, type, size);
+#else
+	// TODO: this turns off buffering altogether because Windows wants us to pass a valid
+	// buffer and length if we're going to pass one of the other modes. We need to
+	// investigate the performance ramifications of this.
+	return ::setvbuf(stream, NULL, _IONBF, 0);
+#endif
+	}
+
 	} // namespace detail
 
 TEST_CASE("util get_unescaped_string")

--- a/src/util.h
+++ b/src/util.h
@@ -305,6 +305,8 @@ double parse_rotate_base_time(const char* rotate_base_time);
 // This function is thread-safe.
 double calc_next_rotate(double current, double rotate_interval, double base);
 
+int setvbuf(FILE* stream, char* buf, int type, size_t size);
+
 	} // namespace detail
 
 template <class T> void delete_each(T* t)


### PR DESCRIPTION
We already have this workaround in src/File.cc, but apparently I missed a few uses of `setvbuf` in other places. They need the same workaround to avoid calling `abort`. This fixes some aborts when running btests on Windows. Note this doesn't do the performance investigation requested in https://github.com/zeek/zeek/issues/2570, it just fixes the additional aborts.