### PR TITLE
Fix smith-waterman sorting to follow correct Compare semantics

### DIFF
--- a/src/SmithWaterman.cc
+++ b/src/SmithWaterman.cc
@@ -172,10 +172,7 @@ bool SubstringCmp::operator()(const Substring* bst1, const Substring* bst2) cons
 		return false;
 		}
 
-	if ( bst1->GetAlignments()[_index].index <= bst2->GetAlignments()[_index].index )
-		return true;
-
-	return false;
+	return (bst1->GetAlignments()[_index].index < bst2->GetAlignments()[_index].index);
 	}
 
 // A node in Smith-Waterman's dynamic programming matrix.  Each node

--- a/testing/btest/Baseline/language.smith-waterman-test/output
+++ b/testing/btest/Baseline/language.smith-waterman-test/output
@@ -29,5 +29,5 @@ tok 0: Accept (27/0, T)
 tok 1: e^M^JAccept (22/15, T)
 tok 2: Accept (27/29, T)
 xxAAxxAAxx - yyyyyAAyyyyy:
-tok 0: AA (2/5, T)
-tok 1: AA (6/5, T)
+tok 0: AA (6/5, T)
+tok 1: AA (2/5, T)


### PR DESCRIPTION
Windows currently throws an exception with the language.smith-waterman-test btest, resulting in a call to `abort()`. The sort comparator in the Smith-Waterman code triggers the exception because the comparator will return true if two elements are equal, where their std::sort implementation requires the comparator to return false in that case. Effectively it's expecting the same semantics as `std::less`. This PR fixes the comparator to only use `<` instead of `<=`, which fixes the exception. 

Unfortunately, it also changes the output from the test, so there's a consideration about whether this is correct or not.