### PR TITLE
Surround string assignments in zeek-config in quotes

### DIFF
--- a/zeek-config.in
+++ b/zeek-config.in
@@ -1,22 +1,22 @@
 #!/bin/sh
 
-binpac_root=@ZEEK_CONFIG_BINPAC_ROOT_DIR@
-broker_root=@ZEEK_CONFIG_BROKER_ROOT_DIR@
-btest_tools_dir=@ZEEK_CONFIG_BTEST_TOOLS_DIR@
-build_type=@CMAKE_BUILD_TYPE_LOWER@
-cmake_dir=@ZEEK_CMAKE_CONFIG_DIR@
-config_dir=@ZEEK_ETC_INSTALL_DIR@
-have_spicy=@USE_SPICY_ANALYZERS@
-include_dir=@CMAKE_INSTALL_PREFIX@/include
-lib_dir=@CMAKE_INSTALL_FULL_LIBDIR@
-plugin_dir=@ZEEK_PLUGIN_DIR@
-prefix=@CMAKE_INSTALL_PREFIX@
-python_dir=@PY_MOD_INSTALL_DIR@
-script_dir=@ZEEK_SCRIPT_INSTALL_PATH@
-site_dir=@ZEEK_SCRIPT_INSTALL_PATH@/site
-version=@VERSION@
-zeek_dist=@ZEEK_DIST@
-zeekpath=@DEFAULT_ZEEKPATH@
+binpac_root="@ZEEK_CONFIG_BINPAC_ROOT_DIR@"
+broker_root="@ZEEK_CONFIG_BROKER_ROOT_DIR@"
+btest_tools_dir="@ZEEK_CONFIG_BTEST_TOOLS_DIR@"
+build_type="@CMAKE_BUILD_TYPE_LOWER@"
+cmake_dir="@ZEEK_CMAKE_CONFIG_DIR@"
+config_dir="@ZEEK_ETC_INSTALL_DIR@"
+have_spicy="@USE_SPICY_ANALYZERS@"
+include_dir="@CMAKE_INSTALL_PREFIX@/include"
+lib_dir="@CMAKE_INSTALL_FULL_LIBDIR@"
+plugin_dir="@ZEEK_PLUGIN_DIR@"
+prefix="@CMAKE_INSTALL_PREFIX@"
+python_dir="@PY_MOD_INSTALL_DIR@"
+script_dir="@ZEEK_SCRIPT_INSTALL_PATH@"
+site_dir="@ZEEK_SCRIPT_INSTALL_PATH@/site"
+version="@VERSION@"
+zeek_dist="@ZEEK_DIST@"
+zeekpath="@DEFAULT_ZEEKPATH@"
 
 add_path() {
     # $1: existing path


### PR DESCRIPTION
This fixes some issues with paths with spaces on Windows keeping some of the btests (e.g. `plugins/debug-streams.zeek`) from executing, since the script fails to run altogether in those cases. There's probably some follow-on changes here around what paths should even be stored on Windows, but this allows the tests to at least run and fail instead of being skipped.