### PR TITLE
Add additional length check to IEEE 802.11 analyzer

### DIFF
--- a/src/packet_analysis/protocol/ieee802_11/IEEE802_11.cc
+++ b/src/packet_analysis/protocol/ieee802_11/IEEE802_11.cc
@@ -31,6 +31,12 @@ bool IEEE802_11Analyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* 
 	if ( (data[1] & 0x03) == 0x03 )
 		len_80211 += packet->L2_ADDR_LEN;
 
+	if ( len_80211 >= len )
+		{
+		Weird("truncated_802_11_header", packet);
+		return false;
+		}
+
 	// Look for the QoS indicator bit.
 	if ( (fc_80211 >> 4) & 0x08 )
 		{


### PR DESCRIPTION
This adds an extra length check to the IEEE 802.11 analyzer after the length value was updated, then used as the updated value without rechecking it was valid. This is a follow-up to https://github.com/zeek/zeek/pull/2957 which modified the surrounding code.