### PR TITLE
Bump the OpenSUSE Tumbleweed CI image to get gcc 13

### DIFF
--- a/ci/opensuse-tumbleweed/Dockerfile
+++ b/ci/opensuse-tumbleweed/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/tumbleweed
 
 # A version field to invalide Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220705
+ENV DOCKERFILE_VERSION 20230502
 
 RUN zypper refresh \
  && zypper in -y \

--- a/src/WeirdState.h
+++ b/src/WeirdState.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
This is for GCC 13 coverage on the release/5.0 branch