### PR TITLE
generate-docs: Only update submodule pointer during scheduled builds

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -34,7 +34,13 @@ jobs:
         with:
           submodules: "recursive"
 
+      # Only reset the submodule pointer for scheduled builds. The reason to do
+      # this is to pick up any merge commits or anything that may have been
+      # missed in a merge, but not have any actual content. We don't want to do
+      # it otherwise because PRs should just use the submodule they're pointing
+      # at.
       - name: Switch doc submodule to master
+        if: github.event_name == 'schedule'
         run: cd doc && git checkout master
 
       - name: Fetch Dependencies


### PR DESCRIPTION
I ran into an issue with the generate-docs action running on a pull request against the `release/5.0` branch. It stems this bit from in workflow:

```
      - name: Switch doc submodule to master
        run: cd doc && git checkout master
```

The sequence goes like:
1. Clone repository
2. Check out branch being merged, including updating to the submodules on that branch
3. Go into the docs submodule and checkout the master branch
4. Try to build and run ci/update-zeekygen-docs.sh

The problem is that on the release branches, `master` is not the correct branch to use for docs. Generally, the release branches have their own branches in the docs repo that match. We could change this workflow to instead check out the base branch for the PR, but it'll inevitably run into an issue where that branch doesn't exist (if you're merging from one dev branch to another, for example).

The easier solution (the one in this PR) is to only do this action for PRs against the master branch. The release branches will take care of themselves since regenerating docs is part of the release process.