### PR TITLE
cluster/manager: Warn if there are no proxies

### DIFF
--- a/scripts/base/frameworks/cluster/nodes/manager.zeek
+++ b/scripts/base/frameworks/cluster/nodes/manager.zeek
@@ -23,3 +23,14 @@ redef Log::default_rotation_interval = 24 hrs;
 ## Use the cluster's delete-log script.
 redef Log::default_rotation_postprocessor_cmd = "delete-log";
 @endif
+
+event zeek_init()
+	{
+	if ( Cluster::get_node_count(Cluster::PROXY) == 0 )
+		{
+		Reporter::warning("No proxy nodes configured for this Zeek cluster. "
+		                  + "The software framework as well as certain external "
+		                  + "scripts rely on the presence of proxy nodes to function "
+		                  + "properly and should be considered required.");
+		}
+	}

--- a/testing/btest/scripts/base/frameworks/logging/field-extension-cluster-error.zeek
+++ b/testing/btest/scripts/base/frameworks/logging/field-extension-cluster-error.zeek
@@ -12,6 +12,7 @@
 redef Cluster::nodes = {
 	["manager-1"] = [$node_type=Cluster::MANAGER, $ip=127.0.0.1, $p=to_port(getenv("BROKER_PORT1"))],
 	["worker-1"]  = [$node_type=Cluster::WORKER,  $ip=127.0.0.1, $p=to_port(getenv("BROKER_PORT2")), $manager="manager-1", $interface="eth0"],
+	["proxy-1"]   = [$node_type=Cluster::PROXY,   $ip=127.0.0.1, $p=to_port(getenv("BROKER_PORT2")), $manager="manager-1"],
 };
 @TEST-END-FILE
 


### PR DESCRIPTION
This assumes Reporter::warning() makes it to stderr and is somewhat visible for the manager process.

Closes #2871