### PR TITLE
remote_event_ts_compat: Fix NETWORK_TIMESTAMP to NetworkTimestamp

### DIFF
--- a/testing/btest/broker/remote_event_ts_compat.zeek
+++ b/testing/btest/broker/remote_event_ts_compat.zeek
@@ -82,7 +82,7 @@ with broker.Endpoint() as ep, \
 	print("send event with timestamp")
 	ts = datetime.datetime.fromtimestamp(23.0, broker.utc)
 	metadata = {
-		broker.zeek.Metadata.NETWORK_TIMESTAMP: ts,
+		broker.zeek.MetadataType.NetworkTimestamp: ts,
 	}
 	my_event = broker.zeek.Event("my_event", "with ts", metadata=metadata)
 	ep.publish(broker_topic, my_event)


### PR DESCRIPTION
~The "check" was only meant to prevent going into the background running mode if things aren't looking good, but TEST-REQUIRES skips the test when that was the case.~