### PR TITLE
Fix `get_active_node_count` for node types not present.

### DIFF
--- a/scripts/base/frameworks/cluster/main.zeek
+++ b/scripts/base/frameworks/cluster/main.zeek
@@ -285,7 +285,7 @@ export {
 }
 
 # Track active nodes per type.
-global active_node_ids: table[NodeType] of set[string];
+global active_node_ids: table[NodeType] of set[string] &default=set();
 
 function nodes_with_type(node_type: NodeType): vector of NamedNode
 	{


### PR DESCRIPTION
Tiny fix to prevent `no such index (Cluster::active_node_ids[Cluster::node_type])` errors when calling `get_active_node_count()` for node types not present in the cluster.