### PR TITLE
zeekygen: Render function parameters as `:param x:` instead of `:x:`

### DIFF
--- a/src/zeekygen/utils.cc
+++ b/src/zeekygen/utils.cc
@@ -70,7 +70,7 @@ bool prettify_params(string& s)
 			if ( identifier == "Returns" )
 				subst = ":returns";
 			else
-				subst = ":" + identifier;
+				subst = ":param " + identifier;
 
 			s.replace(identifier_start_pos, identifier.size(), subst);
 			return true;

--- a/testing/btest/Baseline/doc.zeekygen.example/example.rst
+++ b/testing/btest/Baseline/doc.zeekygen.example/example.rst
@@ -260,7 +260,7 @@ Events
    link.  Use the see role instead: :zeek:see:`ZeekygenExample::a_function`.
    
 
-   :name: Describe the argument here.
+   :param name: Describe the argument here.
 
 Functions
 #########
@@ -275,11 +275,11 @@ Functions
    empty comments is optional, but improves readability of script.
    
 
-   :tag: Function arguments can be described
+   :param tag: Function arguments can be described
         like this.
    
 
-   :msg: Another param.
+   :param msg: Another param.
    
 
    :returns: Describe the return type here.

--- a/testing/btest/Baseline/doc.zeekygen.func-params/autogen-reST-func-params.rst
+++ b/testing/btest/Baseline/doc.zeekygen.func-params/autogen-reST-func-params.rst
@@ -7,9 +7,9 @@
    This is a global function declaration.
    
 
-   :i: First param.
+   :param i: First param.
 
-   :j: Second param.
+   :param j: Second param.
    
 
    :returns: A string.
@@ -23,9 +23,9 @@
          This is a record field function.
          
 
-         :i: First param.
+         :param i: First param.
 
-         :j: Second param.
+         :param j: Second param.
          
 
          :returns: A string.

--- a/testing/btest/Baseline/doc.zeekygen.identifier/test.rst
+++ b/testing/btest/Baseline/doc.zeekygen.identifier/test.rst
@@ -212,11 +212,11 @@
    empty comments is optional, but improves readability of script.
    
 
-   :tag: Function arguments can be described
+   :param tag: Function arguments can be described
         like this.
    
 
-   :msg: Another param.
+   :param msg: Another param.
    
 
    :returns: Describe the return type here.
@@ -234,7 +234,7 @@
    link.  Use the see role instead: :zeek:see:`ZeekygenExample::a_function`.
    
 
-   :name: Describe the argument here.
+   :param name: Describe the argument here.
 
 .. zeek:id:: ZeekygenExample::function_without_proto
    :source-code: zeekygen/example.zeek 176 184


### PR DESCRIPTION
We're currently rendering parameter descriptions from .bif file into the .rst as follows:

    :cid: The connection identifier.

    :aid: The analyzer ID.

Switch this to :param cid: instead so that we can have Sphinx deal with this as param docfield and group all parameters into a single section.

Currently, having the bare :cid: style causes sphinx to treat it as an unknown field type, capitalize it and render it.


Goes with: https://github.com/zeek/zeek-docs/pull/188

Old / Current
![Screenshot-20230516-132637](https://github.com/zeek/zeek/assets/2100509/c6801d30-cd8d-4285-b6df-fa5f8b91fff2)

New:
![Screenshot-20230516-203048](https://github.com/zeek/zeek/assets/2100509/ca867c61-2314-4cca-b524-2f1e6bd31cea)
