### PR TITLE
Fix Spicy path issue

### DIFF
--- a/src/spicy/CMakeLists.txt
+++ b/src/spicy/CMakeLists.txt
@@ -1,7 +1,5 @@
 # See the file "COPYING" in the main distribution directory for copyright.
 
-add_subdirectory(spicyz)
-
 zeek_add_subdir_library(
     spicy
     INTERNAL_DEPENDENCIES
@@ -27,3 +25,5 @@ set(ZEEK_SPICY_LIBRARY_PATH "${CMAKE_INSTALL_FULL_DATADIR}/zeek/spicy" CACHE PAT
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/scripts/spicy/" DESTINATION "${ZEEK_SPICY_LIBRARY_PATH}")
 
 set(ZEEK_SPICY_DATA_PATH "${CMAKE_INSTALL_FULL_DATADIR}/zeek" CACHE PATH "")
+
+add_subdirectory(spicyz)

--- a/src/spicy/spicyz/config.h.in
+++ b/src/spicy/spicyz/config.h.in
@@ -2,11 +2,11 @@
 
 #pragma once
 
-#include "zeek/util-config.h"
-
 #include <string>
 
 #include <hilti/rt/filesystem.h>
+
+#include "zeek/util-config.h"
 
 namespace zeek::spicy::configuration {
 
@@ -26,21 +26,21 @@ static inline void add_path(std::string& old_path, const path& new_path) {
 }
 } // namespace
 
-inline const auto InstallBinDir() { return path("${CMAKE_INSTALL_PREFIX}") / "${CMAKE_INSTALL_BINDIR}"; }
-
-inline const auto LibraryPath() {
-    path base;
-
-    if ( auto custom_base = getenv("ZEEK_SPICY_LIBRARY_PATH"); custom_base && *custom_base )
-        base = path(custom_base);
+static path get_env_path_or(const char* name, const char* default_) {
+    assert(std::strlen(default_) != 0);
+    if ( auto p = hilti::rt::getenv(name); p && ! p->empty() )
+        return path(*p);
     else
-        base = path("@ZEEK_SPICY_LIBRARY_PATH@");
-
-    return hilti::rt::filesystem::weakly_canonical(base);
+        return default_;
 }
 
-inline const auto ModulePath() { return path("@ZEEK_SPICY_MODULE_PATH@"); }
-inline const auto DataPath() { return path("@ZEEK_SPICY_DATA_PATH@"); }
+inline const auto InstallBinDir() { return path("${CMAKE_INSTALL_PREFIX}") / "${CMAKE_INSTALL_BINDIR}"; }
+
+inline const auto LibraryPath() { return get_env_path_or("ZEEK_SPICY_LIBRARY_PATH", "@ZEEK_SPICY_LIBRARY_PATH@"); }
+
+inline const auto ModulePath() { return get_env_path_or("ZEEK_SPICY_MODULE_PATH", "@ZEEK_SPICY_MODULE_PATH@"); }
+
+inline const auto DataPath() { return get_env_path_or("ZEEK_SPICY_DATA_PATH", "@ZEEK_SPICY_DATA_PATH@"); }
 
 inline const auto CxxZeekIncludesDirectories() {
     std::string includes;


### PR DESCRIPTION
- Fix an ordering issue in Spicy support's CMake config.
- Introduce environment variables to override more paths configured into `spicyz`.
