### PR TITLE
Enable spicy/disable af_packet in docs builds

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -79,7 +79,7 @@ jobs:
           key: 'docs-gen-${{ github.job }}'
 
       - name: Configure
-        run: ./configure --disable-broker-tests --disable-cpp-tests --disable-spicy --ccache
+        run: ./configure --disable-broker-tests --disable-cpp-tests --disable-af-packet --ccache
 
       - name: Build
         run: cd build && make -j $(nproc)


### PR DESCRIPTION
This is just testing whether the github runner handles a spicy build and how much longer it takes.