### PR TITLE
ci: Disable openh264 repository on tumbleweed

### DIFF
--- a/ci/opensuse-tumbleweed/Dockerfile
+++ b/ci/opensuse-tumbleweed/Dockerfile
@@ -2,7 +2,11 @@ FROM opensuse/tumbleweed
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230428
+ENV DOCKERFILE_VERSION 20230523
+
+# Remove the repo-openh264 repository, it caused intermittent issues
+# and we should not be needing any packages from it.
+RUN zypper modifyrepo --disable repo-openh264 || true
 
 RUN zypper refresh \
  && zypper in -y \


### PR DESCRIPTION
zypper refresh failed on it and we should not be needing packages either.