### PR TITLE
GH-3060: Support negative index lookups for vectors

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -2932,7 +2932,13 @@ ValPtr IndexExpr::Fold(Val* v1, Val* v2) const
 			const ListVal* lv = v2->AsListVal();
 
 			if ( lv->Length() == 1 )
-				v = vect->ValAt(lv->Idx(0)->CoerceToUnsigned());
+				{
+				auto index = lv->Idx(0)->CoerceToInt();
+				if ( index < 0 )
+					index = vect->Size() + index;
+
+				v = vect->ValAt(index);
+				}
 			else
 				return index_slice(vect, lv);
 			}

--- a/testing/btest/Baseline/language.vector/out
+++ b/testing/btest/Baseline/language.vector/out
@@ -80,3 +80,5 @@ hole in vector of managed types, 5, [[a=T], [a=T], , , [a=T]]
 hole in vector of managed types after replacing slice, 3, [[a=T], [a=T], ]
 left shift (PASS)
 right shift (PASS)
+negative index (PASS)
+negative index (PASS)

--- a/testing/btest/language/vector.zeek
+++ b/testing/btest/language/vector.zeek
@@ -223,4 +223,10 @@ event zeek_init()
 	local v23 = v6 >> four_ones;
 	test_case( "left shift", all_set(v22 == vector(20, 40, 60, 80)) );
 	test_case( "right shift", all_set(v23 == vector(5, 10, 15, 20)) );
+
+	# negative indices
+	local v24 = vector( 1, 2, 3, 4, 5 );
+	test_case( "negative index", v24[-1] == 5 );
+	test_case( "negative index", v24[-3] == 3 );
+
 }


### PR DESCRIPTION
This is a slight semantic change in that we don't support positive indexes up to the maximum size of an unsigned int, only to signed int. That should be fine though because we only support signed int values for slices as well.