### PR TITLE
btest.cfg: Set HILTI_CXX_COMPILER_LAUNCHER based on build/CMakeCache.txt

### DIFF
--- a/testing/btest/btest.cfg
+++ b/testing/btest/btest.cfg
@@ -13,6 +13,7 @@ MinVersion  = 0.63
 
 [environment]
 ZEEKPATH=`bash -c %(testbase)s/../../%(build_dir)s/zeek-path-dev`
+HILTI_CXX_COMPILER_LAUNCHER=`f=%(testbase)s/../../%(build_dir)s/CMakeCache.txt && grep -q '^ENABLE_CCACHE:BOOL=true' $f && sed -n 's/^CCACHE_PROGRAM:FILEPATH=\(.*\)$/\1/p' $f`
 ZEEK_SEED_FILE=%(testbase)s/random.seed
 ZEEK_PLUGIN_PATH=
 TZ=UTC


### PR DESCRIPTION
If CMakeCache.txt indicates the Zeek build was done with ccache, take the CCACHE_PROGRAM:FILEPATH= line and populate the HILTI_CXX_COMPILER_LAUNCHER environment.

For local development with ccache, this speeds up the spicy tests significantly after the initial run without knowing or needing know that setting HILTI_CXX_COMPILER_LAUNCHER would've helped.