### PR TITLE
Speed up Spicy-related tests.

### DIFF
--- a/testing/btest/spicy/analyzer-tag.zeek
+++ b/testing/btest/spicy/analyzer-tag.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o ssh.hlto ssh.spicy ./ssh.evt
+# @TEST-EXEC: spicyz -d -o ssh.hlto ssh.spicy ./ssh.evt
 # @TEST-EXEC: zeek -b Zeek::Spicy ssh.hlto %INPUT >>output
 # @TEST-EXEC: echo >>output
 # @TEST-EXEC: zeek -b Zeek::Spicy %INPUT >>output

--- a/testing/btest/spicy/conn-id.spicy
+++ b/testing/btest/spicy/conn-id.spicy
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto %INPUT test.evt
+# @TEST-EXEC: spicyz -d -o test.hlto %INPUT test.evt
 # @TEST-EXEC: zeek -b -r ${TRACES}/ssh/single-conn.trace Zeek::Spicy test.hlto Spicy::enable_print=T >>output
 # @TEST-EXEC: zeek -b -r ${TRACES}/ftp/ipv6.trace Zeek::Spicy test.hlto Spicy::enable_print=T >>output
 # @TEST-EXEC: btest-diff output

--- a/testing/btest/spicy/context.spicy
+++ b/testing/btest/spicy/context.spicy
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o x.hlto %INPUT ./ssh.evt
+# @TEST-EXEC: spicyz -d -o x.hlto %INPUT ./ssh.evt
 # @TEST-EXEC: zeek -b -r ${TRACES}/ssh/single-conn.trace Zeek::Spicy x.hlto Spicy::enable_print=T >output
 # @TEST-EXEC: btest-diff output
 #

--- a/testing/btest/spicy/double-event.zeek
+++ b/testing/btest/spicy/double-event.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto ssh.spicy ./ssh-cond.evt
+# @TEST-EXEC: spicyz -d -o test.hlto ssh.spicy ./ssh-cond.evt
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto %INPUT | sort >output
 # @TEST-EXEC: btest-diff output
 

--- a/testing/btest/spicy/double-type-registration.zeek
+++ b/testing/btest/spicy/double-type-registration.zeek
@@ -1,11 +1,11 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -L . -o a.hlto a.spicy
-# @TEST-EXEC: spicyz -L . -o b.hlto b.spicy
+# @TEST-EXEC: spicyz -L . -d -o a.hlto a.spicy
+# @TEST-EXEC: spicyz -L . -d -o b.hlto b.spicy
 # @TEST-EXEC: zeek a.hlto b.hlto
 #
-# @TEST-EXEC: spicyz -o a.hlto a.spicy common.spicy
-# @TEST-EXEC: spicyz -o b.hlto b.spicy common.spicy
+# @TEST-EXEC: spicyz -d -o a.hlto a.spicy common.spicy
+# @TEST-EXEC: spicyz -d -o b.hlto b.spicy common.spicy
 # @TEST-EXEC: zeek a.hlto b.hlto
 #
 # @TEST-DOC: Regression test for #177.

--- a/testing/btest/spicy/double-types.zeek
+++ b/testing/btest/spicy/double-types.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto dtest.spicy ./dtest.evt
+# @TEST-EXEC: spicyz -d -o test.hlto dtest.spicy ./dtest.evt
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto %INPUT | sort >output
 # @TEST-EXEC: btest-diff output
 

--- a/testing/btest/spicy/event-args-fail.evt
+++ b/testing/btest/spicy/event-args-fail.evt
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC-FAIL: spicyz -o test.hlto %INPUT test.spicy >output 2>&1
+# @TEST-EXEC-FAIL: spicyz -d -o test.hlto %INPUT test.spicy >output 2>&1
 # @TEST-EXEC:      TEST_DIFF_CANONIFIER=diff-canonifier-spicy btest-diff output
 #
 # @TEST-DOC: In EVT, provide access to hooks arguments

--- a/testing/btest/spicy/event-args-mismatch.zeek
+++ b/testing/btest/spicy/event-args-mismatch.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto test.evt test.spicy
+# @TEST-EXEC: spicyz -d -o test.hlto test.evt test.spicy
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto %INPUT >output 2>&1
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=diff-canonifier-spicy btest-diff output
 #

--- a/testing/btest/spicy/event-args.zeek
+++ b/testing/btest/spicy/event-args.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto test.evt test.spicy
+# @TEST-EXEC: spicyz -d -o test.hlto test.evt test.spicy
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto %INPUT >output
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=diff-canonifier-spicy btest-diff output
 #

--- a/testing/btest/spicy/event-cond.zeek
+++ b/testing/btest/spicy/event-cond.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto ssh.spicy ./ssh-cond.evt
+# @TEST-EXEC: spicyz -d -o test.hlto ssh.spicy ./ssh-cond.evt
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto %INPUT | sort  >output
 # @TEST-EXEC: btest-diff output
 

--- a/testing/btest/spicy/export-enum.zeek
+++ b/testing/btest/spicy/export-enum.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o x.hlto tupleenum.spicy ./tupleenum.evt
+# @TEST-EXEC: spicyz -d -o x.hlto tupleenum.spicy ./tupleenum.evt
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace x.hlto %INPUT >>output
 # @TEST-EXEC: zeek -NN x.hlto | grep TestEnum >>output
 #

--- a/testing/btest/spicy/export-types.zeek
+++ b/testing/btest/spicy/export-types.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o export.hlto export.spicy export.evt >>output
+# @TEST-EXEC: spicyz -d -o export.hlto export.spicy export.evt >>output
 # @TEST-EXEC: zeek export.hlto %INPUT >>output
 #
 # Zeek 5.0 doesn't include the ID when printing the enum type

--- a/testing/btest/spicy/file-analysis-data-in-concurrent.zeek
+++ b/testing/btest/spicy/file-analysis-data-in-concurrent.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto ssh.spicy ./ssh-cond.evt
+# @TEST-EXEC: spicyz -d -o test.hlto ssh.spicy ./ssh-cond.evt
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto %INPUT Spicy::enable_print=T >output
 # @TEST-EXEC: btest-diff output
 

--- a/testing/btest/spicy/file-analyzer-nested.zeek
+++ b/testing/btest/spicy/file-analyzer-nested.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o text.hlto text.spicy ./text.evt
+# @TEST-EXEC: spicyz -d -o text.hlto text.spicy ./text.evt
 # @TEST-EXEC: zeek -r ${TRACES}/http/post.trace text.hlto %INPUT Spicy::enable_print=T | sort -k 3 >output
 # @TEST-EXEC: btest-diff output
 # @TEST-EXEC: cat files.log | zeek-cut source analyzers filename mime_type >files

--- a/testing/btest/spicy/file-analyzer-property.zeek
+++ b/testing/btest/spicy/file-analyzer-property.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto text.spicy ./text.evt
+# @TEST-EXEC: spicyz -d -o test.hlto text.spicy ./text.evt
 # @TEST-EXEC: zeek -r ${TRACES}/http/post.trace test.hlto %INPUT >output
 # @TEST-EXEC: btest-diff output
 

--- a/testing/btest/spicy/file-analyzer.zeek
+++ b/testing/btest/spicy/file-analyzer.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto text.spicy ./text.evt
+# @TEST-EXEC: spicyz -d -o test.hlto text.spicy ./text.evt
 # @TEST-EXEC: zeek -r ${TRACES}/http/post.trace test.hlto %INPUT >output
 # @TEST-EXEC: btest-diff output
 # @TEST-EXEC: btest-diff weird.log

--- a/testing/btest/spicy/file-data-in-at-offset.zeek
+++ b/testing/btest/spicy/file-data-in-at-offset.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto ssh.spicy ./ssh-cond.evt
+# @TEST-EXEC: spicyz -d -o test.hlto ssh.spicy ./ssh-cond.evt
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto %INPUT Spicy::enable_print=T | sort  >output
 #
 # @TEST-EXEC: cat x509.log | grep -v ^# | cut -f 4-5 >x509.log.tmp && mv x509.log.tmp x509.log

--- a/testing/btest/spicy/file-replaces.zeek
+++ b/testing/btest/spicy/file-replaces.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o pe.hlto pe.spicy zeek_pe.spicy pe.evt
+# @TEST-EXEC: spicyz -d -o pe.hlto pe.spicy zeek_pe.spicy pe.evt
 # @TEST-EXEC: zeek -r ${TRACES}/pe/pe-single.trace pe.hlto %INPUT ENABLE=T
 # @TEST-EXEC: cat files.log | zeek-cut source analyzers filename mime_type >>output
 # @TEST-EXEC: zeek -r ${TRACES}/pe/pe-single.trace pe.hlto %INPUT ENABLE=F

--- a/testing/btest/spicy/gap-recovery.zeek
+++ b/testing/btest/spicy/gap-recovery.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o analyzer.hlto analyzer.spicy analyzer.evt
+# @TEST-EXEC: spicyz -d -o analyzer.hlto analyzer.spicy analyzer.evt
 # @TEST-EXEC: zeek -Cr ${TRACES}/spicy/gap-recovery.pcap analyzer.hlto Spicy::enable_print=T >output 2>&1
 # @TEST-EXEC: if spicy-version 10503; then btest-diff output; else OUT=output-before-spicy-issue-1303; mv output "$OUT"; btest-diff "$OUT"; fi
 #

--- a/testing/btest/spicy/import-from.zeek
+++ b/testing/btest/spicy/import-from.zeek
@@ -1,7 +1,7 @@
 # @TEST-REQUIRES: have-spicy
 #
 # @TEST-EXEC: mkdir -p a/b/c && mv y.spicy a/b/c
-# @TEST-EXEC: spicyz -o test.hlto ssh.spicy ./ssh.evt
+# @TEST-EXEC: spicyz -d -o test.hlto ssh.spicy ./ssh.evt
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace  test.hlto %INPUT >output
 # @TEST-EXEC: btest-diff output
 

--- a/testing/btest/spicy/list-conversion.zeek
+++ b/testing/btest/spicy/list-conversion.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto listconv.spicy ./listconv.evt
+# @TEST-EXEC: spicyz -d -o test.hlto listconv.spicy ./listconv.evt
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto %INPUT >output
 # @TEST-EXEC: btest-diff output
 

--- a/testing/btest/spicy/module-path.spicy
+++ b/testing/btest/spicy/module-path.spicy
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o x.hlto %INPUT
+# @TEST-EXEC: spicyz -d -o x.hlto %INPUT
 # @TEST-EXEC: zeek -b Zeek::Spicy x.hlto Spicy::enable_print=T >>output
 # @TEST-EXEC: mkdir -p y/z && mv x.hlto y/z
 # @TEST-EXEC: ZEEK_SPICY_MODULE_PATH=FOO:y:BAR zeek -b Zeek::Spicy Spicy::enable_print=T >>output

--- a/testing/btest/spicy/multiple-enum.zeek
+++ b/testing/btest/spicy/multiple-enum.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto dtest.spicy ./dtest.evt
+# @TEST-EXEC: spicyz -d -o test.hlto dtest.spicy ./dtest.evt
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto %INPUT | sort >output
 # @TEST-EXEC: btest-diff output
 

--- a/testing/btest/spicy/network-time.spicy
+++ b/testing/btest/spicy/network-time.spicy
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto %INPUT ./udp-test.evt
+# @TEST-EXEC: spicyz -d -o test.hlto %INPUT ./udp-test.evt
 # @TEST-EXEC: zeek -Cr ${TRACES}/udp-packet.pcap test.hlto Spicy::enable_print=T >output
 # @TEST-EXEC: btest-diff output
 

--- a/testing/btest/spicy/packet-analyzer-on-ip.zeek
+++ b/testing/btest/spicy/packet-analyzer-on-ip.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto spicy/raw-layer.pcap.spicy spicy/raw-layer.pcap.evt
+# @TEST-EXEC: spicyz -d -o test.hlto spicy/raw-layer.pcap.spicy spicy/raw-layer.pcap.evt
 # @TEST-EXEC: zeek -r ${TRACES}/dns/proto255.pcap test.hlto %INPUT >output
 # @TEST-EXEC: btest-diff output
 

--- a/testing/btest/spicy/packet-analyzer-replaces.zeek
+++ b/testing/btest/spicy/packet-analyzer-replaces.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o my-ethernet.hlto my-ethernet.spicy my-ethernet.evt
+# @TEST-EXEC: spicyz -d -o my-ethernet.hlto my-ethernet.spicy my-ethernet.evt
 # @TEST-EXEC: zeek -r ${TRACES}/dns53.pcap my-ethernet.hlto %INPUT ENABLE=T >output-on
 # @TEST-EXEC: zeek -r ${TRACES}/dns53.pcap my-ethernet.hlto %INPUT ENABLE=F >output-off
 # @TEST-EXEC: btest-diff output-on

--- a/testing/btest/spicy/packet-analyzer.zeek
+++ b/testing/btest/spicy/packet-analyzer.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto spicy/raw-layer.pcap.spicy spicy/raw-layer.pcap.evt
+# @TEST-EXEC: spicyz -d -o test.hlto spicy/raw-layer.pcap.spicy spicy/raw-layer.pcap.evt
 # @TEST-EXEC: zeek -r ${TRACES}/spicy/raw-layer.pcap test.hlto %INPUT >output
 # @TEST-EXEC: btest-diff output
 # @TEST-EXEC: btest-diff weird.log

--- a/testing/btest/spicy/parse-error.zeek
+++ b/testing/btest/spicy/parse-error.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto test.evt test.spicy
+# @TEST-EXEC: spicyz -d -o test.hlto test.evt test.spicy
 # @TEST-EXEC: HILTI_DEBUG=zeek zeek -r ${TRACES}/ssh/single-conn.trace misc/dump-events test.hlto %INPUT
 # Zeek versions differ in their quoting of the newline character in dpd.log (two slashes vs one).
 # @TEST-EXEC: cat dpd.log | sed 's#\\\\#\\#g' >dpd.log.tmp && mv dpd.log.tmp dpd.log

--- a/testing/btest/spicy/port-fail.evt
+++ b/testing/btest/spicy/port-fail.evt
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC-FAIL: spicyz %INPUT -o x.hlto >output 2>&1
+# @TEST-EXEC-FAIL: spicyz %INPUT -d -o x.hlto >output 2>&1
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=diff-canonifier-spicy btest-diff output
 
 protocol analyzer spicy::SSH over TCP:

--- a/testing/btest/spicy/preprocessor-fail.evt
+++ b/testing/btest/spicy/preprocessor-fail.evt
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC-FAIL: spicyz -D zeek -o x.hlto %INPUT 2>output
+# @TEST-EXEC-FAIL: spicyz -D zeek -d -o x.hlto %INPUT 2>output
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=diff-canonifier-spicy btest-diff output
 
 @if ZEEK_VERSION < 90000

--- a/testing/btest/spicy/preprocessor.evt
+++ b/testing/btest/spicy/preprocessor.evt
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -D zeek -o x.hlto %INPUT 2>output
+# @TEST-EXEC: spicyz -D zeek -d -o x.hlto %INPUT 2>output
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=diff-canonifier-spicy btest-diff output
 
 protocol analyzer YES_1 over TCP: parse with X;

--- a/testing/btest/spicy/profiling.zeek
+++ b/testing/btest/spicy/profiling.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -Z -o ssh.hlto ssh.spicy ./ssh.evt
+# @TEST-EXEC: spicyz -Z -d -o ssh.hlto ssh.spicy ./ssh.evt
 # @TEST-EXEC: zeek -b -r ${TRACES}/ssh/single-conn.trace Zeek::Spicy ssh.hlto %INPUT Spicy::enable_profiling=T >output 2>prof.log.raw
 # @TEST-EXEC: cat prof.log.raw | awk '{print $1, $2}' | egrep -v 'zeek/rt/debug|zeek/rt/internal_handler' >prof.log
 # @TEST-EXEC: btest-diff output

--- a/testing/btest/spicy/protocol-analyzer-data-in.zeek
+++ b/testing/btest/spicy/protocol-analyzer-data-in.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto ssh.spicy ./ssh-cond.evt
+# @TEST-EXEC: spicyz -d -o test.hlto ssh.spicy ./ssh-cond.evt
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto %INPUT
 # @TEST-EXEC: btest-diff http.log
 

--- a/testing/btest/spicy/protocol-analyzer-tcp-over-udp.spicy
+++ b/testing/btest/spicy/protocol-analyzer-tcp-over-udp.spicy
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto %INPUT ./foo.evt
+# @TEST-EXEC: spicyz -d -o test.hlto %INPUT ./foo.evt
 # @TEST-EXEC: zeek -Cr ${TRACES}/ssh/ssh-over-udp.pcap test.hlto
 # @TEST-EXEC: btest-diff ssh.log
 #

--- a/testing/btest/spicy/replaces-mismatch.zeek
+++ b/testing/btest/spicy/replaces-mismatch.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o ssh.hlto ssh.spicy ./ssh.evt
+# @TEST-EXEC: spicyz -d -o ssh.hlto ssh.spicy ./ssh.evt
 # @TEST-EXEC-FAIL: zeek -r ${TRACES}/ssh/single-conn.trace ssh.hlto >output 2>&1
 # @TEST-EXEC: btest-diff output
 #

--- a/testing/btest/spicy/replaces.zeek
+++ b/testing/btest/spicy/replaces.zeek
@@ -1,7 +1,7 @@
 # @TEST-REQUIRES: have-spicy
 #
 # @TEST-EXEC: mkdir -p modules
-# @TEST-EXEC: spicyz -o modules/ssh.hlto ssh.spicy ./ssh.evt
+# @TEST-EXEC: spicyz -d -o modules/ssh.hlto ssh.spicy ./ssh.evt
 # @TEST-EXEC: ZEEK_SPICY_MODULE_PATH=$(pwd)/modules zeek -r ${TRACES}/ssh/single-conn.trace %INPUT | sort >output
 # @TEST-EXEC: btest-diff output
 #

--- a/testing/btest/spicy/resource-usage.zeek
+++ b/testing/btest/spicy/resource-usage.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto test.evt test.spicy
+# @TEST-EXEC: spicyz -d -o test.hlto test.evt test.spicy
 # @TEST-EXEC: zeek -r ${TRACES}/ssh/single-conn.trace test.hlto Zeek/Spicy/misc/resource-usage | sed 's/=[^ ]*/=XXX/g' >output
 # @TEST-EXEC: btest-diff output
 #

--- a/testing/btest/spicy/spicyz.test
+++ b/testing/btest/spicy/spicyz.test
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz test.spicy test.evt -o test.hlto
+# @TEST-EXEC: spicyz test.spicy test.evt -d -o test.hlto
 # @TEST-EXEC: zeek -NN test.hlto | grep -q ANALYZER_SPICY_TEST
 # @TEST-EXEC: zeek -r ${TRACES}/http/post.trace test.zeek test.hlto "Spicy::enable_print = T;" >>output 2>&1
 # @TEST-EXEC: btest-diff output

--- a/testing/btest/spicy/ssh-banner.zeek
+++ b/testing/btest/spicy/ssh-banner.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o ssh.hlto ssh.spicy ./ssh.evt
+# @TEST-EXEC: spicyz -d -o ssh.hlto ssh.spicy ./ssh.evt
 # @TEST-EXEC: echo === confirmation >>output
 # @TEST-EXEC: zeek -b -r ${TRACES}/ssh/single-conn.trace -s ./ssh.sig Zeek::Spicy base/frameworks/notice/weird ssh.hlto %INPUT ./extern.zeek | sort >>output
 # @TEST-EXEC: btest-diff weird.log

--- a/testing/btest/spicy/terminate-session.zeek
+++ b/testing/btest/spicy/terminate-session.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -o test.hlto test.spicy test.evt
+# @TEST-EXEC: spicyz -d -o test.hlto test.spicy test.evt
 # @TEST-EXEC: zeek -b -r ${TRACES}/dns/long-connection.pcap Zeek::Spicy test.hlto base/protocols/conn %INPUT
 # @TEST-EXEC: cat conn.log | zeek-cut uid -C > conn.log2 && mv conn.log2 conn.log
 # @TEST-EXEC: btest-diff conn.log


### PR DESCRIPTION
This patch changes invocations of `spicyz` and similar Spicy tools in tests which perform compilation to use debug mode via passing `-d`. This in turn leads to Spicy compiling generated C++ code in debug as opposed to release mode which typically seems to require less CPU time and RAM. For a local test running with `btest -j 16` and no caching via `HILTI_CXX_COMPILER_LAUNCER` this sped up running of BTests under `spicy/` by about 40s on my machine (120s vs 160s).