### PR TITLE
CMakeLists: Skip zeek-version.h include for zeek_objs, too

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -511,6 +511,7 @@ collect_headers(zeek_HEADERS ${zeek_SRCS})
 
 add_library(zeek_objs OBJECT ${zeek_SRCS})
 target_link_libraries(zeek_objs PRIVATE $<BUILD_INTERFACE:zeek_internal>)
+target_compile_definitions(zeek_objs PRIVATE ZEEK_CONFIG_SKIP_VERSION_H)
 add_dependencies(zeek_objs zeek_autogen_files)
 add_clang_tidy_files(${zeek_SRCS})
 zeek_target_link_libraries(zeek_objs)


### PR DESCRIPTION
I've continued to see somewhat slower builds after Zeek version bumps. It appears files covered by zeek_objs didn't have -DZEEK_CONFIG_SKIP_VERSION_H set causing ccache invalidation after a version bump.