### PR TITLE
Simplify code generated for Spicy analyzer port ranges.

### DIFF
--- a/scripts/spicy/zeek_rt.hlt
+++ b/scripts/spicy/zeek_rt.hlt
@@ -8,12 +8,15 @@ import hilti;
 public type Val = __library_type("::zeek::ValPtr");
 public type BroType = __library_type("::zeek::TypePtr");
 public type EventHandlerPtr = __library_type("::zeek::EventHandlerPtr");
+public type PortRange = __library_type("::zeek::spicy::rt::PortRange");
+
+declare public PortRange make_port_range(port begin_, port end_) &cxxname="zeek::spicy::rt::make_port_range" &have_prototype;
 
 type ZeekTypeTag = enum {
     Addr, Any, Bool, Count, Double, Enum, Error, File, Func, Int, Interval, List, Opaque, Pattern, Port, Record, String, Subnet, Table, Time, Type, Vector, Void
 } &cxxname="::zeek::spicy::rt::ZeekTypeTag";
 
-declare public void register_protocol_analyzer(string name, hilti::Protocol protocol, vector<port> ports, string parser_orig, string parser_resp, string replaces, string linker_scope) &cxxname="zeek::spicy::rt::register_protocol_analyzer" &have_prototype;
+declare public void register_protocol_analyzer(string name, hilti::Protocol protocol, vector<PortRange> ports, string parser_orig, string parser_resp, string replaces, string linker_scope) &cxxname="zeek::spicy::rt::register_protocol_analyzer" &have_prototype;
 declare public void register_file_analyzer(string name, vector<string> mime_types, string parser, string replaces, string linker_scope) &cxxname="zeek::spicy::rt::register_file_analyzer" &have_prototype;
 declare public void register_packet_analyzer(string name, string parser, string replaces, string linker_scope) &cxxname="zeek::spicy::rt::register_packet_analyzer" &have_prototype;
 declare public void register_type(string ns, string id, BroType t) &cxxname="zeek::spicy::rt::register_type" &have_prototype;

--- a/src/spicy/manager.h
+++ b/src/spicy/manager.h
@@ -17,6 +17,7 @@
 #include "zeek/Tag.h"
 #include "zeek/plugin/Component.h"
 #include "zeek/plugin/Plugin.h"
+#include "zeek/spicy/port-range.h"
 #include "zeek/spicy/spicyz/config.h" // include for Spicy version
 
 // Macro helper to report Spicy debug messages. This forwards to
@@ -81,9 +82,9 @@ public:
      * registration
      */
     void registerProtocolAnalyzer(const std::string& name, hilti::rt::Protocol proto,
-                                  const hilti::rt::Vector<hilti::rt::Port>& ports, const std::string& parser_orig,
-                                  const std::string& parser_resp, const std::string& replaces,
-                                  const std::string& linker_scope);
+                                  const hilti::rt::Vector<::zeek::spicy::rt::PortRange>& ports,
+                                  const std::string& parser_orig, const std::string& parser_resp,
+                                  const std::string& replaces, const std::string& linker_scope);
 
     /**
      * Runtime method to register a file analyzer with its Zeek-side
@@ -325,7 +326,7 @@ private:
         std::string name_parser_resp;
         std::string name_replaces;
         hilti::rt::Protocol protocol = hilti::rt::Protocol::Undef;
-        hilti::rt::Vector<hilti::rt::Port> ports;
+        hilti::rt::Vector<::zeek::spicy::rt::PortRange> ports;
         std::string linker_scope;
 
         // Computed and available once the analyzer has been registered.

--- a/src/spicy/port-range.h
+++ b/src/spicy/port-range.h
@@ -1,0 +1,32 @@
+// See the file "COPYING" in the main distribution directory for copyright.
+
+#pragma once
+
+#include <cassert>
+#include <tuple>
+
+#include <hilti/rt/types/port.h>
+
+namespace zeek::spicy::rt {
+
+/** A closed ranged of ports. */
+struct PortRange {
+    PortRange() = default;
+    PortRange(hilti::rt::Port begin_, hilti::rt::Port end_) : begin(begin_), end(end_) {
+        assert(begin.port() <= end.port());
+        assert(begin.protocol() == end.protocol());
+    }
+
+    hilti::rt::Port begin; /**< first port in the range */
+    hilti::rt::Port end;   /**< last port in the range */
+};
+
+inline bool operator==(const PortRange& a, const PortRange& b) {
+    return std::tie(a.begin, a.end) == std::tie(b.begin, b.end);
+}
+
+inline bool operator!=(const PortRange& a, const PortRange& b) { return ! (a == b); }
+
+inline PortRange make_port_range(hilti::rt::Port begin, hilti::rt::Port end) { return PortRange(begin, end); }
+
+} // namespace zeek::spicy::rt

--- a/src/spicy/runtime-support.cc
+++ b/src/spicy/runtime-support.cc
@@ -21,9 +21,9 @@ using namespace zeek;
 using namespace zeek::spicy;
 
 void rt::register_protocol_analyzer(const std::string& name, hilti::rt::Protocol proto,
-                                    const hilti::rt::Vector<hilti::rt::Port>& ports, const std::string& parser_orig,
-                                    const std::string& parser_resp, const std::string& replaces,
-                                    const std::string& linker_scope) {
+                                    const hilti::rt::Vector<::zeek::spicy::rt::PortRange>& ports,
+                                    const std::string& parser_orig, const std::string& parser_resp,
+                                    const std::string& replaces, const std::string& linker_scope) {
     auto _ = hilti::rt::profiler::start("zeek/rt/register_protocol_analyzer");
     spicy_mgr->registerProtocolAnalyzer(name, proto, ports, parser_orig, parser_resp, replaces, linker_scope);
 }

--- a/src/spicy/runtime-support.h
+++ b/src/spicy/runtime-support.h
@@ -23,6 +23,7 @@
 #include "zeek/Desc.h"
 #include "zeek/spicy/cookie.h"
 #include "zeek/spicy/manager.h"
+#include "zeek/spicy/port-range.h"
 
 namespace zeek::spicy::rt {
 
@@ -93,9 +94,9 @@ public:
  * plugin's runtime.
  */
 void register_protocol_analyzer(const std::string& name, hilti::rt::Protocol proto,
-                                const hilti::rt::Vector<hilti::rt::Port>& ports, const std::string& parser_orig,
-                                const std::string& parser_resp, const std::string& replaces,
-                                const std::string& linker_scope);
+                                const hilti::rt::Vector<::zeek::spicy::rt::PortRange>& ports,
+                                const std::string& parser_orig, const std::string& parser_resp,
+                                const std::string& replaces, const std::string& linker_scope);
 
 /**
  * Registers a Spicy file analyzer with its EVT meta information with the

--- a/src/spicy/spicyz/glue-compiler.h
+++ b/src/spicy/spicyz/glue-compiler.h
@@ -27,6 +27,7 @@
 #include <spicy/ast/types/unit.h>
 
 #include "driver.h"
+#include "zeek/spicy/port-range.h"
 
 namespace spicy::rt {
 struct Parser;
@@ -42,7 +43,7 @@ struct ProtocolAnalyzer {
     hilti::Location location;                                  /**< Location where the analyzer was defined. */
     hilti::ID name;                                            /**< Name of the analyzer. */
     hilti::rt::Protocol protocol = hilti::rt::Protocol::Undef; /**< The transport layer the analyzer uses. */
-    std::vector<hilti::rt::Port> ports;                        /**< The ports associated with the analyzer. */
+    std::vector<::zeek::spicy::rt::PortRange> ports;           /**< The ports associated with the analyzer. */
     hilti::ID unit_name_orig; /**< The fully-qualified name of the unit type to parse the originator
                                  side. */
     hilti::ID unit_name_resp; /**< The fully-qualified name of the unit type to parse the originator


### PR DESCRIPTION
We previously would reprent port ranges from EVT files element-wise. This can potentially generate a lot of code (all on a single line though) which some versions of GCC seem to have trouble with, and which also causes JIT overhead.

With this patch we switch to directly representing ranges. Single ports are represented as ranges `[start, start]`.

Closes #3094.