### PR TITLE
ci/windows: choco --localonly is gone

### DIFF
--- a/ci/windows/prepare.cmd
+++ b/ci/windows/prepare.cmd
@@ -4,4 +4,4 @@ echo %ZEEK_CI_CPUS%
 wmic cpu get NumberOfCores, NumberOfLogicalProcessors/Format:List
 systeminfo
 dir C:
-choco list --localonly
+choco list


### PR DESCRIPTION
choco 2.0 is now used after some caching changes on the Cirrus side [1] and the --localonly flag is gone from choco [2], remove its usage.

[1] https://github.com/cirruslabs/cirrus-ci-docs/issues/1174#issuecomment-1580928673
[2] https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6#the-list-command-now-lists-local-packages-only-and-the-local-only-and-lo-options-have-been-removed

---

Link to failing job:

https://cirrus-ci.com/task/6530009934856192?logs=prepare#L119

I suspect this is needed in the release branches and 6.0?