### PR TITLE
tests: Do not use archiver_rotation_format_func as postprocessor

### DIFF
--- a/testing/btest/scripts/base/frameworks/cluster/leftover-log-rotation-multi-logger.zeek
+++ b/testing/btest/scripts/base/frameworks/cluster/leftover-log-rotation-multi-logger.zeek
@@ -1,11 +1,11 @@
 # @TEST-DOC: Ensure that left-over log rotation tags the logger name on as well.
 
 # @TEST-EXEC: echo ".log" >> .shadow.conn.log
-# @TEST-EXEC: echo "archiver_rotation_format_func" >> .shadow.conn.log
+# @TEST-EXEC: echo "" >> .shadow.conn.log
 # @TEST-EXEC: echo "leftover conn log" > conn.log
 
 # @TEST-EXEC: echo ".log" >> .shadow.dns.log
-# @TEST-EXEC: echo "archiver_rotation_format_func" >> .shadow.dns.log
+# @TEST-EXEC: echo "" >> .shadow.dns.log
 # @TEST-EXEC: echo "leftover dns log" > dns.log
 
 # Start Zeek as cluster node logger-2.


### PR DESCRIPTION
This test triggered ubsan by putting a function with the wrong type as a post-processor into the .shadow file. Don't do that.

Likely Zeek should provide a better error message, but hand-crafting .shadow files isn't what is normally done and this is to fix the master build for now.

Follow-up for #3116 