### PR TITLE
Make dist fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@
 BUILD=build
 REPO=$$(cd $(CURDIR) && basename $$(git config --get remote.origin.url | sed 's/^[^:]*://g'))
 VERSION_FULL=$(REPO)-$$(cd $(CURDIR) && cat VERSION)
-VERSION_MIN=$(REPO)-$$(cd $(CURDIR) && cat VERSION)-minimal
 GITDIR=$$(test -f .git && echo $$(cut -d" " -f2 .git) || echo .git)
 
 all: configured
@@ -48,11 +47,7 @@ dist:
 	@mv ../$(VERSION_FULL) .
 	@COPYFILE_DISABLE=true tar -czf $(VERSION_FULL).tar.gz $(VERSION_FULL)
 	@echo Package: $(VERSION_FULL).tar.gz
-	@mv $(VERSION_FULL) $(VERSION_MIN)
-	@(cd $(VERSION_MIN) && for i in auxil/*; do rm -rf $$i/*; done)
-	@COPYFILE_DISABLE=true tar -czf $(VERSION_MIN).tar.gz $(VERSION_MIN)
-	@echo Package: $(VERSION_MIN).tar.gz
-	@rm -rf $(VERSION_MIN)
+	@rm -rf $(VERSION_FULL)
 
 distclean:
 	rm -rf $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BUILD=build
 REPO=$$(cd $(CURDIR) && basename $$(git config --get remote.origin.url | sed 's/^[^:]*://g'))
 VERSION_FULL=$(REPO)-$$(cd $(CURDIR) && cat VERSION)
 GITDIR=$$(test -f .git && echo $$(cut -d" " -f2 .git) || echo .git)
+REALPATH=$$($$(realpath --relative-to=$(pwd) . >/dev/null 2>&1) && echo 'realpath' || echo 'grealpath')
 
 all: configured
 	$(MAKE) -C $(BUILD) $@
@@ -38,8 +39,8 @@ livehtml:
 dist:
 	@test -e ../$(VERSION_FULL) && rm -ri ../$(VERSION_FULL) || true
 	@cp -R . ../$(VERSION_FULL)
-	@for i in . $$(git submodule foreach -q --recursive realpath --relative-to=$$(pwd) .); do ((cd ../$(VERSION_FULL)/$$i && test -f .git && cp -R $(GITDIR) .gitnew && rm -f .git && mv .gitnew .git && sed -i.bak -e 's#[[:space:]]*worktree[[:space:]]*=[[:space:]]*.*##g' .git/config) || true); done
-	@for i in . $$(git submodule foreach -q --recursive realpath --relative-to=$$(pwd) .); do (cd ../$(VERSION_FULL)/$$i && git reset -q --hard && git clean -ffdxq); done
+	@for i in . $$(git submodule foreach -q --recursive $(REALPATH) --relative-to=$$(pwd) .); do ((cd ../$(VERSION_FULL)/$$i && test -f .git && cp -R $(GITDIR) .gitnew && rm -f .git && mv .gitnew .git && sed -i.bak -e 's#[[:space:]]*worktree[[:space:]]*=[[:space:]]*.*##g' .git/config) || true); done
+	@for i in . $$(git submodule foreach -q --recursive $(REALPATH) --relative-to=$$(pwd) .); do (cd ../$(VERSION_FULL)/$$i && git reset -q --hard && git clean -ffdxq); done
 	@(cd ../$(VERSION_FULL) && find . -name \.git\* | xargs rm -rf)
 	@(cd ../$(VERSION_FULL) && find . -name \.idea -type d | xargs rm -rf)
 	@(cd ../$(VERSION_FULL) && find . -maxdepth 1 -name build\* | xargs rm -rf)


### PR DESCRIPTION
This fixes two issues:

1. Remove generation of the `-minimal.tar.gz` tarball. This tarball hasn't been useful for quite some time since it doesn't include any of the code in the auxil submodules. You can't use it for building Zeek or external plugins, so you would almost always prefer to just download the full tarball. After 6.0, we won't be releasing the minimal tarballs anymore.
2. Fix an issue with running `make dist` on macOS where the built-in `realpath` command doesn't support the `--relative-to` argument on Ventura and later (macOS 13). In the cases where that argument causes an error, fallback to trying the `grealpath` command which can be installed via homebrew.