### PR TITLE
Convert uses of varargs to variadic templates

### DIFF
--- a/cmake_templates/zeek-config.h.in
+++ b/cmake_templates/zeek-config.h.in
@@ -77,6 +77,9 @@
 /* Define if you have the `strsep' function. */
 #cmakedefine HAVE_STRSEP
 
+/* Define if you have the 'asprintf' function. */
+#cmakedefine HAVE_ASPRINTF
+
 /* Define if you have the <sys/ethernet.h> header file. */
 #cmakedefine HAVE_SYS_ETHERNET_H
 

--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -95,19 +95,6 @@ bool StmtLocMapping::StartsAfter(const StmtLocMapping* m2)
 	       (loc.first_line == m2->loc.first_line && loc.first_column > m2->loc.first_column);
 	}
 
-// Generic debug message output.
-int debug_msg(const char* fmt, ...)
-	{
-	va_list args;
-	int retval;
-
-	va_start(args, fmt);
-	retval = vfprintf(stderr, fmt, args);
-	va_end(args);
-
-	return retval;
-	}
-
 // Trace message output
 
 FILE* TraceState::SetTraceFile(const char* trace_filename)
@@ -145,24 +132,17 @@ void TraceState::TraceOff()
 	dbgtrace = false;
 	}
 
-int TraceState::LogTrace(const char* fmt, ...)
+void TraceState::LogTraceHelper()
 	{
-	va_list args;
-	int retval;
-
-	va_start(args, fmt);
-
 	// Prefix includes timestamp and file/line info.
 	fprintf(trace_file, "%.6f ", run_state::network_time);
 
-	const Stmt* stmt;
 	Location loc;
 	loc.filename = nullptr;
 
 	if ( g_frame_stack.size() > 0 && g_frame_stack.back() )
 		{
-		stmt = g_frame_stack.back()->GetNextStmt();
-		if ( stmt )
+		if ( auto stmt = g_frame_stack.back()->GetNextStmt() )
 			loc = *stmt->GetLocationInfo();
 		else
 			{
@@ -183,13 +163,6 @@ int TraceState::LogTrace(const char* fmt, ...)
 	// Each stack frame is indented.
 	for ( int i = 0; i < int(g_frame_stack.size()); ++i )
 		fprintf(trace_file, "\t");
-
-	retval = vfprintf(trace_file, fmt, args);
-
-	fflush(trace_file);
-	va_end(args);
-
-	return retval;
 	}
 
 // Helper functions.

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -67,12 +67,26 @@ public:
 	void TraceOn();
 	void TraceOff();
 
-	int LogTrace(const char* fmt, ...) __attribute__((format(printf, 2, 3)));
-	;
+	template <typename... Args> int LogTrace(const char* fmt, Args&&... args)
+		{
+		LogTraceHelper();
+
+		int retval;
+		if constexpr ( sizeof...(args) > 0 )
+			retval = fprintf(trace_file, fmt, std::forward<Args>(args)...);
+		else
+			retval = fprintf(trace_file, "%s", fmt);
+
+		fflush(trace_file);
+		return retval;
+		}
 
 protected:
 	bool dbgtrace; // print an execution trace
 	FILE* trace_file;
+
+private:
+	void LogTraceHelper();
 	};
 
 extern TraceState g_trace_state;
@@ -193,7 +207,13 @@ extern Frame* g_dbg_locals; // variables created within debugger context
 extern std::map<std::string, Filemap*> g_dbgfilemaps; // filename => filemap
 
 // Perhaps add a code/priority argument to do selective output.
-int debug_msg(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+template <typename... Args> int debug_msg(const char* fmt, Args&&... args)
+	{
+	if constexpr ( sizeof...(args) > 0 )
+		return fprintf(stderr, fmt, std::forward<Args>(args)...);
+	else
+		return fprintf(stderr, "%s", fmt);
+	}
 
 	} // namespace detail
 	} // namespace zeek

--- a/src/DebugLogger.cc
+++ b/src/DebugLogger.cc
@@ -61,7 +61,7 @@ void DebugLogger::OpenDebugLog(const char* filename)
 		file = stderr;
 	}
 
-void DebugLogger::ShowStreamsHelp()
+void DebugLogger::ShowStreamsHelp() const
 	{
 	fprintf(stderr, "\n");
 	fprintf(stderr, "Enable debug output into debug.log with -B <streams>.\n");
@@ -143,7 +143,7 @@ void DebugLogger::EnableStreams(const char* s)
 	delete[] tmp;
 	}
 
-bool DebugLogger::CheckStreams(const std::set<std::string>& plugin_names)
+bool DebugLogger::CheckStreams(const std::set<std::string>& plugin_names) const
 	{
 	bool ok = true;
 
@@ -166,45 +166,9 @@ bool DebugLogger::CheckStreams(const std::set<std::string>& plugin_names)
 	return ok;
 	}
 
-void DebugLogger::Log(DebugStream stream, const char* fmt, ...)
+std::string DebugLogger::GetPluginName(const plugin::Plugin& plugin) const
 	{
-	Stream* g = &streams[int(stream)];
-
-	if ( ! g->enabled )
-		return;
-
-	fprintf(file, "%17.06f/%17.06f [%s] ", run_state::network_time, util::current_time(true),
-	        g->prefix);
-
-	for ( int i = g->indent; i > 0; --i )
-		fputs("   ", file);
-
-	va_list ap;
-	va_start(ap, fmt);
-	vfprintf(file, fmt, ap);
-	va_end(ap);
-
-	fputc('\n', file);
-	fflush(file);
-	}
-
-void DebugLogger::Log(const plugin::Plugin& plugin, const char* fmt, ...)
-	{
-	std::string tok = PluginStreamName(plugin.Name());
-
-	if ( enabled_streams.find(tok) == enabled_streams.end() )
-		return;
-
-	fprintf(file, "%17.06f/%17.06f [plugin %s] ", run_state::network_time, util::current_time(true),
-	        plugin.Name().c_str());
-
-	va_list ap;
-	va_start(ap, fmt);
-	vfprintf(file, fmt, ap);
-	va_end(ap);
-
-	fputc('\n', file);
-	fflush(file);
+	return plugin.Name();
 	}
 
 	} // namespace zeek::detail

--- a/src/Reporter.h
+++ b/src/Reporter.h
@@ -223,7 +223,11 @@ public:
 			return;
 
 		char* buf;
+#ifdef HAVE_ASPRINTF
 		asprintf(&buf, fmt, std::forward<Args>(args)...);
+#else
+		util::asprintf(&buf, fmt, std::forward<Args>(args)...);
+#endif
 		DoSyslog(buf);
 		free(buf);
 		}

--- a/src/Reporter.h
+++ b/src/Reporter.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <stdarg.h>
+#include <stdio.h>
 #include <list>
 #include <map>
 #include <string>
@@ -11,14 +11,20 @@
 #include <unordered_set>
 #include <utility>
 
+#include "zeek/Desc.h"
+#include "zeek/Event.h"
+#include "zeek/RunState.h"
 #include "zeek/ZeekList.h"
 #include "zeek/net_util.h"
+
+extern zeek::EventHandlerPtr reporter_info;
+extern zeek::EventHandlerPtr reporter_warning;
+extern zeek::EventHandlerPtr reporter_error;
 
 namespace zeek
 	{
 
 class Connection;
-class EventHandlerPtr;
 class RecordVal;
 class StringVal;
 class IPAddr;
@@ -84,43 +90,110 @@ public:
 
 	// Report an informational message, nothing that needs specific
 	// attention.
-	void Info(const char* fmt, ...) FMT_ATTR;
+	template <typename... Args> void Info(const char* fmt, Args&&... args)
+		{
+		FILE* out = EmitToStderr(info_to_stderr) ? stderr : nullptr;
+		DoLog("", reporter_info, out, nullptr, nullptr, true, true, "", fmt, args...);
+		}
 
 	// Report a warning that may indicate a problem.
-	void Warning(const char* fmt, ...) FMT_ATTR;
+	template <typename... Args> void Warning(const char* fmt, Args&&... args)
+		{
+		FILE* out = EmitToStderr(info_to_stderr) ? stderr : nullptr;
+		DoLog("warning", reporter_warning, out, nullptr, nullptr, true, true, "", fmt, args...);
+		}
 
 	// Report a non-fatal error. Processing proceeds normally after the error
 	// has been reported.
-	void Error(const char* fmt, ...) FMT_ATTR;
+	template <typename... Args> void Error(const char* fmt, Args&&... args)
+		{
+		++errors;
+		FILE* out = EmitToStderr(info_to_stderr) ? stderr : nullptr;
+		DoLog("error", reporter_error, out, nullptr, nullptr, true, true, "", fmt, args...);
+		}
 
 	// Returns the number of errors reported so far.
 	int Errors() { return errors; }
 
 	// Report a fatal error. Zeek will terminate after the message has been
 	// reported.
-	[[noreturn]] void FatalError(const char* fmt, ...) FMT_ATTR;
+	template <typename... Args> [[noreturn]] void FatalError(const char* fmt, Args&&... args)
+		{
+		// Always log to stderr.
+		DoLog("fatal error", nullptr, stderr, nullptr, nullptr, true, false, "", fmt, args...);
+		util::detail::set_processing_status("TERMINATED", "fatal_error");
+		fflush(stderr);
+		fflush(stdout);
+		_exit(1);
+		}
 
 	// Report a fatal error. Zeek will terminate after the message has been
 	// reported and always generate a core dump.
-	[[noreturn]] void FatalErrorWithCore(const char* fmt, ...) FMT_ATTR;
+	template <typename... Args>
+	[[noreturn]] void FatalErrorWithCore(const char* fmt, Args&&... args)
+		{
+		// Always log to stderr.
+		DoLog("fatal error", nullptr, stderr, nullptr, nullptr, true, false, "", fmt, args...);
+		util::detail::set_processing_status("TERMINATED", "fatal_error");
+		abort();
+		}
 
 	// Report a runtime error in evaluating a Zeek script expression. This
 	// function will not return but raise an InterpreterException.
-	[[noreturn]] void ExprRuntimeError(const detail::Expr* expr, const char* fmt, ...)
-		__attribute__((format(printf, 3, 4)));
+	template <typename... Args>
+	[[noreturn]] void ExprRuntimeError(const detail::Expr* expr, const char* fmt, Args&&... args)
+		{
+		++errors;
+
+		ODesc d;
+		DescribeExpr(expr, d);
+		FILE* out = EmitToStderr(errors_to_stderr) ? stderr : nullptr;
+		DoLog("expression error", reporter_error, out, nullptr, nullptr, true, true,
+		      d.Description(), fmt, args...);
+		PopLocation();
+		throw InterpreterException();
+		}
 
 	// Report a runtime error in evaluating a Zeek script expression. This
 	// function will not return but raise an InterpreterException.
-	[[noreturn]] void RuntimeError(const detail::Location* location, const char* fmt, ...)
-		__attribute__((format(printf, 3, 4)));
+	template <typename... Args>
+	[[noreturn]] void RuntimeError(const detail::Location* location, const char* fmt,
+	                               Args&&... args)
+		{
+		++errors;
+		PushLocation(location);
+		FILE* out = EmitToStderr(errors_to_stderr) ? stderr : nullptr;
+		DoLog("runtime error", reporter_error, out, nullptr, nullptr, true, true, "", fmt, args...);
+		PopLocation();
+		throw InterpreterException();
+		}
 
 	// Report a rutnime warning in evaluating a Zeek script expression.
-	void ExprRuntimeWarning(const detail::Expr* expr, const char* fmt, ...)
-		__attribute__((format(printf, 3, 4)));
+	template <typename... Args>
+	void ExprRuntimeWarning(const detail::Expr* expr, const char* fmt, Args&&... args)
+		{
+		ODesc d;
+		DescribeExpr(expr, d);
+		FILE* out = EmitToStderr(warnings_to_stderr) ? stderr : nullptr;
+		DoLog("expression warning", reporter_warning, out, nullptr, nullptr, true, true,
+		      d.Description(), fmt, args...);
+		PopLocation();
+		}
 
 	// Report a runtime error in executing a compiled script. This
 	// function will not return but raise an InterpreterException.
-	[[noreturn]] void CPPRuntimeError(const char* fmt, ...) __attribute__((format(printf, 2, 3)));
+	template <typename... Args> [[noreturn]] void CPPRuntimeError(const char* fmt, Args&&... args)
+		{
+		++errors;
+		FILE* out = EmitToStderr(errors_to_stderr) ? stderr : nullptr;
+		DoLog("runtime error in compiled code", reporter_error, out, nullptr, nullptr, true, true,
+		      "", fmt, args...);
+
+		if ( abort_on_scripting_errors )
+			abort();
+
+		throw InterpreterException();
+		}
 
 	// Report a traffic weirdness, i.e., an unexpected protocol situation
 	// that may lead to incorrectly processing a connection.
@@ -144,21 +217,49 @@ public:
 
 	// Syslog a message. This methods does nothing if we're running
 	// offline from a trace.
-	void Syslog(const char* fmt, ...) FMT_ATTR;
+	template <typename... Args> void Syslog(const char* fmt, Args&&... args)
+		{
+		if ( run_state::reading_traces )
+			return;
+
+		char* buf;
+		asprintf(&buf, fmt, std::forward<Args>(args)...);
+		DoSyslog(buf);
+		free(buf);
+		}
 
 	// Report about a potential internal problem. Zeek will continue
 	// normally.
-	void InternalWarning(const char* fmt, ...) FMT_ATTR;
+	template <typename... Args> void InternalWarning(const char* fmt, Args&&... args)
+		{
+		FILE* out = EmitToStderr(warnings_to_stderr) ? stderr : nullptr;
+		// TODO: would be nice to also log a call stack.
+		DoLog("internal warning", reporter_warning, out, nullptr, nullptr, true, true, "", fmt,
+		      args...);
+		}
 
 	// Report an internal program error. Zeek will terminate with a core
 	// dump after the message has been reported.
-	[[noreturn]] void InternalError(const char* fmt, ...) FMT_ATTR;
+	template <typename... Args> [[noreturn]] void InternalError(const char* fmt, Args&&... args)
+		{
+		// Always log to stderr.
+		DoLog("internal error", nullptr, stderr, nullptr, nullptr, true, false, "", fmt, args...);
+		util::detail::set_processing_status("TERMINATED", "internal_error");
+		abort();
+		}
 
 	// Report an analyzer error. That analyzer will be set to not process
 	// any further input, but Zeek otherwise continues normally.
-	void AnalyzerError(analyzer::Analyzer* a, const char* fmt, ...)
-		__attribute__((format(printf, 3, 4)));
-	;
+	template <typename... Args>
+	void AnalyzerError(analyzer::Analyzer* a, const char* fmt, Args&&... args)
+		{
+		SetAnalyzerSkip(a);
+
+		// Always log to stderr.
+		// TODO: would be nice to also log a call stack.
+		DoLog("analyzer error", reporter_error, stderr, nullptr, nullptr, true, true, "", fmt,
+		      args...);
+		}
 
 	// Toggle whether non-fatal messages should be reported through the
 	// scripting layer rather on standard output. Fatal errors are always
@@ -172,7 +273,7 @@ public:
 	void PushLocation(const detail::Location* location)
 		{
 		locations.push_back(
-			std::pair<const detail::Location*, const detail::Location*>(location, 0));
+			std::pair<const detail::Location*, const detail::Location*>(location, nullptr));
 		}
 
 	void PushLocation(const detail::Location* loc1, const detail::Location* loc2)
@@ -300,15 +401,126 @@ public:
 		}
 
 private:
-	void DoLog(const char* prefix, EventHandlerPtr event, FILE* out, Connection* conn,
-	           ValPList* addl, bool location, bool time, const char* postfix, const char* fmt,
-	           va_list ap) __attribute__((format(printf, 10, 0)));
+	void SetAnalyzerSkip(analyzer::Analyzer* a) const;
 
-	// WeirdHelper doesn't really have to be variadic, but it calls DoLog
-	// and that takes va_list anyway.
-	void WeirdHelper(EventHandlerPtr event, ValPList vl, const char* fmt_name, ...)
-		__attribute__((format(printf, 4, 5)));
-	;
+	void DoSyslog(std::string_view msg);
+
+	std::string BuildLogLocationString() const;
+
+	void DoLogEvents(std::string_view prefix, EventHandlerPtr event, Connection* conn,
+	                 ValPList* addl, bool location, bool time, std::string_view buffer,
+	                 std::string_view loc_str) const;
+
+	void DescribeExpr(const detail::Expr* expr, ODesc& d);
+
+	template <typename... Args>
+	void DoLog(std::string_view prefix, EventHandlerPtr event, FILE* out, Connection* conn,
+	           ValPList* addl, bool location, bool time, std::string_view postfix,
+	           std::string_view fmt, Args&&... args)
+		{
+		static char tmp[512];
+		int size = sizeof(tmp);
+		char* buffer = tmp;
+		char* allocated = nullptr;
+
+		std::string loc_str;
+		if ( location )
+			loc_str = BuildLogLocationString();
+
+		while ( true )
+			{
+			int n;
+
+			if constexpr ( sizeof...(args) > 0 )
+				n = snprintf(buffer, size, fmt.data(), std::forward<Args>(args)...);
+			else
+				n = snprintf(buffer, size, "%s", fmt.data());
+
+			if ( ! postfix.empty() )
+				n += postfix.size() + 10;
+
+			if ( n > -1 && n < size )
+				// We had enough space;
+				break;
+
+			// Enlarge buffer;
+			size *= 2;
+			buffer = allocated = (char*)realloc(allocated, size);
+
+			if ( ! buffer )
+				FatalError("out of memory in Reporter");
+			}
+
+		if ( ! postfix.empty() )
+			// Note, if you change this fmt string, adjust the additional
+			// buffer size above.
+			snprintf(buffer + strlen(buffer), size - strlen(buffer), " (%s)", postfix.data());
+
+		DoLogEvents(prefix, event, conn, addl, location, time, buffer, loc_str);
+
+		if ( out )
+			{
+			std::string s = "";
+
+			if ( run_state::zeek_start_network_time != 0.0 )
+				{
+				char tmp[32];
+				snprintf(tmp, 32, "%.6f", run_state::network_time);
+				s += std::string(tmp) + " ";
+				}
+
+			if ( ! prefix.empty() )
+				{
+				if ( loc_str != "" )
+					s += std::string(prefix) + " in " + loc_str + ": ";
+				else
+					s += std::string(prefix) + ": ";
+				}
+
+			else
+				{
+				if ( loc_str != "" )
+					s += loc_str + ": ";
+				}
+
+			s += buffer;
+
+#ifdef ENABLE_ZEEK_UNIT_TESTS
+			if ( doctest::is_running_in_test )
+				{
+				try
+					{
+					MESSAGE(s);
+					}
+				catch ( const doctest::detail::TestFailureException& e )
+					{
+					// If doctest throws an exception, just write the string out to stdout
+					// like normal, just so it's captured somewhere.
+					fprintf(out, "%s\n", s.c_str());
+					}
+				}
+			else
+				{
+#endif
+				s += "\n";
+				fprintf(out, "%s", s.c_str());
+#ifdef ENABLE_ZEEK_UNIT_TESTS
+				}
+#endif
+			}
+
+		if ( allocated )
+			free(allocated);
+		}
+
+	// WeirdHelper doesn't really have to be variadic, but it calls DoLog and that's variadic
+	// anyway.
+	template <typename... Args>
+	void WeirdHelper(EventHandlerPtr event, ValPList vl, const char* fmt_name, Args&&... args)
+		{
+		DoLog("weird", event, nullptr, nullptr, &vl, false, false, "", fmt_name, args...);
+		}
+
 	void UpdateWeirdStats(const char* name);
 	inline bool WeirdOnSamplingWhiteList(const char* name)
 		{

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -907,19 +907,6 @@ size_t Manager::FlushLogBuffers()
 	return rval;
 	}
 
-void Manager::Error(const char* format, ...)
-	{
-	va_list args;
-	va_start(args, format);
-	auto msg = util::vfmt(format, args);
-	va_end(args);
-
-	if ( script_scope )
-		emit_builtin_error(msg);
-	else
-		reporter->Error("%s", msg);
-	}
-
 bool Manager::AutoPublishEvent(string topic, Val* event)
 	{
 	if ( event->GetType()->Tag() != TYPE_FUNC )

--- a/src/input/Manager.h
+++ b/src/input/Manager.h
@@ -271,6 +271,12 @@ private:
 		ERROR
 		};
 
+#ifdef HAVE_ASPRINTF
+#define zeek_asprintf asprintf
+#else
+#define zeek_asprintf util::asprintf
+#endif
+
 	template <typename... Args>
 	void ErrorHandler(const Stream* i, ErrorType et, bool reporter_send, const char* fmt,
 	                  Args&&... args) const
@@ -279,9 +285,9 @@ private:
 
 		int n;
 		if constexpr ( sizeof...(args) > 0 )
-			n = asprintf(&buf, fmt, std::forward<Args>(args)...);
+			n = zeek_asprintf(&buf, fmt, std::forward<Args>(args)...);
 		else
-			n = asprintf(&buf, "%s", fmt);
+			n = zeek_asprintf(&buf, "%s", fmt);
 
 		if ( n < 0 || buf == nullptr )
 			{

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -108,11 +108,37 @@ struct Stem
 
 	void ReportStatus(const SupervisorNode& node) const;
 
-	void Log(std::string_view type, const char* format, va_list args) const;
+	template <typename... Args>
+	void Log(std::string_view type, const char* format, Args&&... args) const
+		{
+		std::string raw_msg;
+		if constexpr ( sizeof...(args) > 0 )
+			raw_msg = util::fmt(format, std::forward<Args>(args)...);
+		else
+			raw_msg = util::fmt("%s", format);
 
-	void LogDebug(const char* format, ...) const __attribute__((format(printf, 2, 3)));
+		if ( getenv("ZEEK_DEBUG_STEM_STDERR") )
+			{
+			// Useful when debugging a breaking change to the IPC mechanism itself.
+			fprintf(stderr, "%s\n", raw_msg.c_str());
+			return;
+			}
 
-	void LogError(const char* format, ...) const __attribute__((format(printf, 2, 3)));
+		std::string msg{type.data(), type.size()};
+		msg += " ";
+		msg += raw_msg;
+		util::safe_write(pipe->OutFD(), msg.data(), msg.size() + 1);
+		}
+
+	template <typename... Args> void LogDebug(const char* format, Args&&... args) const
+		{
+		Log("debug", format, args...);
+		}
+
+	template <typename... Args> void LogError(const char* format, Args&&... args) const
+		{
+		Log("error", format, args...);
+		}
 
 	pid_t parent_pid;
 	int last_signal = -1;
@@ -930,39 +956,6 @@ void Stem::ReportStatus(const SupervisorNode& node) const
 	{
 	std::string msg = util::fmt("status %s %d", node.Name().data(), node.pid);
 	util::safe_write(pipe->OutFD(), msg.data(), msg.size() + 1);
-	}
-
-void Stem::Log(std::string_view type, const char* format, va_list args) const
-	{
-	auto raw_msg = util::vfmt(format, args);
-
-	if ( getenv("ZEEK_DEBUG_STEM_STDERR") )
-		{
-		// Useful when debugging a breaking change to the IPC mechanism itself.
-		fprintf(stderr, "%s\n", raw_msg);
-		return;
-		}
-
-	std::string msg{type.data(), type.size()};
-	msg += " ";
-	msg += raw_msg;
-	util::safe_write(pipe->OutFD(), msg.data(), msg.size() + 1);
-	}
-
-void Stem::LogDebug(const char* format, ...) const
-	{
-	va_list args;
-	va_start(args, format);
-	Log("debug", format, args);
-	va_end(args);
-	}
-
-void Stem::LogError(const char* format, ...) const
-	{
-	va_list args;
-	va_start(args, format);
-	Log("error", format, args);
-	va_end(args);
 	}
 
 SupervisedNode Stem::Run()

--- a/src/threading/BasicThread.cc
+++ b/src/threading/BasicThread.cc
@@ -10,9 +10,6 @@
 
 namespace zeek::threading
 	{
-
-static const int STD_FMT_BUF_LEN = 2048;
-
 uint64_t BasicThread::thread_counter = 0;
 
 BasicThread::BasicThread()
@@ -52,34 +49,6 @@ void BasicThread::SetOSName(const char* arg_name)
 	if constexpr ( std::is_same_v<std::thread::native_handle_type, pthread_t> )
 		zeek::util::detail::set_thread_name(arg_name,
 		                                    reinterpret_cast<pthread_t>(thread.native_handle()));
-	}
-
-const char* BasicThread::Fmt(const char* format, ...)
-	{
-	if ( buf_len > 10 * STD_FMT_BUF_LEN )
-		{
-		// Shrink back to normal.
-		buf = (char*)util::safe_realloc(buf, STD_FMT_BUF_LEN);
-		buf_len = STD_FMT_BUF_LEN;
-		}
-
-	va_list al;
-	va_start(al, format);
-	int n = vsnprintf(buf, buf_len, format, al);
-	va_end(al);
-
-	if ( (unsigned int)n >= buf_len )
-		{ // Not enough room, grow the buffer.
-		buf_len = n + 32;
-		buf = (char*)util::safe_realloc(buf, buf_len);
-
-		// Is it portable to restart?
-		va_start(al, format);
-		n = vsnprintf(buf, buf_len, format, al);
-		va_end(al);
-		}
-
-	return buf;
 	}
 
 const char* BasicThread::Strerror(int err)

--- a/src/threading/BasicThread.h
+++ b/src/threading/BasicThread.h
@@ -9,8 +9,11 @@
 #include <iosfwd>
 #include <thread>
 
+#include "zeek/util.h"
+
 namespace zeek::threading
 	{
+constexpr int STD_FMT_BUF_LEN = 2048;
 
 class Manager;
 
@@ -120,8 +123,35 @@ public:
 	 * This is safe to call from Run() but must not be used from any
 	 * other thread than the current one.
 	 */
-	const char* Fmt(const char* format, ...) __attribute__((format(printf, 2, 3)));
-	;
+	template <typename... Args> const char* Fmt(const char* format, Args&&... args)
+		{
+		if ( buf_len > 10 * STD_FMT_BUF_LEN )
+			{
+			// Shrink back to normal.
+			buf = (char*)util::safe_realloc(buf, STD_FMT_BUF_LEN);
+			buf_len = STD_FMT_BUF_LEN;
+			}
+
+		int n;
+		if constexpr ( sizeof...(args) > 0 )
+			n = snprintf(buf, buf_len, format, std::forward<Args>(args)...);
+		else
+			n = snprintf(buf, buf_len, "%s", format);
+
+		if ( (unsigned int)n >= buf_len )
+			{ // Not enough room, grow the buffer.
+			buf_len = n + 32;
+			buf = (char*)util::safe_realloc(buf, buf_len);
+
+			// Is it portable to restart?
+			if constexpr ( sizeof...(args) > 0 )
+				n = snprintf(buf, buf_len, format, std::forward<Args>(args)...);
+			else
+				n = snprintf(buf, buf_len, "%s", format);
+			}
+
+		return buf;
+		}
 
 	/**
 	 * A version of strerror() that the thread can safely use. This is

--- a/src/util.h
+++ b/src/util.h
@@ -668,5 +668,19 @@ inline std::vector<std::wstring_view> split(const wchar_t* s, const wchar_t* del
 	return split(std::wstring_view(s), std::wstring_view(delim));
 	}
 
+#ifndef HAVE_ASPRINTF
+
+inline int asprintf(char** strp, const char* format, ...)
+	{
+	va_list ap;
+	va_start(ap, format);
+	int retval = vasprintf(strp, format, ap);
+	va_end(ap);
+
+	return retval;
+	}
+
+#endif
+
 	} // namespace util
 	} // namespace zeek


### PR DESCRIPTION
This is something I've had sitting on a branch for a long time. I figured I'd dig it out, clean it up for the current state of the source, and open a draft PR for it.

This PR changes all of the uses (minus two) of varargs/va_list for logging functions into variadic templates/parameter packs. This is in preparation for potentially using libfmt/std::format for text formatting, and converting all of these into modern C++ facilitates that goal a bit. The two uses missing are util::fmt and util::vfmt, since those two would effectively be replaced by a different formatter method if the follow-on work takes place. There are a few other places where varargs are used, but they weren't logging-related so I left them alone for now.

There are some drawbacks to this approach:
1. We lose the ability to ensure that the format arguments for log functions are proper `printf`-style formats, due to the loss of the `__attribute__` tags applied to the functions. Clang 15.x gains this function on template functions, but not until then.
2. Build times will be longer, due to the addition of a bunch of template methods in heavily-used headers (Reporter.h, for example).