### PR TITLE
CI: Force rebuild of tumbleweed VM to pick up newer version of python

### DIFF
--- a/ci/opensuse-tumbleweed/Dockerfile
+++ b/ci/opensuse-tumbleweed/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/tumbleweed
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230523
+ENV DOCKERFILE_VERSION 20230620
 
 # Remove the repo-openh264 repository, it caused intermittent issues
 # and we should not be needing any packages from it.


### PR DESCRIPTION
The version of python included in the existing VM doesn't have the sqlite module included for some reason. Forcing the VM to rebuild installs python311 which does include it, fixing a build failure.

No idea why this is a thing all of a sudden, but builds are failing on CI because of it.