### PR TITLE
GSSAPI: basic support for MIC/WRAP tokens

### DIFF
--- a/src/analyzer/protocol/gssapi/gssapi.pac
+++ b/src/analyzer/protocol/gssapi/gssapi.pac
@@ -23,7 +23,7 @@ connection GSSAPI_Conn(zeek_analyzer: ZeekAnalyzer) {
 
 # Now we define the flow:
 flow GSSAPI_Flow(is_orig: bool) {
-	datagram = GSSAPI_NEG_TOKEN(is_orig) withcontext(connection, this);
+	datagram = GSSAPI_SELECT(is_orig) withcontext(connection, this);
 };
 
 %include gssapi-analyzer.pac


### PR DESCRIPTION
When MIC/WRAP tokens are encountered, we now skip the message, instead of raising a parse error. The data in the messages is encrypted - so it does not seem work to raise an event at the moment.

Fixes GH-3144