### PR TITLE
fix http AUTHORIZATION base64 decode failed

### DIFF
--- a/scripts/base/protocols/http/main.zeek
+++ b/scripts/base/protocols/http/main.zeek
@@ -290,7 +290,7 @@ event http_header(c: connection, is_orig: bool, name: string, value: string) &pr
 			{
 			if ( /^[bB][aA][sS][iI][cC] / in value )
 				{
-				local userpass = decode_base64_conn(c$id, sub(value, /[bB][aA][sS][iI][cC][[:blank:]]/, ""));
+				local userpass = decode_base64_conn(c$id, sub(value, /[bB][aA][sS][iI][cC][[:blank:]]+/, ""));
 				local up = split_string(userpass, /:/);
 				if ( |up| >= 2 )
 					{


### PR DESCRIPTION
During our actual testing process, we found that in the "Authorization" field of the HTTP request header, there are often one or more extra spaces after "Basic," causing Zeek to report an error when decoding the base64.

For example:

```
GET /ucs/xxxxxxxxxx HTTP/1.1
Host: xxxxx.com
Connection: keep-alive
Accept: application/json, text/plain, */*
Authorization: Basic[space][space]dGVzdDoxMjM0
User-Agent: Mozilla/5.0 (Linux; Android 13; ANY-AN00 Build/HONORANY-AN00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/99.0.4844.88 Mobile Safari/537.36
Accept-Encoding: gzip, deflate
Accept-Language: q=0.9,en-US;q=0.8,en;q=0.7
```

