### PR TITLE
Rename magic __bro_plugin__ file to __zeek_plugin__

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,12 @@ Breaking Changes
 
 - ``assert`` is now a reserved keyword for the new ``assert`` statement.
 
+- The ``__bro_plugin__`` file that gets generated as part of plugin builds was
+  renamed to ``__zeek_plugin__``. This will affect the ability for older
+  versions of ``zkg`` to use the ``zkg unload`` and ``zkg load`` commands. This
+  should only cause breakage for people using a version of ``zkg` that doesn't
+  come bundled with Zeek (which we generally don't recommend doing).
+
 New Functionality
 -----------------
 

--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -94,7 +94,7 @@ void Manager::SearchDynamicPlugins(const std::string& dir)
 
 	// Check if it's a plugin directory.
 
-	const std::string magic = dir + "/__bro_plugin__";
+	const std::string magic = dir + "/__zeek_plugin__";
 
 	if ( util::is_file(magic) )
 		{


### PR DESCRIPTION
This is part of the on-going removal of Bro naming from zkg. Related PRs: https://github.com/zeek/zeek-docs/pull/198 and https://github.com/zeek/cmake/pull/86