### PR TITLE
Clang-tidy `modernize` fixups

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -502,10 +502,14 @@ set(zeek_SRCS
     ${FLEX_Scanner_INPUT}
     ${BISON_Parser_INPUT}
     ${CMAKE_CURRENT_BINARY_DIR}/DebugCmdConstants.h
-    ${CMAKE_CURRENT_BINARY_DIR}/ZAM-MethodDecls.h
-    ${THIRD_PARTY_SRCS}
-    ${HH_SRCS}
-    ${MAIN_SRCS})
+    ${CMAKE_CURRENT_BINARY_DIR}/ZAM-MethodDecls.h)
+
+# Add the above files to the list of clang tidy sources before adding the third party and HH
+# sources. Also, the main_SRCS will get added to that list separately.
+add_clang_tidy_files(${zeek_SRCS})
+list(APPEND zeek_SRCS ${THIRD_PARTY_SRCS})
+list(APPEND zeek_SRCS ${HH_SRCS})
+list(APPEND zeek_SRCS ${MAIN_SRCS})
 
 collect_headers(zeek_HEADERS ${zeek_SRCS})
 
@@ -515,7 +519,6 @@ set_target_properties(zeek_objs PROPERTIES CXX_EXTENSIONS OFF)
 target_link_libraries(zeek_objs PRIVATE $<BUILD_INTERFACE:zeek_internal>)
 target_compile_definitions(zeek_objs PRIVATE ZEEK_CONFIG_SKIP_VERSION_H)
 add_dependencies(zeek_objs zeek_autogen_files)
-add_clang_tidy_files(${zeek_SRCS})
 zeek_target_link_libraries(zeek_objs)
 
 if (HAVE_SPICY)

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -929,7 +929,7 @@ bool CompositeHash::ReserveSingleTypeKeySize(HashKey& hk, Type* bt, const Val* v
 					{
 					reporter->InternalError(
 						"bad index type in CompositeHash::ReserveSingleTypeKeySize");
-					return 0;
+					return false;
 					}
 				}
 

--- a/src/DNS_Mapping.cc
+++ b/src/DNS_Mapping.cc
@@ -63,7 +63,7 @@ DNS_Mapping::DNS_Mapping(FILE* f)
 	else
 		req_addr = IPAddr(req_buf);
 
-	names.push_back(name_buf);
+	names.emplace_back(name_buf);
 
 	for ( int i = 0; i < num_addrs; ++i )
 		{
@@ -74,7 +74,7 @@ DNS_Mapping::DNS_Mapping(FILE* f)
 		if ( newline )
 			*newline = '\0';
 
-		addrs.emplace_back(IPAddr(buf));
+		addrs.emplace_back(buf);
 		}
 
 	init_failed = false;
@@ -134,16 +134,16 @@ void DNS_Mapping::Init(struct hostent* h)
 	if ( h->h_name )
 		// for now, just use the official name
 		// TODO: this could easily be expanded to include all of the aliases as well
-		names.push_back(h->h_name);
+		names.emplace_back(h->h_name);
 
 	if ( h->h_addr_list )
 		{
 		for ( int i = 0; h->h_addr_list[i] != NULL; ++i )
 			{
 			if ( h->h_addrtype == AF_INET )
-				addrs.push_back(IPAddr(IPv4, (uint32_t*)h->h_addr_list[i], IPAddr::Network));
+				addrs.emplace_back(IPv4, (uint32_t*)h->h_addr_list[i], IPAddr::Network);
 			else if ( h->h_addrtype == AF_INET6 )
-				addrs.push_back(IPAddr(IPv6, (uint32_t*)h->h_addr_list[i], IPAddr::Network));
+				addrs.emplace_back(IPv6, (uint32_t*)h->h_addr_list[i], IPAddr::Network);
 			}
 		}
 

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -1610,7 +1610,7 @@ class TestDNS_Mgr final : public DNS_Mgr
 	{
 public:
 	explicit TestDNS_Mgr(DNS_MgrMode mode) : DNS_Mgr(mode) { }
-	void Process();
+	void Process() override;
 	};
 
 void TestDNS_Mgr::Process()

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -206,7 +206,7 @@ class DNS_Request
 public:
 	DNS_Request(std::string host, int request_type, bool async = false);
 	DNS_Request(const IPAddr& addr, bool async = false);
-	~DNS_Request();
+	~DNS_Request() = default;
 
 	std::string Host() const { return host; }
 	const IPAddr& Addr() const { return addr; }
@@ -240,8 +240,6 @@ DNS_Request::DNS_Request(const IPAddr& addr, bool async) : addr(addr), async(asy
 	{
 	request_type = T_PTR;
 	}
-
-DNS_Request::~DNS_Request() { }
 
 void DNS_Request::MakeRequest(ares_channel channel, DNS_Mgr* mgr)
 	{

--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -342,7 +342,7 @@ static void parse_function_name(vector<ParseLocationRec>& result, ParseLocationR
 vector<ParseLocationRec> parse_location_string(const string& s)
 	{
 	vector<ParseLocationRec> result;
-	result.push_back(ParseLocationRec());
+	result.emplace_back();
 	ParseLocationRec& plr = result[0];
 
 	// If PLR_FILE_AND_LINE, set this to the filename you want; for
@@ -531,7 +531,7 @@ void tokenize(const char* cstr, string& operation, vector<string>& arguments)
 		if ( ! num_tokens )
 			operation = string(str, start, len);
 		else
-			arguments.push_back(string(str, start, len));
+			arguments.emplace_back(str, start, len);
 
 		++num_tokens;
 		}

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -388,10 +388,10 @@ int dbg_cmd_break(DebugCmd cmd, const vector<string>& args)
 			vector<ID*> choices;
 			choose_global_symbols_regex(args[0], choices, true);
 			for ( unsigned int i = 0; i < choices.size(); ++i )
-				locstrings.push_back(choices[i]->Name());
+				locstrings.emplace_back(choices[i]->Name());
 			}
 		else
-			locstrings.push_back(args[0].c_str());
+			locstrings.push_back(args[0]);
 
 		for ( unsigned int strindex = 0; strindex < locstrings.size(); ++strindex )
 			{

--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -267,28 +267,26 @@ size_t ODesc::StartsWithEscapeSequence(const char* start, const char* end)
 
 std::pair<const char*, size_t> ODesc::FirstEscapeLoc(const char* bytes, size_t n)
 	{
-	using escape_pos = std::pair<const char*, size_t>;
-
 	if ( IsBinary() )
-		return escape_pos(0, 0);
+		return {nullptr, 0};
 
 	for ( size_t i = 0; i < n; ++i )
 		{
 		auto printable = isprint(bytes[i]);
 
 		if ( ! printable && ! utf8 )
-			return escape_pos(bytes + i, 1);
+			return {bytes + i, 1};
 
 		if ( bytes[i] == '\\' )
-			return escape_pos(bytes + i, 1);
+			return {bytes + i, 1};
 
 		size_t len = StartsWithEscapeSequence(bytes + i, bytes + n);
 
 		if ( len )
-			return escape_pos(bytes + i, len);
+			return {bytes + i, len};
 		}
 
-	return escape_pos(nullptr, 0);
+	return {nullptr, 0};
 	}
 
 void ODesc::AddBytes(const void* bytes, unsigned int n)
@@ -429,7 +427,7 @@ std::string obj_desc(const Obj* o)
 	d.SP();
 	o->GetLocationInfo()->Describe(&d);
 
-	return std::string(d.Description());
+	return d.Description();
 	}
 
 std::string obj_desc_short(const Obj* o)
@@ -440,7 +438,7 @@ std::string obj_desc_short(const Obj* o)
 	d.Clear();
 	o->Describe(&d);
 
-	return std::string(d.Description());
+	return d.Description();
 	}
 
 	} // namespace zeek

--- a/src/Dict.cc
+++ b/src/Dict.cc
@@ -340,7 +340,7 @@ class DictTestDummy
 	{
 public:
 	DictTestDummy(int v) : v(v) { }
-	~DictTestDummy() { }
+	~DictTestDummy() = default;
 	int v = 0;
 	};
 

--- a/src/Discard.cc
+++ b/src/Discard.cc
@@ -27,8 +27,6 @@ Discarder::Discarder()
 	discarder_maxlen = static_cast<int>(id::find_val("discarder_maxlen")->AsCount());
 	}
 
-Discarder::~Discarder() { }
-
 bool Discarder::IsActive()
 	{
 	return check_ip || check_tcp || check_udp || check_icmp;

--- a/src/Discard.h
+++ b/src/Discard.h
@@ -18,11 +18,11 @@ using FuncPtr = IntrusivePtr<Func>;
 namespace detail
 	{
 
-class Discarder
+class Discarder final
 	{
 public:
 	Discarder();
-	~Discarder();
+	~Discarder() = default;
 
 	bool IsActive();
 

--- a/src/EventRegistry.cc
+++ b/src/EventRegistry.cc
@@ -169,8 +169,6 @@ EventGroupPtr EventRegistry::LookupGroup(EventGroupKind kind, std::string_view n
 
 EventGroup::EventGroup(EventGroupKind kind, std::string_view name) : kind(kind), name(name) { }
 
-EventGroup::~EventGroup() noexcept { }
-
 // Run through all ScriptFunc instances associated with this group and
 // update their bodies after a group's enable/disable state has changed.
 // Once that has completed, also update the Func's has_enabled_bodies

--- a/src/EventRegistry.h
+++ b/src/EventRegistry.h
@@ -37,7 +37,7 @@ using ScriptFuncPtr = zeek::IntrusivePtr<ScriptFunc>;
 	}
 
 // The registry keeps track of all events that we provide or handle.
-class EventRegistry
+class EventRegistry final
 	{
 public:
 	EventRegistry();
@@ -135,11 +135,11 @@ private:
  * bodies of the tracked ScriptFuncs and updates them to reflect the current
  * group state.
  */
-class EventGroup
+class EventGroup final
 	{
 public:
 	EventGroup(EventGroupKind kind, std::string_view name);
-	~EventGroup() noexcept;
+	~EventGroup() noexcept = default;
 	EventGroup(const EventGroup& g) = delete;
 	EventGroup& operator=(const EventGroup&) = delete;
 

--- a/src/EventTrace.cc
+++ b/src/EventTrace.cc
@@ -101,8 +101,6 @@ ValTrace::ValTrace(const ValPtr& _v) : v(_v)
 		}
 	}
 
-ValTrace::~ValTrace() { }
-
 bool ValTrace::operator==(const ValTrace& vt) const
 	{
 	auto& vt_v = vt.GetVal();

--- a/src/EventTrace.h
+++ b/src/EventTrace.h
@@ -47,7 +47,7 @@ class ValTrace
 	{
 public:
 	ValTrace(const ValPtr& v);
-	~ValTrace();
+	~ValTrace() = default;
 
 	const ValPtr& GetVal() const { return v; }
 	const TypePtr& GetType() const { return t; }

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -4237,8 +4237,6 @@ TableCoerceExpr::TableCoerceExpr(ExprPtr arg_op, TableTypePtr tt, bool type_chec
 		ExprError("coercion of non-table/set to table/set");
 	}
 
-TableCoerceExpr::~TableCoerceExpr() { }
-
 ValPtr TableCoerceExpr::Fold(Val* v) const
 	{
 	TableVal* tv = v->AsTableVal();
@@ -4264,8 +4262,6 @@ VectorCoerceExpr::VectorCoerceExpr(ExprPtr arg_op, VectorTypePtr v)
 		ExprError("coercion of non-vector to vector");
 	}
 
-VectorCoerceExpr::~VectorCoerceExpr() { }
-
 ValPtr VectorCoerceExpr::Fold(Val* v) const
 	{
 	VectorVal* vv = v->AsVectorVal();
@@ -4280,8 +4276,6 @@ ScheduleTimer::ScheduleTimer(const EventHandlerPtr& arg_event, Args arg_args, do
 	: Timer(t, TIMER_SCHEDULE), event(arg_event), args(std::move(arg_args))
 	{
 	}
-
-ScheduleTimer::~ScheduleTimer() { }
 
 void ScheduleTimer::Dispatch(double /* t */, bool /* is_expire */)
 	{

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -1330,7 +1330,7 @@ class TableCoerceExpr final : public UnaryExpr
 	{
 public:
 	TableCoerceExpr(ExprPtr op, TableTypePtr r, bool type_check = true);
-	~TableCoerceExpr() override;
+	~TableCoerceExpr() override = default;
 
 	// Optimization-related:
 	ExprPtr Duplicate() override;
@@ -1343,7 +1343,7 @@ class VectorCoerceExpr final : public UnaryExpr
 	{
 public:
 	VectorCoerceExpr(ExprPtr op, VectorTypePtr v);
-	~VectorCoerceExpr() override;
+	~VectorCoerceExpr() override = default;
 
 	// Optimization-related:
 	ExprPtr Duplicate() override;
@@ -1356,7 +1356,7 @@ class ScheduleTimer final : public Timer
 	{
 public:
 	ScheduleTimer(const EventHandlerPtr& event, zeek::Args args, double t);
-	~ScheduleTimer() override;
+	~ScheduleTimer() override = default;
 
 	void Dispatch(double t, bool is_expire) override;
 

--- a/src/File.cc
+++ b/src/File.cc
@@ -148,7 +148,7 @@ bool File::Open(FILE* file, const char* mode)
 		}
 
 	is_open = true;
-	open_files.emplace_back(std::make_pair(name, this));
+	open_files.emplace_back(name, this);
 
 	RaiseOpenEvent();
 

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -801,8 +801,6 @@ BuiltinFunc::BuiltinFunc(built_in_func arg_func, const char* arg_name, bool arg_
 	id->SetConst();
 	}
 
-BuiltinFunc::~BuiltinFunc() { }
-
 bool BuiltinFunc::IsPure() const
 	{
 	return is_pure;

--- a/src/Func.h
+++ b/src/Func.h
@@ -336,7 +336,7 @@ class BuiltinFunc final : public Func
 	{
 public:
 	BuiltinFunc(built_in_func func, const char* name, bool is_pure);
-	~BuiltinFunc() override;
+	~BuiltinFunc() override = default;
 
 	bool IsPure() const override;
 	ValPtr Invoke(zeek::Args* args, Frame* parent) const override;

--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -27,21 +27,20 @@ alignas(16) unsigned long long KeyedHash::shared_siphash_key[2];
 
 // we use the following lines to not pull in the highwayhash headers in Hash.h - but to check the
 // types did not change underneath us.
-static_assert(std::is_same<hash64_t, highwayhash::HHResult64>::value,
+static_assert(std::is_same_v<hash64_t, highwayhash::HHResult64>,
               "Highwayhash return values must match hash_x_t");
-static_assert(std::is_same<hash128_t, highwayhash::HHResult128>::value,
+static_assert(std::is_same_v<hash128_t, highwayhash::HHResult128>,
               "Highwayhash return values must match hash_x_t");
-static_assert(std::is_same<hash256_t, highwayhash::HHResult256>::value,
+static_assert(std::is_same_v<hash256_t, highwayhash::HHResult256>,
               "Highwayhash return values must match hash_x_t");
 
 void KeyedHash::InitializeSeeds(const std::array<uint32_t, SEED_INIT_SIZE>& seed_data)
 	{
-	static_assert(std::is_same<decltype(KeyedHash::shared_siphash_key),
-	                           highwayhash::SipHashState::Key>::value,
-	              "Highwayhash Key is not unsigned long long[2]");
 	static_assert(
-		std::is_same<decltype(KeyedHash::shared_highwayhash_key), highwayhash::HHKey>::value,
-		"Highwayhash HHKey is not uint64_t[4]");
+		std::is_same_v<decltype(KeyedHash::shared_siphash_key), highwayhash::SipHashState::Key>,
+		"Highwayhash Key is not unsigned long long[2]");
+	static_assert(std::is_same_v<decltype(KeyedHash::shared_highwayhash_key), highwayhash::HHKey>,
+	              "Highwayhash HHKey is not uint64_t[4]");
 	if ( seeds_initialized )
 		return;
 

--- a/src/IP.cc
+++ b/src/IP.cc
@@ -612,28 +612,29 @@ bool IPv6_Hdr_Chain::IsFragment() const
 IPAddr IPv6_Hdr_Chain::SrcAddr() const
 	{
 	if ( homeAddr )
-		return IPAddr(*homeAddr);
+		return {*homeAddr};
+
 	if ( chain.empty() )
 		{
 		reporter->InternalWarning("empty IPv6 header chain");
-		return IPAddr();
+		return {};
 		}
 
-	return IPAddr(((const struct ip6_hdr*)(chain[0]->Data()))->ip6_src);
+	return IPAddr{((const struct ip6_hdr*)(chain[0]->Data()))->ip6_src};
 	}
 
 IPAddr IPv6_Hdr_Chain::DstAddr() const
 	{
 	if ( finalDst )
-		return IPAddr(*finalDst);
+		return {*finalDst};
 
 	if ( chain.empty() )
 		{
 		reporter->InternalWarning("empty IPv6 header chain");
-		return IPAddr();
+		return {};
 		}
 
-	return IPAddr(((const struct ip6_hdr*)(chain[0]->Data()))->ip6_dst);
+	return IPAddr{((const struct ip6_hdr*)(chain[0]->Data()))->ip6_dst};
 	}
 
 void IPv6_Hdr_Chain::ProcessRoutingHeader(const struct ip6_rthdr* r, uint16_t len)

--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -50,8 +50,6 @@ OpaqueMgr* OpaqueMgr::mgr()
 
 OpaqueVal::OpaqueVal(OpaqueTypePtr t) : Val(std::move(t)) { }
 
-OpaqueVal::~OpaqueVal() { }
-
 const std::string& OpaqueMgr::TypeID(const OpaqueVal* v) const
 	{
 	auto x = _types.find(v->OpaqueName());

--- a/src/OpaqueVal.h
+++ b/src/OpaqueVal.h
@@ -118,7 +118,7 @@ class OpaqueVal : public Val
 	{
 public:
 	explicit OpaqueVal(OpaqueTypePtr t);
-	~OpaqueVal() override;
+	~OpaqueVal() override = default;
 
 	/**
 	 * Serializes the value into a Broker representation.

--- a/src/PrefixTable.cc
+++ b/src/PrefixTable.cc
@@ -79,7 +79,7 @@ std::list<std::tuple<IPPrefix, void*>> PrefixTable::FindAll(const IPAddr& addr, 
 	patricia_search_all(tree, prefix, &list, &elems);
 
 	for ( int i = 0; i < elems; ++i )
-		out.push_back(std::make_tuple(PrefixToIPPrefix(list[i]->prefix), list[i]->data));
+		out.emplace_back(PrefixToIPPrefix(list[i]->prefix), list[i]->data);
 
 	Deref_Prefix(prefix);
 	free(list);

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -203,7 +203,7 @@ std::string Specific_RE_Matcher::LookupDef(const std::string& def)
 	if ( iter != defs.end() )
 		return iter->second;
 
-	return std::string();
+	return {};
 	}
 
 bool Specific_RE_Matcher::MatchAll(const char* s)

--- a/src/ScriptCoverageManager.cc
+++ b/src/ScriptCoverageManager.cc
@@ -24,12 +24,12 @@ void ScriptCoverageManager::AddStmt(Stmt* s)
 	if ( ignoring != 0 )
 		return;
 
-	stmts.push_back({NewRef{}, s});
+	stmts.emplace_back(NewRef{}, s);
 	}
 
 void ScriptCoverageManager::AddFunction(IDPtr func_id, StmtPtr body)
 	{
-	func_instances.push_back({func_id, body});
+	func_instances.emplace_back(func_id, body);
 	}
 
 bool ScriptCoverageManager::ReadStats()

--- a/src/ScriptValidation.cc
+++ b/src/ScriptValidation.cc
@@ -14,7 +14,7 @@ class BreakNextScriptValidation : public TraversalCallback
 public:
 	BreakNextScriptValidation(bool _report) : report(_report) { }
 
-	TraversalCode PreStmt(const Stmt* stmt)
+	TraversalCode PreStmt(const Stmt* stmt) override
 		{
 		if ( ! StmtIsRelevant(stmt) )
 			return TC_CONTINUE;
@@ -31,7 +31,7 @@ public:
 		return TC_CONTINUE;
 		}
 
-	TraversalCode PostStmt(const Stmt* stmt)
+	TraversalCode PostStmt(const Stmt* stmt) override
 		{
 		if ( ! StmtIsRelevant(stmt) )
 			return TC_CONTINUE;
@@ -43,7 +43,7 @@ public:
 		return TC_CONTINUE;
 		}
 
-	TraversalCode PreFunction(const zeek::Func* func)
+	TraversalCode PreFunction(const zeek::Func* func) override
 		{
 		if ( func->Flavor() == zeek::FUNC_FLAVOR_HOOK )
 			++hook_depth;
@@ -53,7 +53,7 @@ public:
 		return TC_CONTINUE;
 		}
 
-	TraversalCode PostFunction(const zeek::Func* func)
+	TraversalCode PostFunction(const zeek::Func* func) override
 		{
 		if ( func->Flavor() == zeek::FUNC_FLAVOR_HOOK )
 			--hook_depth;

--- a/src/SerializationFormat.cc
+++ b/src/SerializationFormat.cc
@@ -103,10 +103,6 @@ bool SerializationFormat::WriteData(const void* b, size_t count)
 	return true;
 	}
 
-BinarySerializationFormat::BinarySerializationFormat() { }
-
-BinarySerializationFormat::~BinarySerializationFormat() { }
-
 bool BinarySerializationFormat::Read(int* v, const char* tag)
 	{
 	uint32_t tmp;

--- a/src/SerializationFormat.h
+++ b/src/SerializationFormat.h
@@ -106,8 +106,8 @@ protected:
 class BinarySerializationFormat final : public SerializationFormat
 	{
 public:
-	BinarySerializationFormat();
-	~BinarySerializationFormat() override;
+	BinarySerializationFormat() = default;
+	~BinarySerializationFormat() override = default;
 
 	bool Read(int* v, const char* tag) override;
 	bool Read(uint16_t* v, const char* tag) override;

--- a/src/SmithWaterman.cc
+++ b/src/SmithWaterman.cc
@@ -37,7 +37,7 @@ const Substring& Substring::operator=(const Substring& bst)
 
 void Substring::AddAlignment(const String* str, int index)
 	{
-	_aligns.push_back(BSSAlign(str, index));
+	_aligns.emplace_back(str, index);
 	}
 
 bool Substring::DoesCover(const Substring* bst) const

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -2085,7 +2085,7 @@ void WhenInfo::BuildProfile()
 		if ( ! is_present )
 			{
 			IDPtr wl_ptr = {NewRef{}, const_cast<ID*>(wl)};
-			cl->emplace_back(FuncType::Capture{wl_ptr, false});
+			cl->emplace_back(wl_ptr, false);
 			}
 
 		// In addition, don't treat them as external locals that
@@ -2098,7 +2098,7 @@ void WhenInfo::BuildProfile()
 		// We need IDPtr versions of the locals so we can manipulate
 		// them during script optimization.
 		auto non_const_w = const_cast<ID*>(w);
-		when_expr_locals.push_back({NewRef{}, non_const_w});
+		when_expr_locals.emplace_back(NewRef{}, non_const_w);
 		}
 	}
 

--- a/src/Trigger.cc
+++ b/src/Trigger.cc
@@ -31,7 +31,7 @@ public:
 		{
 		}
 
-	virtual TraversalCode PreExpr(const Expr*) override;
+	TraversalCode PreExpr(const Expr*) override;
 
 private:
 	IDSet& globals;
@@ -76,7 +76,7 @@ public:
 		time = run_state::network_time;
 		}
 
-	~TriggerTimer() { Unref(trigger); }
+	~TriggerTimer() override { Unref(trigger); }
 
 	void Dispatch(double t, bool is_expire) override
 		{

--- a/src/Trigger.cc
+++ b/src/Trigger.cc
@@ -398,7 +398,7 @@ void Trigger::Register(const ID* const_id)
 	notifier::detail::registry.Register(id, this);
 
 	Ref(id);
-	objs.push_back({id, id});
+	objs.emplace_back(id, id);
 	}
 
 void Trigger::Register(Val* val)

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1196,7 +1196,7 @@ void RecordType::AddField(unsigned int field, const TypeDecl* td)
 		else
 			{
 			auto efi = std::make_unique<detail::ExprFieldInit>(def_expr, type);
-			creation_inits.emplace_back(std::make_pair(field, std::move(efi)));
+			creation_inits.emplace_back(field, std::move(efi));
 			}
 		}
 
@@ -1793,7 +1793,7 @@ EnumType::enum_name_list EnumType::Names() const
 	{
 	enum_name_list n;
 	for ( NameMap::const_iterator iter = names.begin(); iter != names.end(); ++iter )
-		n.push_back(std::make_pair(iter->first, iter->second));
+		n.emplace_back(iter->first, iter->second);
 
 	return n;
 	}

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1024,7 +1024,7 @@ class DirectManagedFieldInit final : public FieldInit
 	{
 public:
 	DirectManagedFieldInit(ZVal _init_val) : init_val(_init_val) { }
-	~DirectManagedFieldInit() { ZVal::DeleteManagedType(init_val); }
+	~DirectManagedFieldInit() override { ZVal::DeleteManagedType(init_val); }
 
 	ZVal Generate() const override
 		{

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1012,7 +1012,7 @@ StringValPtr StringVal::Replace(RE_Matcher* re, const String& repl, bool do_all)
 			break;
 
 		// s[offset .. offset+end_of_match-1] matches re.
-		cut_points.push_back({offset, offset + end_of_match});
+		cut_points.emplace_back(offset, offset + end_of_match);
 
 		offset += end_of_match;
 		n -= end_of_match;

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1563,8 +1563,6 @@ ListVal::ListVal(TypeTag t) : Val(make_intrusive<TypeList>(t == TYPE_ANY ? nullp
 	tag = t;
 	}
 
-ListVal::~ListVal() { }
-
 ValPtr ListVal::SizeVal() const
 	{
 	return val_mgr->Count(vals.size());

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -956,13 +956,13 @@ const char* StringVal::CheckString() const
 string StringVal::ToStdString() const
 	{
 	auto* bs = AsString();
-	return string((char*)bs->Bytes(), bs->Len());
+	return {(char*)bs->Bytes(), static_cast<size_t>(bs->Len())};
 	}
 
 string_view StringVal::ToStdStringView() const
 	{
 	auto* bs = AsString();
-	return string_view((char*)bs->Bytes(), bs->Len());
+	return {(char*)bs->Bytes(), static_cast<size_t>(bs->Len())};
 	}
 
 StringVal* StringVal::ToUpper()

--- a/src/Val.h
+++ b/src/Val.h
@@ -663,7 +663,7 @@ class ListVal final : public Val
 public:
 	explicit ListVal(TypeTag t);
 
-	~ListVal() override;
+	~ListVal() override = default;
 
 	TypeTag BaseTag() const { return tag; }
 

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -20,7 +20,7 @@ public:
 	AnalyzerTimer(Analyzer* arg_analyzer, analyzer_timer_func arg_timer, double arg_t,
 	              int arg_do_expire, zeek::detail::TimerType arg_type);
 
-	virtual ~AnalyzerTimer();
+	~AnalyzerTimer() override;
 
 	void Dispatch(double t, bool is_expire) override;
 

--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -21,8 +21,6 @@ ConnSize_Analyzer::ConnSize_Analyzer(Connection* c)
 	start_time = c->StartTime();
 	}
 
-ConnSize_Analyzer::~ConnSize_Analyzer() { }
-
 void ConnSize_Analyzer::Init()
 	{
 	Analyzer::Init();

--- a/src/analyzer/protocol/conn-size/ConnSize.h
+++ b/src/analyzer/protocol/conn-size/ConnSize.h
@@ -12,7 +12,7 @@ class ConnSize_Analyzer : public analyzer::Analyzer
 	{
 public:
 	explicit ConnSize_Analyzer(Connection* c);
-	~ConnSize_Analyzer() override;
+	~ConnSize_Analyzer() override = default;
 
 	void Init() override;
 	void Done() override;

--- a/src/analyzer/protocol/dnp3/DNP3.cc
+++ b/src/analyzer/protocol/dnp3/DNP3.cc
@@ -403,8 +403,6 @@ DNP3_TCP_Analyzer::DNP3_TCP_Analyzer(Connection* c)
 	{
 	}
 
-DNP3_TCP_Analyzer::~DNP3_TCP_Analyzer() { }
-
 void DNP3_TCP_Analyzer::Done()
 	{
 	TCP_ApplicationAnalyzer::Done();
@@ -443,8 +441,6 @@ void DNP3_TCP_Analyzer::EndpointEOF(bool is_orig)
 	}
 
 DNP3_UDP_Analyzer::DNP3_UDP_Analyzer(Connection* c) : DNP3_Base(this), Analyzer("DNP3_UDP", c) { }
-
-DNP3_UDP_Analyzer::~DNP3_UDP_Analyzer() { }
 
 void DNP3_UDP_Analyzer::DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq,
                                       const IP_Hdr* ip, int caplen)

--- a/src/analyzer/protocol/dnp3/DNP3.h
+++ b/src/analyzer/protocol/dnp3/DNP3.h
@@ -71,7 +71,7 @@ class DNP3_TCP_Analyzer : public detail::DNP3_Base, public analyzer::tcp::TCP_Ap
 	{
 public:
 	explicit DNP3_TCP_Analyzer(Connection* conn);
-	~DNP3_TCP_Analyzer() override;
+	~DNP3_TCP_Analyzer() override = default;
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;
@@ -85,7 +85,7 @@ class DNP3_UDP_Analyzer : public detail::DNP3_Base, public analyzer::Analyzer
 	{
 public:
 	explicit DNP3_UDP_Analyzer(Connection* conn);
-	~DNP3_UDP_Analyzer() override;
+	~DNP3_UDP_Analyzer() override = default;
 
 	void DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip,
 	                   int caplen) override;

--- a/src/analyzer/protocol/login/RSH.cc
+++ b/src/analyzer/protocol/login/RSH.cc
@@ -30,8 +30,6 @@ Contents_Rsh_Analyzer::Contents_Rsh_Analyzer(Connection* conn, bool orig,
 		}
 	}
 
-Contents_Rsh_Analyzer::~Contents_Rsh_Analyzer() { }
-
 void Contents_Rsh_Analyzer::DoDeliver(int len, const u_char* data)
 	{
 	int endp_state;

--- a/src/analyzer/protocol/login/RSH.h
+++ b/src/analyzer/protocol/login/RSH.h
@@ -28,7 +28,7 @@ class Contents_Rsh_Analyzer final : public analyzer::tcp::ContentLine_Analyzer
 	{
 public:
 	Contents_Rsh_Analyzer(Connection* conn, bool orig, Rsh_Analyzer* analyzer);
-	~Contents_Rsh_Analyzer() override;
+	~Contents_Rsh_Analyzer() override = default;
 
 	rsh_state RshSaveState() const { return save_state; }
 

--- a/src/analyzer/protocol/login/Rlogin.cc
+++ b/src/analyzer/protocol/login/Rlogin.cc
@@ -26,8 +26,6 @@ Contents_Rlogin_Analyzer::Contents_Rlogin_Analyzer(Connection* conn, bool orig,
 		state = save_state = RLOGIN_SERVER_ACK;
 	}
 
-Contents_Rlogin_Analyzer::~Contents_Rlogin_Analyzer() { }
-
 void Contents_Rlogin_Analyzer::DoDeliver(int len, const u_char* data)
 	{
 	int endp_state;

--- a/src/analyzer/protocol/login/Rlogin.h
+++ b/src/analyzer/protocol/login/Rlogin.h
@@ -36,7 +36,7 @@ class Contents_Rlogin_Analyzer final : public analyzer::tcp::ContentLine_Analyze
 	{
 public:
 	Contents_Rlogin_Analyzer(Connection* conn, bool orig, Rlogin_Analyzer* analyzer);
-	~Contents_Rlogin_Analyzer() override;
+	~Contents_Rlogin_Analyzer() override = default;
 
 	void SetPeer(Contents_Rlogin_Analyzer* arg_peer) { peer = arg_peer; }
 

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -169,8 +169,6 @@ Contents_NCP_Analyzer::Contents_NCP_Analyzer(Connection* conn, bool orig,
 	resync_set = false;
 	}
 
-Contents_NCP_Analyzer::~Contents_NCP_Analyzer() { }
-
 void Contents_NCP_Analyzer::DeliverStream(int len, const u_char* data, bool orig)
 	{
 	analyzer::tcp::TCP_SupportAnalyzer::DeliverStream(len, data, orig);

--- a/src/analyzer/protocol/ncp/NCP.h
+++ b/src/analyzer/protocol/ncp/NCP.h
@@ -91,7 +91,7 @@ class Contents_NCP_Analyzer : public analyzer::tcp::TCP_SupportAnalyzer
 	{
 public:
 	Contents_NCP_Analyzer(Connection* conn, bool orig, detail::NCP_Session* session);
-	~Contents_NCP_Analyzer() override;
+	~Contents_NCP_Analyzer() override = default;
 
 protected:
 	void DeliverStream(int len, const u_char* data, bool orig) override;

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -222,7 +222,7 @@ void POP3_Analyzer::ProcessRequest(int length, const char* line)
 		// Some clients pipeline their commands (i.e., keep sending
 		// without waiting for a server's responses). Therefore we
 		// keep a list of pending commands.
-		cmds.push_back(std::string(line));
+		cmds.emplace_back(line);
 
 		if ( cmds.size() == 1 )
 			// Not waiting for another server response,

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -52,8 +52,6 @@ POP3_Analyzer::POP3_Analyzer(Connection* conn)
 	AddSupportAnalyzer(cl_resp);
 	}
 
-POP3_Analyzer::~POP3_Analyzer() { }
-
 void POP3_Analyzer::Done()
 	{
 	analyzer::tcp::TCP_ApplicationAnalyzer::Done();

--- a/src/analyzer/protocol/pop3/POP3.h
+++ b/src/analyzer/protocol/pop3/POP3.h
@@ -74,7 +74,7 @@ class POP3_Analyzer final : public analyzer::tcp::TCP_ApplicationAnalyzer
 	{
 public:
 	explicit POP3_Analyzer(Connection* conn);
-	~POP3_Analyzer() override;
+	~POP3_Analyzer() override = default;
 
 	void Done() override;
 	void DeliverStream(int len, const u_char* data, bool orig) override;

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -297,8 +297,6 @@ Portmapper_Analyzer::Portmapper_Analyzer(Connection* conn)
 	orig_rpc = resp_rpc = nullptr;
 	}
 
-Portmapper_Analyzer::~Portmapper_Analyzer() { }
-
 void Portmapper_Analyzer::Init()
 	{
 	RPC_Analyzer::Init();

--- a/src/analyzer/protocol/rpc/Portmap.h
+++ b/src/analyzer/protocol/rpc/Portmap.h
@@ -33,7 +33,7 @@ class Portmapper_Analyzer : public RPC_Analyzer
 	{
 public:
 	explicit Portmapper_Analyzer(Connection* conn);
-	~Portmapper_Analyzer() override;
+	~Portmapper_Analyzer() override = default;
 	void Init() override;
 
 	static analyzer::Analyzer* Instantiate(Connection* conn)

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -423,8 +423,6 @@ void Contents_RPC::Init()
 	analyzer::tcp::TCP_SupportAnalyzer::Init();
 	}
 
-Contents_RPC::~Contents_RPC() { }
-
 void Contents_RPC::Undelivered(uint64_t seq, int len, bool orig)
 	{
 	analyzer::tcp::TCP_SupportAnalyzer::Undelivered(seq, len, orig);

--- a/src/analyzer/protocol/rpc/RPC.h
+++ b/src/analyzer/protocol/rpc/RPC.h
@@ -212,7 +212,7 @@ class Contents_RPC final : public analyzer::tcp::TCP_SupportAnalyzer
 	{
 public:
 	Contents_RPC(Connection* conn, bool orig, detail::RPC_Interpreter* interp);
-	~Contents_RPC() override;
+	~Contents_RPC() override = default;
 
 protected:
 	enum state_t

--- a/src/analyzer/protocol/sip/sip-analyzer.pac
+++ b/src/analyzer/protocol/sip/sip-analyzer.pac
@@ -71,7 +71,7 @@ refine flow SIP_Flow += {
 
 		if ( build_headers )
 			{
-			headers.push_back({zeek::AdoptRef{}, build_sip_header_val(name, value)});
+			headers.emplace_back(zeek::AdoptRef{}, build_sip_header_val(name, value));
 			}
 
 		return true;

--- a/src/analyzer/protocol/ssl/ssl-defs.pac
+++ b/src/analyzer/protocol/ssl/ssl-defs.pac
@@ -42,8 +42,6 @@ string orig_label(bool is_orig)
 		  ((uint64)num->byte4() << 16) | ((uint64)num->byte5() << 8) | (uint64)num->byte6();
 		}
 	};
-
-	string state_label(int state_nr);
 %}
 
 extern type to_int;

--- a/src/analyzer/protocol/ssl/ssl-defs.pac
+++ b/src/analyzer/protocol/ssl/ssl-defs.pac
@@ -24,7 +24,7 @@ type uint48 = record {
 %code{
 string orig_label(bool is_orig)
 		{
-		return string(is_orig ? "originator" :"responder");
+		return is_orig ? "originator" :"responder";
 		}
 %}
 

--- a/src/analyzer/protocol/ssl/ssl-dtls-protocol.pac
+++ b/src/analyzer/protocol/ssl/ssl-dtls-protocol.pac
@@ -21,22 +21,6 @@ enum AnalyzerState {
 	STATE_ENCRYPTED
 };
 
-%code{
-	string state_label(int state_nr)
-		{
-		switch ( state_nr ) {
-		case STATE_CLEAR:
-			return "CLEAR";
-
-		case STATE_ENCRYPTED:
-			return "ENCRYPTED";
-
-		default:
-			return zeek::util::fmt("UNKNOWN (%d)", state_nr);
-		}
-		}
-%}
-
 ######################################################################
 # Change Cipher Spec Protocol (7.1.)
 ######################################################################

--- a/src/analyzer/protocol/ssl/ssl-dtls-protocol.pac
+++ b/src/analyzer/protocol/ssl/ssl-dtls-protocol.pac
@@ -26,13 +26,13 @@ enum AnalyzerState {
 		{
 		switch ( state_nr ) {
 		case STATE_CLEAR:
-			return string("CLEAR");
+			return "CLEAR";
 
 		case STATE_ENCRYPTED:
-			return string("ENCRYPTED");
+			return "ENCRYPTED";
 
 		default:
-			return string(zeek::util::fmt("UNKNOWN (%d)", state_nr));
+			return zeek::util::fmt("UNKNOWN (%d)", state_nr);
 		}
 		}
 %}

--- a/src/analyzer/protocol/xmpp/XMPP.cc
+++ b/src/analyzer/protocol/xmpp/XMPP.cc
@@ -11,7 +11,7 @@ namespace zeek::analyzer::xmpp
 XMPP_Analyzer::XMPP_Analyzer(Connection* conn)
 	: analyzer::tcp::TCP_ApplicationAnalyzer("XMPP", conn)
 	{
-	interp = unique_ptr<binpac::XMPP::XMPP_Conn>(new binpac::XMPP::XMPP_Conn(this));
+	interp = std::make_unique<binpac::XMPP::XMPP_Conn>(this);
 	had_gap = false;
 	tls_active = false;
 	}

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -889,7 +889,7 @@ broker::expected<broker::data> val_to_data(const Val* v)
 			std::string name(f->Name());
 
 			broker::vector rval;
-			rval.push_back(name);
+			rval.emplace_back(name);
 
 			if ( name.find("lambda_<") == 0 )
 				{

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -246,8 +246,6 @@ Manager::Manager(bool arg_use_real_time)
 	writer_id_type = nullptr;
 	}
 
-Manager::~Manager() { }
-
 void Manager::InitPostScript()
 	{
 	DBG_LOG(DBG_BROKER, "Initializing");

--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -96,7 +96,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	~Manager() override;
+	~Manager() override = default;
 
 	/**
 	 * Initialization of the manager. This is called late during Zeek's

--- a/src/file_analysis/Component.cc
+++ b/src/file_analysis/Component.cc
@@ -23,8 +23,6 @@ void Component::Initialize()
 	file_mgr->RegisterComponent(this, "ANALYZER_");
 	}
 
-Component::~Component() { }
-
 void Component::DoDescribe(ODesc* d) const
 	{
 	if ( factory_func )

--- a/src/file_analysis/Component.h
+++ b/src/file_analysis/Component.h
@@ -60,7 +60,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	~Component() override;
+	~Component() override = default;
 
 	/**
 	 * Initialization function. This function has to be called before any

--- a/src/input/Component.cc
+++ b/src/input/Component.cc
@@ -21,8 +21,6 @@ void Component::Initialize()
 	input_mgr->RegisterComponent(this, "READER_");
 	}
 
-Component::~Component() { }
-
 void Component::DoDescribe(ODesc* d) const
 	{
 	d->Add("Input::READER_");

--- a/src/input/Component.h
+++ b/src/input/Component.h
@@ -36,7 +36,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	~Component() override;
+	~Component() override = default;
 
 	/**
 	 * Initialization function. This function has to be called before any

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -130,7 +130,7 @@ public:
 	string file_id;
 
 	AnalysisStream();
-	~AnalysisStream() override;
+	~AnalysisStream() override = default;
 	};
 
 Manager::TableStream::TableStream()
@@ -176,8 +176,6 @@ Manager::TableStream::~TableStream()
 	}
 
 Manager::AnalysisStream::AnalysisStream() : Manager::Stream::Stream(ANALYSIS_STREAM), file_id() { }
-
-Manager::AnalysisStream::~AnalysisStream() { }
 
 Manager::Manager() : plugin::ComponentManager<input::Component>("Input", "Reader")
 	{

--- a/src/input/readers/ascii/Ascii.cc
+++ b/src/input/readers/ascii/Ascii.cc
@@ -44,7 +44,7 @@ FieldMapping::FieldMapping(const FieldMapping& arg)
 
 FieldMapping FieldMapping::subType()
 	{
-	return FieldMapping(name, subtype, position);
+	return {name, subtype, position};
 	}
 
 FieldMapping& FieldMapping::operator=(const FieldMapping& arg)

--- a/src/input/readers/config/Config.cc
+++ b/src/input/readers/config/Config.cc
@@ -54,8 +54,6 @@ Config::Config(ReaderFrontend* frontend) : ReaderBackend(frontend)
 		}
 	}
 
-Config::~Config() { }
-
 void Config::DoClose() { }
 
 bool Config::DoInit(const ReaderInfo& info, int num_fields, const Field* const* fields)

--- a/src/input/readers/config/Config.h
+++ b/src/input/readers/config/Config.h
@@ -23,7 +23,7 @@ class Config : public ReaderBackend
 	{
 public:
 	explicit Config(ReaderFrontend* frontend);
-	~Config() override;
+	~Config() override = default;
 
 	// prohibit copying and moving
 	Config(const Config&) = delete;

--- a/src/input/readers/raw/Plugin.cc
+++ b/src/input/readers/raw/Plugin.cc
@@ -7,8 +7,6 @@ namespace zeek::plugin::detail::Zeek_RawReader
 
 Plugin plugin;
 
-Plugin::Plugin() { }
-
 zeek::plugin::Configuration Plugin::Configure()
 	{
 	AddComponent(new zeek::input::Component("Raw", zeek::input::reader::detail::Raw::Instantiate));

--- a/src/input/readers/raw/Plugin.h
+++ b/src/input/readers/raw/Plugin.h
@@ -13,7 +13,7 @@ namespace zeek::plugin::detail::Zeek_RawReader
 class Plugin : public plugin::Plugin
 	{
 public:
-	Plugin();
+	Plugin() = default;
 
 	plugin::Configuration Configure() override;
 

--- a/src/iosource/Component.cc
+++ b/src/iosource/Component.cc
@@ -17,8 +17,6 @@ Component::Component(plugin::component::Type type, const std::string& name)
 	{
 	}
 
-Component::~Component() { }
-
 PktSrcComponent::PktSrcComponent(const std::string& arg_name, const std::string& arg_prefix,
                                  InputType arg_type, factory_callback arg_factory)
 	: Component(plugin::component::PKTSRC, arg_name)
@@ -27,8 +25,6 @@ PktSrcComponent::PktSrcComponent(const std::string& arg_name, const std::string&
 	type = arg_type;
 	factory = arg_factory;
 	}
-
-PktSrcComponent::~PktSrcComponent() { }
 
 const std::vector<std::string>& PktSrcComponent::Prefixes() const
 	{
@@ -109,8 +105,6 @@ PktDumperComponent::PktDumperComponent(const std::string& name, const std::strin
 	util::tokenize_string(arg_prefix, ":", &prefixes);
 	factory = arg_factory;
 	}
-
-PktDumperComponent::~PktDumperComponent() { }
 
 PktDumperComponent::factory_callback PktDumperComponent::Factory() const
 	{

--- a/src/iosource/Component.h
+++ b/src/iosource/Component.h
@@ -33,7 +33,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	~Component() override;
+	~Component() override = default;
 
 protected:
 	/**
@@ -84,7 +84,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	~PktSrcComponent() override;
+	~PktSrcComponent() override = default;
 
 	/**
 	 * Returns the prefix(es) passed to the constructor.
@@ -145,7 +145,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	~PktDumperComponent() override;
+	~PktDumperComponent() override = default;
 
 	/**
 	 * Returns the prefix(es) passed to the constructor.

--- a/src/iosource/PktDumper.cc
+++ b/src/iosource/PktDumper.cc
@@ -16,8 +16,6 @@ PktDumper::PktDumper()
 	errmsg = "";
 	}
 
-PktDumper::~PktDumper() { }
-
 void PktDumper::Init()
 	{
 	Open();

--- a/src/iosource/PktDumper.h
+++ b/src/iosource/PktDumper.h
@@ -28,7 +28,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	virtual ~PktDumper();
+	virtual ~PktDumper() = default;
 
 	/**
 	 * Returns the path associated with the dumper.

--- a/src/iosource/pcap/Dumper.cc
+++ b/src/iosource/pcap/Dumper.cc
@@ -20,8 +20,6 @@ PcapDumper::PcapDumper(const std::string& path, bool arg_append)
 	pd = nullptr;
 	}
 
-PcapDumper::~PcapDumper() { }
-
 void PcapDumper::Open()
 	{
 	int linktype = -1;

--- a/src/iosource/pcap/Dumper.h
+++ b/src/iosource/pcap/Dumper.h
@@ -18,7 +18,7 @@ class PcapDumper : public PktDumper
 	{
 public:
 	PcapDumper(const std::string& path, bool append);
-	~PcapDumper() override;
+	~PcapDumper() override = default;
 
 	static PktDumper* Instantiate(const std::string& path, bool append);
 

--- a/src/logging/Component.cc
+++ b/src/logging/Component.cc
@@ -21,8 +21,6 @@ void Component::Initialize()
 	log_mgr->RegisterComponent(this, "WRITER_");
 	}
 
-Component::~Component() { }
-
 void Component::DoDescribe(ODesc* d) const
 	{
 	d->Add("Log::WRITER_");

--- a/src/logging/Component.h
+++ b/src/logging/Component.h
@@ -36,7 +36,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	~Component() override;
+	~Component() override = default;
 
 	/**
 	 * Initialization function. This function has to be called before any

--- a/src/logging/WriterFrontend.cc
+++ b/src/logging/WriterFrontend.cc
@@ -41,7 +41,7 @@ public:
 		{
 		}
 
-	virtual ~RotateMessage() { delete[] rotated_path; }
+	~RotateMessage() override { delete[] rotated_path; }
 
 	bool Process() override { return Object()->Rotate(rotated_path, open, close, terminating); }
 

--- a/src/logging/writers/none/None.cc
+++ b/src/logging/writers/none/None.cc
@@ -23,7 +23,7 @@ bool None::DoInit(const WriterInfo& info, int num_fields, const threading::Field
 
 		for ( WriterInfo::config_map::const_iterator i = info.config.begin();
 		      i != info.config.end(); i++ )
-			keys.push_back(std::make_pair(i->first, i->second));
+			keys.emplace_back(i->first, i->second);
 
 		std::sort(keys.begin(), keys.end());
 

--- a/src/module_util.cc
+++ b/src/module_util.cc
@@ -39,7 +39,7 @@ string extract_module_name(const char* name)
 	string::size_type pos = module_name.rfind("::");
 
 	if ( pos == string::npos )
-		return string(GLOBAL_MODULE_NAME);
+		return GLOBAL_MODULE_NAME;
 
 	module_name.erase(pos);
 
@@ -63,7 +63,7 @@ string extract_var_name(const char* name)
 		return var_name;
 
 	if ( pos + 2 > var_name.size() )
-		return string("");
+		return "";
 
 	return var_name.substr(pos + 2);
 	}
@@ -81,7 +81,7 @@ string normalized_module_name(const char* module_name)
 	if ( (mod_len = strlen(module_name)) >= 2 && streq(module_name + mod_len - 2, "::") )
 		mod_len -= 2;
 
-	return string(module_name, mod_len);
+	return {module_name, static_cast<size_t>(mod_len)};
 	}
 
 TEST_CASE("module_util make_full_var_name")
@@ -103,7 +103,7 @@ string make_full_var_name(const char* module_name, const char* var_name)
 		if ( streq(GLOBAL_MODULE_NAME, extract_module_name(var_name).c_str()) )
 			return extract_var_name(var_name);
 
-		return string(var_name);
+		return var_name;
 		}
 
 	string full_name = normalized_module_name(module_name);

--- a/src/packet_analysis/protocol/arp/Plugin.cc
+++ b/src/packet_analysis/protocol/arp/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_ARP
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"ARP", zeek::packet_analysis::ARP::ARPAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/ayiya/Plugin.cc
+++ b/src/packet_analysis/protocol/ayiya/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_AYIYA
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"AYIYA", zeek::packet_analysis::AYIYA::AYIYAAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/ethernet/Plugin.cc
+++ b/src/packet_analysis/protocol/ethernet/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_Ethernet
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"Ethernet", zeek::packet_analysis::Ethernet::EthernetAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/fddi/Plugin.cc
+++ b/src/packet_analysis/protocol/fddi/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_FDDI
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"FDDI", zeek::packet_analysis::FDDI::FDDIAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/geneve/Plugin.cc
+++ b/src/packet_analysis/protocol/geneve/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_Geneve
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"Geneve", zeek::packet_analysis::Geneve::GeneveAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/gre/Plugin.cc
+++ b/src/packet_analysis/protocol/gre/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_GRE
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"GRE", zeek::packet_analysis::GRE::GREAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/gtpv1/Plugin.cc
+++ b/src/packet_analysis/protocol/gtpv1/Plugin.cc
@@ -8,7 +8,7 @@
 namespace zeek::plugin::detail::Zeek_GTPv1
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
 	zeek::plugin::Configuration Configure() override

--- a/src/packet_analysis/protocol/icmp/Plugin.cc
+++ b/src/packet_analysis/protocol/icmp/Plugin.cc
@@ -10,10 +10,10 @@
 namespace zeek::plugin::Zeek_ICMP
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"ICMP", zeek::packet_analysis::ICMP::ICMPAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/ieee802_11/Plugin.cc
+++ b/src/packet_analysis/protocol/ieee802_11/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_IEEE802_11
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"IEEE802_11", zeek::packet_analysis::IEEE802_11::IEEE802_11Analyzer::Instantiate));

--- a/src/packet_analysis/protocol/ieee802_11_radio/Plugin.cc
+++ b/src/packet_analysis/protocol/ieee802_11_radio/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_IEEE802_11_Radio
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"IEEE802_11_Radio",

--- a/src/packet_analysis/protocol/ip/Plugin.cc
+++ b/src/packet_analysis/protocol/ip/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_IP
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"IP", zeek::packet_analysis::IP::IPAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/iptunnel/Plugin.cc
+++ b/src/packet_analysis/protocol/iptunnel/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_IPTunnel
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"IPTunnel", zeek::packet_analysis::IPTunnel::IPTunnelAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/linux_sll/Plugin.cc
+++ b/src/packet_analysis/protocol/linux_sll/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_LinuxSLL
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"LinuxSLL", zeek::packet_analysis::LinuxSLL::LinuxSLLAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/linux_sll2/Plugin.cc
+++ b/src/packet_analysis/protocol/linux_sll2/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_LinuxSLL2
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"LinuxSLL2", zeek::packet_analysis::LinuxSLL2::LinuxSLL2Analyzer::Instantiate));

--- a/src/packet_analysis/protocol/llc/Plugin.cc
+++ b/src/packet_analysis/protocol/llc/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_LLC
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"LLC", zeek::packet_analysis::LLC::LLCAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/mpls/Plugin.cc
+++ b/src/packet_analysis/protocol/mpls/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_MPLS
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"MPLS", zeek::packet_analysis::MPLS::MPLSAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/nflog/Plugin.cc
+++ b/src/packet_analysis/protocol/nflog/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_NFLog
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"NFLog", zeek::packet_analysis::NFLog::NFLogAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/novell_802_3/Plugin.cc
+++ b/src/packet_analysis/protocol/novell_802_3/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_Novell_802_3
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"NOVELL_802_3",

--- a/src/packet_analysis/protocol/null/Plugin.cc
+++ b/src/packet_analysis/protocol/null/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_Null
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"Null", zeek::packet_analysis::Null::NullAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/pbb/Plugin.cc
+++ b/src/packet_analysis/protocol/pbb/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_PBB
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"PBB", zeek::packet_analysis::PBB::PBBAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/ppp_serial/Plugin.cc
+++ b/src/packet_analysis/protocol/ppp_serial/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_PPPSerial
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"PPPSerial", zeek::packet_analysis::PPPSerial::PPPSerialAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/pppoe/Plugin.cc
+++ b/src/packet_analysis/protocol/pppoe/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_PPPoE
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"PPPoE", zeek::packet_analysis::PPPoE::PPPoEAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/root/Plugin.cc
+++ b/src/packet_analysis/protocol/root/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_Root
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"Root", zeek::packet_analysis::Root::RootAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/skip/Plugin.cc
+++ b/src/packet_analysis/protocol/skip/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_Skip
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"Skip", zeek::packet_analysis::Skip::SkipAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/snap/Plugin.cc
+++ b/src/packet_analysis/protocol/snap/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_SNAP
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"SNAP", zeek::packet_analysis::SNAP::SNAPAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/tcp/Plugin.cc
+++ b/src/packet_analysis/protocol/tcp/Plugin.cc
@@ -10,10 +10,10 @@
 namespace zeek::plugin::Zeek_TCP
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"TCP", zeek::packet_analysis::TCP::TCPAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/teredo/Plugin.cc
+++ b/src/packet_analysis/protocol/teredo/Plugin.cc
@@ -8,7 +8,7 @@
 namespace zeek::plugin::detail::Zeek_Teredo
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
 	zeek::plugin::Configuration Configure() override

--- a/src/packet_analysis/protocol/udp/Plugin.cc
+++ b/src/packet_analysis/protocol/udp/Plugin.cc
@@ -10,10 +10,10 @@
 namespace zeek::plugin::Zeek_UDP
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"UDP", zeek::packet_analysis::UDP::UDPAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/vlan/Plugin.cc
+++ b/src/packet_analysis/protocol/vlan/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_VLAN
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"VLAN", zeek::packet_analysis::VLAN::VLANAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/vntag/Plugin.cc
+++ b/src/packet_analysis/protocol/vntag/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_VNTag
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"VNTag", zeek::packet_analysis::VNTag::VNTagAnalyzer::Instantiate));

--- a/src/packet_analysis/protocol/vxlan/Plugin.cc
+++ b/src/packet_analysis/protocol/vxlan/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_VXLAN
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"VXLAN", zeek::packet_analysis::VXLAN::VXLAN_Analyzer::Instantiate));

--- a/src/packet_analysis/protocol/wrapper/Plugin.cc
+++ b/src/packet_analysis/protocol/wrapper/Plugin.cc
@@ -8,10 +8,10 @@
 namespace zeek::plugin::Zeek_Wrapper
 	{
 
-class Plugin : public zeek::plugin::Plugin
+class Plugin final : public zeek::plugin::Plugin
 	{
 public:
-	zeek::plugin::Configuration Configure()
+	zeek::plugin::Configuration Configure() override
 		{
 		AddComponent(new zeek::packet_analysis::Component(
 			"Wrapper", zeek::packet_analysis::Wrapper::WrapperAnalyzer::Instantiate));

--- a/src/parse.y
+++ b/src/parse.y
@@ -2033,7 +2033,7 @@ case_type_list:
 case_type:
 		TOK_TYPE type
 			{
-			$$ = new ID(0, SCOPE_FUNCTION, 0);
+			$$ = new ID(0, SCOPE_FUNCTION, false);
 			$$->SetType({AdoptRef{}, $2});
 			}
 
@@ -2164,17 +2164,17 @@ local_id:
 	;
 
 global_id:
-	{ resolving_global_ID = 1; } global_or_event_id
+	{ resolving_global_ID = true; } global_or_event_id
 		{ $$ = $2; }
 	;
 
 def_global_id:
-	{ defining_global_ID = 1; } global_id { defining_global_ID = 0; }
+	{ defining_global_ID = true; } global_id { defining_global_ID = false; }
 		{ $$ = $2; }
 	;
 
 event_id:
-	{ resolving_global_ID = 0; } global_or_event_id
+	{ resolving_global_ID = false; } global_or_event_id
 		{ $$ = $2; }
 	;
 

--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -189,7 +189,7 @@ bool Manager::ActivateDynamicPluginInternal(const std::string& name, bool ok_if_
 				return true;
 			}
 
-		errors->push_back(util::fmt("plugin %s is not available", name.c_str()));
+		errors->emplace_back(util::fmt("plugin %s is not available", name.c_str()));
 		return false;
 		}
 
@@ -216,7 +216,7 @@ bool Manager::ActivateDynamicPluginInternal(const std::string& name, bool ok_if_
 				"dynamic plugin %s from directory %s conflicts with %s plugin %s (%d.%d.%d)",
 				name.c_str(), dir.c_str(), p->DynamicPlugin() ? "dynamic" : "built-in",
 				p->Name().c_str(), v.major, v.minor, v.patch);
-			errors->push_back(error);
+			errors->emplace_back(error);
 			return false;
 			}
 		}
@@ -245,14 +245,14 @@ bool Manager::ActivateDynamicPluginInternal(const std::string& name, bool ok_if_
 			if ( ! hdl )
 				{
 				const char* err = dlerror();
-				errors->push_back(util::fmt("cannot load plugin library %s: %s", path,
-				                            err ? err : "<unknown error>"));
+				errors->emplace_back(util::fmt("cannot load plugin library %s: %s", path,
+				                               err ? err : "<unknown error>"));
 				continue;
 				}
 
 			if ( ! current_plugin )
 				{
-				errors->push_back(
+				errors->emplace_back(
 					util::fmt("load plugin library %s did not instantiate a plugin", path));
 				dlclose(hdl);
 				continue;
@@ -275,8 +275,8 @@ bool Manager::ActivateDynamicPluginInternal(const std::string& name, bool ok_if_
 			// what we expect from its magic file.
 			if ( util::strtolower(current_plugin->Name()) != util::strtolower(name) )
 				{
-				errors->push_back(util::fmt("inconsistent plugin name: %s vs %s",
-				                            current_plugin->Name().c_str(), name.c_str()));
+				errors->emplace_back(util::fmt("inconsistent plugin name: %s vs %s",
+				                               current_plugin->Name().c_str(), name.c_str()));
 				continue;
 				}
 
@@ -577,7 +577,7 @@ Manager::inactive_plugin_list Manager::InactivePlugins() const
 			}
 
 		if ( ! found )
-			inactives.push_back(*i);
+			inactives.emplace_back(*i);
 		}
 
 	return inactives;
@@ -646,7 +646,7 @@ std::list<std::pair<HookType, int>> Manager::HooksEnabledForPlugin(const Plugin*
 		if ( hook_list* l = hooks[i] )
 			for ( const auto& [hook, hook_plugin] : *l )
 				if ( hook_plugin == plugin )
-					enabled.push_back(std::make_pair(static_cast<HookType>(i), hook));
+					enabled.emplace_back(static_cast<HookType>(i), hook);
 		}
 
 	return enabled;
@@ -666,7 +666,7 @@ void Manager::EnableHook(HookType hook, Plugin* plugin, int prio)
 			return;
 		}
 
-	l->push_back(std::make_pair(prio, plugin));
+	l->emplace_back(prio, plugin);
 	l->sort(hook_cmp);
 	}
 
@@ -710,9 +710,9 @@ int Manager::HookLoadFile(const Plugin::LoadType type, const string& file, const
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(HookArgument(type));
-		args.push_back(HookArgument(file));
-		args.push_back(HookArgument(resolved));
+		args.emplace_back(type);
+		args.emplace_back(file);
+		args.emplace_back(resolved);
 		MetaHookPre(HOOK_LOAD_FILE, args);
 		}
 
@@ -745,9 +745,9 @@ Manager::HookLoadFileExtended(const Plugin::LoadType type, const string& file,
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(HookArgument(type));
-		args.push_back(HookArgument(file));
-		args.push_back(HookArgument(resolved));
+		args.emplace_back(type);
+		args.emplace_back(file);
+		args.emplace_back(resolved);
 		MetaHookPre(HOOK_LOAD_FILE_EXT, args);
 		}
 
@@ -785,9 +785,9 @@ std::pair<bool, ValPtr> Manager::HookCallFunction(const Func* func, zeek::detail
 		for ( const auto& v : *vecargs )
 			vargs.push_back(v.get());
 
-		args.push_back(HookArgument(func));
-		args.push_back(HookArgument(parent));
-		args.push_back(HookArgument(&vargs));
+		args.emplace_back(func);
+		args.emplace_back(parent);
+		args.emplace_back(&vargs);
 		MetaHookPre(HOOK_CALL_FUNCTION, args);
 		}
 
@@ -821,7 +821,7 @@ bool Manager::HookQueueEvent(Event* event) const
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(HookArgument(event));
+		args.emplace_back(event);
 		MetaHookPre(HOOK_QUEUE_EVENT, args);
 		}
 
@@ -873,7 +873,7 @@ void Manager::HookSetupAnalyzerTree(Connection* conn) const
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(HookArgument(conn));
+		args.emplace_back(conn);
 		MetaHookPre(HOOK_SETUP_ANALYZER_TREE, args);
 		}
 
@@ -900,7 +900,7 @@ void Manager::HookUpdateNetworkTime(double network_time) const
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(HookArgument(network_time));
+		args.emplace_back(network_time);
 		MetaHookPre(HOOK_UPDATE_NETWORK_TIME, args);
 		}
 
@@ -923,7 +923,7 @@ void Manager::HookObjDtor(void* obj) const
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(HookArgument(obj));
+		args.emplace_back(obj);
 		MetaHookPre(HOOK_OBJ_DTOR, args);
 		}
 
@@ -948,13 +948,13 @@ void Manager::HookLogInit(const std::string& writer, const std::string& instanti
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(HookArgument(writer));
-		args.push_back(HookArgument(instantiating_filter));
-		args.push_back(HookArgument(local));
-		args.push_back(HookArgument(remote));
-		args.push_back(HookArgument(&info));
-		args.push_back(HookArgument(num_fields));
-		args.push_back(HookArgument(std::make_pair(num_fields, fields)));
+		args.emplace_back(writer);
+		args.emplace_back(instantiating_filter);
+		args.emplace_back(local);
+		args.emplace_back(remote);
+		args.emplace_back(&info);
+		args.emplace_back(num_fields);
+		args.emplace_back(std::make_pair(num_fields, fields));
 		MetaHookPre(HOOK_LOG_INIT, args);
 		}
 
@@ -979,12 +979,12 @@ bool Manager::HookLogWrite(const std::string& writer, const std::string& filter,
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(HookArgument(writer));
-		args.push_back(HookArgument(filter));
-		args.push_back(HookArgument(&info));
-		args.push_back(HookArgument(num_fields));
-		args.push_back(HookArgument(std::make_pair(num_fields, fields)));
-		args.push_back(HookArgument(vals));
+		args.emplace_back(writer);
+		args.emplace_back(filter);
+		args.emplace_back(&info);
+		args.emplace_back(num_fields);
+		args.emplace_back(std::make_pair(num_fields, fields));
+		args.emplace_back(vals);
 		MetaHookPre(HOOK_LOG_WRITE, args);
 		}
 
@@ -1021,14 +1021,14 @@ bool Manager::HookReporter(const std::string& prefix, const EventHandlerPtr even
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.push_back(HookArgument(prefix));
-		args.push_back(HookArgument(conn));
-		args.push_back(HookArgument(addl));
-		args.push_back(HookArgument(location1));
-		args.push_back(HookArgument(location2));
-		args.push_back(HookArgument(location));
-		args.push_back(HookArgument(time));
-		args.push_back(HookArgument(message));
+		args.emplace_back(prefix);
+		args.emplace_back(conn);
+		args.emplace_back(addl);
+		args.emplace_back(location1);
+		args.emplace_back(location2);
+		args.emplace_back(location);
+		args.emplace_back(time);
+		args.emplace_back(message);
 		MetaHookPre(HOOK_REPORTER, args);
 		}
 
@@ -1063,7 +1063,7 @@ void Manager::HookUnprocessedPacket(const Packet* packet) const
 
 	if ( HavePluginForHook(META_HOOK_PRE) )
 		{
-		args.emplace_back(HookArgument{packet});
+		args.emplace_back(packet);
 		MetaHookPre(HOOK_UNPROCESSED_PACKET, args);
 		}
 

--- a/src/plugin/Plugin.cc
+++ b/src/plugin/Plugin.cc
@@ -66,8 +66,6 @@ BifItem& BifItem::operator=(const BifItem& other)
 	return *this;
 	}
 
-BifItem::~BifItem() { }
-
 void HookArgument::Describe(ODesc* d) const
 	{
 	switch ( type )

--- a/src/plugin/Plugin.h
+++ b/src/plugin/Plugin.h
@@ -190,7 +190,7 @@ private:
 /**
  * A class describing an item defined in \c *.bif file.
  */
-class BifItem
+class BifItem final
 	{
 public:
 	/**
@@ -228,7 +228,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	~BifItem();
+	~BifItem() = default;
 
 	/**
 	 * Returns the script-level ID as passed into the constructor.

--- a/src/probabilistic/CardinalityCounter.cc
+++ b/src/probabilistic/CardinalityCounter.cc
@@ -115,8 +115,6 @@ CardinalityCounter::CardinalityCounter(uint64_t arg_size, uint64_t arg_V, double
 	p = log2(m);
 	}
 
-CardinalityCounter::~CardinalityCounter() { }
-
 uint8_t CardinalityCounter::Rank(uint64_t hash_modified) const
 	{
 	hash_modified = hash_modified >> p;

--- a/src/probabilistic/CardinalityCounter.h
+++ b/src/probabilistic/CardinalityCounter.h
@@ -61,7 +61,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	~CardinalityCounter();
+	~CardinalityCounter() = default;
 
 	/**
 	 * Add a new element to the counter.

--- a/src/probabilistic/Hasher.cc
+++ b/src/probabilistic/Hasher.cc
@@ -119,7 +119,7 @@ DefaultHasher::DefaultHasher(size_t k, Hasher::seed_t seed) : Hasher(k, seed)
 		{
 		seed_t s = Seed();
 		s.h[0] += util::detail::prng(i);
-		hash_functions.push_back(UHF(s));
+		hash_functions.emplace_back(s);
 		}
 	}
 

--- a/src/probabilistic/Hasher.cc
+++ b/src/probabilistic/Hasher.cc
@@ -108,7 +108,7 @@ UHF::UHF(Hasher::seed_t arg_seed)
 // times.
 Hasher::digest UHF::hash(const void* x, size_t n) const
 	{
-	static_assert(std::is_same<highwayhash::SipHashState::Key, decltype(seed.h)>::value,
+	static_assert(std::is_same_v<highwayhash::SipHashState::Key, decltype(seed.h)>,
 	              "Seed value is not the same type as highwayhash key");
 	return highwayhash::SipHash(seed.h, reinterpret_cast<const char*>(x), n);
 	}

--- a/src/rule-parse.y
+++ b/src/rule-parse.y
@@ -220,16 +220,16 @@ rule_attr:
 			}
 
 	|	TOK_REQUIRES_SIGNATURE TOK_IDENT
-			{ current_rule->AddRequires($2, 0, 0); }
+			{ current_rule->AddRequires($2, false, false); }
 
 	|	TOK_REQUIRES_SIGNATURE '!' TOK_IDENT
-			{ current_rule->AddRequires($3, 0, 1); }
+			{ current_rule->AddRequires($3, false, true); }
 
 	|	TOK_REQUIRES_REVERSE_SIGNATURE TOK_IDENT
-			{ current_rule->AddRequires($2, 1, 0); }
+			{ current_rule->AddRequires($2, true, false); }
 
 	|	TOK_REQUIRES_REVERSE_SIGNATURE '!' TOK_IDENT
-			{ current_rule->AddRequires($3, 1, 1); }
+			{ current_rule->AddRequires($3, true, true); }
 
 	|	TOK_SAME_IP
 			{ current_rule->AddCondition(new zeek::detail::RuleConditionSameIP()); }

--- a/src/scan.l
+++ b/src/scan.l
@@ -813,8 +813,7 @@ void begin_RE()
 
 class LocalNameFinder : public zeek::detail::TraversalCallback {
 public:
-	LocalNameFinder()
-		{}
+	LocalNameFinder() = default;
 
 	virtual zeek::detail::TraversalCode PreExpr(const zeek::detail::Expr* expr)
 		{

--- a/src/scan.l
+++ b/src/scan.l
@@ -811,11 +811,11 @@ void begin_RE()
 	BEGIN(RE);
 	}
 
-class LocalNameFinder : public zeek::detail::TraversalCallback {
+class LocalNameFinder final : public zeek::detail::TraversalCallback {
 public:
 	LocalNameFinder() = default;
 
-	virtual zeek::detail::TraversalCode PreExpr(const zeek::detail::Expr* expr)
+	zeek::detail::TraversalCode PreExpr(const zeek::detail::Expr* expr) override
 		{
 		if ( expr->Tag() != EXPR_NAME )
 			return zeek::detail::TC_CONTINUE;

--- a/src/scan.l
+++ b/src/scan.l
@@ -104,7 +104,7 @@ char last_tok[128];
 static std::string find_relative_file(const std::string& filename, const std::string& ext)
 	{
 	if ( filename.empty() )
-		return std::string();
+		return {};
 
 	if ( filename[0] == '.' )
 		return zeek::util::find_file(filename, zeek::util::SafeDirname(::filename).result, ext);
@@ -115,7 +115,7 @@ static std::string find_relative_file(const std::string& filename, const std::st
 static std::string find_relative_script_file(const std::string& filename)
 	{
 	if ( filename.empty() )
-		return std::string();
+		return {};
 
 	if ( filename[0] == '.' )
 		return zeek::util::find_script_file(filename, zeek::util::SafeDirname(::filename).result);

--- a/src/script_opt/CPP/Consts.cc
+++ b/src/script_opt/CPP/Consts.cc
@@ -156,7 +156,7 @@ shared_ptr<CPP_InitInfo> CPPCompile::RegisterConstant(const ValPtr& vp, int& con
 	const_vals[v] = constants[c_desc] = gi;
 
 	consts_offset = const_offsets[v] = constants_offsets[c_desc] = consts.size();
-	consts.emplace_back(pair(tag, gi->Offset()));
+	consts.emplace_back(tag, gi->Offset());
 
 	return gi;
 	}

--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -1352,7 +1352,7 @@ string CPPCompile::GenField(const ExprPtr& rec, int field)
 		ASSERT(pt != processed_types.end());
 		auto rt_offset = pt->second->Offset();
 		string field_name = rt->FieldName(field);
-		field_decls.emplace_back(pair(rt_offset, rt->FieldDecl(field)));
+		field_decls.emplace_back(rt_offset, rt->FieldDecl(field));
 
 		if ( rfm != record_field_mappings.end() )
 			// We're already tracking this record.
@@ -1392,7 +1392,7 @@ string CPPCompile::GenEnum(const TypePtr& t, const ValPtr& ev)
 		mapping_slot = num_ev_mappings++;
 
 		string enum_name = et->Lookup(v);
-		enum_names.emplace_back(pair(TypeOffset(t), std::move(enum_name)));
+		enum_names.emplace_back(TypeOffset(t), std::move(enum_name));
 
 		if ( evm != enum_val_mappings.end() )
 			{

--- a/src/script_opt/CPP/RuntimeInitSupport.cc
+++ b/src/script_opt/CPP/RuntimeInitSupport.cc
@@ -208,7 +208,7 @@ FuncValPtr lookup_func__CPP(string name, int num_bodies, vector<p_hash_type> has
 		ASSERT(cs != compiled_scripts.end());
 
 		const auto& f = cs->second;
-		bodies.push_back(f.body);
+		bodies.emplace_back(f.body);
 		priorities.push_back(f.priority);
 
 		// This might register the same event more than once,

--- a/src/script_opt/GenIDDefs.cc
+++ b/src/script_opt/GenIDDefs.cc
@@ -26,7 +26,7 @@ void GenIDDefs::TraverseFunction(const Func* f, ScopePtr scope, StmtPtr body)
 	// Establish the outermost barrier and associated set of
 	// identifiers.
 	barrier_blocks.push_back(0);
-	modified_IDs.push_back({});
+	modified_IDs.emplace_back();
 
 	for ( const auto& g : pf->Globals() )
 		{
@@ -434,7 +434,7 @@ void GenIDDefs::StartConfluenceBlock(const Stmt* s)
 		barrier_blocks.push_back(confluence_blocks.size());
 
 	confluence_blocks.push_back(s);
-	modified_IDs.push_back({});
+	modified_IDs.emplace_back();
 	}
 
 void GenIDDefs::EndConfluenceBlock(bool no_orig)

--- a/src/script_opt/IDOptInfo.cc
+++ b/src/script_opt/IDOptInfo.cc
@@ -77,7 +77,7 @@ void IDOptInfo::AddInitExpr(ExprPtr init_expr, InitClass ic)
 		return;
 
 	if ( my_id->IsGlobal() )
-		global_init_exprs.emplace_back(IDInitInfo(my_id, init_expr, ic));
+		global_init_exprs.emplace_back(my_id, init_expr, ic);
 
 	init_exprs.emplace_back(std::move(init_expr));
 	}

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -92,7 +92,7 @@ void add_func_analysis_pattern(AnalyOpt& opts, const char* pat)
 	try
 		{
 		std::string full_pat = std::string("^(") + pat + ")$";
-		opts.only_funcs.emplace_back(std::regex(full_pat));
+		opts.only_funcs.emplace_back(full_pat);
 		}
 	catch ( const std::regex_error& e )
 		{
@@ -105,7 +105,7 @@ void add_file_analysis_pattern(AnalyOpt& opts, const char* pat)
 	try
 		{
 		std::string full_pat = std::string("^.*(") + pat + ").*$";
-		opts.only_files.emplace_back(std::regex(full_pat));
+		opts.only_files.emplace_back(full_pat);
 		}
 	catch ( const std::regex_error& e )
 		{

--- a/src/script_opt/ZAM/Branches.cc
+++ b/src/script_opt/ZAM/Branches.cc
@@ -11,7 +11,7 @@ namespace zeek::detail
 
 void ZAMCompiler::PushGoTos(GoToSets& gotos)
 	{
-	gotos.push_back({});
+	gotos.emplace_back();
 	}
 
 void ZAMCompiler::ResolveGoTos(GoToSets& gotos, const InstLabel l)

--- a/src/script_opt/ZAM/Stmt.cc
+++ b/src/script_opt/ZAM/Stmt.cc
@@ -837,7 +837,7 @@ const ZAMStmt ZAMCompiler::LoopOverTable(const ForStmt* f, const NameExpr* val)
 		aux->value_var_type = value_var->GetType();
 
 	auto iter_slot = table_iters.size();
-	table_iters.emplace_back(TableIterInfo());
+	table_iters.emplace_back();
 
 	auto z = ZInstI(OP_INIT_TABLE_LOOP_VV, FrameSlot(val), iter_slot);
 	z.op_type = OP_VV_I2;

--- a/src/script_opt/ZAM/Support.cc
+++ b/src/script_opt/ZAM/Support.cc
@@ -55,7 +55,7 @@ StringVal* ZAM_to_lower(const StringVal* sv)
 
 	*ls++ = '\0';
 
-	return new StringVal(new String(1, lower_s, n));
+	return new StringVal(new String(true, lower_s, n));
 	}
 
 StringVal* ZAM_sub_bytes(const StringVal* s, zeek_uint_t start, zeek_int_t n)
@@ -76,7 +76,7 @@ StringValPtr ZAM_val_cat(const ValPtr& v)
 
 	v->Describe(&d);
 
-	String* s = new String(1, d.TakeBytes(), d.Len());
+	String* s = new String(true, d.TakeBytes(), d.Len());
 	s->SetUseFreeToDelete(true);
 
 	return make_intrusive<StringVal>(s);

--- a/src/telemetry/Manager.cc
+++ b/src/telemetry/Manager.cc
@@ -58,8 +58,6 @@ Manager::Manager()
 	pimpl.swap(ptr);
 	}
 
-Manager::~Manager() { }
-
 void Manager::InitPostScript() { }
 
 void Manager::InitPostBrokerSetup(broker::endpoint& ep)

--- a/src/telemetry/Manager.cc
+++ b/src/telemetry/Manager.cc
@@ -320,7 +320,7 @@ public:
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::dbl_counter_hdl* counter,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		if ( matches(family) )
 			metrics.emplace_back(MetricType::Counter, family, extract_label_values(labels),
@@ -329,7 +329,7 @@ public:
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::int_counter_hdl* counter,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		if ( matches(family) )
 			metrics.emplace_back(MetricType::Counter, family, extract_label_values(labels),
@@ -338,7 +338,7 @@ public:
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::dbl_gauge_hdl* gauge,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		if ( matches(family) )
 			metrics.emplace_back(MetricType::Gauge, family, extract_label_values(labels),
@@ -347,7 +347,7 @@ public:
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::int_gauge_hdl* gauge,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		if ( matches(family) )
 			metrics.emplace_back(MetricType::Gauge, family, extract_label_values(labels),
@@ -356,14 +356,14 @@ public:
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::dbl_histogram_hdl* histogram,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		// Ignored
 		}
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::int_histogram_hdl* histogram,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		// Ignored
 		}
@@ -400,35 +400,35 @@ public:
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::dbl_counter_hdl* counter,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		// Ignored
 		}
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::int_counter_hdl* counter,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		// Ignored
 		}
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::dbl_gauge_hdl* gauge,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		// Ignored
 		}
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::int_gauge_hdl* gauge,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		// Ignored
 		}
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::dbl_histogram_hdl* histogram,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		if ( ! matches(family) )
 			return;
@@ -452,7 +452,7 @@ public:
 
 	void operator()(const broker::telemetry::metric_family_hdl* family,
 	                const broker::telemetry::int_histogram_hdl* histogram,
-	                broker::telemetry::const_label_list labels)
+	                broker::telemetry::const_label_list labels) override
 		{
 		if ( ! matches(family) )
 			return;

--- a/src/telemetry/Manager.h
+++ b/src/telemetry/Manager.h
@@ -50,7 +50,7 @@ public:
 
 	Manager& operator=(const Manager&) = delete;
 
-	virtual ~Manager();
+	virtual ~Manager() = default;
 
 	/**
 	 * Initialization of the manager. This is called late during Zeek's

--- a/src/threading/BasicThread.cc
+++ b/src/threading/BasicThread.cc
@@ -49,7 +49,7 @@ void BasicThread::SetName(const char* arg_name)
 void BasicThread::SetOSName(const char* arg_name)
 	{
 	// Do it only if libc++ supports pthread_t.
-	if constexpr ( std::is_same<std::thread::native_handle_type, pthread_t>::value )
+	if constexpr ( std::is_same_v<std::thread::native_handle_type, pthread_t> )
 		zeek::util::detail::set_thread_name(arg_name,
 		                                    reinterpret_cast<pthread_t>(thread.native_handle()));
 	}

--- a/src/threading/Formatter.cc
+++ b/src/threading/Formatter.cc
@@ -20,8 +20,6 @@ Formatter::Formatter(threading::MsgThread* t)
 	thread = t;
 	}
 
-Formatter::~Formatter() { }
-
 std::string Formatter::Render(const threading::Value::addr_t& addr)
 	{
 	if ( addr.family == IPv4 )

--- a/src/threading/Formatter.h
+++ b/src/threading/Formatter.h
@@ -33,7 +33,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	virtual ~Formatter();
+	virtual ~Formatter() = default;
 
 	/**
 	 * Convert a list of threading values into an implementation specific

--- a/src/threading/Manager.cc
+++ b/src/threading/Manager.cc
@@ -277,7 +277,7 @@ const threading::Manager::msg_stats_list& threading::Manager::GetMsgThreadStats(
 		MsgThread::Stats s;
 		t->GetStats(&s);
 
-		stats.push_back(std::make_pair(t->Name(), s));
+		stats.emplace_back(t->Name(), s);
 		}
 
 	return stats;

--- a/src/threading/MsgThread.cc
+++ b/src/threading/MsgThread.cc
@@ -352,7 +352,7 @@ std::string MsgThread::BuildMsgWithLocation(const char* msg)
 		}
 
 	desc.Add(msg);
-	return std::string(desc.Description());
+	return desc.Description();
 	}
 
 void MsgThread::Info(const char* msg)

--- a/src/threading/formatters/Ascii.cc
+++ b/src/threading/formatters/Ascii.cc
@@ -53,8 +53,6 @@ Ascii::Ascii(MsgThread* t, const SeparatorInfo& info) : Formatter(t)
 	separators = info;
 	}
 
-Ascii::~Ascii() { }
-
 bool Ascii::Describe(ODesc* desc, int num_fields, const Field* const* fields, Value** vals) const
 	{
 	for ( int i = 0; i < num_fields; i++ )

--- a/src/threading/formatters/Ascii.h
+++ b/src/threading/formatters/Ascii.h
@@ -47,7 +47,7 @@ public:
 	 * separators.
 	 */
 	Ascii(MsgThread* t, const SeparatorInfo& info);
-	~Ascii() override;
+	~Ascii() override = default;
 
 	virtual bool Describe(ODesc* desc, Value* val, const std::string& name = "") const override;
 	virtual bool Describe(ODesc* desc, int num_fields, const Field* const* fields,

--- a/src/threading/formatters/JSON.cc
+++ b/src/threading/formatters/JSON.cc
@@ -37,8 +37,6 @@ JSON::JSON(MsgThread* t, TimeFormat tf, bool arg_include_unset_fields)
 	{
 	}
 
-JSON::~JSON() { }
-
 bool JSON::Describe(ODesc* desc, int num_fields, const Field* const* fields, Value** vals) const
 	{
 	rapidjson::StringBuffer buffer;

--- a/src/threading/formatters/JSON.h
+++ b/src/threading/formatters/JSON.h
@@ -36,7 +36,7 @@ public:
 		};
 
 	JSON(MsgThread* t, TimeFormat tf, bool include_unset_fields = false);
-	~JSON() override;
+	~JSON() override = default;
 
 	bool Describe(ODesc* desc, Value* val, const std::string& name = "") const override;
 	bool Describe(ODesc* desc, int num_fields, const Field* const* fields,

--- a/src/util.cc
+++ b/src/util.cc
@@ -2002,7 +2002,7 @@ static string find_file_in_path(const string& filename, const string& path,
                                 const vector<string>& opt_ext)
 	{
 	if ( filename.empty() )
-		return string();
+		return {};
 
 	zeek::filesystem::path filepath(filename);
 
@@ -2012,7 +2012,7 @@ static string find_file_in_path(const string& filename, const string& path,
 		if ( can_read(filename) )
 			return filename;
 		else
-			return string();
+			return {};
 		}
 
 	auto abs_path = (zeek::filesystem::path(path) / filepath).string();
@@ -2031,7 +2031,7 @@ static string find_file_in_path(const string& filename, const string& path,
 	if ( can_read(abs_path) )
 		return abs_path;
 
-	return string();
+	return {};
 	}
 
 string find_file(const string& filename, const string& path_set, const string& opt_ext)
@@ -2051,7 +2051,7 @@ string find_file(const string& filename, const string& path_set, const string& o
 			return f;
 		}
 
-	return string();
+	return {};
 	}
 
 string find_script_file(const string& filename, const string& path_set)
@@ -2069,7 +2069,7 @@ string find_script_file(const string& filename, const string& path_set)
 			return f;
 		}
 
-	return string();
+	return {};
 	}
 
 RETSIGTYPE sig_handler(int signo);

--- a/src/zeekygen/IdentifierInfo.cc
+++ b/src/zeekygen/IdentifierInfo.cc
@@ -67,7 +67,7 @@ vector<string> IdentifierInfo::GetFieldComments(const string& field) const
 	record_field_map::const_iterator it = fields.find(field);
 
 	if ( it == fields.end() )
-		return vector<string>();
+		return {};
 
 	return it->second->comments;
 	}

--- a/src/zeekygen/ScriptInfo.cc
+++ b/src/zeekygen/ScriptInfo.cc
@@ -51,11 +51,11 @@ static void add_summary_rows(const ODesc& id_desc, const vector<string>& cmnts,
                              ReStructuredTextTable* table)
 	{
 	vector<string> row;
-	row.push_back(id_desc.Description());
+	row.emplace_back(id_desc.Description());
 
 	if ( cmnts.empty() )
 		{
-		row.push_back("");
+		row.emplace_back();
 		table->AddRow(row);
 		return;
 		}
@@ -66,7 +66,7 @@ static void add_summary_rows(const ODesc& id_desc, const vector<string>& cmnts,
 	for ( size_t i = 1; i < cmnts.size(); ++i )
 		{
 		row.clear();
-		row.push_back("");
+		row.emplace_back();
 		row.push_back(cmnts[i]);
 		table->AddRow(row);
 		}

--- a/src/zeekygen/Target.cc
+++ b/src/zeekygen/Target.cc
@@ -505,7 +505,7 @@ vector<string> dir_contents_recursive(string dir)
 	while ( (n = fts_read(fts)) )
 		{
 		if ( n->fts_info & FTS_F )
-			rval.push_back(n->fts_path);
+			rval.emplace_back(n->fts_path);
 		}
 
 	if ( errno )


### PR DESCRIPTION
This is a whole bunch of fixups for some of the clang-tidy `modernize` checkers. These are the checkers I ran here:

- modernize-concat-nested-namespaces
  - this still has a lot of findings in generated binpac code, but I left those
- modernize-make-shared (no findings)
- modernize-make-unique (e6a30a1f392184000e6413c8f56930d5b5982608)
- modernize-return-braced-init-list (845b9b917d95f795135f612e23824f55f7ce9c37)
- modernize-shrink-to-fit (no findings)
- modernize-type-traits (76b73ee3a1d438d29c61d3d78a7dee64b1d1b675)
- modernize-use-bool-literals (51f607431a31b7f8a1092d897c99a2beca93ef55
  - this also had a lot of leftover findings in generated binpac code
- modernize-use-emplace (ea7b95bbf6b5ee1d08562d47f59b3d25900cf826)
- modernize-use-equals-default (ddecaba4348e8fc56271e54a96c4ea9fa2bfa21a)
- modernize-use-override (7e49b8be29bec37e2bc1fba26d7adf97e6924a5f, a34c1574631dac9aebc02f9a52f3074f0c0920d2)
- modernize-use-using
  - There were some findings for this in generated bison/flex code. I left those alone.

Also included is a fix to our cmake setup where were including a bunch of 3rd party files that don't need to be scanned by us.