### PR TITLE
Migrated some raw pointers to smart pointers

### DIFF
--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -205,7 +205,7 @@ void get_first_statement(Stmt* list, Stmt*& first, Location& loc)
 	while ( first->Tag() == STMT_LIST )
 		{
 		if ( first->AsStmtList()->Stmts()[0] )
-			first = first->AsStmtList()->Stmts()[0];
+			first = first->AsStmtList()->Stmts()[0].get();
 		else
 			break;
 		}

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -777,8 +777,8 @@ StmtPtr ScriptFunc::AddInits(StmtPtr body, const std::vector<IDPtr>& inits)
 		return body;
 
 	auto stmt_series = make_intrusive<StmtList>();
-	stmt_series->Stmts().push_back(new InitStmt(inits));
-	stmt_series->Stmts().push_back(body.release());
+	stmt_series->Stmts().push_back(make_intrusive<InitStmt>(inits));
+	stmt_series->Stmts().push_back(std::move(body));
 
 	return stmt_series;
 	}

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -1677,7 +1677,7 @@ ValPtr StmtList::Exec(Frame* f, StmtFlowType& flow)
 	RegisterAccess();
 	flow = FLOW_NEXT;
 
-	for ( const auto& stmt_ptr : Stmts() )
+	for ( const auto& stmt_ptr : stmts )
 		{
 		auto stmt = stmt_ptr.get();
 
@@ -1702,7 +1702,7 @@ ValPtr StmtList::Exec(Frame* f, StmtFlowType& flow)
 
 bool StmtList::IsPure() const
 	{
-	for ( const auto& stmt : Stmts() )
+	for ( const auto& stmt : stmts )
 		if ( ! stmt->IsPure() )
 			return false;
 	return true;
@@ -1727,7 +1727,7 @@ void StmtList::StmtDescribe(ODesc* d) const
 			d->NL();
 			}
 
-		for ( const auto& stmt : Stmts() )
+		for ( const auto& stmt : stmts )
 			{
 			stmt->Describe(d);
 			d->NL();
@@ -1743,7 +1743,7 @@ TraversalCode StmtList::Traverse(TraversalCallback* cb) const
 	TraversalCode tc = cb->PreStmt(this);
 	HANDLE_TC_STMT_PRE(tc);
 
-	for ( const auto& stmt : Stmts() )
+	for ( const auto& stmt : stmts )
 		{
 		tc = stmt->Traverse(cb);
 		HANDLE_TC_STMT_PRE(tc);

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -464,8 +464,8 @@ public:
 
 	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
-	const StmtPList& Stmts() const { return *stmts; }
-	StmtPList& Stmts() { return *stmts; }
+	const auto& Stmts() const { return stmts; }
+	auto& Stmts() { return stmts; }
 
 	void StmtDescribe(ODesc* d) const override;
 
@@ -481,23 +481,18 @@ public:
 	bool NoFlowAfter(bool ignore_break) const override;
 
 	// Idioms commonly used in reduction.
-	StmtList(StmtPtr s1, Stmt* s2);
 	StmtList(StmtPtr s1, StmtPtr s2);
 	StmtList(StmtPtr s1, StmtPtr s2, StmtPtr s3);
 
 protected:
 	bool IsPure() const override;
 
-	StmtPList* stmts;
+	std::vector<StmtPtr> stmts;
 
 	// Optimization-related:
-	bool ReduceStmt(int& s_i, StmtPList* f_stmts, Reducer* c);
+	bool ReduceStmt(int& s_i, std::vector<StmtPtr>& f_stmts, Reducer* c);
 
-	void ResetStmts(StmtPList* new_stmts)
-		{
-		delete stmts;
-		stmts = new_stmts;
-		}
+	void ResetStmts(std::vector<StmtPtr> new_stmts) { stmts = std::move(new_stmts); }
 	};
 
 class InitStmt final : public Stmt
@@ -690,9 +685,7 @@ private:
 class WhenStmt final : public Stmt
 	{
 public:
-	// The constructor takes ownership of the WhenInfo object.
-	WhenStmt(WhenInfo* wi);
-	~WhenStmt() override;
+	WhenStmt(std::shared_ptr<WhenInfo> wi);
 
 	ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 	bool IsPure() const override;
@@ -703,7 +696,7 @@ public:
 	StmtPtr TimeoutBody() const { return wi->TimeoutStmt(); }
 	bool IsReturn() const { return wi->IsReturn(); }
 
-	WhenInfo* Info() const { return wi; }
+	auto Info() const { return wi; }
 
 	void StmtDescribe(ODesc* d) const override;
 
@@ -716,7 +709,7 @@ public:
 	StmtPtr DoReduce(Reducer* c) override;
 
 private:
-	WhenInfo* wi;
+	std::shared_ptr<WhenInfo> wi;
 	};
 
 // Internal statement used for inlining.  Executes a block and stops

--- a/src/Trigger.cc
+++ b/src/Trigger.cc
@@ -99,7 +99,7 @@ protected:
 	double time;
 	};
 
-Trigger::Trigger(WhenInfo* wi, double timeout, const IDSet& _globals,
+Trigger::Trigger(std::shared_ptr<WhenInfo> wi, double timeout, const IDSet& _globals,
                  std::vector<ValPtr> _local_aggrs, Frame* f, const Location* loc)
 	{
 	timeout_value = timeout;

--- a/src/Trigger.h
+++ b/src/Trigger.h
@@ -48,8 +48,8 @@ public:
 	// statements are executed immediately and the object is deleted
 	// right away.
 
-	Trigger(WhenInfo* wi, double timeout, const IDSet& globals, std::vector<ValPtr> local_aggrs,
-	        Frame* f, const Location* loc);
+	Trigger(std::shared_ptr<WhenInfo> wi, double timeout, const IDSet& globals,
+	        std::vector<ValPtr> local_aggrs, Frame* f, const Location* loc);
 
 	~Trigger() override;
 

--- a/src/ZeekList.h
+++ b/src/ZeekList.h
@@ -23,7 +23,6 @@ class Type;
 using ValPList = PList<Val>;
 using ExprPList = PList<detail::Expr>;
 using IDPList = PList<detail::ID>;
-using StmtPList = PList<detail::Stmt>;
 using TypePList = PList<Type>;
 using AttrPList = PList<detail::Attr>;
 using TimerPList = PList<detail::Timer, ListOrder::UNORDERED>;

--- a/src/parse.y
+++ b/src/parse.y
@@ -395,7 +395,7 @@ zeek:
 		stmt_list
 			{
 			if ( stmts )
-				stmts->AsStmtList()->Stmts().push_back($3);
+				stmts->AsStmtList()->Stmts().push_back({AdoptRef{}, $3});
 			else
 				stmts = $3;
 
@@ -1931,7 +1931,8 @@ stmt:
 
 	|	when_clause
 			{
-			$$ = new WhenStmt($1);
+			std::shared_ptr<WhenInfo> wi($1);
+			$$ = new WhenStmt(wi);
 			script_coverage_mgr.AddStmt($$);
 			}
 
@@ -1968,7 +1969,7 @@ stmt_list:
 		stmt_list stmt
 			{
 			set_location(@1, @2);
-			$1->AsStmtList()->Stmts().push_back($2);
+			$1->AsStmtList()->Stmts().push_back({AdoptRef{}, $2});
 			$1->UpdateLocationEndInfo(@2);
 			}
 	|

--- a/src/script_opt/Reduce.cc
+++ b/src/script_opt/Reduce.cc
@@ -654,7 +654,7 @@ ExprPtr Reducer::UpdateExpr(ExprPtr e)
 	return make_intrusive<ConstExpr>(c->ValuePtr());
 	}
 
-StmtPtr Reducer::MergeStmts(const NameExpr* lhs, ExprPtr rhs, Stmt* succ_stmt)
+StmtPtr Reducer::MergeStmts(const NameExpr* lhs, ExprPtr rhs, const StmtPtr& succ_stmt)
 	{
 	// First check for tmp=rhs.
 	auto lhs_id = lhs->Id();

--- a/src/script_opt/Reduce.h
+++ b/src/script_opt/Reduce.h
@@ -137,7 +137,7 @@ public:
 	// Given an lhs=rhs statement followed by succ_stmt, returns
 	// a (new) merge of the two if they're of the form tmp=rhs, var=tmp;
 	// otherwise, nil.
-	StmtPtr MergeStmts(const NameExpr* lhs, ExprPtr rhs, Stmt* succ_stmt);
+	StmtPtr MergeStmts(const NameExpr* lhs, ExprPtr rhs, const StmtPtr& succ_stmt);
 
 	// Update expressions with optimized versions.  They are distinct
 	// because the first two (meant for calls in a Stmt reduction

--- a/src/script_opt/Stmt.cc
+++ b/src/script_opt/Stmt.cc
@@ -699,25 +699,25 @@ StmtPtr StmtList::Duplicate()
 	{
 	auto new_sl = new StmtList();
 
-	for ( auto& stmt : Stmts() )
-		new_sl->Stmts().push_back(stmt->Duplicate());
+	for ( auto& stmt : stmts )
+		new_sl->stmts.push_back(stmt->Duplicate());
 
 	return SetSucc(new_sl);
 	}
 
 void StmtList::Inline(Inliner* inl)
 	{
-	for ( const auto& stmt : Stmts() )
+	for ( const auto& stmt : stmts )
 		stmt->Inline(inl);
 	}
 
 bool StmtList::IsReduced(Reducer* c) const
 	{
-	auto n = Stmts().size();
+	auto n = stmts.size();
 
 	for ( auto i = 0; i < n; ++i )
 		{
-		auto& s_i = Stmts()[i];
+		auto& s_i = stmts[i];
 		if ( ! s_i->IsReduced(c) )
 			return false;
 
@@ -733,14 +733,14 @@ StmtPtr StmtList::DoReduce(Reducer* c)
 	std::vector<StmtPtr> f_stmts;
 	bool did_change = false;
 
-	auto n = Stmts().size();
+	auto n = stmts.size();
 
 	for ( auto i = 0; i < n; ++i )
 		{
 		if ( ReduceStmt(i, f_stmts, c) )
 			did_change = true;
 
-		if ( i < n - 1 && Stmts()[i]->NoFlowAfter(false) )
+		if ( i < n - 1 && stmts[i]->NoFlowAfter(false) )
 			{
 			did_change = true;
 			break;
@@ -768,7 +768,7 @@ StmtPtr StmtList::DoReduce(Reducer* c)
 bool StmtList::ReduceStmt(int& s_i, std::vector<StmtPtr>& f_stmts, Reducer* c)
 	{
 	bool did_change = false;
-	auto stmt = Stmts()[s_i];
+	auto stmt = stmts[s_i];
 	auto old_stmt = stmt;
 
 	stmt = stmt->Reduce(c);
@@ -813,10 +813,10 @@ bool StmtList::ReduceStmt(int& s_i, std::vector<StmtPtr>& f_stmts, Reducer* c)
 		auto var = lhs->AsNameExpr();
 		auto rhs = a->GetOp2();
 
-		if ( s_i < Stmts().size() - 1 )
+		if ( s_i < stmts.size() - 1 )
 			{
 			// See if we can compress an assignment chain.
-			auto& s_i_succ = Stmts()[s_i + 1];
+			auto& s_i_succ = stmts[s_i + 1];
 
 			// Don't reduce s_i_succ.  If it's what we're
 			// looking for, it's already reduced.  Plus
@@ -864,7 +864,7 @@ bool StmtList::ReduceStmt(int& s_i, std::vector<StmtPtr>& f_stmts, Reducer* c)
 
 bool StmtList::NoFlowAfter(bool ignore_break) const
 	{
-	for ( auto& s : Stmts() )
+	for ( auto& s : stmts )
 		{
 		// For "break" statements, if ignore_break is set then
 		// by construction flow *does* go to after this statement

--- a/src/script_opt/Stmt.cc
+++ b/src/script_opt/Stmt.cc
@@ -91,7 +91,7 @@ StmtPtr ExprListStmt::DoReduce(Reducer* c)
 			new_l->Append(red_e);
 
 			if ( red_e_stmt )
-				s->Stmts().push_back(red_e_stmt.release());
+				s->Stmts().push_back(red_e_stmt);
 			}
 		}
 
@@ -103,7 +103,7 @@ StmtPtr ExprListStmt::DoReduce(Reducer* c)
 
 	else
 		{
-		s->Stmts().push_back(DoSubclassReduce(new_l, c).release());
+		s->Stmts().push_back(DoSubclassReduce(new_l, c));
 		return s->Reduce(c);
 		}
 	}
@@ -296,7 +296,7 @@ StmtPtr IfStmt::DoReduce(Reducer* c)
 		}
 
 	if ( red_e_stmt )
-		return TransformMe(make_intrusive<StmtList>(red_e_stmt, this), c);
+		return TransformMe(make_intrusive<StmtList>(red_e_stmt, ThisPtr()), c);
 
 	return ThisPtr();
 	}
@@ -382,7 +382,14 @@ StmtPtr SwitchStmt::DoReduce(Reducer* rc)
 	// Note, the compiler checks for constant switch expressions.
 
 	if ( red_e_stmt )
-		s->Stmts().push_back(red_e_stmt.release());
+		s->Stmts().push_back(red_e_stmt);
+
+	// Update type cases.
+	for ( auto& i : case_label_type_list )
+		{
+		IDPtr idp = {NewRef{}, i.first};
+		i.first = rc->UpdateID(idp).release();
+		}
 
 	for ( const auto& c : *cases )
 		{
@@ -393,7 +400,7 @@ StmtPtr SwitchStmt::DoReduce(Reducer* rc)
 			auto red_cases = c_e->Reduce(rc, c_e_stmt);
 
 			if ( c_e_stmt )
-				s->Stmts().push_back(c_e_stmt.release());
+				s->Stmts().push_back(c_e_stmt);
 			}
 
 		auto c_t = c->TypeCases();
@@ -403,14 +410,7 @@ StmtPtr SwitchStmt::DoReduce(Reducer* rc)
 		c->UpdateBody(c->Body()->Reduce(rc));
 		}
 
-	// Update type cases.
-	for ( auto& i : case_label_type_list )
-		{
-		IDPtr idp = {NewRef{}, i.first};
-		i.first = rc->UpdateID(idp).release();
-		}
-
-	if ( s->Stmts().length() > 0 )
+	if ( ! s->Stmts().empty() )
 		{
 		StmtPtr me = ThisPtr();
 		auto pre_and_me = make_intrusive<StmtList>(s, me);
@@ -634,7 +634,7 @@ StmtPtr ForStmt::DoReduce(Reducer* c)
 		Warn("empty \"for\" body leaves loop variables in indeterminate state");
 
 	if ( red_e_stmt )
-		return TransformMe(make_intrusive<StmtList>(red_e_stmt, this), c);
+		return TransformMe(make_intrusive<StmtList>(red_e_stmt, ThisPtr()), c);
 
 	return ThisPtr();
 	}
@@ -677,33 +677,22 @@ StmtPtr ReturnStmt::DoReduce(Reducer* c)
 	return ThisPtr();
 	}
 
-StmtList::StmtList(StmtPtr s1, Stmt* s2) : Stmt(STMT_LIST)
-	{
-	stmts = new StmtPList;
-	if ( s1 )
-		stmts->append(s1.release());
-	if ( s2 )
-		stmts->append(s2);
-	}
-
 StmtList::StmtList(StmtPtr s1, StmtPtr s2) : Stmt(STMT_LIST)
 	{
-	stmts = new StmtPList;
 	if ( s1 )
-		stmts->append(s1.release());
+		stmts.push_back(std::move(s1));
 	if ( s2 )
-		stmts->append(s2.release());
+		stmts.push_back(std::move(s2));
 	}
 
 StmtList::StmtList(StmtPtr s1, StmtPtr s2, StmtPtr s3) : Stmt(STMT_LIST)
 	{
-	stmts = new StmtPList;
 	if ( s1 )
-		stmts->append(s1.release());
+		stmts.push_back(std::move(s1));
 	if ( s2 )
-		stmts->append(s2.release());
+		stmts.push_back(std::move(s2));
 	if ( s3 )
-		stmts->append(s3.release());
+		stmts.push_back(std::move(s3));
 	}
 
 StmtPtr StmtList::Duplicate()
@@ -711,7 +700,7 @@ StmtPtr StmtList::Duplicate()
 	auto new_sl = new StmtList();
 
 	for ( auto& stmt : Stmts() )
-		new_sl->Stmts().push_back(stmt->Duplicate().release());
+		new_sl->Stmts().push_back(stmt->Duplicate());
 
 	return SetSucc(new_sl);
 	}
@@ -724,7 +713,7 @@ void StmtList::Inline(Inliner* inl)
 
 bool StmtList::IsReduced(Reducer* c) const
 	{
-	int n = Stmts().length();
+	auto n = Stmts().size();
 
 	for ( auto i = 0; i < n; ++i )
 		{
@@ -741,10 +730,10 @@ bool StmtList::IsReduced(Reducer* c) const
 
 StmtPtr StmtList::DoReduce(Reducer* c)
 	{
-	StmtPList* f_stmts = new StmtPList{};
+	std::vector<StmtPtr> f_stmts;
 	bool did_change = false;
 
-	int n = Stmts().length();
+	auto n = Stmts().size();
 
 	for ( auto i = 0; i < n; ++i )
 		{
@@ -761,31 +750,25 @@ StmtPtr StmtList::DoReduce(Reducer* c)
 			return ThisPtr();
 		}
 
-	if ( f_stmts->length() == 0 )
-		{
-		delete f_stmts;
+	if ( f_stmts.empty() )
 		return TransformMe(make_intrusive<NullStmt>(), c);
-		}
 
-	if ( f_stmts->length() == 1 )
-		return (*f_stmts)[0]->Reduce(c);
+	if ( f_stmts.size() == 1 )
+		return f_stmts[0]->Reduce(c);
 
 	if ( did_change )
 		{
-		ResetStmts(f_stmts);
+		ResetStmts(std::move(f_stmts));
 		return Reduce(c);
 		}
-	else
-		delete f_stmts;
 
 	return ThisPtr();
 	}
 
-bool StmtList::ReduceStmt(int& s_i, StmtPList* f_stmts, Reducer* c)
+bool StmtList::ReduceStmt(int& s_i, std::vector<StmtPtr>& f_stmts, Reducer* c)
 	{
 	bool did_change = false;
-	auto stmt = Stmts()[s_i]->ThisPtr();
-
+	auto stmt = Stmts()[s_i];
 	auto old_stmt = stmt;
 
 	stmt = stmt->Reduce(c);
@@ -814,7 +797,7 @@ bool StmtList::ReduceStmt(int& s_i, StmtPList* f_stmts, Reducer* c)
 
 		if ( e->Tag() != EXPR_ASSIGN )
 			{
-			f_stmts->append(stmt.release());
+			f_stmts.push_back(std::move(stmt));
 			return false;
 			}
 
@@ -823,14 +806,14 @@ bool StmtList::ReduceStmt(int& s_i, StmtPList* f_stmts, Reducer* c)
 
 		if ( lhs->Tag() != EXPR_NAME )
 			{
-			f_stmts->append(stmt.release());
+			f_stmts.push_back(std::move(stmt));
 			return false;
 			}
 
 		auto var = lhs->AsNameExpr();
 		auto rhs = a->GetOp2();
 
-		if ( s_i < Stmts().length() - 1 )
+		if ( s_i < Stmts().size() - 1 )
 			{
 			// See if we can compress an assignment chain.
 			auto& s_i_succ = Stmts()[s_i + 1];
@@ -842,7 +825,7 @@ bool StmtList::ReduceStmt(int& s_i, StmtPList* f_stmts, Reducer* c)
 			auto merge = c->MergeStmts(var, rhs, s_i_succ);
 			if ( merge )
 				{
-				f_stmts->append(merge.release());
+				f_stmts.push_back(std::move(merge));
 
 				// Skip both this statement and the next,
 				// now that we've substituted the merge.
@@ -864,7 +847,7 @@ bool StmtList::ReduceStmt(int& s_i, StmtPList* f_stmts, Reducer* c)
 		auto sl = stmt->AsStmtList();
 
 		for ( auto& sub_stmt : sl->Stmts() )
-			f_stmts->append(sub_stmt->Ref());
+			f_stmts.push_back(sub_stmt);
 
 		did_change = true;
 		}
@@ -874,10 +857,7 @@ bool StmtList::ReduceStmt(int& s_i, StmtPList* f_stmts, Reducer* c)
 		did_change = true;
 
 	else
-		// No need to Ref() because the StmtPList destructor
-		// doesn't Unref(), only the explicit list-walking
-		// in the ~StmtList destructor.
-		f_stmts->append(stmt.release());
+		f_stmts.push_back(std::move(stmt));
 
 	return did_change;
 	}
@@ -971,7 +951,7 @@ void WhenInfo::UpdateIDs(Reducer* c)
 
 StmtPtr WhenStmt::Duplicate()
 	{
-	return SetSucc(new WhenStmt(new WhenInfo(wi)));
+	return SetSucc(new WhenStmt(wi));
 	}
 
 bool WhenStmt::IsReduced(Reducer* c) const

--- a/src/script_opt/UseDefs.cc
+++ b/src/script_opt/UseDefs.cc
@@ -197,20 +197,20 @@ UDs UseDefs::PropagateUDs(const Stmt* s, UDs succ_UDs, const Stmt* succ_stmt, bo
 			auto sl = s->AsStmtList();
 			const auto& stmts = sl->Stmts();
 
-			for ( int i = stmts.length(); --i >= 0; )
+			for ( int i = stmts.size(); --i >= 0; )
 				{
-				auto s_i = stmts[i];
+				auto s_i = stmts[i].get();
 
 				const Stmt* succ;
 
-				if ( i == stmts.length() - 1 )
+				if ( i == stmts.size() - 1 )
 					{ // Very last statement.
 					succ = succ_stmt;
 					if ( successor2.find(s) != successor2.end() )
 						successor2[s_i] = successor2[s];
 					}
 				else
-					succ = stmts[i + 1];
+					succ = stmts[i + 1].get();
 
 				succ_UDs = PropagateUDs(s_i, succ_UDs, succ, second_pass);
 				}

--- a/src/script_opt/ZAM/Low-Level.cc
+++ b/src/script_opt/ZAM/Low-Level.cc
@@ -193,7 +193,8 @@ const Stmt* ZAMCompiler::LastStmt(const Stmt* s) const
 	if ( s->Tag() == STMT_LIST )
 		{
 		auto sl = s->AsStmtList()->Stmts();
-		return sl[sl.length() - 1];
+		ASSERT(! sl.empty());
+		return sl.back().get();
 		}
 
 	else

--- a/src/script_opt/ZAM/ZInst.h
+++ b/src/script_opt/ZAM/ZInst.h
@@ -437,9 +437,8 @@ public:
 	// ... and its name.
 	std::string lambda_name;
 
-	// For "when" statements.  Needs to be non-const so we can
-	// Instantiate() it as needed.
-	WhenInfo* wi;
+	// For "when" statements.
+	std::shared_ptr<WhenInfo> wi;
 
 	// A parallel array for the cat() built-in replacement.
 	std::unique_ptr<CatArg>* cat_args = nullptr;


### PR DESCRIPTION
This PR gets rid of old-style `StmtPList`s and replaces them with `std::vector<StmtPtr>`.  It also upgrades uses of `WhenInfo` pointers to `std::shared_ptr<WhenInfo>`. Both of these changes are laying groundwork for a much more involved set of changes aimed at reducing the memory footprint of ZAM-compiled scripts (which currently is quite high due to vestigial ASTs that could in fact be discarded ... if things are memory safe). (FYI, in the process of developing the latter I ran across some significant ZAM problems, so PRs for fixing those will likely come first.)