### PR TITLE
allow signature actions to be dynamically updated

### DIFF
--- a/scripts/base/frameworks/signatures/main.zeek
+++ b/scripts/base/frameworks/signatures/main.zeek
@@ -101,8 +101,8 @@ export {
 		host_count: count        &log &optional;
 	};
 
-	## Actions for a signature.
-	const actions: table[string] of Action =  {
+	## Actions for a signature.  Can be updated dynamically.
+	global actions: table[string] of Action =  {
 		["unspecified"] = SIG_IGNORE, # place-holder
 	} &redef &default = SIG_ALARM;
 


### PR DESCRIPTION
This very simple PR just tweaks `Signatures::actions` to be `global` rather than `const`, enabling dynamic updates. The use-case is a `zeek_init()` handler that spins through a set of signature names and adds them to `actions`; later, a `signature_match()` handler will check whether `state$sig_id` is in that same set in order to know that it's seeing one of the signatures it's focused on. Without this PR's change, there need to be two separate definitions, one to create the set and another to adjust `actions` for the set (for example, to `SIG_IGNORE`, because the new `signature_match() handler will take care of all of the processing for them).