### PR TITLE
Print type of opaque instead of 'no value description'

### DIFF
--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -158,6 +158,16 @@ ValPtr OpaqueVal::DoClone(CloneState* state)
 	return state->NewClone(this, std::move(rval));
 	}
 
+void OpaqueVal::ValDescribe(ODesc* d) const
+	{
+	d->Add(util::fmt("<opaque of %s>", OpaqueName()));
+	}
+
+void OpaqueVal::ValDescribeReST(ODesc* d) const
+	{
+	d->Add(util::fmt("<opaque of %s>", OpaqueName()));
+	}
+
 bool HashVal::IsValid() const
 	{
 	return valid;

--- a/src/OpaqueVal.h
+++ b/src/OpaqueVal.h
@@ -182,6 +182,9 @@ protected:
 	 * during unserialization. Returns the type at reference count +1.
 	 */
 	static TypePtr UnserializeType(const broker::data& data);
+
+	void ValDescribe(ODesc* d) const override;
+	void ValDescribeReST(ODesc* d) const override;
 	};
 
 class HashVal : public OpaqueVal


### PR DESCRIPTION
This came up while tinkering with a paraglob test related to #3196. When printing opaques from script land, you get a not-very-useful `<no value description>` output. This PR fixes that to print that it's an opaque, and what's contained inside:

```
% cat opaque.zeek
local test: opaque of topk = topk_init(4);
print(test);
% ./src/zeek opaque.zeek
<opaque of TopkVal>
```