### PR TITLE
-O gen-C++ generated code cleanup

### DIFF
--- a/ci/alpine/Dockerfile
+++ b/ci/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230113
+ENV DOCKERFILE_VERSION 20230725
 
 RUN apk add --no-cache \
   bash \

--- a/ci/debian-11/Dockerfile
+++ b/ci/debian-11/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20220725
 
 RUN apt-get update && apt-get -y install \
     bison \

--- a/src/script_opt/CPP/DeclFunc.cc
+++ b/src/script_opt/CPP/DeclFunc.cc
@@ -133,7 +133,7 @@ void CPPCompile::DeclareSubclass(const FuncTypePtr& ft, const ProfileFunc* pf, c
 			auto tn = FullTypeName(id->GetType());
 			addl_args = addl_args + ", " + tn + " _" + name;
 
-			inits = inits + ", " + name + "(_" + name + ")";
+			inits = inits + ", " + name + "(std::move(_" + name + "))";
 			}
 		}
 

--- a/src/script_opt/CPP/DeclFunc.cc
+++ b/src/script_opt/CPP/DeclFunc.cc
@@ -117,7 +117,7 @@ void CPPCompile::DeclareSubclass(const FuncTypePtr& ft, const ProfileFunc* pf, c
 	NL();
 	Emit("static %s %s(%s);", yt_decl, fname, ParamDecl(ft, lambda_ids, pf));
 
-	Emit("class %s_cl : public CPPStmt", fname);
+	Emit("class %s_cl final : public CPPStmt", fname);
 	StartBlock();
 
 	Emit("public:");
@@ -151,7 +151,7 @@ void CPPCompile::DeclareSubclass(const FuncTypePtr& ft, const ProfileFunc* pf, c
 	if ( lambda_ids && lambda_ids->length() > 0 )
 		Emit("%s_cl(const char* name) : CPPStmt(name, %s) { }", fname, loc_info);
 
-	Emit("ValPtr Exec(Frame* f, StmtFlowType& flow) override final");
+	Emit("ValPtr Exec(Frame* f, StmtFlowType& flow) override");
 	StartBlock();
 
 	Emit("flow = FLOW_RETURN;");
@@ -182,13 +182,13 @@ void CPPCompile::DeclareDynCPPStmt()
 	Emit("// dispatch.  All of this is ugly, and only needed because clang");
 	Emit("// goes nuts (super slow) in the face of thousands of templates");
 	Emit("// in a given context (initializers, or a function body).");
-	Emit("class CPPDynStmt : public CPPStmt");
+	Emit("class CPPDynStmt final : public CPPStmt");
 	Emit("\t{");
 	Emit("public:");
 	Emit("\tCPPDynStmt(const char* _name, void* _func, int _type_signature, const char* filename, "
 	     "int line_num) : CPPStmt(_name, filename, line_num), "
 	     "func(_func), type_signature(_type_signature) { }");
-	Emit("\tValPtr Exec(Frame* f, StmtFlowType& flow) override final;");
+	Emit("\tValPtr Exec(Frame* f, StmtFlowType& flow) override;");
 	Emit("private:");
 	Emit("\t// The function to call in Exec().");
 	Emit("\tvoid* func;");

--- a/src/script_opt/CPP/Inits.cc
+++ b/src/script_opt/CPP/Inits.cc
@@ -44,7 +44,7 @@ void CPPCompile::GenInitExpr(std::shared_ptr<CallExprInitInfo> ce_init)
 
 	// Create the Func subclass that can be used in a CallExpr to
 	// evaluate 'e'.
-	Emit("class %s : public CPPFunc", wc);
+	Emit("class %s final : public CPPFunc", wc);
 	StartBlock();
 
 	Emit("public:");
@@ -57,7 +57,7 @@ void CPPCompile::GenInitExpr(std::shared_ptr<CallExprInitInfo> ce_init)
 
 	EndBlock();
 
-	Emit("ValPtr Invoke(zeek::Args* args, Frame* parent) const override final");
+	Emit("ValPtr Invoke(zeek::Args* args, Frame* parent) const override");
 	StartBlock();
 
 	if ( IsNativeType(t) )

--- a/src/script_opt/CPP/maint/check-CPP-gen.sh
+++ b/src/script_opt/CPP/maint/check-CPP-gen.sh
@@ -6,7 +6,7 @@ gen_out=CPP-test/gen.$abbr
 
 (
     /bin/echo -n $1" "
-    if ! src/zeek -O gen-C++ --optimize-files=testing/btest $1 >&$gen_out 2>&1; then
+    if ! src/zeek -O gen-C++ --optimize-files=testing/btest $1 >$gen_out 2>&1; then
         echo "fail"
         exit 1
     fi

--- a/src/script_opt/CPP/maint/check-zeek.sh
+++ b/src/script_opt/CPP/maint/check-zeek.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 /bin/echo -n $1" "
-(src/zeek --parse-only $1 >&/dev/null && echo "success") || echo "fail"
+(src/zeek --parse-only $1 >/dev/null 2>&1 && echo "success") || echo "fail"

--- a/src/script_opt/CPP/maint/do-CPP-btest.sh
+++ b/src/script_opt/CPP/maint/do-CPP-btest.sh
@@ -7,10 +7,10 @@ cp zeek.HOLD src/zeek || (
     exit 1
 ) || exit 1
 
-if [ "$1" == "-U" ]; then
+if [ "$1" = "-U" ]; then
     btest_opt=-U
     shift
-elif [ "$1" == "-d" ]; then
+elif [ "$1" = "-d" ]; then
     btest_opt=-d
     shift
 else
@@ -32,7 +32,7 @@ export ZEEK_OPT_FILES="testing/btest"
 )
 
 # export -n ZEEK_GEN_CPP ZEEK_CPP_DIR ZEEK_OPT_FUNCS ZEEK_OPT_FILES
-export -n ZEEK_GEN_CPP ZEEK_REPORT_UNCOMPILABLE ZEEK_CPP_DIR ZEEK_OPT_FILES
+unset ZEEK_GEN_CPP ZEEK_REPORT_UNCOMPILABLE ZEEK_CPP_DIR ZEEK_OPT_FILES
 
 ninja
 

--- a/src/script_opt/CPP/maint/find-test-files.sh
+++ b/src/script_opt/CPP/maint/find-test-files.sh
@@ -5,6 +5,6 @@ find ../testing/btest -type f |
     grep -E '\.(zeek|test)$' |
     sort |
     xargs grep -E -l '^[ 	]*(event|print)' |
-    xargs grep -E -lc 'REQUIRES.*CPP.*((!=.*1)|(==.*0))' |
+    xargs grep -E -c 'REQUIRES.*CPP.*((!=.*1)|(==.*0))' |
     grep ':0$' |
     sed 's,:0,,'


### PR DESCRIPTION
This is a couple fixes for the code generated by `-O gen-C++`:

- Remove all uses of `override final` (which was slightly incorrect anyways) and mark all derived classes as `final` instead.
- Use `std::move` in constructors instead of copying everything, since all arguments are passed by value. This may result in a few unnecessary moves of primitive types, but those cases are minor overall.

It also fixes some issues with the maintenance scripts that were causing them to fail on Linux.