### PR TITLE
fix for installing identifiers for lambdas into the global scope

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -4674,7 +4674,7 @@ LambdaExpr::LambdaExpr(FunctionIngredientsPtr arg_ing, IDPList arg_outer_ids, st
 		my_name = name;
 
 	// Install that in the global_scope
-	lambda_id = install_ID(my_name.c_str(), current_module.c_str(), true, false);
+	lambda_id = install_ID(my_name.c_str(), "", true, false);
 
 	// Update lamb's name
 	primary_func->SetName(my_name.c_str());


### PR DESCRIPTION
While the `LambdaExpr` is documented to put the associated identifier in the global scope, it actually has been putting them into the current scope. Doing so complicates things for the compile-to-C++ script compiler. This tweak puts them back in the global scope. 