### PR TITLE
Fix memory leak in script_opt's Expr code

### DIFF
--- a/src/script_opt/Expr.cc
+++ b/src/script_opt/Expr.cc
@@ -1909,7 +1909,7 @@ ExprPtr IndexExprWhen::Duplicate()
 
 ExprPtr FieldExpr::Duplicate()
 	{
-	return SetSucc(new FieldExpr(op->Duplicate(), util::copy_string(field_name)));
+	return SetSucc(new FieldExpr(op->Duplicate(), field_name));
 	}
 
 ExprPtr HasFieldExpr::Duplicate()


### PR DESCRIPTION
The `FieldExpr` constructor calls `util::copy_string` itself, and so the copied string passed in here is copied a second time and never deleted.

Fixes Coverity finding 1518154.