### PR TITLE
Force refresh of all CI docker images

### DIFF
--- a/ci/alpine/Dockerfile
+++ b/ci/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230725
+ENV DOCKERFILE_VERSION 20230801
 
 RUN apk add --no-cache \
   bash \

--- a/ci/centos-7/Dockerfile
+++ b/ci/centos-7/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230312
+ENV DOCKERFILE_VERSION 20230801
 
 ENV FLEX_VERSION=2.6.4
 ENV FLEX_DIR=/opt/flex

--- a/ci/centos-stream-8/Dockerfile
+++ b/ci/centos-stream-8/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream8
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230320
+ENV DOCKERFILE_VERSION 20230801
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 RUN dnf config-manager --set-enabled powertools

--- a/ci/centos-stream-9/Dockerfile
+++ b/ci/centos-stream-9/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream9
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20230801
 
 # dnf config-manager isn't available at first, and
 # we need it to install the CRB repo below.

--- a/ci/debian-10/Dockerfile
+++ b/ci/debian-10/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20230801
 
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"

--- a/ci/debian-11/Dockerfile
+++ b/ci/debian-11/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220725
+ENV DOCKERFILE_VERSION 20230801
 
 RUN apt-get update && apt-get -y install \
     bison \

--- a/ci/debian-12/Dockerfile
+++ b/ci/debian-12/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230413
+ENV DOCKERFILE_VERSION 20230801
 
 RUN apt-get update && apt-get -y install \
     bison \

--- a/ci/fedora-37/Dockerfile
+++ b/ci/fedora-37/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:37
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230413
+ENV DOCKERFILE_VERSION 20230801
 
 RUN dnf -y install \
     bison \

--- a/ci/fedora-38/Dockerfile
+++ b/ci/fedora-38/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:38
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230428
+ENV DOCKERFILE_VERSION 20230801
 
 RUN dnf -y install \
     bison \

--- a/ci/opensuse-leap-15.4/Dockerfile
+++ b/ci/opensuse-leap-15.4/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/leap:15.4
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220615
+ENV DOCKERFILE_VERSION 20230801
 
 RUN zypper addrepo https://download.opensuse.org/repositories/openSUSE:Leap:15.4:Update/standard/openSUSE:Leap:15.4:Update.repo \
  && zypper refresh \

--- a/ci/opensuse-tumbleweed/Dockerfile
+++ b/ci/opensuse-tumbleweed/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/tumbleweed
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230620
+ENV DOCKERFILE_VERSION 20230801
 
 # Remove the repo-openh264 repository, it caused intermittent issues
 # and we should not be needing any packages from it.

--- a/ci/ubuntu-18.04/Dockerfile
+++ b/ci/ubuntu-18.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20230801
 
 ENV CMAKE_DIR "/opt/cmake"
 ENV CMAKE_VERSION "3.19.1"

--- a/ci/ubuntu-20.04/Dockerfile
+++ b/ci/ubuntu-20.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220519
+ENV DOCKERFILE_VERSION 20230801
 
 RUN apt-get update && apt-get -y install \
     bc \

--- a/ci/ubuntu-22.04/Dockerfile
+++ b/ci/ubuntu-22.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20220614
+ENV DOCKERFILE_VERSION 20230801
 
 RUN apt-get update && apt-get -y install \
     bc \

--- a/ci/ubuntu-22.10/Dockerfile
+++ b/ci/ubuntu-22.10/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230711
+ENV DOCKERFILE_VERSION 20230801
 
 RUN apt-get update && apt-get -y install \
     bc \

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -5,7 +5,7 @@ SHELL [ "powershell" ]
 
 # A version field to invalidatea Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230728
+ENV DOCKERFILE_VERSION 20230801
 
 RUN Set-ExecutionPolicy Unrestricted -Force
 


### PR DESCRIPTION
There's something going on with the image cache on Cirrus where the images are sometimes vanishing from the cache, thus causing builds to fail because it can't load them. This forces a rebuild of all of the images, thus refreshing the cached version of all of them.

We've been seeing this on images one a time, so hopefully refreshing all of them at once will put off having to do it again for a while.