### PR TITLE
Upgrade ThreadSanitizer CI build to Ubuntu 22.04

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -390,7 +390,7 @@ ubsan_sanitizer_task:
 tsan_sanitizer_task:
   container:
     # Just uses a recent/common distro to run memory error/leak checks.
-    dockerfile: ci/ubuntu-20.04/Dockerfile
+    dockerfile: ci/ubuntu-22.04/Dockerfile
     << : *SANITIZERS_RESOURCE_TEMPLATE
 
   << : *CI_TEMPLATE

--- a/ci/tsan_suppressions.txt
+++ b/ci/tsan_suppressions.txt
@@ -17,6 +17,7 @@ race:std::ctype<char>::narrow
 race:broker::internal::connector::run_impl
 race:caf::net::multiplexer::set_thread_id
 race:caf::action::run
+mutex:caf::detail::ringbuffer<std::unique_ptr<caf::detail::thread_safe_actor_clock::schedule_entry, std::default_delete<caf::detail::thread_safe_actor_clock::schedule_entry> >, 64ul>::push_back
 
 # This one causes supervisor.config-bare-mode to fail occasionally but not always
 signal:caf::actor_control_block::enqueue
@@ -32,3 +33,12 @@ race:sqlite3_initialize
 # This one isn't actually in sqlite code, but some StringVal object gets ref'd by
 # zeek::id::find_const and throws a data race.
 race:zeek::logging::writer::detail::SQLite::DoInit
+
+# These findings were suppressed after the CI build was upgraded to Ubuntu 22.04.
+# They weren't reported by prior compiler versions.
+race:zeek::threading::MsgThread::RetrieveIn
+race:zeek::threading::MsgThread::Run
+race:zeek::threading::InputMessage<zeek::threading::MsgThread>::Object
+mutex:zeek::threading::Queue<zeek::threading::BasicInputMessage*>::Put
+mutex:zeek::threading::Queue<zeek::threading::BasicInputMessage*>::LocksForAllQueues
+deadlock:zeek::threading::Queue<zeek::threading::BasicInputMessage*>::LocksForAllQueues


### PR DESCRIPTION
This fixes the current build failure on CI with 20.04 after the Dockerfile upgrade in https://github.com/zeek/zeek/pull/3210. This also includes some new suppressions for new findings reported after the compiler upgrade. I opted to add the suppressions since we already have some there. They need to be investigated as part of https://github.com/zeek/zeek/issues/2749.