### PR TITLE
ci: Bump centos-7

### DIFF
--- a/ci/centos-7/Dockerfile
+++ b/ci/centos-7/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230801
+ENV DOCKERFILE_VERSION 20230807
 
 ENV FLEX_VERSION=2.6.4
 ENV FLEX_DIR=/opt/flex


### PR DESCRIPTION
Failing currently with:

    Failed to start an instance! Failed to pull null image! Repository does not exist or may require authentication.
    Container errored with 'ImagePullBackOff: Back-off pulling image "gcr.io/cirrus-ci-community/zeek/zeek/ci/centos-7/dockerfile:a0c25357a3a7dc08f6c1e61e6f81ad36"'