### PR TITLE
Modbus: Add early return in case of data being too short to parse

### DIFF
--- a/src/analyzer/protocol/modbus/modbus-analyzer.pac
+++ b/src/analyzer/protocol/modbus/modbus-analyzer.pac
@@ -370,6 +370,7 @@ refine flow ModbusTCP_Flow += {
 				{
 				zeek::reporter->Weird("modbus_diag_invalid_request_data",
 				                      zeek::util::fmt("%s", data->CheckString()));
+				return false;
 				}
 
 			switch (${message.subfunction})


### PR DESCRIPTION
This was a miss in https://github.com/zeek/zeek/pull/3204. If the data is too small to be parsed we need to exit early or else later parsing will crash. It still emits a weird in that case though. This could be moved down into the individual case blocks, but it'd just be repeating the code.