### PR TITLE
Force pre-commit to use python 3.9

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,4 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
     - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,10 @@ repos:
   rev: 3.3.1.8
   hooks:
     - id: shfmt
+      # We force python3.9 since as of its current version `shfmt-py` has a
+      # `setup.cfg` not conforming to PEP639 (`license_file` instead of
+      # `license_files`) which triggers a warning with newer Python versions.
+      language_version: "3.9"
       args: ["-w", "-i", "4", "-ci"]
 
 - repo: https://github.com/pre-commit/mirrors-yapf


### PR DESCRIPTION
This fixes the errors with shfmt-py and python 3.10. It's not a permanent fix, but it works for now until shfmt-py updates.