### PR TITLE
Forward declare openssl structure instead of including header

### DIFF
--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/zeek-config.h"
 
+#include <openssl/evp.h>
+
 #include "zeek/Base64.h"
 #include "zeek/NetVar.h"
 #include "zeek/Reporter.h"

--- a/src/analyzer/protocol/mime/MIME.h
+++ b/src/analyzer/protocol/mime/MIME.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <openssl/evp.h>
 #include <cassert>
 #include <cstdio>
 #include <queue>
@@ -9,6 +8,9 @@
 #include "zeek/Reporter.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/Analyzer.h"
+
+struct evp_md_ctx_st;
+typedef evp_md_ctx_st EVP_MD_CTX;
 
 namespace zeek
 	{


### PR DESCRIPTION
@vpax had this come up while trying to build an external plugin that doesn't depend on openssl. It included `MIME.h` but didn't have the include path in the compilation for openssl, so it failed to find the openssl header required. This PR changes MIME.h to forward declare the required openssl structure and moves the actual include to the .cc file instead.