### PR TITLE
File: Drop krb5.h include

### DIFF
--- a/cmake_templates/zeek-config.h.in
+++ b/cmake_templates/zeek-config.h.in
@@ -80,9 +80,6 @@
 /* Define if you have the <sys/ethernet.h> header file. */
 #cmakedefine HAVE_SYS_ETHERNET_H
 
-/* Include krb5.h */
-#cmakedefine NEED_KRB5_H
-
 /* Compatibility for Darwin */
 #cmakedefine NEED_NAMESER_COMPAT_H
 

--- a/src/File.h
+++ b/src/File.h
@@ -7,10 +7,6 @@
 #include <string>
 #include <utility>
 
-#ifdef NEED_KRB5_H
-#include <krb5.h>
-#endif // NEED_KRB5_H
-
 #include "zeek/Val.h"
 #include "zeek/util.h"
 


### PR DESCRIPTION
It looks as if krb5.h was only ever needed together with OpenSSL, then
OpenSSL includes were removed, but the krb5.h ones stayed around.

References:
https://github.com/zeek/zeek/commit/610d081c4bd882830541b5b748803f60698ca021
https://github.com/zeek/zeek/commit/d7c10ca7c36ff5446bee4a623bcb1020e19482b8


Cmake submodule:
https://github.com/zeek/cmake/pull/91