### PR TITLE
Forward OpenSSL include path to plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,10 @@ target_include_directories(
     zeek_dynamic_plugin_base
     INTERFACE $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
               $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
+if (OPENSSL_INCLUDE_DIR)
+    target_include_directories(zeek_dynamic_plugin_base INTERFACE "${OPENSSL_INCLUDE_DIR}")
+endif ()
+target_link_libraries(zeek_dynamic_plugin_base INTERFACE Threads::Threads)
 add_library(Zeek::DynamicPluginBase ALIAS zeek_dynamic_plugin_base)
 set_target_properties(zeek_dynamic_plugin_base PROPERTIES EXPORT_NAME DynamicPluginBase)
 install(TARGETS zeek_dynamic_plugin_base EXPORT ZeekTargets)
@@ -750,7 +754,7 @@ endif ()
 
 # Forward user-defined hint for OpenSSL to the plugins. Use a cache variable to
 # make sure this variable survives CMake re-runs. Note: This variable is picked
-# up in ZeekPluginConfig.cmake.in.
+# up in ZeekPluginConfig.cmake.in and ZeekConfig.cmake.in.
 if (OPENSSL_ROOT_DIR)
     set(ZeekOpenSSLHint "${OPENSSL_ROOT_DIR}" CACHE INTERNAL "" FORCE)
 elseif (DEFINED ENV{OPENSSL_ROOT_DIR})

--- a/src/ZeekConfig.cmake.in
+++ b/src/ZeekConfig.cmake.in
@@ -12,6 +12,12 @@ set(CMAKE_THREAD_PREFER_PTHREAD ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_dependency(Threads REQUIRED)
 
+# Find OpenSSL and Forward hints from Zeek's build config.
+set(ZeekOpenSSLHint "@ZeekOpenSSLHint@")
+if (ZeekOpenSSLHint AND NOT OPENSSL_ROOT_DIR)
+    set(OPENSSL_ROOT_DIR "${ZeekOpenSSLHint}" CACHE
+        PATH "Directory hint for finding OpenSSL" FORCE)
+endif ()
 find_dependency(OpenSSL REQUIRED)
 
 # In our MSVC build, we have these extra dependencies from Conan.


### PR DESCRIPTION
Addresses the regression from #3247 for plugins that need to find the OpenSSL headers. We probably also need to forward a couple more (like pcap), but I'll file a followup for those.