### PR TITLE
DNS_Mgr: Fixes around timeouts and IO loop behavior

### DIFF
--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -1471,6 +1471,15 @@ void DNS_Mgr::ProcessFd(int fd, int flags)
 	IssueAsyncRequests();
 	}
 
+void DNS_Mgr::Process()
+	{
+	// Process() is called when DNS_Mgr is found "ready" when its
+	// GetNextTimeout() returns 0.0, but there's no active FD.
+	//
+	// Kick off timeouts at least.
+	ares_process_fd(channel, ARES_SOCKET_BAD, ARES_SOCKET_BAD);
+	}
+
 void DNS_Mgr::GetStats(Stats* stats)
 	{
 	// TODO: can this use the telemetry framework?

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -1456,8 +1456,7 @@ double DNS_Mgr::GetNextTimeout()
 
 	struct timeval* tvp = ares_timeout(channel, &tv, &tv);
 
-	return run_state::network_time + static_cast<double>(tvp->tv_sec) +
-	       (static_cast<double>(tvp->tv_usec) / 1e6);
+	return static_cast<double>(tvp->tv_sec) + (static_cast<double>(tvp->tv_usec) / 1e6);
 	}
 
 void DNS_Mgr::ProcessFd(int fd, int flags)

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -285,7 +285,7 @@ protected:
 	void IssueAsyncRequests();
 
 	// IOSource interface.
-	void Process() override { }
+	void Process() override;
 	void ProcessFd(int fd, int flags) override;
 	void InitSource() override;
 	const char* Tag() override { return "DNS_Mgr"; }


### PR DESCRIPTION
On Slack we were discussing below reproducer causing memory growth due to un-fulfilled when statements related to DNS_Mgr, lookup_addr(), ...

The two commits in this PR fix the state growth.

The most problematic scenario is triggered when 20 (MAX_PENDING_REQUESTS) DNS requests are pending, but none of them is ever responded to (so there's no FD activity in the future). Due to essentially non-existing timeout functionality, this would cause any future `lookup_addr()` calls to never be resolved.

@timwoj , I think this is 6.0.1 material, minimally 6.0.2 if that ship has sailed. Unfortunately I'm uncertain how this is best tested automatically without putting in much effort.

---

> Think I have a better one because possibly a bit more real (DNS server restarting) - seems there's more going on.
> * Replace 192.168.0.1 above with 10.0.0.1, this results in NXdomain responses every 5 seconds on my system. In-between the cache is used. No memory growth.
> Stop local resolver: systemctl stop systemd-resolved
> Wait until cache timeout expires, observe memory growth even after 5 second DNS timeout should kick in.
> Restart resolver: Expect memory growth to stop because DNS is available again. It doesn't recover and memory keeps growing.

Sketch of script for reproduction:
```
redef exit_only_after_terminate=T;

global s = F;

global x: table[addr] of string;

event stats_tick() {
        local stats = get_proc_stats();
        print "stats", network_time(), stats$mem, get_dns_stats();
        schedule 1sec { stats_tick() };  # default DNS timeout
}

function f(a: addr) {
        when [a] ( local name = lookup_addr(a) )
                {
                x[a] = cat_sep(" ", "", network_time(), a, name);
                }
}

event tick() {
        f(10.0.0.1);
        schedule 10msec { tick() };
}

event zeek_init()
        {
        event tick();
        event stats_tick();
        }
```

