### PR TITLE
Extend the timeouts on some of the supervisor btests

### DIFF
--- a/testing/btest/scripts/policy/frameworks/management/controller/agent-checkin.zeek
+++ b/testing/btest/scripts/policy/frameworks/management/controller/agent-checkin.zeek
@@ -8,7 +8,7 @@
 # @TEST-PORT: BROKER_PORT
 
 # @TEST-EXEC: ZEEK_MANAGEMENT_TESTING=1 btest-bg-run zeek zeek -j %INPUT
-# @TEST-EXEC: btest-bg-wait 10
+# @TEST-EXEC: btest-bg-wait 30
 # @TEST-EXEC: btest-diff zeek/nodes/controller/stdout
 
 @load policy/frameworks/management/agent

--- a/testing/btest/supervisor/config-cluster-log-archival.zeek
+++ b/testing/btest/supervisor/config-cluster-log-archival.zeek
@@ -4,21 +4,21 @@
 
 # Test default log rotation/archival behavior (rotate into log-queue dir)
 # @TEST-EXEC: btest-bg-run zeek zeek -j -b %INPUT
-# @TEST-EXEC: btest-bg-wait 45
+# @TEST-EXEC: btest-bg-wait 60
 # @TEST-EXEC: cp zeek/logger-1/log-queue/test*.log test.default.log
 # @TEST-EXEC: btest-diff test.default.log
 # @TEST-EXEC: rm -rf ./zeek
 
 # Test rotation/archival behavior with in-flight compression
 # @TEST-EXEC: btest-bg-run zeek zeek -j -b LogAscii::gzip_level=1 %INPUT
-# @TEST-EXEC: btest-bg-wait 45
+# @TEST-EXEC: btest-bg-wait 60
 # @TEST-EXEC: gunzip -c zeek/logger-1/log-queue/test*.log.gz > test.zip-in-flight.log
 # @TEST-EXEC: btest-diff test.zip-in-flight.log
 # @TEST-EXEC: rm -rf ./zeek
 
 # Test rotation/archival behavior with in-flight compression + custom file extension
 # @TEST-EXEC: btest-bg-run zeek zeek -j -b LogAscii::gzip_level=1 LogAscii::gzip_file_extension="mygz" %INPUT
-# @TEST-EXEC: btest-bg-wait 45
+# @TEST-EXEC: btest-bg-wait 60
 # @TEST-EXEC: cp zeek/logger-1/log-queue/test*.log.mygz test.log.gz
 # @TEST-EXEC: gunzip -c test.log.gz > test.zip-in-flight-custom-ext.log
 # @TEST-EXEC: btest-diff test.zip-in-flight-custom-ext.log
@@ -26,7 +26,7 @@
 
 # Test rotation/archival behavior with a custom rotation dir
 # @TEST-EXEC: btest-bg-run zeek zeek -j -b %INPUT Log::default_rotation_dir=my-logs
-# @TEST-EXEC: btest-bg-wait 45
+# @TEST-EXEC: btest-bg-wait 60
 # @TEST-EXEC: cp zeek/logger-1/my-logs/test*.log test.custom-dir.log
 # @TEST-EXEC: btest-diff test.custom-dir.log
 # @TEST-EXEC: rm -rf ./zeek

--- a/testing/btest/supervisor/config-output-redirect.zeek
+++ b/testing/btest/supervisor/config-output-redirect.zeek
@@ -1,6 +1,6 @@
 # @TEST-PORT: BROKER_PORT
 # @TEST-EXEC: btest-bg-run zeek zeek -j -b %INPUT
-# @TEST-EXEC: btest-bg-wait 30
+# @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff zeek/supervisor.out
 # @TEST-EXEC: btest-diff zeek/qux/grault.stdout
 # @TEST-EXEC: btest-diff zeek/qux/grault.stderr

--- a/testing/btest/supervisor/output-redirect-hook.zeek
+++ b/testing/btest/supervisor/output-redirect-hook.zeek
@@ -1,6 +1,6 @@
 # @TEST-PORT: BROKER_PORT
 # @TEST-EXEC: btest-bg-run zeek zeek -j -b %INPUT
-# @TEST-EXEC: btest-bg-wait 30
+# @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff zeek/supervisor.out
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-sort btest-diff zeek/.stdout
 # @TEST-EXEC: TEST_DIFF_CANONIFIER="$SCRIPTS/diff-sort | grep -v 'while waiting for thread'" btest-diff zeek/.stderr

--- a/testing/btest/supervisor/output-redirect.zeek
+++ b/testing/btest/supervisor/output-redirect.zeek
@@ -1,6 +1,6 @@
 # @TEST-PORT: BROKER_PORT
 # @TEST-EXEC: btest-bg-run zeek zeek -j -b %INPUT
-# @TEST-EXEC: btest-bg-wait 30
+# @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff zeek/supervisor.out
 # @TEST-EXEC: btest-diff zeek/.stdout
 # @TEST-EXEC: TEST_DIFF_CANONIFIER="$SCRIPTS/diff-sort | grep -v 'while waiting for thread'" btest-diff zeek/.stderr


### PR DESCRIPTION
This fixes testing failures on Cirrus, where for some reason the timeouts are being hit and the tests are failing because zeek is being killed early. This shouldn't affect local test runs.