### PR TITLE
Move allocation of analyzer_hash to file_mgr

### DIFF
--- a/src/file_analysis/AnalyzerSet.cc
+++ b/src/file_analysis/AnalyzerSet.cc
@@ -22,10 +22,6 @@ static void analyzer_del_func(void* v)
 
 AnalyzerSet::AnalyzerSet(File* arg_file) : file(arg_file)
 	{
-	auto t = make_intrusive<TypeList>();
-	t->Append(file_mgr->GetTagType());
-	t->Append(BifType::Record::Files::AnalyzerArgs);
-	analyzer_hash = new zeek::detail::CompositeHash(std::move(t));
 	analyzer_map.SetDeleteFunc(analyzer_del_func);
 	}
 
@@ -38,8 +34,6 @@ AnalyzerSet::~AnalyzerSet()
 		delete mod;
 		mod_queue.pop();
 		}
-
-	delete analyzer_hash;
 	}
 
 Analyzer* AnalyzerSet::Find(const zeek::Tag& tag, RecordValPtr args)
@@ -153,7 +147,7 @@ std::unique_ptr<zeek::detail::HashKey> AnalyzerSet::GetKey(const zeek::Tag& t,
 	auto lv = make_intrusive<ListVal>(TYPE_ANY);
 	lv->Append(t.AsVal());
 	lv->Append(std::move(args));
-	auto key = analyzer_hash->MakeHashKey(*lv, true);
+	auto key = file_mgr->GetAnalyzerHash()->MakeHashKey(*lv, true);
 
 	if ( ! key )
 		reporter->InternalError("AnalyzerArgs type mismatch");

--- a/src/file_analysis/AnalyzerSet.h
+++ b/src/file_analysis/AnalyzerSet.h
@@ -14,11 +14,6 @@ namespace zeek
 class RecordVal;
 using RecordValPtr = IntrusivePtr<RecordVal>;
 
-namespace detail
-	{
-class CompositeHash;
-	}
-
 namespace file_analysis
 	{
 
@@ -143,7 +138,6 @@ protected:
 
 private:
 	File* file; /**< File which owns the set */
-	zeek::detail::CompositeHash* analyzer_hash; /**< AnalyzerArgs hashes. */
 	PDict<file_analysis::Analyzer> analyzer_map; /**< Indexed by AnalyzerArgs. */
 
 	/**

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -4,6 +4,7 @@
 
 #include <openssl/md5.h>
 
+#include "zeek/CompHash.h"
 #include "zeek/Event.h"
 #include "zeek/UID.h"
 #include "zeek/analyzer/Manager.h"
@@ -35,11 +36,18 @@ Manager::~Manager()
 		delete entry.second;
 
 	delete magic_state;
+	delete analyzer_hash;
 	}
 
 void Manager::InitPreScript() { }
 
-void Manager::InitPostScript() { }
+void Manager::InitPostScript()
+	{
+	auto t = make_intrusive<TypeList>();
+	t->Append(GetTagType());
+	t->Append(BifType::Record::Files::AnalyzerArgs);
+	analyzer_hash = new zeek::detail::CompositeHash(std::move(t));
+	}
 
 void Manager::InitMagic()
 	{

--- a/src/file_analysis/Manager.h
+++ b/src/file_analysis/Manager.h
@@ -32,6 +32,11 @@ class Analyzer;
 
 	} // namespace analyzer
 
+namespace detail
+	{
+class CompositeHash;
+	}
+
 namespace file_analysis
 	{
 
@@ -361,6 +366,8 @@ public:
 
 	uint64_t CumulativeFiles() { return cumulative_files; }
 
+	zeek::detail::CompositeHash* GetAnalyzerHash() const { return analyzer_hash; }
+
 protected:
 	friend class detail::FileTimer;
 
@@ -442,6 +449,8 @@ private:
 
 	size_t cumulative_files;
 	size_t max_files;
+
+	zeek::detail::CompositeHash* analyzer_hash = nullptr;
 	};
 
 /**


### PR DESCRIPTION
This avoids recreating this CompositeHash object every time a new AnalyzerSet is created. Since the object the hash is based on doesn't change, there's no reason to recreate it for each new file. For reference, the 2009-M57-day11-18.trace file creates 4738 new analyzer sets.