### PR TITLE
Avoid assertion/tag error on invalid table constructor index expression

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -3605,8 +3605,14 @@ TableConstructorExpr::TableConstructorExpr(ListExprPtr constructor_list,
 		auto val_expr = expr->AsAssignExpr()->GetOp2();
 		auto yield_type = GetType()->AsTableType()->Yield();
 
+		if ( idx_expr->Tag() != EXPR_LIST )
+			{
+			expr->Error("table constructor index is not a list");
+			SetError();
+			return;
+			}
+
 		// Promote LHS
-		assert(idx_expr->Tag() == EXPR_LIST);
 		ExprPList& idx_exprs = idx_expr->AsListExpr()->Exprs();
 
 		if ( idx_exprs.length() != static_cast<int>(indices.size()) )


### PR DESCRIPTION
If an index expression in a table constructor isn't a list, don't abort with an assertion failure (on debug builds) or a bad tag check. Instead, mark the constructor expression erroneous and return gracefully. The following...

```
global a_table: table[subnet] of string = {
        1.2.3.4/24 = "unspecified",    # should have been [1.2.3.4/24] = "unspecified",
};
```
...now yields:
```
$ zeek ./test.zeek
error in ././test.zeek, line 2: table constructor index is not a list (1.2.3.0/24 = unspecified)
error in ././test.zeek, line 2: type clash in assignment (a_table = table(1.2.3.0/24 = unspecified))
```
I'm not adding a test because we don't normally test syntax errors of this nature — happy to do so though if people prefer.

Resolves #3263