### PR TITLE
Correctly compute name for spicyz export with debug log.

### DIFF
--- a/src/spicy/spicyz/glue-compiler.cc
+++ b/src/spicy/spicyz/glue-compiler.cc
@@ -1318,14 +1318,7 @@ struct VisitorZeekType : hilti::visitor::PreOrder<hilti::Result<hilti::Expressio
                 SPICY_DEBUG(hilti::util::fmt("Creating Zeek record type %s::%s with fields:", ns, local));
 
                 for ( const auto& f : fields )
-                    SPICY_DEBUG(hilti::util::fmt("  %s", f.as<hilti::expression::Ctor>()
-                                                             .ctor()
-                                                             .as<hilti::ctor::Tuple>()
-                                                             .value()[0]
-                                                             .as<hilti::expression::Ctor>()
-                                                             .ctor()
-                                                             .as<hilti::ctor::String>()
-                                                             .value()));
+                    SPICY_DEBUG(hilti::util::fmt("  %s", f));
             }
             else
                 SPICY_DEBUG(hilti::util::fmt("Creating (empty) Zeek record type %s::%s", ns, local));

--- a/testing/btest/spicy/export-type-with-fields.zeek
+++ b/testing/btest/spicy/export-type-with-fields.zeek
@@ -1,6 +1,7 @@
 # @TEST-REQUIRES: have-spicy
 #
-# @TEST-EXEC: spicyz -do export.hlto export.spicy export.evt
+# Running with `-D zeek` to excercise debug streams.
+# @TEST-EXEC: spicyz -D zeek -do export.hlto export.spicy export.evt
 # @TEST-EXEC: zeek export.hlto %INPUT >>output
 # @TEST-EXEC: btest-diff output
 #


### PR DESCRIPTION
In 36a6770e9891114b4f42dac3728040c67cc9411e we changed the way Spicy fields exported as
record fields are represented. This broke the `zeek` debug log which hardcoded a different representation.

This patch brings the generation of the debug log in line with the actual AST structure. We also enable debug logging in one test to validate that it works, at least for the case we hit here.