### PR TITLE
Remove some unnecessary includes of telemetry headers

### DIFF
--- a/src/iosource/PktSrc.h
+++ b/src/iosource/PktSrc.h
@@ -9,7 +9,6 @@
 #include "zeek/iosource/BPF_Program.h"
 #include "zeek/iosource/IOSource.h"
 #include "zeek/iosource/Packet.h"
-#include "zeek/telemetry/Manager.h"
 
 struct pcap_pkthdr;
 

--- a/src/session/Manager.h
+++ b/src/session/Manager.h
@@ -10,7 +10,6 @@
 #include "zeek/Hash.h"
 #include "zeek/NetVar.h"
 #include "zeek/session/Session.h"
-#include "zeek/telemetry/Manager.h"
 
 namespace zeek
 	{


### PR DESCRIPTION
These came up while working on the telemetry prototype, and I figured they'd be good to have in master earlier than that will land.