### PR TITLE
POC: Replace Dictionary with std::map/unordered_map

### DIFF
--- a/src/OpaqueVal.h
+++ b/src/OpaqueVal.h
@@ -132,6 +132,16 @@ public:
      */
     static OpaqueValPtr Unserialize(BrokerListView data);
 
+    size_t Hash() const override {
+        printf("opaqueval hash nop\n");
+        return 0;
+    }
+
+    bool IsSameAs(const Val& other) const override {
+        printf("opaqueval same nop\n");
+        return false;
+    }
+
 protected:
     friend class Val;
     friend class OpaqueMgr;

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -13,6 +13,7 @@
 #include "zeek/EquivClass.h"
 #include "zeek/Reporter.h"
 #include "zeek/ZeekString.h"
+#include "zeek/util.h"
 
 zeek::detail::CCL* zeek::detail::curr_ccl = nullptr;
 zeek::detail::Specific_RE_Matcher* zeek::detail::rem = nullptr;
@@ -435,6 +436,37 @@ void RE_Matcher::MakeSingleLine() {
 
     is_single_line = true;
 }
+
+size_t RE_Matcher::Hash() const {
+    size_t h = std::hash<std::string>{}(orig_text);
+    if ( re_anywhere )
+        h = util::hash_combine(h, re_anywhere->Hash());
+    if ( re_exact )
+        h = util::hash_combine(h, re_exact->Hash());
+
+    return h;
+}
+
+bool RE_Matcher::operator==(const RE_Matcher& other) const {
+    if ( orig_text != other.orig_text || is_case_insensitive != other.is_case_insensitive ||
+         is_single_line != other.is_single_line )
+        return false;
+
+    if ( (! re_anywhere && other.re_anywhere) || (re_anywhere && ! other.re_anywhere) )
+        return false;
+
+    if ( re_anywhere && other.re_anywhere && *re_anywhere != *other.re_anywhere )
+        return false;
+
+    if ( (! re_exact && other.re_exact) || (re_exact && ! other.re_exact) )
+        return false;
+
+    if ( re_exact && other.re_exact && *re_exact != *other.re_exact )
+        return false;
+
+    return true;
+}
+
 
 bool RE_Matcher::Compile(bool lazy) { return re_anywhere->Compile(lazy) && re_exact->Compile(lazy); }
 

--- a/src/RE.h
+++ b/src/RE.h
@@ -124,6 +124,10 @@ public:
 
     void Dump(FILE* f);
 
+    size_t Hash() const { return std::hash<std::string>{}(pattern_text); }
+    bool operator==(const Specific_RE_Matcher& other) { return pattern_text == other.pattern_text; }
+    bool operator!=(const Specific_RE_Matcher& other) { return pattern_text != other.pattern_text; }
+
 protected:
     void AddAnywherePat(const char* pat);
     void AddExactPat(const char* pat);
@@ -241,6 +245,10 @@ public:
     // Original text used to construct this matcher.  Empty unless
     // the main ("explicit") constructor was used.
     const char* OrigText() const { return orig_text.c_str(); }
+
+    size_t Hash() const;
+
+    bool operator==(const RE_Matcher& other) const;
 
 protected:
     std::string orig_text;

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -232,6 +232,11 @@ void Type::DescribeReST(ODesc* d, bool roles_only) const { d->Add(util::fmt(":ze
 
 void Type::SetError() { tag = TYPE_ERROR; }
 
+bool Type::operator==(const Type& other) const {
+    return (tag == other.tag) && (internal_tag == other.internal_tag) && (is_network_order == other.is_network_order) &&
+           (base_type == other.base_type) && (name == other.name);
+}
+
 detail::TraversalCode Type::Traverse(detail::TraversalCallback* cb) const {
     auto tc = cb->PreType(this);
     HANDLE_TC_TYPE_PRE(tc);

--- a/src/Type.h
+++ b/src/Type.h
@@ -288,6 +288,8 @@ public:
         return it->second.emplace(std::move(type)).second;
     }
 
+    bool operator==(const Type& type) const;
+
 protected:
     virtual void DoDescribe(ODesc* d) const;
 

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -41,6 +41,7 @@
 #include "zeek/broker/Manager.h"
 #include "zeek/broker/Store.h"
 #include "zeek/threading/formatters/detail/json.h"
+#include "zeek/util.h"
 
 using namespace std;
 
@@ -667,6 +668,16 @@ ValPtr AddrVal::DoClone(CloneState* state) {
     return {NewRef{}, this};
 }
 
+size_t AddrVal::Hash() const {
+    auto h = addr_val->MakeHashKey();
+    return h->Hash();
+}
+
+bool AddrVal::IsSameAs(const Val& other) const {
+    auto op = other.AsAddrVal();
+    return *addr_val == *op->addr_val;
+}
+
 SubNetVal::SubNetVal(const char* text) : Val(base_type(TYPE_SUBNET)) {
     subnet_val = new IPPrefix();
 
@@ -733,6 +744,16 @@ bool SubNetVal::Contains(const IPAddr& addr) const { return subnet_val->Contains
 ValPtr SubNetVal::DoClone(CloneState* state) {
     // Immutable.
     return {NewRef{}, this};
+}
+
+size_t SubNetVal::Hash() const {
+    auto h = subnet_val->MakeHashKey();
+    return h->Hash();
+}
+
+bool SubNetVal::IsSameAs(const Val& other) const {
+    auto op = other.AsSubNetVal();
+    return *subnet_val == *op->subnet_val;
 }
 
 StringVal::StringVal(String* s) : Val(base_type(TYPE_STRING)) { string_val = s; }
@@ -1183,6 +1204,13 @@ ValPtr StringVal::DoClone(CloneState* state) {
                                      new String((u_char*)string_val->Bytes(), string_val->Len(), true)));
 }
 
+size_t StringVal::Hash() const { return std::hash<std::string_view>{}(ToStdStringView()); }
+
+bool StringVal::IsSameAs(const Val& other) const {
+    auto so = other.AsStringVal();
+    return so && Bstr_eq(string_val, so->string_val);
+}
+
 FuncVal::FuncVal(FuncPtr f) : Val(f->GetType()) { func_val = std::move(f); }
 
 FuncPtr FuncVal::AsFuncPtr() const { return func_val; }
@@ -1192,6 +1220,16 @@ ValPtr FuncVal::SizeVal() const { return val_mgr->Count(func_val->GetType()->Par
 void FuncVal::ValDescribe(ODesc* d) const { func_val->Describe(d); }
 
 ValPtr FuncVal::DoClone(CloneState* state) { return make_intrusive<FuncVal>(func_val->DoClone()); }
+
+size_t FuncVal::Hash() const {
+    printf("funcval hash nop\n");
+    return 0;
+}
+
+bool FuncVal::IsSameAs(const Val& other) const {
+    printf("funcval same nop\n");
+    return false;
+}
 
 FileVal::FileVal(FilePtr f) : Val(make_intrusive<FileType>(base_type(TYPE_STRING))) {
     file_val = std::move(f);
@@ -1214,6 +1252,16 @@ ValPtr FileVal::DoClone(CloneState* state) {
     // get the non-cached pointer back which is brought back into the
     // cache when written to.
     return {NewRef{}, this};
+}
+
+size_t FileVal::Hash() const {
+    printf("fileval hash nop\n");
+    return 0;
+}
+
+bool FileVal::IsSameAs(const Val& other) const {
+    printf("fileval same nop\n");
+    return false;
 }
 
 PatternVal::PatternVal(RE_Matcher* re) : Val(base_type(TYPE_PATTERN)) { re_val = re; }
@@ -1259,6 +1307,13 @@ ValPtr PatternVal::DoClone(CloneState* state) {
     auto re = new RE_Matcher(re_val->PatternText(), re_val->AnywherePatternText());
     re->Compile();
     return state->NewClone(this, make_intrusive<PatternVal>(re));
+}
+
+size_t PatternVal::Hash() const { return re_val->Hash(); }
+
+bool PatternVal::IsSameAs(const Val& other) const {
+    auto op = other.AsPattern();
+    return *re_val == *op;
 }
 
 ListVal::ListVal(TypeTag t) : Val(make_intrusive<TypeList>(t == TYPE_ANY ? nullptr : base_type(t))) { tag = t; }
@@ -1348,6 +1403,35 @@ unsigned int ListVal::ComputeFootprint(std::unordered_set<const Val*>* analyzed_
         fp += val->Footprint(analyzed_vals);
 
     return fp;
+}
+
+bool ListVal::IsSameAs(const Val& other) const {
+    // This will type-check the object as well.
+    auto lo = (&other)->AsListVal();
+
+    if ( ! lo || vals.size() != lo->vals.size() )
+        return false;
+
+    for ( size_t i = 0; i < vals.size(); i++ )
+        if ( ! vals[i]->IsSameAs(*(lo->vals[i])) )
+            return false;
+
+    return true;
+}
+
+std::size_t ListVal::Hash() const {
+    size_t hash = 0;
+
+    for ( const auto& v : vals )
+        hash = util::hash_combine(hash, v->Hash());
+
+    return hash;
+}
+
+size_t ListValHasher::operator()(const zeek::IntrusivePtr<zeek::ListVal>& val) const noexcept { return val->Hash(); }
+
+bool ListValEqualTo::operator()(const IntrusivePtr<ListVal>& a, const IntrusivePtr<ListVal>& b) const noexcept {
+    return a->IsSameAs(*b);
 }
 
 TableEntryVal* TableEntryVal::Clone(Val::CloneState* state) {
@@ -2762,6 +2846,24 @@ void TableVal::RebuildTable(ParseTimeTableState ptts) {
         Assign(std::move(key), std::move(val));
 }
 
+size_t TableVal::Hash() const {
+    size_t h = 0;
+    for ( auto it = table_val->begin(); it != table_val->end(); ++it ) {
+        auto v = it->value;
+        uint64_t k = *(uint32_t*)it->GetKey();
+
+        h = util::hash_combine(h, v->GetVal()->Hash());
+        h = util::hash_combine(h, std::hash<uint64_t>{}(k));
+    }
+
+    return h;
+}
+
+bool TableVal::IsSameAs(const Val& other) const {
+    auto op = other.AsTableVal();
+    return EqualTo(*op);
+}
+
 TableVal::ParseTimeTableStates TableVal::parse_time_table_states;
 
 TableVal::TableRecordDependencies TableVal::parse_time_table_record_dependencies;
@@ -3034,6 +3136,48 @@ unsigned int RecordVal::ComputeFootprint(std::unordered_set<const Val*>* analyze
     return fp;
 }
 
+size_t RecordVal::Hash() const {
+    size_t hash = 0;
+
+    int num_fields = rt->NumFields();
+    for ( int i = 0; i < num_fields; ++i ) {
+        auto rv_i = GetField(i);
+
+        detail::Attributes* a = rt->FieldDecl(i)->attrs.get();
+        bool optional_attr = (a && a->Find(detail::ATTR_OPTIONAL));
+
+        if ( ! rv_i || optional_attr )
+            continue;
+
+        hash = util::hash_combine(hash, rv_i->Hash());
+    }
+
+    return hash;
+}
+
+bool RecordVal::IsSameAs(const Val& other) const {
+    auto ro = (&other)->AsRecordVal();
+
+    if ( ! ro || NumFields() != ro->NumFields() )
+        return false;
+
+    for ( size_t i = 0; i < NumFields(); i++ ) {
+        if ( HasField(i) != ro->HasField(i) )
+            return false;
+
+        auto f = GetField(i);
+        auto of = ro->GetField(i);
+
+        if ( ! f && ! of )
+            continue;
+
+        if ( ! f || ! of || ! f->IsSameAs(*of) )
+            return false;
+    }
+
+    return true;
+}
+
 ValPtr EnumVal::SizeVal() const { return val_mgr->Int(AsInt()); }
 
 void EnumVal::ValDescribe(ODesc* d) const {
@@ -3050,11 +3194,27 @@ ValPtr EnumVal::DoClone(CloneState* state) {
     return {NewRef{}, this};
 }
 
+bool EnumVal::IsSameAs(const Val& other) const {
+    auto eo = other.AsEnumVal();
+
+    return eo && type == eo->type && int_val == eo->int_val;
+}
+
 void TypeVal::ValDescribe(ODesc* d) const { d->Add(type->AsTypeType()->GetType()->GetName()); }
 
 ValPtr TypeVal::DoClone(CloneState* state) {
     // Immutable.
     return {NewRef{}, this};
+}
+
+size_t TypeVal::Hash() const {
+    printf("typeval hash nop\n");
+    return 0;
+}
+
+bool TypeVal::IsSameAs(const Val& other) const {
+    auto op = other.AsTypeVal();
+    return *type == *op->Get();
 }
 
 VectorVal::VectorVal(VectorTypePtr t) : Val(t) {
@@ -3546,6 +3706,41 @@ void VectorVal::ValDescribe(ODesc* d) const {
     }
 
     d->Add("]");
+}
+
+size_t VectorVal::Hash() const {
+    size_t h = 0;
+
+    for ( auto i = 0; i < Size(); i++ ) {
+        auto v = ValAt(i);
+        if ( v )
+            h = util::hash_combine(h, v->Hash());
+        else
+            h = util::hash_combine(h, 0);
+    }
+
+    return h;
+}
+
+bool VectorVal::IsSameAs(const Val& other) const {
+    auto op = other.AsVectorVal();
+
+    if ( Size() != op->Size() )
+        return false;
+    if ( yield_type != op->RawYieldType() )
+        return false;
+
+    for ( auto i = 0; i < Size(); i++ ) {
+        auto v = ValAt(i);
+        auto o_v = op->ValAt(i);
+
+        if ( v && o_v && ! v->IsSameAs(*o_v) )
+            return false;
+        if ( v != o_v )
+            return false;
+    }
+
+    return true;
 }
 
 ValPtr check_and_promote(ValPtr v, const TypePtr& new_type, bool is_init, const detail::Location* expr_location) {

--- a/src/file_analysis/AnalyzerSet.cc
+++ b/src/file_analysis/AnalyzerSet.cc
@@ -10,15 +10,7 @@
 #include "zeek/file_analysis/file_analysis.bif.h"
 
 namespace zeek::file_analysis::detail {
-
-static void analyzer_del_func(void* v) {
-    file_analysis::Analyzer* a = (file_analysis::Analyzer*)v;
-
-    a->Done();
-    delete a;
-}
-
-AnalyzerSet::AnalyzerSet(File* arg_file) : file(arg_file) { analyzer_map.SetDeleteFunc(analyzer_del_func); }
+AnalyzerSet::AnalyzerSet(File* arg_file) : file(arg_file) {}
 
 AnalyzerSet::~AnalyzerSet() {
     while ( ! mod_queue.empty() ) {
@@ -27,48 +19,67 @@ AnalyzerSet::~AnalyzerSet() {
         delete mod;
         mod_queue.pop();
     }
+
+    for ( const auto& a : analyzer_map )
+        delete a.second;
+
+    analyzer_map.clear();
 }
 
 Analyzer* AnalyzerSet::Find(const zeek::Tag& tag, RecordValPtr args) {
-    auto key = GetKey(tag, std::move(args));
-    Analyzer* rval = analyzer_map.Lookup(key.get());
-    return rval;
+    auto lv = make_intrusive<ListVal>(TYPE_ANY);
+    lv->Append(tag.AsVal());
+    lv->Append(std::move(args));
+
+    auto it = analyzer_map.find(lv);
+    if ( it != analyzer_map.end() )
+        return it->second;
+
+    return nullptr;
 }
 
 bool AnalyzerSet::Add(const zeek::Tag& tag, RecordValPtr args) {
-    auto key = GetKey(tag, args);
+    auto lv = make_intrusive<ListVal>(TYPE_ANY);
+    lv->Append(tag.AsVal());
+    lv->Append(args);
 
-    if ( analyzer_map.Lookup(key.get()) ) {
+    if ( analyzer_map.count(lv) != 0 ) {
         DBG_LOG(DBG_FILE_ANALYSIS, "[%s] Instantiate analyzer %s skipped: already exists", file->GetID().c_str(),
                 file_mgr->GetComponentName(tag).c_str());
 
         return true;
     }
 
-    file_analysis::Analyzer* a = InstantiateAnalyzer(tag, std::move(args));
+    file_analysis::Analyzer* a = InstantiateAnalyzer(tag, args);
 
     if ( ! a )
         return false;
 
-    Insert(a, std::move(key));
+    Insert(a, tag, std::move(args));
 
     return true;
 }
 
 Analyzer* AnalyzerSet::QueueAdd(const zeek::Tag& tag, RecordValPtr args) {
-    auto key = GetKey(tag, args);
-    file_analysis::Analyzer* a = InstantiateAnalyzer(tag, std::move(args));
+    file_analysis::Analyzer* a = InstantiateAnalyzer(tag, args);
 
     if ( ! a )
         return nullptr;
 
-    mod_queue.push(new AddMod(a, std::move(key)));
+    mod_queue.push(new AddMod(a, tag, std::move(args)));
 
     return a;
 }
 
+AnalyzerSet::AddMod::AddMod(file_analysis::Analyzer* arg_a, const zeek::Tag& arg_tag, RecordValPtr arg_args)
+    : Modification(), a(arg_a), tag(arg_tag), args(std::move(arg_args)) {}
+
 bool AnalyzerSet::AddMod::Perform(AnalyzerSet* set) {
-    if ( set->analyzer_map.Lookup(key.get()) ) {
+    auto lv = make_intrusive<ListVal>(TYPE_ANY);
+    lv->Append(tag.AsVal());
+    lv->Append(args);
+
+    if ( set->analyzer_map.find(lv) != set->analyzer_map.end() ) {
         DBG_LOG(DBG_FILE_ANALYSIS, "[%s] Add analyzer %s skipped: already exists", a->GetFile()->GetID().c_str(),
                 file_mgr->GetComponentName(a->Tag()).c_str());
 
@@ -76,19 +87,21 @@ bool AnalyzerSet::AddMod::Perform(AnalyzerSet* set) {
         return true;
     }
 
-    set->Insert(a, std::move(key));
+    set->Insert(a, tag, args);
 
     return true;
 }
 
 void AnalyzerSet::AddMod::Abort() { delete a; }
 
-bool AnalyzerSet::Remove(const zeek::Tag& tag, RecordValPtr args) { return Remove(tag, GetKey(tag, std::move(args))); }
+bool AnalyzerSet::Remove(const zeek::Tag& tag, RecordValPtr args) {
+    auto lv = make_intrusive<ListVal>(TYPE_ANY);
+    lv->Append(tag.AsVal());
+    lv->Append(std::move(args));
 
-bool AnalyzerSet::Remove(const zeek::Tag& tag, std::unique_ptr<zeek::detail::HashKey> key) {
-    auto a = (file_analysis::Analyzer*)analyzer_map.Remove(key.get());
+    auto a = analyzer_map.find(lv);
 
-    if ( ! a ) {
+    if ( a == analyzer_map.end() ) {
         DBG_LOG(DBG_FILE_ANALYSIS, "[%s] Skip remove analyzer %s", file->GetID().c_str(),
                 file_mgr->GetComponentName(tag).c_str());
         return false;
@@ -97,36 +110,33 @@ bool AnalyzerSet::Remove(const zeek::Tag& tag, std::unique_ptr<zeek::detail::Has
     DBG_LOG(DBG_FILE_ANALYSIS, "[%s] Remove analyzer %s", file->GetID().c_str(),
             file_mgr->GetComponentName(tag).c_str());
 
-    a->Done();
+    a->second->Done();
 
     // We don't delete the analyzer object right here because the remove
     // operation may execute at a time when it can still be accessed.
     // Instead we let the file know to delete the analyzer later.
-    file->DoneWithAnalyzer(a);
+    file->DoneWithAnalyzer(a->second);
+
+    analyzer_map.erase(a);
 
     return true;
 }
 
 bool AnalyzerSet::QueueRemove(const zeek::Tag& tag, RecordValPtr args) {
-    auto key = GetKey(tag, std::move(args));
-    auto rval = analyzer_map.Lookup(key.get());
-    mod_queue.push(new RemoveMod(tag, std::move(key)));
-    return rval;
-}
-
-bool AnalyzerSet::RemoveMod::Perform(AnalyzerSet* set) { return set->Remove(tag, std::move(key)); }
-
-std::unique_ptr<zeek::detail::HashKey> AnalyzerSet::GetKey(const zeek::Tag& t, RecordValPtr args) const {
     auto lv = make_intrusive<ListVal>(TYPE_ANY);
-    lv->Append(t.AsVal());
-    lv->Append(std::move(args));
-    auto key = file_mgr->GetAnalyzerHash()->MakeHashKey(*lv, true);
+    lv->Append(tag.AsVal());
+    lv->Append(args);
 
-    if ( ! key )
-        reporter->InternalError("AnalyzerArgs type mismatch");
+    auto it = analyzer_map.find(lv);
 
-    return key;
+    mod_queue.push(new RemoveMod(tag, std::move(args)));
+    return it != analyzer_map.end();
 }
+
+AnalyzerSet::RemoveMod::RemoveMod(const zeek::Tag& arg_tag, RecordValPtr arg_args)
+    : Modification(), tag(arg_tag), args(std::move(arg_args)) {}
+
+bool AnalyzerSet::RemoveMod::Perform(AnalyzerSet* set) { return set->Remove(tag, args); }
 
 file_analysis::Analyzer* AnalyzerSet::InstantiateAnalyzer(const Tag& tag, RecordValPtr args) const {
     auto a = file_mgr->InstantiateAnalyzer(tag, std::move(args), file);
@@ -145,10 +155,15 @@ file_analysis::Analyzer* AnalyzerSet::InstantiateAnalyzer(const Tag& tag, Record
     return a;
 }
 
-void AnalyzerSet::Insert(file_analysis::Analyzer* a, std::unique_ptr<zeek::detail::HashKey> key) {
+void AnalyzerSet::Insert(file_analysis::Analyzer* a, const Tag& tag, RecordValPtr args) {
     DBG_LOG(DBG_FILE_ANALYSIS, "[%s] Add analyzer %s", file->GetID().c_str(),
             file_mgr->GetComponentName(a->Tag()).c_str());
-    analyzer_map.Insert(key.get(), a);
+
+    auto lv = make_intrusive<ListVal>(TYPE_ANY);
+    lv->Append(tag.AsVal());
+    lv->Append(std::move(args));
+
+    analyzer_map.insert({lv, a});
 
     a->Init();
 }

--- a/src/file_analysis/AnalyzerSet.h
+++ b/src/file_analysis/AnalyzerSet.h
@@ -7,6 +7,7 @@
 
 #include "zeek/Dict.h"
 #include "zeek/Tag.h"
+#include "zeek/Val.h"
 
 namespace zeek {
 
@@ -87,9 +88,9 @@ public:
     void DrainModifications();
 
     // Iterator support
-    using iterator = zeek::DictIterator<file_analysis::Analyzer>;
-    ;
-    using const_iterator = const iterator;
+    using MapType = std::unordered_map<IntrusivePtr<ListVal>, file_analysis::Analyzer*, ListValHasher, ListValEqualTo>;
+    using iterator = MapType::iterator;
+    using const_iterator = MapType::const_iterator;
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -100,15 +101,9 @@ public:
     const_iterator cbegin() { return analyzer_map.cbegin(); }
     const_iterator cend() { return analyzer_map.cend(); }
 
-protected:
-    /**
-     * Get a hash key which represents an analyzer instance.
-     * @param tag the file analyzer tag.
-     * @param args an \c AnalyzerArgs value which specifies an analyzer.
-     * @return the hash key calculated from \a args
-     */
-    std::unique_ptr<zeek::detail::HashKey> GetKey(const zeek::Tag& tag, RecordValPtr args) const;
+    size_t Size() const { return analyzer_map.size(); }
 
+protected:
     /**
      * Create an instance of a file analyzer.
      * @param tag the tag of a file analyzer.
@@ -122,7 +117,7 @@ protected:
      * @param a an analyzer instance.
      * @param key the hash key which represents the analyzer's \c AnalyzerArgs.
      */
-    void Insert(file_analysis::Analyzer* a, std::unique_ptr<zeek::detail::HashKey> key);
+    void Insert(file_analysis::Analyzer* a, const zeek::Tag& tag, RecordValPtr args);
 
     /**
      * Remove an analyzer instance from the set.
@@ -133,8 +128,8 @@ protected:
     bool Remove(const zeek::Tag& tag, std::unique_ptr<zeek::detail::HashKey> key);
 
 private:
-    File* file;                                  /**< File which owns the set */
-    PDict<file_analysis::Analyzer> analyzer_map; /**< Indexed by AnalyzerArgs. */
+    File* file; /**< File which owns the set */
+    MapType analyzer_map;
 
     /**
      * Abstract base class for analyzer set modifications.
@@ -166,15 +161,15 @@ private:
          * @param arg_a an analyzer instance to add to an analyzer set.
          * @param arg_key hash key representing the analyzer's \c AnalyzerArgs.
          */
-        AddMod(file_analysis::Analyzer* arg_a, std::unique_ptr<zeek::detail::HashKey> arg_key)
-            : Modification(), a(arg_a), key(std::move(arg_key)) {}
-        ~AddMod() override {}
+        AddMod(file_analysis::Analyzer* arg_a, const zeek::Tag& arg_tag, RecordValPtr arg_args);
+        ~AddMod() override = default;
         bool Perform(AnalyzerSet* set) override;
         void Abort() override;
 
     protected:
         file_analysis::Analyzer* a;
-        std::unique_ptr<zeek::detail::HashKey> key;
+        zeek::Tag tag;
+        RecordValPtr args;
     };
 
     /**
@@ -187,15 +182,14 @@ private:
          * @param arg_a an analyzer instance to add to an analyzer set.
          * @param arg_key hash key representing the analyzer's \c AnalyzerArgs.
          */
-        RemoveMod(const zeek::Tag& arg_tag, std::unique_ptr<zeek::detail::HashKey> arg_key)
-            : Modification(), tag(arg_tag), key(std::move(arg_key)) {}
-        ~RemoveMod() override {}
+        RemoveMod(const zeek::Tag& arg_tag, RecordValPtr arg_args);
+        ~RemoveMod() override = default;
         bool Perform(AnalyzerSet* set) override;
         void Abort() override {}
 
     protected:
         zeek::Tag tag;
-        std::unique_ptr<zeek::detail::HashKey> key;
+        RecordValPtr args;
     };
 
     using ModQueue = std::queue<Modification*>;

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -330,7 +330,7 @@ void File::DeliverStream(const u_char* data, uint64_t len) {
             util::fmt_bytes((const char*)data, std::min((uint64_t)40, len)), len > 40 ? "..." : "");
 
     for ( const auto& entry : analyzers ) {
-        auto* a = entry.value;
+        auto* a = entry.second;
 
         DBG_LOG(DBG_FILE_ANALYSIS, "stream delivery to analyzer %s", file_mgr->GetComponentName(a->Tag()).c_str());
         if ( ! a->GotStreamDelivery() ) {
@@ -418,7 +418,7 @@ void File::DeliverChunk(const u_char* data, uint64_t len, uint64_t offset) {
             util::fmt_bytes((const char*)data, std::min((uint64_t)40, len)), len > 40 ? "..." : "");
 
     for ( const auto& entry : analyzers ) {
-        auto* a = entry.value;
+        auto* a = entry.second;
 
         DBG_LOG(DBG_FILE_ANALYSIS, "chunk delivery to analyzer %s", file_mgr->GetComponentName(a->Tag()).c_str());
         if ( ! a->Skipping() ) {
@@ -470,7 +470,7 @@ void File::EndOfFile() {
     done = true;
 
     for ( const auto& entry : analyzers ) {
-        auto* a = entry.value;
+        auto* a = entry.second;
 
         if ( ! a->EndOfFile() )
             analyzers.QueueRemove(a->Tag(), a->GetArgs());
@@ -500,7 +500,7 @@ void File::Gap(uint64_t offset, uint64_t len) {
     }
 
     for ( const auto& entry : analyzers ) {
-        auto* a = entry.value;
+        auto* a = entry.second;
 
         if ( ! a->Undelivered(offset, len) )
             analyzers.QueueRemove(a->Tag(), a->GetArgs());

--- a/src/util.h
+++ b/src/util.h
@@ -643,5 +643,13 @@ inline std::vector<std::wstring_view> split(const wchar_t* s, const wchar_t* del
     return split(std::wstring_view(s), std::wstring_view(delim));
 }
 
+inline size_t hash_combine(size_t h1, size_t h2) {
+    // Taken from Boost.  See for example
+    // https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
+    // or
+    // https://stackoverflow.com/questions/4948780/magic-number-in-boosthash-combine
+    return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+}
+
 } // namespace util
 } // namespace zeek


### PR DESCRIPTION
This is a proof-of-concept I've been working on a little bit to prototype replacing our `Dict` type with `std::map`/`std::unordered_map` (or one of the many third-party hashtable/dictionary types). I started with `file_analysis::AnalyzerSet` since it's a very simple usage of `Dict`, and it's easy to rework to use a different type. It adds the following to all of the `Val` types:
- A `Hash()` method that computes a `std::size_t` hash value suitable for use in hash table types such as `std::unordered_map`.
- A 'IsSameAs()` method that computes whether two Val objects are semantically the same.

These methods for some of the Val types are currently unimplemented since I only finished the ones necessary to make the changes to `AnalyzerSet` work. The rest shouldn't be hard to fill out. The container types such as `ListVal`, `RecordVal`, etc parse down to their constituent parts to build up a correct representation of the hash or equality.

It also adds two methods to `ListVal` to be passed during the creation of the `unordered_map` in `AnalyzerSet`.

I haven't run any benchmarks on this at all, but I'm looking forward to seeing what @awelzel's recent changes to zeek-benchmarker says about it.

This is somewhat related to https://github.com/zeek/zeek/issues/3262.