### PR TITLE
RecordVal/VectorVal: Embed record_val and vector_val

### DIFF
--- a/src/EventTrace.cc
+++ b/src/EventTrace.cc
@@ -314,13 +314,13 @@ void ValTrace::TraceTable(const TableValPtr& tv)
 void ValTrace::TraceVector(const VectorValPtr& vv)
 	{
 	auto& vec = vv->RawVec();
-	auto n = vec->size();
+	auto n = vec.size();
 	auto& yt = vv->RawYieldType();
 	auto& yts = vv->RawYieldTypes();
 
 	for ( auto i = 0U; i < n; ++i )
 		{
-		auto& elem = (*vec)[i];
+		auto& elem = vec[i];
 		if ( elem )
 			{
 			auto& t = yts ? (*yts)[i] : yt;

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -1411,7 +1411,7 @@ ValPtr ForStmt::DoExec(Frame* f, Val* v, StmtFlowType& flow)
 	else if ( v->GetType()->Tag() == TYPE_VECTOR )
 		{
 		VectorVal* vv = v->AsVectorVal();
-		const auto& raw_vv = *vv->RawVec();
+		const auto& raw_vv = vv->RawVec();
 
 		for ( auto i = 0u; i < vv->Size(); ++i )
 			{

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -3155,17 +3155,15 @@ RecordVal::RecordVal(RecordTypePtr t, bool init_fields) : Val(t), is_managed(t->
 	if ( run_state::is_parsing )
 		parse_time_records[rt.get()].emplace_back(NewRef{}, this);
 
-	record_val = new std::vector<std::optional<ZVal>>;
-
 	if ( init_fields )
 		{
-		record_val->resize(n);
+		record_val.resize(n);
 
 		for ( auto& e : rt->CreationInits() )
 			{
 			try
 				{
-				(*record_val)[e.first] = e.second->Generate();
+				record_val[e.first] = e.second->Generate();
 				}
 			catch ( InterpreterException& e )
 				{
@@ -3177,21 +3175,19 @@ RecordVal::RecordVal(RecordTypePtr t, bool init_fields) : Val(t), is_managed(t->
 		}
 
 	else
-		record_val->reserve(n);
+		record_val.reserve(n);
 	}
 
 RecordVal::~RecordVal()
 	{
-	auto n = record_val->size();
+	auto n = record_val.size();
 
 	for ( unsigned int i = 0; i < n; ++i )
 		{
-		auto f_i = (*record_val)[i];
+		auto f_i = record_val[i];
 		if ( f_i && IsManaged(i) )
 			ZVal::DeleteManagedType(*f_i);
 		}
-
-	delete record_val;
 	}
 
 ValPtr RecordVal::SizeVal() const
@@ -3206,7 +3202,7 @@ void RecordVal::Assign(int field, ValPtr new_val)
 		DeleteFieldIfManaged(field);
 
 		auto t = rt->GetFieldType(field);
-		(*record_val)[field] = ZVal(new_val, t);
+		record_val[field] = ZVal(new_val, t);
 		Modified();
 		}
 	else
@@ -3215,7 +3211,7 @@ void RecordVal::Assign(int field, ValPtr new_val)
 
 void RecordVal::Remove(int field)
 	{
-	auto& f_i = (*record_val)[field];
+	auto& f_i = record_val[field];
 	if ( f_i )
 		{
 		if ( IsManaged(field) )
@@ -3357,7 +3353,7 @@ TableValPtr RecordVal::GetRecordFieldsVal() const
 
 void RecordVal::Describe(ODesc* d) const
 	{
-	auto n = record_val->size();
+	auto n = record_val.size();
 
 	if ( d->IsBinary() )
 		{
@@ -3393,7 +3389,7 @@ void RecordVal::Describe(ODesc* d) const
 
 void RecordVal::DescribeReST(ODesc* d) const
 	{
-	auto n = record_val->size();
+	auto n = record_val.size();
 	auto rt = GetType()->AsRecordType();
 
 	d->Add("{");

--- a/src/Val.h
+++ b/src/Val.h
@@ -1154,7 +1154,7 @@ public:
 	// The following provide efficient record field assignments.
 	void Assign(int field, bool new_val)
 		{
-		(*record_val)[field] = ZVal(zeek_int_t(new_val));
+		record_val[field] = ZVal(zeek_int_t(new_val));
 		AddedField(field);
 		}
 
@@ -1162,28 +1162,28 @@ public:
 	// convenience, since sometimes the caller has one rather than the other.
 	void Assign(int field, int32_t new_val)
 		{
-		(*record_val)[field] = ZVal(zeek_int_t(new_val));
+		record_val[field] = ZVal(zeek_int_t(new_val));
 		AddedField(field);
 		}
 	void Assign(int field, int64_t new_val)
 		{
-		(*record_val)[field] = ZVal(zeek_int_t(new_val));
+		record_val[field] = ZVal(zeek_int_t(new_val));
 		AddedField(field);
 		}
 	void Assign(int field, uint32_t new_val)
 		{
-		(*record_val)[field] = ZVal(zeek_uint_t(new_val));
+		record_val[field] = ZVal(zeek_uint_t(new_val));
 		AddedField(field);
 		}
 	void Assign(int field, uint64_t new_val)
 		{
-		(*record_val)[field] = ZVal(zeek_uint_t(new_val));
+		record_val[field] = ZVal(zeek_uint_t(new_val));
 		AddedField(field);
 		}
 
 	void Assign(int field, double new_val)
 		{
-		(*record_val)[field] = ZVal(new_val);
+		record_val[field] = ZVal(new_val);
 		AddedField(field);
 		}
 
@@ -1196,7 +1196,7 @@ public:
 
 	void Assign(int field, StringVal* new_val)
 		{
-		auto& fv = (*record_val)[field];
+		auto& fv = record_val[field];
 		if ( fv )
 			ZVal::DeleteManagedType(*fv);
 		fv = ZVal(new_val);
@@ -1222,7 +1222,7 @@ public:
 	 * Returns the number of fields in the record.
 	 * @return  The number of fields in the record.
 	 */
-	unsigned int NumFields() const { return record_val->size(); }
+	unsigned int NumFields() const { return record_val.size(); }
 
 	/**
 	 * Returns true if the given field is in the record, false if
@@ -1232,7 +1232,7 @@ public:
 	 */
 	bool HasField(int field) const
 		{
-		if ( (*record_val)[field] )
+		if ( record_val[field] )
 			return true;
 
 		return rt->DeferredInits()[field] != nullptr;
@@ -1257,7 +1257,7 @@ public:
 	 */
 	ValPtr GetField(int field) const
 		{
-		auto& fv = (*record_val)[field];
+		auto& fv = record_val[field];
 		if ( ! fv )
 			{
 			const auto& fi = rt->DeferredInits()[field];
@@ -1342,32 +1342,32 @@ public:
 		{
 		if constexpr ( std::is_same_v<T, BoolVal> || std::is_same_v<T, IntVal> ||
 		               std::is_same_v<T, EnumVal> )
-			return record_val->operator[](field)->int_val;
+			return record_val[field]->int_val;
 		else if constexpr ( std::is_same_v<T, CountVal> )
-			return record_val->operator[](field)->uint_val;
+			return record_val[field]->uint_val;
 		else if constexpr ( std::is_same_v<T, DoubleVal> || std::is_same_v<T, TimeVal> ||
 		                    std::is_same_v<T, IntervalVal> )
-			return record_val->operator[](field)->double_val;
+			return record_val[field]->double_val;
 		else if constexpr ( std::is_same_v<T, PortVal> )
-			return val_mgr->Port(record_val->at(field)->uint_val);
+			return val_mgr->Port(record_val[field]->uint_val);
 		else if constexpr ( std::is_same_v<T, StringVal> )
-			return record_val->operator[](field)->string_val->Get();
+			return record_val[field]->string_val->Get();
 		else if constexpr ( std::is_same_v<T, AddrVal> )
-			return record_val->operator[](field)->addr_val->Get();
+			return record_val[field]->addr_val->Get();
 		else if constexpr ( std::is_same_v<T, SubNetVal> )
-			return record_val->operator[](field)->subnet_val->Get();
+			return record_val[field]->subnet_val->Get();
 		else if constexpr ( std::is_same_v<T, File> )
-			return *(record_val->operator[](field)->file_val);
+			return *(record_val[field]->file_val);
 		else if constexpr ( std::is_same_v<T, Func> )
-			return *(record_val->operator[](field)->func_val);
+			return *(record_val[field]->func_val);
 		else if constexpr ( std::is_same_v<T, PatternVal> )
-			return record_val->operator[](field)->re_val->Get();
+			return record_val[field]->re_val->Get();
 		else if constexpr ( std::is_same_v<T, RecordVal> )
-			return record_val->operator[](field)->record_val;
+			return record_val[field]->record_val;
 		else if constexpr ( std::is_same_v<T, VectorVal> )
-			return record_val->operator[](field)->vector_val;
+			return record_val[field]->vector_val;
 		else if constexpr ( std::is_same_v<T, TableVal> )
-			return record_val->operator[](field)->table_val->Get();
+			return record_val[field]->table_val->Get();
 		else
 			{
 			// It's an error to reach here, although because of
@@ -1381,11 +1381,11 @@ public:
 	T GetFieldAs(int field) const
 		{
 		if constexpr ( std::is_integral_v<T> && std::is_signed_v<T> )
-			return record_val->operator[](field)->int_val;
+			return record_val[field]->int_val;
 		else if constexpr ( std::is_integral_v<T> && std::is_unsigned_v<T> )
-			return record_val->operator[](field)->uint_val;
+			return record_val[field]->uint_val;
 		else if constexpr ( std::is_floating_point_v<T> )
-			return record_val->operator[](field)->double_val;
+			return record_val[field]->double_val;
 
 		// Note: we could add other types here using type traits,
 		// such as is_same_v<T, std::string>, etc.
@@ -1460,9 +1460,9 @@ protected:
 	void AppendField(ValPtr v, const TypePtr& t)
 		{
 		if ( v )
-			record_val->emplace_back(ZVal(v, t));
+			record_val.emplace_back(ZVal(v, t));
 		else
-			record_val->emplace_back(std::nullopt);
+			record_val.emplace_back(std::nullopt);
 		}
 
 	// For internal use by low-level ZAM instructions and event tracing.
@@ -1471,7 +1471,7 @@ protected:
 	// The second version ensures that the optional value is present.
 	std::optional<ZVal>& RawOptField(int field)
 		{
-		auto& f = (*record_val)[field];
+		auto& f = record_val[field];
 		if ( ! f )
 			{
 			const auto& fi = rt->DeferredInits()[field];
@@ -1502,7 +1502,7 @@ protected:
 private:
 	void DeleteFieldIfManaged(unsigned int field)
 		{
-		auto& f = (*record_val)[field];
+		auto& f = record_val[field];
 		if ( f && IsManaged(field) )
 			ZVal::DeleteManagedType(*f);
 		}
@@ -1518,7 +1518,9 @@ private:
 	RecordTypePtr rt;
 
 	// Low-level values of each of the fields.
-	std::vector<std::optional<ZVal>>* record_val;
+	//
+	// Lazily modified during GetField(), so mutable.
+	mutable std::vector<std::optional<ZVal>> record_val;
 
 	// Whether a given field requires explicit memory management.
 	const std::vector<bool>& is_managed;

--- a/src/Val.h
+++ b/src/Val.h
@@ -1592,7 +1592,7 @@ public:
 	// Returns true if successful.
 	bool AddTo(Val* v, bool is_first_init) const override;
 
-	unsigned int Size() const { return vector_val->size(); }
+	unsigned int Size() const { return vector_val.size(); }
 
 	// Is there any way to reclaim previously-allocated memory when you
 	// shrink a vector?  The return value is the old size.
@@ -1662,10 +1662,7 @@ public:
 
 	ValPtr ValAt(unsigned int index) const { return At(index); }
 
-	bool Has(unsigned int index) const
-		{
-		return index < vector_val->size() && (*vector_val)[index];
-		}
+	bool Has(unsigned int index) const { return index < vector_val.size() && vector_val[index]; }
 
 	/**
 	 * Returns the given element in a given underlying representation.
@@ -1675,26 +1672,17 @@ public:
 	 * @param index  The position in the vector of the element to return.
 	 * @return  The element's underlying value.
 	 */
-	zeek_int_t IntAt(unsigned int index) const { return (*vector_val)[index]->int_val; }
-	zeek_uint_t CountAt(unsigned int index) const { return (*vector_val)[index]->uint_val; }
-	double DoubleAt(unsigned int index) const { return (*vector_val)[index]->double_val; }
-	const RecordVal* RecordValAt(unsigned int index) const
-		{
-		return (*vector_val)[index]->record_val;
-		}
-	bool BoolAt(unsigned int index) const
-		{
-		return static_cast<bool>((*vector_val)[index]->uint_val);
-		}
-	const StringVal* StringValAt(unsigned int index) const
-		{
-		return (*vector_val)[index]->string_val;
-		}
+	zeek_int_t IntAt(unsigned int index) const { return vector_val[index]->int_val; }
+	zeek_uint_t CountAt(unsigned int index) const { return vector_val[index]->uint_val; }
+	double DoubleAt(unsigned int index) const { return vector_val[index]->double_val; }
+	const RecordVal* RecordValAt(unsigned int index) const { return vector_val[index]->record_val; }
+	bool BoolAt(unsigned int index) const { return static_cast<bool>(vector_val[index]->uint_val); }
+	const StringVal* StringValAt(unsigned int index) const { return vector_val[index]->string_val; }
 	const String* StringAt(unsigned int index) const { return StringValAt(index)->AsString(); }
 
 	// Only intended for low-level access by internal or compiled code.
-	const auto& RawVec() const { return vector_val; }
-	auto& RawVec() { return vector_val; }
+	const std::vector<std::optional<ZVal>>& RawVec() const { return vector_val; }
+	std::vector<std::optional<ZVal>>& RawVec() { return vector_val; }
 
 	const auto& RawYieldType() const { return yield_type; }
 	const auto& RawYieldTypes() const { return yield_types; }
@@ -1730,7 +1718,7 @@ private:
 	// Add the given number of "holes" to the end of a vector.
 	void AddHoles(int nholes);
 
-	std::vector<std::optional<ZVal>>* vector_val;
+	std::vector<std::optional<ZVal>> vector_val;
 
 	// For homogeneous vectors (the usual case), the type of the
 	// elements.  Will be TYPE_VOID for empty vectors created using

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -1113,7 +1113,7 @@ threading::Value* Manager::ValToLogVal(std::optional<ZVal>& val, Type* ty)
 
 			for ( zeek_int_t i = 0; i < lval->val.vector_val.size; i++ )
 				{
-				lval->val.vector_val.vals[i] = ValToLogVal((*vv)[i], vt.get());
+				lval->val.vector_val.vals[i] = ValToLogVal(vv[i], vt.get());
 				}
 
 			break;

--- a/src/script_opt/ZAM/Ops.in
+++ b/src/script_opt/ZAM/Ops.in
@@ -364,7 +364,7 @@ eval	auto vv = frame[z.v1].vector_val;
 		vv->Assign(0, $1.ToVal(z.t));
 	else
 		{
-		vv->RawVec()->push_back(CopyVal($1));
+		vv->RawVec().push_back(CopyVal($1));
 		vv->Modified();
 		}
 
@@ -876,9 +876,9 @@ eval	AssignV1(frame[z.v2].int_val ? CopyVal(z.c) : CopyVal(frame[z.v3]))
 op Bool-Vec-Cond
 type VVVV
 set-type $2
-eval	auto& vsel = *frame[z.v2].vector_val->RawVec();
-	auto& v1 = *frame[z.v3].vector_val->RawVec();
-	auto& v2 = *frame[z.v4].vector_val->RawVec();
+eval	auto& vsel = frame[z.v2].vector_val->RawVec();
+	auto& v1 = frame[z.v3].vector_val->RawVec();
+	auto& v2 = frame[z.v4].vector_val->RawVec();
 	auto n = v1.size();
 	auto res = new vector<std::optional<ZVal>>(n);
 	for ( auto i = 0U; i < n; ++i )
@@ -968,11 +968,11 @@ eval	EvalIndexVec(frame[z.v3].uint_val)
 
 macro EvalIndexVec(index)
 	auto& vv = frame[z.v2].vector_val->RawVec();
-	const auto& vec = *vv;
+	const auto& vec = vv;
 	zeek_int_t ind = index;
 	if ( ind < 0 )
-		ind += vv->size();
-	if ( ind < 0 || ind >= vv->size() )
+		ind += vv.size();
+	if ( ind < 0 || ind >= vv.size() )
 		ZAM_run_time_error(z.loc, "no such index");
 	AssignV1(CopyVal(*vec[ind]))
 
@@ -1847,7 +1847,7 @@ internal-op Init-Vector-Loop
 type VV
 op1-read
 eval	auto& vv = frame[z.v1].vector_val->RawVec();
-	step_iters[z.v2].InitLoop(vv);
+	step_iters[z.v2].InitLoop(&vv);
 
 macro NextVectorIterCore(info, branch)
 	auto& si = step_iters[info];

--- a/src/script_opt/ZAM/ZBody.cc
+++ b/src/script_opt/ZAM/ZBody.cc
@@ -60,7 +60,7 @@ static bool copy_vec_elem(VectorVal* vv, zeek_uint_t ind, ZVal zv, const TypePtr
 	if ( vv->Size() <= ind )
 		vv->Resize(ind + 1);
 
-	auto& elem = (*vv->RawVec())[ind];
+	auto& elem = vv->RawVec()[ind];
 
 	if ( ! ZVal::IsManagedType(t) )
 		{
@@ -96,12 +96,12 @@ static void vec_exec(ZOp op, TypePtr t, VectorVal*& v1, const VectorVal* v2, con
 #define VEC_COERCE(tag, lhs_type, cast, rhs_accessor, ov_check, ov_err)                            \
 	static VectorVal* vec_coerce_##tag(VectorVal* vec, const ZInst& z)                             \
 		{                                                                                          \
-		auto& v = *vec->RawVec();                                                                  \
+		auto& v = vec->RawVec();                                                                   \
 		auto yt = make_intrusive<VectorType>(base_type(lhs_type));                                 \
 		auto res_zv = new VectorVal(yt);                                                           \
 		auto n = v.size();                                                                         \
 		res_zv->Resize(n);                                                                         \
-		auto& res = *res_zv->RawVec();                                                             \
+		auto& res = res_zv->RawVec();                                                              \
 		for ( auto i = 0U; i < n; ++i )                                                            \
 			if ( v[i] )                                                                            \
 				{                                                                                  \
@@ -479,7 +479,7 @@ static void vec_exec(ZOp op, TypePtr t, VectorVal*& v1, const VectorVal* v2, con
 	// well move the whole kit-and-caboodle into the Exec method).  But
 	// that seems like a lot of code bloat for only a very modest gain.
 
-	auto& vec2 = *v2->RawVec();
+	auto& vec2 = v2->RawVec();
 	auto n = vec2.size();
 	auto vec1_ptr = new vector<std::optional<ZVal>>(n);
 	auto& vec1 = *vec1_ptr;
@@ -511,8 +511,8 @@ static void vec_exec(ZOp op, TypePtr t, VectorVal*& v1, const VectorVal* v2, con
 	{
 	// See comment above re further speed-up.
 
-	auto& vec2 = *v2->RawVec();
-	auto& vec3 = *v3->RawVec();
+	auto& vec2 = v2->RawVec();
+	auto& vec3 = v3->RawVec();
 	auto n = vec2.size();
 	auto vec1_ptr = new vector<std::optional<ZVal>>(n);
 	auto& vec1 = *vec1_ptr;


### PR DESCRIPTION
This should remove one malloc/free per created and destroyed record instance and avoid one extra pointer indirection to access fields.

Separate motivation of this changeset is to test `zeek-benchmarker`, actually :-)