### PR TITLE
Do not require cookie for `reject_protocol` during teardown.

### DIFF
--- a/src/spicy/runtime-support.cc
+++ b/src/spicy/runtime-support.cc
@@ -453,7 +453,12 @@ void rt::confirm_protocol() {
 void rt::reject_protocol(const std::string& reason) {
     auto _ = hilti::rt::profiler::start("zeek/rt/reject_protocol");
     auto cookie = static_cast<Cookie*>(hilti::rt::context::cookie());
-    assert(cookie);
+
+    // We might be invoked during teardown when the cookie has already been
+    // cleared. These other code paths also take care of sending an analyzer
+    // violation to Zeek, so we can immediately return for such cases here.
+    if ( ! cookie )
+        return;
 
     if ( auto x = cookie->protocol ) {
         auto tag = spicy_mgr->tagForProtocolAnalyzer(x->analyzer->GetAnalyzerTag());


### PR DESCRIPTION
A user reported that they ran into a situation where a parse error caused an assertion failure in `reject_protocol`. printf debugging points to the `CookieSetter`s in the `try`/`catch` blocks during processing already clearing the cookie RAII-style; since their `catch` blocks already send an analyzer violation no further sending of one from `reject_protocol` is required.

This patch replaces the assert in `reject_protocol` with a runtime check and an early return if the cookie is already cleared.