### PR TITLE
CI: Disable tsan task until it can be fixed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -387,21 +387,21 @@ ubsan_sanitizer_task:
     ZEEK_TAILORED_UB_CHECKS: 1
     UBSAN_OPTIONS: print_stacktrace=1
 
-tsan_sanitizer_task:
-  container:
-    # Just uses a recent/common distro to run memory error/leak checks.
-    dockerfile: ci/ubuntu-22.04/Dockerfile
-    << : *SANITIZERS_RESOURCE_TEMPLATE
+# tsan_sanitizer_task:
+#   container:
+#     # Just uses a recent/common distro to run memory error/leak checks.
+#     dockerfile: ci/ubuntu-22.04/Dockerfile
+#     << : *SANITIZERS_RESOURCE_TEMPLATE
 
-  << : *CI_TEMPLATE
-  << : *SKIP_TASK_ON_PR
-  env:
-    ZEEK_CI_CONFIGURE_FLAGS: *TSAN_SANITIZER_CONFIG
-    ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1
-    # If this is defined directly in the environment, configure fails to find
-    # OpenSSL. Instead we define it with a different name and then give it
-    # the correct name in the testing scripts.
-    ZEEK_TSAN_OPTIONS: suppressions=/zeek/ci/tsan_suppressions.txt
+#   << : *CI_TEMPLATE
+#   << : *SKIP_TASK_ON_PR
+#   env:
+#     ZEEK_CI_CONFIGURE_FLAGS: *TSAN_SANITIZER_CONFIG
+#     ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1
+#     # If this is defined directly in the environment, configure fails to find
+#     # OpenSSL. Instead we define it with a different name and then give it
+#     # the correct name in the testing scripts.
+#     ZEEK_TSAN_OPTIONS: suppressions=/zeek/ci/tsan_suppressions.txt
 
 windows_task:
   # 2 hour timeout just for potential of building Docker image taking a while


### PR DESCRIPTION
The ThreadSanitizer task is currently broken due to some infrastructure issues on the CI host (namely their base VM image). This PR disables it for the time being in the interest of keeping it from causing every build we do to be marked as failed. I'm currently working with the Cirrus people on a way around the VM issue, and will re-enable it when we have it fixed.