### PR TITLE
zeek-setup: Early exit when parsing failed

### DIFF
--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -820,12 +820,15 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 		// when we actually end up reading interactively from stdin.
 		set_signal_mask(false);
 		run_state::is_parsing = true;
-		yyparse();
+		int yyparse_result = yyparse();
 		run_state::is_parsing = false;
 		set_signal_mask(true);
 
 		RecordVal::DoneParsing();
 		TableVal::DoneParsing();
+
+		if ( yyparse_result != 0 || zeek::reporter->Errors() > 0 )
+			exit(1);
 
 		init_general_global_var();
 		init_net_var();


### PR DESCRIPTION
When there are errors reported during yyparse(), Zeek still continued running initialization functions like init_general_global_var(), init_net_var() and run_bif_initializers(). These usually call abort() in unexpected situations causing misleading and confusing errors. This patch prevents this by exiting earlier.

Closes #3316