### PR TITLE
Fix GCC warnings about unintended pointer comparisions

### DIFF
--- a/src/spicy/runtime-support.h
+++ b/src/spicy/runtime-support.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 
@@ -882,7 +883,7 @@ inline ValPtr to_val(const T& t, TypePtr target) {
 
     auto num_fields = rtype->NumFields();
 
-    t.__visit([&](const auto& name, const auto& val) {
+    t.__visit([&](std::string_view name, const auto& val) {
         if ( idx >= num_fields )
             throw TypeMismatch(hilti::rt::fmt("no matching record field for field '%s'", name));
 


### PR DESCRIPTION
When inspecting Spicy values for marshalling to Zeek we should receive field identifiers as owned `std::string` so it should be safe to directly compare them against `const char[]`. It seems that e.g., gcc-9.4.0's analysis sees things differently and warns of a comparision of `const char*` (which as written would compare pointer values; the correct API for this would be `::strlen`).

This patch addresses that warning by visiting with type which supports `==` comparison, in particular, take a `std::string_view` so we could even visit `const char*` identifiers.