### PR TITLE
generate-docs: Bump ccache from 500M to 2000M

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -77,6 +77,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: 'docs-gen-${{ github.job }}'
+          max-size: '2000M'
 
       - name: Configure
         run: ./configure --disable-broker-tests --disable-cpp-tests --ccache


### PR DESCRIPTION
Since enabling Spicy, 500M (default) of ccache max-size size is not sufficient for efficient cache usage of a Zeek build anymore, so we end up thrashing the configured ccache. Build times have increased from 5-10 minutes to 1+ hour after enabling Spicy in the docs build.