### PR TITLE
Monthly script optimization maintenance - Oct 23

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -52,6 +52,7 @@ enum ExprTag : int
 	EXPR_REMOVE_FROM,
 	EXPR_TIMES,
 	EXPR_DIVIDE,
+	EXPR_MASK,
 	EXPR_MOD,
 	EXPR_AND,
 	EXPR_OR,
@@ -819,6 +820,15 @@ public:
 	ExprPtr Duplicate() override;
 	bool WillTransform(Reducer* c) const override;
 	ExprPtr Reduce(Reducer* c, StmtPtr& red_stmt) override;
+	};
+
+class MaskExpr final : public BinaryExpr
+	{
+public:
+	MaskExpr(ExprPtr op1, ExprPtr op2);
+
+	// Optimization-related:
+	ExprPtr Duplicate() override;
 
 protected:
 	ValPtr AddrFold(Val* v1, Val* v2) const override;

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -304,11 +304,11 @@ public:
 	// True if this expression can be the RHS for a field assignment.
 	bool IsFieldAssignable(const Expr* e) const;
 
-	// True if the expression will transform to one of another type
-	// upon reduction, for non-constant operands.  "Transform" means
-	// something beyond assignment to a temporary.  Necessary so that
-	// we know to fully reduce such expressions if they're the RHS
-	// of an assignment.
+	// True if the expression will transform to one of another AST node
+	// (perhaps of the same type) upon reduction, for non-constant
+	// operands.  "Transform" means something beyond assignment to a
+	// temporary.  Necessary so that we know to fully reduce such
+	// expressions if they're the RHS of an assignment.
 	virtual bool WillTransform(Reducer* c) const { return false; }
 
 	// The same, but for the expression when used in a conditional context.

--- a/src/Type.h
+++ b/src/Type.h
@@ -744,6 +744,11 @@ public:
 	// initialization can not be deferred, otherwise possible.
 	bool IsDeferrable() const;
 
+	// Whether values of this record type are equivalent upon initial
+	// creation, or might differ (e.g. due to function calls or changes
+	// to global state) - used for script optimization.
+	bool IdempotentCreation() const { return creation_inits.empty(); }
+
 	static void InitPostScript();
 
 private:

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -3921,10 +3921,6 @@ bool VectorVal::Concretize(const TypePtr& t)
 		// shouldn't happen in any case.
 		return yield_type->Tag() == t->Tag();
 
-	if ( vector_val.empty() )
-		// Trivially concretized.
-		return true;
-
 	auto n = vector_val.size();
 	for ( auto i = 0U; i < n; ++i )
 		{

--- a/src/parse.y
+++ b/src/parse.y
@@ -633,7 +633,10 @@ expr:
 	|	expr '/' expr
 			{
 			set_location(@1, @3);
-			$$ = new DivideExpr({AdoptRef{}, $1}, {AdoptRef{}, $3});
+			if ( $1->GetType()->Tag() == TYPE_ADDR )
+				$$ = new MaskExpr({AdoptRef{}, $1}, {AdoptRef{}, $3});
+			else
+				$$ = new DivideExpr({AdoptRef{}, $1}, {AdoptRef{}, $3});
 			}
 
 	|	expr '%' expr

--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -80,6 +80,7 @@ string CPPCompile::GenExpr(const Expr* e, GenType gt, bool top_level)
 		case EXPR_TIMES:
 			return GenBinary(e, gt, "*", "mul");
 		case EXPR_DIVIDE:
+		case EXPR_MASK: // later code will split into addr masking
 			return GenBinary(e, gt, "/", "div");
 		case EXPR_MOD:
 			return GenBinary(e, gt, "%", "mod");
@@ -1060,7 +1061,7 @@ string CPPCompile::GenBinaryAddr(const Expr* e, GenType gt, const char* op)
 	{
 	auto v1 = GenExpr(e->GetOp1(), GEN_DONT_CARE) + "->AsAddr()";
 
-	if ( e->Tag() == EXPR_DIVIDE )
+	if ( e->Tag() == EXPR_MASK )
 		{
 		auto gen = string("addr_mask__CPP(") + v1 + ", " + GenExpr(e->GetOp2(), GEN_NATIVE) + ")";
 

--- a/src/script_opt/CPP/maint/README
+++ b/src/script_opt/CPP/maint/README
@@ -30,18 +30,20 @@ The maintenance workflow:
     compiler that you'll want to subsequent run against the test suite,
     per the following.
 
-2.  Run "find-test-files.sh" to generate a list (to stdout) of all of the
+2.  "mkdir CPP-test" - a directory for holding results relating to C++ testing
+
+3.  Run "find-test-files.sh" to generate a list (to stdout) of all of the
     possible Zeek source files found in the test suite.
 
-3.  For each such Zeek file, run "check-zeek.sh" to see whether Zeek can
+4.  For each such Zeek file, run "check-zeek.sh" to see whether Zeek can
     parse it.  This helps remove from further consideration difficult
     tests (like those that have embedded input files, or multiple separate
-    scripts).
+    scripts).  Each run writes a report into CPP-test/cz.* file.
 
-4.  "mkdir CPP-test" - a directory for holding results relating to C++ testing
+    This step is parallelizable, say using xargs -P 10 -n 1.
 
 5.  Run "check-CPP-gen.sh" for each Zeek file that passed "check-zeek.sh".
-    This will generate a corresponding file in CPP-test/out* indicating whether
+    This will generate a corresponding file in CPP-test/out.* indicating whether
     "-O gen-C++" can successfully run on the input.  Presently, it should
     be able to do so for all of them except a few that have conditional code,
     which I've left active (no @TEST-REQUIRES to prune) given hopes of

--- a/src/script_opt/CPP/maint/check-zeek.sh
+++ b/src/script_opt/CPP/maint/check-zeek.sh
@@ -1,4 +1,9 @@
 #! /bin/sh
 
-/bin/echo -n $1" "
-(src/zeek --parse-only $1 >/dev/null 2>&1 && echo "success") || echo "fail"
+abbr=$(echo $1 | sed 's,\.\./,,;s,/,#,g')
+out=CPP-test/cz.$abbr
+
+(
+    /bin/echo -n $1" "
+    (src/zeek --parse-only $1 >/dev/null 2>&1 && echo "success") || echo "fail"
+) >$out

--- a/src/script_opt/Expr.cc
+++ b/src/script_opt/Expr.cc
@@ -1812,8 +1812,9 @@ ExprPtr AssignExpr::Reduce(Reducer* c, StmtPtr& red_stmt)
 	if ( op2->WillTransform(c) )
 		{
 		StmtPtr xform_stmt;
+		StmtPtr lhs_stmt = lhs_ref->ReduceToLHS(c);
 		op2 = op2->ReduceToSingleton(c, xform_stmt);
-		red_stmt = MergeStmts(rhs_reduce, xform_stmt);
+		red_stmt = MergeStmts(lhs_stmt, rhs_reduce, xform_stmt);
 		return ThisPtr();
 		}
 

--- a/src/script_opt/Expr.cc
+++ b/src/script_opt/Expr.cc
@@ -253,6 +253,7 @@ bool Expr::IsFieldAssignable(const Expr* e) const
 		case EXPR_SUB:
 		case EXPR_TIMES:
 		case EXPR_DIVIDE:
+		case EXPR_MASK:
 		case EXPR_MOD:
 		case EXPR_AND:
 		case EXPR_OR:
@@ -1091,18 +1092,22 @@ ExprPtr DivideExpr::Duplicate()
 
 bool DivideExpr::WillTransform(Reducer* c) const
 	{
-	return GetType()->Tag() != TYPE_SUBNET && op2->IsOne();
+	return op2->IsOne();
 	}
 
 ExprPtr DivideExpr::Reduce(Reducer* c, StmtPtr& red_stmt)
 	{
-	if ( GetType()->Tag() != TYPE_SUBNET )
-		{
-		if ( op2->IsOne() )
-			return op1->ReduceToSingleton(c, red_stmt);
-		}
+	if ( op2->IsOne() )
+		return op1->ReduceToSingleton(c, red_stmt);
 
 	return BinaryExpr::Reduce(c, red_stmt);
+	}
+
+ExprPtr MaskExpr::Duplicate()
+	{
+	auto op1_d = op1->Duplicate();
+	auto op2_d = op2->Duplicate();
+	return SetSucc(new MaskExpr(op1_d, op2_d));
 	}
 
 ExprPtr ModExpr::Duplicate()

--- a/src/script_opt/Expr.cc
+++ b/src/script_opt/Expr.cc
@@ -196,7 +196,7 @@ bool Expr::IsReducedConditional(Reducer* c) const
 			if ( op1->Tag() != EXPR_NAME && op1->Tag() != EXPR_LIST )
 				return NonReduced(this);
 
-			if ( op2->GetType()->Tag() != TYPE_TABLE || ! op2->IsReduced(c) )
+			if ( op2->GetType()->Tag() != TYPE_TABLE || ! op2->IsSingleton(c) )
 				return NonReduced(this);
 
 			if ( op1->Tag() == EXPR_LIST )
@@ -889,13 +889,13 @@ bool AddToExpr::IsReduced(Reducer* c) const
 	auto tag = t->Tag();
 
 	if ( tag == TYPE_PATTERN )
-		return op1->HasReducedOps(c) && op2->IsReduced(c);
+		return op1->HasReducedOps(c) && op2->IsSingleton(c);
 
 	if ( tag == TYPE_TABLE )
-		return op1->IsReduced(c) && op2->IsReduced(c);
+		return op1->IsReduced(c) && op2->IsSingleton(c);
 
 	if ( tag == TYPE_VECTOR && IsVector(op2->GetType()->Tag()) && same_type(t, op2->GetType()) )
-		return op1->IsReduced(c) && op2->IsReduced(c);
+		return op1->IsReduced(c) && op2->IsSingleton(c);
 
 	return NonReduced(this);
 	}
@@ -919,7 +919,7 @@ ExprPtr AddToExpr::Reduce(Reducer* c, StmtPtr& red_stmt)
 				op1 = op1->Reduce(c, red_stmt1);
 
 			auto& t = op1->GetType();
-			op2 = op2->Reduce(c, red_stmt2);
+			op2 = op2->ReduceToSingleton(c, red_stmt2);
 
 			red_stmt = MergeStmts(red_stmt1, red_stmt2);
 
@@ -1015,7 +1015,7 @@ ExprPtr RemoveFromExpr::Duplicate()
 bool RemoveFromExpr::IsReduced(Reducer* c) const
 	{
 	if ( op1->GetType()->Tag() == TYPE_TABLE )
-		return op1->IsReduced(c) && op2->IsReduced(c);
+		return op1->IsReduced(c) && op2->IsSingleton(c);
 
 	return NonReduced(this);
 	}
@@ -1028,7 +1028,7 @@ ExprPtr RemoveFromExpr::Reduce(Reducer* c, StmtPtr& red_stmt)
 		StmtPtr red_stmt2;
 
 		op1 = op1->Reduce(c, red_stmt1);
-		op2 = op2->Reduce(c, red_stmt2);
+		op2 = op2->ReduceToSingleton(c, red_stmt2);
 
 		red_stmt = MergeStmts(red_stmt1, red_stmt2);
 

--- a/src/script_opt/Reduce.h
+++ b/src/script_opt/Reduce.h
@@ -332,6 +332,10 @@ protected:
 	// renders the CSE unsafe.
 	const std::vector<const ID*>& ids;
 
+	// Whether the list of identifiers includes some that we should
+	// consider potentially altered by a function call.
+	bool sensitive_to_calls = false;
+
 	// Where in the AST to start our analysis.  This is the initial
 	// assignment expression.
 	const Expr* start_e;

--- a/src/script_opt/ZAM/Expr.cc
+++ b/src/script_opt/ZAM/Expr.cc
@@ -736,6 +736,12 @@ const ZAMStmt ZAMCompiler::CompileIndex(const NameExpr* n1, int n2_slot, const T
 				z = ZInstI(zop, Frame1Slot(n1, zop), n2_slot, c3);
 				}
 
+			// See the discussion in CSE_ValidityChecker::PreExpr
+			// regarding always needing to treat this as potentially
+			// modifying globals.
+			z.aux = new ZInstAux(0);
+			z.aux->can_change_non_locals = true;
+
 			return AddInst(z);
 			}
 		}
@@ -1184,6 +1190,9 @@ const ZAMStmt ZAMCompiler::ConstructRecord(const NameExpr* n, const Expr* e)
 		}
 
 	z.t = e->GetType();
+
+	if ( ! rc->GetType<RecordType>()->IdempotentCreation() )
+		z.aux->can_change_non_locals = true;
 
 	return AddInst(z);
 	}

--- a/src/script_opt/ZAM/Ops.in
+++ b/src/script_opt/ZAM/Ops.in
@@ -490,7 +490,16 @@ eval-pre	if ( $2 == 0 )
 			break;
 			}
 eval $1 / $2
-#
+
+binary-expr-op Mask
+op-type I
+vector
+### Note that this first "eval" is a dummy - we'll never generate code
+### that uses it because "Mask" expressions don't have LHS operands of
+### type "int". We could omit this if we modified Gen-ZAM to understand
+### that an op-type of 'X' for a binary-expr-op means "skip the usual case
+### of two operands of the same type".
+eval $1 / $2
 eval-mixed A I	auto mask = static_cast<uint32_t>($2);
 		auto a = $1->AsAddr();
 		if ( a.GetFamily() == IPv4 && mask > 32 )

--- a/testing/btest/Baseline.zam/spicy.ssh-banner/analyzer.log
+++ b/testing/btest/Baseline.zam/spicy.ssh-banner/analyzer.log
@@ -7,6 +7,6 @@
 #open XXXX-XX-XX-XX-XX-XX
 #fields	ts	cause	analyzer_kind	analyzer_name	uid	fuid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	failure_reason	failure_data
 #types	time	string	string	string	string	string	addr	port	addr	port	string	string
-XXXXXXXXXX.XXXXXX	violation	protocol	SPICY_SSH	CHhAvVGS1DHFjwGM9	-	141.142.228.5	53595	54.243.55.129	80	protocol rejected	-
+XXXXXXXXXX.XXXXXX	violation	protocol	SPICY_SSH	CHhAvVGS1DHFjwGM9	-	141.142.228.5	53595	54.243.55.129	80	kaputt	-
 XXXXXXXXXX.XXXXXX	violation	protocol	SPICY_SSH	CHhAvVGS1DHFjwGM9	-	141.142.228.5	53595	54.243.55.129	80	failed to match regular expression (<...>/ssh.spicy:7:15)	POST /post HTTP/1.1\x0d\x0aUser-Agent: curl/7.
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/btest/Baseline.zam/spicy.ssh-banner/output
+++ b/testing/btest/Baseline.zam/spicy.ssh-banner/output
@@ -7,4 +7,4 @@ SSH banner, [orig_h=192.150.186.169, orig_p=49244/tcp, resp_h=131.159.14.23, res
 confirm, AllAnalyzers::ANALYZER_ANALYZER_SPICY_SSH
 === violation
 violation, AllAnalyzers::ANALYZER_ANALYZER_SPICY_SSH, failed to match regular expression (<...>/ssh.spicy:7:15)
-violation, AllAnalyzers::ANALYZER_ANALYZER_SPICY_SSH, protocol rejected
+violation, AllAnalyzers::ANALYZER_ANALYZER_SPICY_SSH, kaputt

--- a/testing/btest/language/table-iterate-record-key-default.zeek
+++ b/testing/btest/language/table-iterate-record-key-default.zeek
@@ -80,10 +80,18 @@ global tbl: table[R] of R;
 	{
 	print seq, "populating table, expecting 8 my_seq() invocations";
 
-	tbl[R()] = R();
-	tbl[R()] = R();
-	tbl[R()] = R();
-	tbl[R()] = R();
+	# The following structure is used to avoid order-of-evaluation
+	# ambiguity. If we use "tbl[R()] = R()" statements then script
+	# optimization might create different table indices/values than
+	# interpreted execution.
+	local v = R();
+	tbl[R()] = v;
+	v = R();
+	tbl[R()] = v;
+	v = R();
+	tbl[R()] = v;
+	v = R();
+	tbl[R()] = v;
 
 	print seq, "iterating table, expecting no my_seq() invocations";
 	for ( [r1], r2 in tbl )


### PR DESCRIPTION
Some of our content ran into a ZAM bug and that led me to tackling the monthly script optimization maintenance a bit early.

There was nothing substantive for the compile-to-C++ functionality, just a couple of tweaks to maintenance scripts/notes (in particular, modifying one of the maintenance scripts to be amenable to parallelized execution).

For ZAM, the changes are:

- A new `EXPR_MASK` AST node to use for address masking, instead of the overloaded `EXPR_DIVIDE` node. This change simplifies some internals and in particular let me fix a ZAM bug for `/0` address masks without having to make changes to `gen-zam`.
- A fix for "concretizing" empty vectors that are used in a typed context so that they keep that type. (I'm not sure why this one didn't cause problems for the interpreter, too.)
- Modified one of the recently introduced BTests to remove order-of-execution ambiguities that led to benign differences between regular and ZAM execution.
- Fixes to the AST and low-level ZAM optimizers to accommodate the recent change to record field initialization.
- Fix for a nasty ZAM inliner bug that led to incorrect values being used when a local was assigned to a parameter.