### PR TITLE
Enable ccache-backed Spicy JIT for users of developer scripts.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -170,9 +170,6 @@ env:
   # a solution for the mtime pruning above.
   ZEEK_CCACHE_EPOCH: 2
 
-  # Cache Spicy JIT results.
-  HILTI_CXX_COMPILER_LAUNCHER: ccache
-
 # Linux EOL timelines: https://linuxlifecycle.com/
 # Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,7 +535,16 @@ file(
     "setenv ZEEK_SPICY_LIBRARY_PATH \"${cmake_source_dir}/scripts/spicy\"\n"
     "setenv SPICY_BUILD_DIRECTORY \"${cmake_binary_dir}/auxil/spicy\"\n")
 
+if (CMAKE_CXX_COMPILER_LAUNCHER)
+    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/zeek-path-dev.sh
+         "export HILTI_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}\n")
+
+    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/zeek-path-dev.csh
+         "setenv HILTI_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}\n")
+endif ()
+
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" ZEEK_VERSION_FULL LIMIT_COUNT 1)
+
 execute_process(
     COMMAND grep "^constexpr int PLUGIN_API_VERSION"
     INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/src/plugin/Plugin.h


### PR DESCRIPTION
For CI and more general BTest execution we already enabled ccache previously, but developers using a Spicy build out of the build directory still needed to manually set up caching.

With this patch we enable it for such cases as well via `zeek-path-dev.*sh`.