### PR TITLE
ci/update-zeekygen-docs.sh: Do output stderr by default

### DIFF
--- a/ci/update-zeekygen-docs.sh
+++ b/ci/update-zeekygen-docs.sh
@@ -13,7 +13,6 @@ source_dir="$(cd $dir/.. && pwd)"
 build_dir=$source_dir/build
 conf_file=$build_dir/zeekygen-test.conf
 output_dir=$source_dir/doc
-zeek_error_file=$build_dir/zeekygen-test-stderr.txt
 
 if [ -n "$1" ]; then
     output_dir=$1
@@ -29,11 +28,10 @@ cd $build_dir
 export ZEEK_SEED_FILE=$source_dir/testing/btest/random.seed
 
 function run_zeek {
-    ZEEK_ALLOW_INIT_ERRORS=1 zeek -X $conf_file zeekygen >/dev/null 2>$zeek_error_file
+    ZEEK_ALLOW_INIT_ERRORS=1 zeek -X $conf_file zeekygen >/dev/null
 
     if [ $? -ne 0 ]; then
-        echo "Failed running zeek with zeekygen config file $conf_file"
-        echo "See stderr in $zeek_error_file"
+        echo "Failed running zeek with zeekygen config file $conf_file" >&2
         exit 1
     fi
 }

--- a/scripts/zeekygen/__load__.zeek
+++ b/scripts/zeekygen/__load__.zeek
@@ -21,7 +21,14 @@
 
 @load ./example.zeek
 
-event zeek_init()
+event zeek_init() &priority=1000
 	{
+	# Disable events in modules that use zeek_init() to do stuff and may
+	# fail when run under zeekygen. For the purpose of zeekygen, we could
+	# probably disable all modules, too.
+	disable_module_events("Control");
+	disable_module_events("Management::Agent::Runtime");
+	disable_module_events("Management::Controller::Runtime");
+	disable_module_events("Management::Node");
 	terminate();
 	}

--- a/scripts/zeekygen/example.zeek
+++ b/scripts/zeekygen/example.zeek
@@ -173,7 +173,7 @@ export {
 
 # This function isn't exported, so it won't appear anywhere in the generated
 # documentation.  So using ``##``-style comments is pointless here.
-function function_without_proto(tag: string): string
+function function_without_proto(tag: string): string &is_used
     {
     # Zeekygen-style comments only apply to entities at global-scope so
     # Zeekygen doesn't associate the following comments with anything.

--- a/testing/btest/Baseline/doc.zeekygen.identifier/test.rst
+++ b/testing/btest/Baseline/doc.zeekygen.identifier/test.rst
@@ -240,6 +240,7 @@
    :source-code: zeekygen/example.zeek 176 184
 
    :Type: :zeek:type:`function` (tag: :zeek:type:`string`) : :zeek:type:`string`
+   :Attributes: :zeek:attr:`&is_used`
 
 
 .. zeek:type:: ZeekygenExample::PrivateRecord


### PR DESCRIPTION
stderr was only produced when there was a real failure as it had been a
bit noisy previously, but that has hidden actual problems. Now that there is
less noise, just output stderr all the time.


---

This is using module event groups to disable `zeek_init()` handlers in the management and control framework modules. They expect a certain environment / invocation and otherwise cause errors.