### PR TITLE
Docker builder CI fixes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -496,6 +496,7 @@ docker_build_template: &DOCKER_BUILD_TEMPLATE
     CIRRUS_LOG_TIMESTAMP: true
     BUILDER_IMAGE_CACHE_DIR: /tmp/builder-image-cache
     ZEEK_IMAGE_CACHE_DIR: /tmp/zeek-image-cache-${CIRRUS_ARCH}
+    BUILDKIT_PROGRESS: plain
 
   always:
     ccache_cache:

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -3,6 +3,10 @@
 # Layer to build Zeek.
 FROM debian:bookworm-slim
 
+# Make the shell split commands in the log so we can determine reasons for
+# failures more easily.
+SHELL ["/bin/sh", "-x", "-c"]
+
 # Allow apt to retry 3 times before failing.
 RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
 

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -3,7 +3,12 @@
 # Layer to build Zeek.
 FROM debian:bookworm-slim
 
+# Allow apt to retry 3 times before failing.
 RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+
+# Force apt to timeout retrieval of data after 3 minutes.
+RUN echo 'Acquire::http::timeout "180";' > /etc/apt/apt.conf.d/99-timeouts
+RUN echo 'Acquire::https::timeout "180";' >> /etc/apt/apt.conf.d/99-timeouts
 
 # Configure system for build.
 RUN apt-get -q update \

--- a/docker/final.Dockerfile
+++ b/docker/final.Dockerfile
@@ -3,7 +3,12 @@
 # Final layer containing all artifacts.
 FROM debian:bookworm-slim
 
+# Allow apt to retry 3 times before failing.
 RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+
+# Force apt to timeout retrieval of data after 3 minutes.
+RUN echo 'Acquire::http::timeout "180";' > /etc/apt/apt.conf.d/99-timeouts
+RUN echo 'Acquire::https::timeout "180";' >> /etc/apt/apt.conf.d/99-timeouts
 
 RUN apt-get -q update \
  && apt-get install -q -y --no-install-recommends \

--- a/docker/final.Dockerfile
+++ b/docker/final.Dockerfile
@@ -3,6 +3,10 @@
 # Final layer containing all artifacts.
 FROM debian:bookworm-slim
 
+# Make the shell split commands in the log so we can determine reasons for
+# failures more easily.
+SHELL ["/bin/sh", "-x", "-c"]
+
 # Allow apt to retry 3 times before failing.
 RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
 


### PR DESCRIPTION
This does two things:

- Adds a timeout for the http/https connections from `apt` commands to the docker files. This should help force the connections to fail and retry if they're taking a long time to complete.
- Split the `apt` commands in the docker files in to separate `RUN` commands so as to get better diagnostics about which step is failing to complete.

This is obviously hard to test since they're timeouts, and they're very spurious on CI.