### PR TITLE
Fix missing version number in `spicyz`.

### DIFF
--- a/src/spicy/spicyz/config.h.in
+++ b/src/spicy/spicyz/config.h.in
@@ -60,8 +60,8 @@ inline const auto CxxZeekIncludesDirectories() {
 #cmakedefine SPICY_VERSION_NUMBER ${SPICY_VERSION_NUMBER}
 #cmakedefine ZEEK_VERSION_NUMBER ${ZEEK_VERSION_NUMBER}
 
-inline const auto SpicyVersion = "${SPICY_VERSION}";
-inline const auto ZeekVersion = "${VERSION}";
+inline const auto SpicyVersion = "${SPICY_VERSION_LONG}";
+inline const auto ZeekVersion = "${ZEEK_VERSION_FULL}";
 inline const auto InstallPrefix = path("${CMAKE_INSTALL_PREFIX}");
 
 } // namespace zeek::spicy::configuration


### PR DESCRIPTION
Needs associated `cmake` PR.

Closes #3383.
