### PR TITLE
Speed up code for exporting Spicy types to Zeek

### DIFF
--- a/src/spicy/spicyz/glue-compiler.h
+++ b/src/spicy/spicyz/glue-compiler.h
@@ -199,12 +199,14 @@ public:
      */
     ExportedField exportForField(const hilti::ID& zeek_id, const hilti::ID& field_id) const;
 
+    using ZeekTypeCache = std::map<hilti::ID, hilti::Expression>;
+
     /**
      * Generates code to convert a HILTI type to a corresponding Zeek type at
      * runtime. The code is added to the given body.
      */
     hilti::Result<hilti::Nothing> createZeekType(const hilti::Type& t, const hilti::ID& id,
-                                                 hilti::builder::Builder* body) const;
+                                                 hilti::builder::Builder* body, ZeekTypeCache* cache) const;
 
     /** Return type for `recordField()`. */
     struct RecordField {

--- a/src/spicy/spicyz/glue-compiler.h
+++ b/src/spicy/spicyz/glue-compiler.h
@@ -16,6 +16,7 @@
 
 #include <spicy/rt/mime.h>
 
+#include <hilti/ast/builder/builder.h>
 #include <hilti/ast/declarations/function.h>
 #include <hilti/ast/expression.h>
 #include <hilti/ast/module.h>
@@ -198,8 +199,12 @@ public:
      */
     ExportedField exportForField(const hilti::ID& zeek_id, const hilti::ID& field_id) const;
 
-    /** Generates code to convert a HILTI type to a corresponding Zeek type at runtime. */
-    hilti::Result<hilti::Expression> createZeekType(const hilti::Type& t, const hilti::ID& id) const;
+    /**
+     * Generates code to convert a HILTI type to a corresponding Zeek type at
+     * runtime. The code is added to the given body.
+     */
+    hilti::Result<hilti::Nothing> createZeekType(const hilti::Type& t, const hilti::ID& id,
+                                                 hilti::builder::Builder* body) const;
 
     /** Return type for `recordField()`. */
     struct RecordField {


### PR DESCRIPTION
- Spicy: Unroll Zeek type registrations.
- Spicy: Avoid creating Zeek types multiple times.

Closes #3370.
