### PR TITLE
event: Reinitialize EventMgr's flare after fork() from stem

### DIFF
--- a/src/Event.cc
+++ b/src/Event.cc
@@ -207,4 +207,12 @@ void EventMgr::InitPostScript()
 		reporter->FatalError("Failed to register event manager FD with iosource_mgr");
 	}
 
+void EventMgr::InitPostFork()
+	{
+	// Re-initialize the flare, closing and re-opening the underlying
+	// pipe FDs. This is needed so that each Zeek process in a supervisor
+	// setup has its own pipe instead of them all sharing a single pipe.
+	queue_flare = zeek::detail::Flare{};
+	}
+
 	} // namespace zeek

--- a/src/Event.h
+++ b/src/Event.h
@@ -118,6 +118,9 @@ public:
 	const char* Tag() override { return "EventManager"; }
 	void InitPostScript();
 
+	// Initialization to be done after a fork() happened.
+	void InitPostFork();
+
 	uint64_t num_events_queued = 0;
 	uint64_t num_events_dispatched = 0;
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -554,7 +554,13 @@ SetupResult setup(int argc, char** argv, Options* zopts)
 	auto stem = Supervisor::CreateStem(options.supervisor_mode);
 
 	if ( Supervisor::ThisNode() )
+		{
+		// If we get here, we're a supervised node that just returned
+		// from CreateStem() after being forked from the stem.
 		Supervisor::ThisNode()->Init(&options);
+
+		event_mgr.InitPostFork();
+		}
 
 	script_coverage_mgr.ReadStats();
 


### PR DESCRIPTION
Because EventMgr is defined globally as an object (rather than a global
pointer to an EventMgr object), its pipe is created even before main()
is entered. This further means that in the fork-based supervisor setup,
all Zeek processes created from the top-level supervisor process share
the same pipe object for the EventMgr. In turn, whenever any of the
processes enqueued an event, the flare was fired and ready for reading
on all other processes in the cluster, causing much contention and
unneeded overhead.

Closes #3190

---

Added a `InitPostFork()` that only runs on supervised nodes post fork(). If we have more cases where this matters we can make it more generic or look at `pthread_atexit`. As long as it's just the EventMgr, didn't seem worth it.

After this fix, worker CPU usage is comparable with the Python supervisor mentioned in #3190 

Credits to @J-Gras for the report.