### PR TITLE
subdir-btest: Allow setting build_dir

### DIFF
--- a/testing/external/subdir-btest.cfg
+++ b/testing/external/subdir-btest.cfg
@@ -1,3 +1,6 @@
+[DEFAULT]
+build_dir = build
+
 [btest]
 TestDirs    = tests
 TmpDir      = %(testbase)s/.tmp
@@ -7,18 +10,18 @@ IgnoreFiles = *.tmp *.swp #* *.trace .gitignore *.skeleton
 MinVersion  = 0.63
 
 [environment]
-ZEEKPATH=`bash -c %(testbase)s/../../../build/zeek-path-dev`:%(testbase)s/../scripts
+ZEEKPATH=`bash -c %(testbase)s/../../../%(build_dir)s/zeek-path-dev`:%(testbase)s/../scripts
 ZEEK_SEED_FILE=%(testbase)s/../random.seed
 TZ=UTC
 LC_ALL=C
-PATH=%(testbase)s/../../../build/src:%(testbase)s/../../../auxil/btest:%(testbase)s/../../scripts:%(default_path)s
+PATH=%(testbase)s/../../../%(build_dir)s/src:%(testbase)s/../../../auxil/btest:%(testbase)s/../../scripts:%(default_path)s
 TEST_DIFF_CANONIFIER=%(testbase)s/../../scripts/diff-canonifier-external
 TEST_DIFF_BRIEF=1
 TRACES=%(testbase)s/Traces
 SCRIPTS=%(testbase)s/../scripts
 SCRIPTS_LOCAL=%(testbase)s/scripts
 DIST=%(testbase)s/../../..
-BUILD=%(testbase)s/../../../build
+BUILD=%(testbase)s/../../../%(build_dir)s
 ZEEK_PROFILER_FILE=%(testbase)s/.tmp/script-coverage/XXXXXX
 ZEEK_DNS_FAKE=1
 # Fedora/CentOS/RedHat have MD5 disabled for certificate verification and need setting an environment variable to permit it:


### PR DESCRIPTION
We have that functionality in btest.cfg and it's actually nice to use it for toggling between a debug/asan and release build.