### PR TITLE
CI: Pass -A flag to btest for cluster-testing builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -695,7 +695,7 @@ cluster_testing_docker_builder:
   test_script:
     # Invoke btest directly here. This mirrors ci/test.sh, ensures we don't
     # accidentally build a Docker image, and enables console-level output:
-    - cd testing/external/zeek-testing-cluster && ../../../auxil/btest/btest -d -b -j ${ZEEK_CI_BTEST_JOBS}
+    - cd testing/external/zeek-testing-cluster && ../../../auxil/btest/btest -A -d -b -j ${ZEEK_CI_BTEST_JOBS}
   on_failure:
     upload_cluster_testing_artifacts:
       path: "testing/external/zeek-testing-cluster/.tmp/**"


### PR DESCRIPTION
The cluster-testing tasks times out periodically during the test step, but we're not passing `-A` to btest so we don't have any indication as to which tests are causing it to timeout. We're passing this flag to btest in all of the other builds, so it's worth passing it here as well.