### PR TITLE
fuzzer-setup: Allow customization without recompiling

### DIFF
--- a/src/fuzzers/standalone-driver.cc
+++ b/src/fuzzers/standalone-driver.cc
@@ -15,10 +15,11 @@ int main(int argc, char** argv)
 	{
 	using namespace std::chrono;
 	auto agg_start = high_resolution_clock::now();
-	auto num_inputs = argc - 1;
-	printf("Standalone fuzzer processing %d inputs\n", num_inputs);
 
 	LLVMFuzzerInitialize(&argc, &argv);
+
+	auto num_inputs = argc - 1;
+	printf("Standalone fuzzer processing %d inputs\n", num_inputs);
 	auto fuzz_start = high_resolution_clock::now();
 
 	for ( auto i = 0; i < num_inputs; ++i )


### PR DESCRIPTION
This change allows to invoke a reproducer with different script options and extra scripts to ease debugging and investigation. For example, enabling the DPD debug stream and adding misc/dump-events can be done as follows after this change:

    ZEEK_DEBUG_LOG_STDERR=1 ../../build/src/fuzzers/zeek-pop3-fuzzer <test-case> -- -B dpd misc/dump-events