### PR TITLE
Force OpenSSL as a dependency on all plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,7 +294,8 @@ target_include_directories(
 if (OPENSSL_INCLUDE_DIR)
     target_include_directories(zeek_dynamic_plugin_base INTERFACE "${OPENSSL_INCLUDE_DIR}")
 endif ()
-target_link_libraries(zeek_dynamic_plugin_base INTERFACE Threads::Threads)
+target_link_libraries(zeek_dynamic_plugin_base INTERFACE Threads::Threads OpenSSL::SSL
+                                                         OpenSSL::Crypto)
 add_library(Zeek::DynamicPluginBase ALIAS zeek_dynamic_plugin_base)
 set_target_properties(zeek_dynamic_plugin_base PROPERTIES EXPORT_NAME DynamicPluginBase)
 install(TARGETS zeek_dynamic_plugin_base EXPORT ZeekTargets)


### PR DESCRIPTION
Relates #3408.

Here's the TLDR:

- We forward OpenSSL paths to the plugins (and finding OpenSSL works for me).
- Nothing forces plugins to pick up OpenSSL as an actual dependency (yet).

This patch changes the latter and forces OpenSSL as a dependency on all plugins even if they don't actually need it.

The alternative solution is to have plugins opt-in to OpenSSL if they really do need it. They can do this by using `DEPENDENCIES OpenSSL::SSL OpenSSL::Crypto`, e.g.,

```
 zeek_add_plugin(
      Zeek
        MoreHashes
      DEPENDENCIES OpenSSL::SSL OpenSSL::Crypto
      SOURCES
        ...
```

If we want to go this way, just close this PR.

I'd personally prefer the second option and not have OpenSSL forced on all plugins. However, I also don't know how many plugins we might break, so my opinion might be naïve.