### PR TITLE
Require `truncate` for a test using it

### DIFF
--- a/testing/btest/Baseline/core.mmdb.temporary-error/reporter.log
+++ b/testing/btest/Baseline/core.mmdb.temporary-error/reporter.log
@@ -3,15 +3,15 @@ ts	level	message	location
 1299470395.000000	Reporter::INFO	Modification time change detected for MaxMind DB [.<...>/GeoLite2-ASN.mmdb]	<params>, line 1
 1299470395.000000	Reporter::INFO	Closing stale MaxMind DB [.<...>/GeoLite2-ASN.mmdb]	<params>, line 1
 1299470395.000000	Reporter::INFO	Failed to open MaxMind DB: .<...>/GeoLite2-ASN.mmdb [The MaxMind DB file contains invalid metadata]	<params>, line 1
-1299470395.000000	Reporter::ERROR	Failed to open GeoIP ASN database (lookup_autonomous_system(128.3.0.1))	<...>/temporary-error.zeek, line 99
+1299470395.000000	Reporter::ERROR	Failed to open GeoIP ASN database (lookup_autonomous_system(128.3.0.1))	<...>/temporary-error.zeek, line 100
 1299470395.000000	Reporter::INFO	Modification time change detected for MaxMind DB [.<...>/GeoLite2-City.mmdb]	<params>, line 1
 1299470395.000000	Reporter::INFO	Closing stale MaxMind DB [.<...>/GeoLite2-City.mmdb]	<params>, line 1
 1299470395.000000	Reporter::INFO	Failed to open MaxMind DB: .<...>/GeoLite2-City.mmdb [The MaxMind DB file contains invalid metadata]	<params>, line 1
-1299470395.000000	Reporter::ERROR	Failed to open GeoIP location database (lookup_location(128.3.0.1))	<...>/temporary-error.zeek, line 100
+1299470395.000000	Reporter::ERROR	Failed to open GeoIP location database (lookup_location(128.3.0.1))	<...>/temporary-error.zeek, line 101
 1299473995.000000	Reporter::INFO	Closing stale MaxMind DB [.<...>/GeoLite2-ASN.mmdb]	<params>, line 1
-1299473995.000000	Reporter::ERROR	Failed to open GeoIP ASN database (lookup_autonomous_system(128.3.0.1))	<...>/temporary-error.zeek, line 99
+1299473995.000000	Reporter::ERROR	Failed to open GeoIP ASN database (lookup_autonomous_system(128.3.0.1))	<...>/temporary-error.zeek, line 100
 1299473995.000000	Reporter::INFO	Closing stale MaxMind DB [.<...>/GeoLite2-City.mmdb]	<params>, line 1
-1299473995.000000	Reporter::ERROR	Failed to open GeoIP location database (lookup_location(128.3.0.1))	<...>/temporary-error.zeek, line 100
+1299473995.000000	Reporter::ERROR	Failed to open GeoIP location database (lookup_location(128.3.0.1))	<...>/temporary-error.zeek, line 101
 1299477595.000000	Reporter::INFO	Inode change detected for MaxMind DB [.<...>/GeoLite2-ASN.mmdb]	<params>, line 1
 1299477595.000000	Reporter::INFO	Closing stale MaxMind DB [.<...>/GeoLite2-ASN.mmdb]	<params>, line 1
 1299477595.000000	Reporter::INFO	Inode change detected for MaxMind DB [.<...>/GeoLite2-City.mmdb]	<params>, line 1

--- a/testing/btest/core/mmdb/temporary-error.zeek
+++ b/testing/btest/core/mmdb/temporary-error.zeek
@@ -1,6 +1,7 @@
 # @TEST-DOC: Test a few error and recovery cases (corrupted, removed and restored MMDB databases).
 #
 # @TEST-REQUIRES: grep -q "#define USE_GEOIP" $BUILD/zeek-config.h
+# @TEST-REQUIRES: command -v truncate
 #
 # @TEST-EXEC: cp -R $FILES/mmdb ./mmdb
 # @TEST-EXEC: cp -R $FILES/mmdb ./mmdb-backup


### PR DESCRIPTION
It looks like older versions of macOS like Monterey do not ship with `truncate`. Make a recently added test require it to suppress spurious failures.