### PR TITLE
Avoid OpenSSL header dependencies

### DIFF
--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -45,7 +45,7 @@ void KeyedHash::InitializeSeeds(const std::array<uint32_t, SEED_INIT_SIZE>& seed
     // yes, we use the same buffer twice to initialize two different keys. This should not really be
     // a security problem of any kind: hmac-md5 is not really used anymore - and even if it was, the
     // hashes should not reveal any information about their initialization vector.
-    static_assert(sizeof(shared_highwayhash_key) == SHA256_DIGEST_LENGTH);
+    static_assert(sizeof(shared_highwayhash_key) == ZEEK_SHA256_DIGEST_LENGTH);
     calculate_digest(Hash_SHA256, (const u_char*)seed_data.data(), sizeof(seed_data) - 16,
                      reinterpret_cast<unsigned char*>(shared_highwayhash_key));
     memcpy(shared_siphash_key, reinterpret_cast<const char*>(seed_data.data()) + 64, 16);

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/zeek-config.h"
 
+#include <openssl/evp.h>
+
 #include "zeek/Base64.h"
 #include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
@@ -1123,8 +1125,7 @@ TableValPtr MIME_Message::ToHeaderTable(MIME_HeaderList& hlist) {
     return t;
 }
 
-MIME_Mail::MIME_Mail(analyzer::Analyzer* mail_analyzer, bool orig, int buf_size)
-    : MIME_Message(mail_analyzer), md5_hash() {
+MIME_Mail::MIME_Mail(analyzer::Analyzer* mail_analyzer, bool orig, int buf_size) : MIME_Message(mail_analyzer) {
     analyzer = mail_analyzer;
 
     min_overlap_length = zeek::detail::mime_segment_overlap_length;
@@ -1179,7 +1180,7 @@ void MIME_Mail::Done() {
 
 MIME_Mail::~MIME_Mail() {
     if ( md5_hash )
-        EVP_MD_CTX_free(md5_hash);
+        zeek::detail::hash_state_free(md5_hash);
 
     delete_strings(all_content);
     delete data_buffer;

--- a/src/analyzer/protocol/mime/MIME.h
+++ b/src/analyzer/protocol/mime/MIME.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <openssl/evp.h>
 #include <cassert>
 #include <cstdio>
 #include <queue>
@@ -9,6 +8,7 @@
 #include "zeek/Reporter.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/Analyzer.h"
+#include "zeek/digest.h"
 
 namespace zeek {
 
@@ -254,7 +254,7 @@ protected:
     int data_start;
     int compute_content_hash;
     int content_hash_length;
-    EVP_MD_CTX* md5_hash;
+    detail::HashDigestState* md5_hash = nullptr;
     std::vector<const String*> entity_content;
     std::vector<const String*> all_content;
 

--- a/src/analyzer/protocol/ssh/ssh-analyzer.pac
+++ b/src/analyzer/protocol/ssh/ssh-analyzer.pac
@@ -203,7 +203,7 @@ refine flow SSH_Flow += {
 		%{
 		if ( ssh_server_host_key )
 			{
-			unsigned char digest[MD5_DIGEST_LENGTH];
+			unsigned char digest[ZEEK_MD5_DIGEST_LENGTH];
 			zeek::detail::internal_md5(${key}.data(), ${key}.length(), digest);
 
 			zeek::BifEvent::enqueue_ssh_server_host_key(connection()->zeek_analyzer(),
@@ -225,7 +225,7 @@ refine flow SSH_Flow += {
 		%{
 		if ( ssh_server_host_key )
 			{
-			unsigned char digest[MD5_DIGEST_LENGTH];
+			unsigned char digest[ZEEK_MD5_DIGEST_LENGTH];
 			auto ctx = zeek::detail::hash_init(zeek::detail::Hash_MD5);
 			// Fingerprint is calculated over concatenation of modulus + exponent.
 			zeek::detail::hash_update(ctx, ${mod}.data(), ${mod}.length());

--- a/src/communityid.bif
+++ b/src/communityid.bif
@@ -86,7 +86,7 @@ function community_id_v1%(cid: conn_id, seed: count &default=0, do_base64: bool 
         std::swap(hash_src_port, hash_dst_port);
     }
 
-    auto digest_update = [](EVP_MD_CTX *ctx, const void* data, unsigned long len) {
+    auto digest_update = [](auto*ctx, const void* data, unsigned long len) {
         zeek::detail::hash_update(ctx, data, len);
         return len;
     };
@@ -102,7 +102,7 @@ function community_id_v1%(cid: conn_id, seed: count &default=0, do_base64: bool 
     dlen += digest_update(ctx, &hash_src_port, 2);
     dlen += digest_update(ctx, &hash_dst_port, 2);
 
-    u_char digest[SHA_DIGEST_LENGTH];
+    u_char digest[ZEEK_SHA_DIGEST_LENGTH];
     zeek::detail::hash_final(ctx, digest);
 
     // We currently have no real versioning/hash configuration logic,
@@ -115,7 +115,7 @@ function community_id_v1%(cid: conn_id, seed: count &default=0, do_base64: bool 
         int outlen = 0;
 
         zeek::detail::Base64Converter enc{nullptr};
-        enc.Encode(SHA_DIGEST_LENGTH, digest, &outlen, &outbuf);
+        enc.Encode(ZEEK_SHA_DIGEST_LENGTH, digest, &outlen, &outbuf);
         res = new zeek::String(ver + std::string(outbuf, outlen));
         // When given outlen = 0, the Encode() method creates the
         // buffer it returns as outbuf, so we must delete it.

--- a/src/digest.cc
+++ b/src/digest.cc
@@ -6,11 +6,38 @@
 
 #include "zeek/digest.h"
 
+#include <openssl/evp.h>
+#include <openssl/md5.h>
+#include <openssl/sha.h>
+
 #include "zeek/Reporter.h"
+
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#define EVP_MD_CTX_new EVP_MD_CTX_create
+#define EVP_MD_CTX_free EVP_MD_CTX_destroy
+#endif
+
+static_assert(ZEEK_MD5_DIGEST_LENGTH == MD5_DIGEST_LENGTH);
+
+static_assert(ZEEK_SHA_DIGEST_LENGTH == SHA_DIGEST_LENGTH);
+
+static_assert(ZEEK_SHA224_DIGEST_LENGTH == SHA224_DIGEST_LENGTH);
+
+static_assert(ZEEK_SHA256_DIGEST_LENGTH == SHA256_DIGEST_LENGTH);
+
+static_assert(ZEEK_SHA384_DIGEST_LENGTH == SHA384_DIGEST_LENGTH);
+
+static_assert(ZEEK_SHA512_DIGEST_LENGTH == SHA512_DIGEST_LENGTH);
 
 namespace zeek::detail {
 
-EVP_MD_CTX* hash_init(HashAlgorithm alg) {
+namespace {
+auto* to_native_ptr(HashDigestState* ptr) { return reinterpret_cast<EVP_MD_CTX*>(ptr); }
+auto* to_native_ptr(const HashDigestState* ptr) { return reinterpret_cast<const EVP_MD_CTX*>(ptr); }
+auto* to_opaque_ptr(EVP_MD_CTX* ptr) { return reinterpret_cast<HashDigestState*>(ptr); }
+} // namespace
+
+HashDigestState* hash_init(HashAlgorithm alg) {
     EVP_MD_CTX* c = EVP_MD_CTX_new();
     const EVP_MD* md;
 
@@ -33,19 +60,31 @@ EVP_MD_CTX* hash_init(HashAlgorithm alg) {
     if ( ! EVP_DigestInit_ex(c, md, NULL) )
         reporter->InternalError("EVP_DigestInit failed");
 
-    return c;
+    return to_opaque_ptr(c);
 }
 
-void hash_update(EVP_MD_CTX* c, const void* data, unsigned long len) {
-    if ( ! EVP_DigestUpdate(c, data, len) )
+void hash_update(HashDigestState* c, const void* data, unsigned long len) {
+    if ( ! EVP_DigestUpdate(to_native_ptr(c), data, len) )
         reporter->InternalError("EVP_DigestUpdate failed");
 }
 
-void hash_final(EVP_MD_CTX* c, u_char* md) {
-    if ( ! EVP_DigestFinal(c, md, NULL) )
-        reporter->InternalError("EVP_DigestFinal failed");
+void hash_final(HashDigestState* c, u_char* md) {
+    hash_final_no_free(c, md);
+    EVP_MD_CTX_free(to_native_ptr(c));
+}
 
-    EVP_MD_CTX_free(c);
+void hash_final_no_free(HashDigestState* c, u_char* md) {
+    if ( ! EVP_DigestFinal(to_native_ptr(c), md, NULL) )
+        reporter->InternalError("EVP_DigestFinal failed");
+}
+
+void hash_state_free(HashDigestState* c) {
+    if ( c != nullptr )
+        EVP_MD_CTX_free(to_native_ptr(c));
+}
+
+void hash_copy(HashDigestState* out, const HashDigestState* in) {
+    EVP_MD_CTX_copy_ex(to_native_ptr(out), to_native_ptr(in));
 }
 
 unsigned char* internal_md5(const unsigned char* data, unsigned long len, unsigned char* out) {
@@ -59,7 +98,7 @@ unsigned char* calculate_digest(HashAlgorithm alg, const unsigned char* data, ui
     if ( ! out )
         out = static_out; // use static array for return, see OpenSSL man page
 
-    EVP_MD_CTX* c = hash_init(alg);
+    auto* c = hash_init(alg);
     hash_update(c, data, len);
     hash_final(c, out);
     return out;

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -16,6 +16,7 @@
 #endif
 
 #include "zeek/Event.h"
+#include "zeek/digest.h"
 #include "zeek/file_analysis/File.h"
 #include "zeek/file_analysis/Manager.h"
 #include "zeek/file_analysis/analyzer/x509/events.bif.h"

--- a/src/probabilistic/BitVector.cc
+++ b/src/probabilistic/BitVector.cc
@@ -403,7 +403,7 @@ BitVector::size_type BitVector::FindNext(size_type i) const {
 uint64_t BitVector::Hash() const {
     u_char buf[SHA256_DIGEST_LENGTH];
     uint64_t digest;
-    EVP_MD_CTX* ctx = zeek::detail::hash_init(zeek::detail::Hash_SHA256);
+    auto* ctx = zeek::detail::hash_init(zeek::detail::Hash_SHA256);
 
     for ( size_type i = 0; i < Blocks(); ++i )
         zeek::detail::hash_update(ctx, &bits[i], sizeof(bits[i]));

--- a/src/probabilistic/Hasher.cc
+++ b/src/probabilistic/Hasher.cc
@@ -14,9 +14,9 @@
 namespace zeek::probabilistic::detail {
 
 Hasher::seed_t Hasher::MakeSeed(const void* data, size_t size) {
-    u_char buf[SHA256_DIGEST_LENGTH];
+    u_char buf[ZEEK_SHA256_DIGEST_LENGTH];
     seed_t tmpseed;
-    EVP_MD_CTX* ctx = zeek::detail::hash_init(zeek::detail::Hash_SHA256);
+    auto* ctx = zeek::detail::hash_init(zeek::detail::Hash_SHA256);
 
     assert(sizeof(tmpseed) == 16);
 

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -586,7 +586,7 @@ function piped_exec%(program: string, to_write: string%): bool
 ##      friends.
 function md5_hash%(...%): string
 	%{
-	unsigned char digest[MD5_DIGEST_LENGTH];
+	unsigned char digest[ZEEK_MD5_DIGEST_LENGTH];
 	MD5Val::digest(@ARG@, digest);
 	return zeek::make_intrusive<zeek::StringVal>(zeek::detail::md5_digest_print(digest));
 	%}
@@ -606,7 +606,7 @@ function md5_hash%(...%): string
 ##      friends.
 function sha1_hash%(...%): string
 	%{
-	unsigned char digest[SHA_DIGEST_LENGTH];
+	unsigned char digest[ZEEK_SHA_DIGEST_LENGTH];
 	SHA1Val::digest(@ARG@, digest);
 	return zeek::make_intrusive<zeek::StringVal>(zeek::detail::sha1_digest_print(digest));
 	%}
@@ -626,7 +626,7 @@ function sha1_hash%(...%): string
 ##      friends.
 function sha256_hash%(...%): string
 	%{
-	unsigned char digest[SHA256_DIGEST_LENGTH];
+	unsigned char digest[ZEEK_SHA256_DIGEST_LENGTH];
 	SHA256Val::digest(@ARG@, digest);
 	return zeek::make_intrusive<zeek::StringVal>(zeek::detail::sha256_digest_print(digest));
 	%}
@@ -642,7 +642,7 @@ function sha256_hash%(...%): string
 ##    sha256_hash sha256_hash_init sha256_hash_update sha256_hash_finish
 function md5_hmac%(...%): string
 	%{
-	unsigned char hmac[MD5_DIGEST_LENGTH];
+	unsigned char hmac[ZEEK_MD5_DIGEST_LENGTH];
 	MD5Val::hmac(@ARG@, zeek::detail::KeyedHash::shared_hmac_md5_key, hmac);
 	return zeek::make_intrusive<zeek::StringVal>(zeek::detail::md5_digest_print(hmac));
 	%}


### PR DESCRIPTION
Followup to the discussion in #3409. Instead of forcing OpenSSL as a dependency on modules, this PR attempts to remove OpenSSL includes from public Zeek headers.

There are some OpenSSL includes left in Zeek headers:

- file_analysis/analyzer/x509/OCSP.h
- file_analysis/analyzer/x509/X509Common.h

Is it safe to assume that plugins don't include these Zeek headers? Otherwise, we'll need to get rid of the OpenSSL includes in those files as well.