### PR TITLE
Upgrade c-ares submodule to 1.21.0

### DIFF
--- a/ci/windows/conanfile_windows.txt
+++ b/ci/windows/conanfile_windows.txt
@@ -1,7 +1,7 @@
 [requires]
 zlib/1.2.11
 libpcap/1.10.1
-c-ares/1.18.1
+c-ares/1.21.0
 
 [generators]
 cmake_find_package


### PR DESCRIPTION
This updates us from 1.20.1 to 1.21.0. The changelog is here: https://c-ares.org/changelog.html#1_21_0

The big notable change is the new memory-safe parser architecture.