### PR TITLE
Bind scan_path to the scope; avoid heap allocation

### DIFF
--- a/src/zeekygen/Target.cc
+++ b/src/zeekygen/Target.cc
@@ -439,15 +439,12 @@ vector<string> dir_contents_recursive(string dir) {
     while ( dir[dir.size() - 1] == '/' )
         dir.erase(dir.size() - 1, 1);
 
-    char** scan_path = new char*[2];
-    scan_path[0] = dir.data();
-    scan_path[1] = NULL;
+    char* scan_path[2] = {dir.data(), nullptr};
 
     FTS* fts = fts_open(scan_path, FTS_NOCHDIR, 0);
 
     if ( ! fts ) {
         reporter->Error("fts_open failure: %s", strerror(errno));
-        delete[] scan_path;
         return rval;
     }
 
@@ -464,7 +461,6 @@ vector<string> dir_contents_recursive(string dir) {
     if ( fts_close(fts) < 0 )
         reporter->Error("fts_close failure: %s", strerror(errno));
 
-    delete[] scan_path;
     return rval;
 }
 


### PR DESCRIPTION
@awelzel I think that Coverity warning was a bit overzealous. However, `scan_path` shouldn't be heap allocated in the first place, so I think it's still a worthwhile change.