### PR TITLE
Add jq to dockerfile

### DIFF
--- a/docker/final.Dockerfile
+++ b/docker/final.Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -q update \
  && apt-get install -q -y --no-install-recommends \
      ca-certificates \
      git \
+     jq \
      libmaxminddb0 \
      libnode108 \
      libpython3.11 \


### PR DESCRIPTION
Whenever using zeek docker I always install jq - https://github.com/jqlang/jq. In zeek RTD use of jq is widespread. Its ~1MB. These are the dependencies for jq:

- libtool
- make
- automake
- autoconf