### PR TITLE
strings.bif: Implement do_split_string() using RE_Match_State

### DIFF
--- a/src/RE.cc
+++ b/src/RE.cc
@@ -268,6 +268,7 @@ bool RE_Match_State::Match(const u_char* bv, int n, bool bol, bool eol, bool cle
 
         // Initialize state and copy the accepting states of the start
         // state into the acceptance set.
+        current_pos = 0;
         current_state = dfa->StartState();
 
         const AcceptingSet* ac = current_state->Accept();
@@ -276,13 +277,14 @@ bool RE_Match_State::Match(const u_char* bv, int n, bool bol, bool eol, bool cle
             AddMatches(*ac, 0);
     }
 
-    else if ( clear )
+    else if ( clear ) {
+        current_pos = 0;
         current_state = dfa->StartState();
+    }
 
     if ( ! current_state )
         return false;
 
-    current_pos = 0;
 
     size_t old_matches = accepted_matches.size();
 

--- a/src/RE.h
+++ b/src/RE.h
@@ -163,6 +163,10 @@ public:
     // If clear is true, starts matching over.
     bool Match(const u_char* bv, int n, bool bol, bool eol, bool clear);
 
+    // Returns true if no matter what is passed to Match() the DFA
+    // will not make progress. Useful for short-circuiting.
+    bool Jammed() const { return current_pos >= 0 && current_state == nullptr; }
+
     void Clear() {
         current_pos = -1;
         current_state = nullptr;

--- a/src/RE.h
+++ b/src/RE.h
@@ -235,6 +235,9 @@ public:
     // the main ("explicit") constructor was used.
     const char* OrigText() const { return orig_text.c_str(); }
 
+    // Access to the underlying re_exact Matcher.
+    detail::Specific_RE_Matcher* GetExactMatcher() const { return re_exact; }
+
 protected:
     std::string orig_text;
 

--- a/src/RE.h
+++ b/src/RE.h
@@ -169,7 +169,9 @@ public:
         accepted_matches.clear();
     }
 
-    void AddMatches(const AcceptingSet& as, MatchPos position);
+    // Add all indices from AcceptingSet. Returns true if a new match
+    // was found.
+    bool AddMatches(const AcceptingSet& as, MatchPos position);
 
 protected:
     DFA_Machine* dfa;

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -274,20 +274,47 @@ static zeek::VectorValPtr do_split_string(zeek::StringVal* str_val,
 	// string_vec is used early in the version script - do not use the NetVar.
 	auto rval = zeek::make_intrusive<zeek::VectorVal>(zeek::id::find_type<zeek::VectorType>("string_vec"));
 	const u_char* s = str_val->Bytes();
+	const u_char* s_orig = str_val->Bytes();
 	int n = str_val->Len();
 	const u_char* end_of_s = s + n;
 	int num = 0;
 	int num_sep = 0;
 
-	int offset = 0;
+	zeek::detail::RE_Match_State match_state{re->GetExactMatcher()};
+
 	while ( n >= 0 )
 		{
-		offset = 0;
-		// Find next match offset.
+		// Feed each byte into match_state with BOL and EOL based
+		// on the full input string. If there's any match, the current
+		// position is the beginning of a match and the last one
+		// the end of the match.
+		int offset = 0;
 		int end_of_match = 0;
-		while ( n > 0 &&
-		        (end_of_match = re->MatchPrefix(s + offset, n)) <= 0 )
+
+		while ( n > 0 )
 			{
+			match_state.Clear();
+			// std::fprintf(stderr, "offset=%d Trying to match '%s'\n", offset, s + offset);
+			for ( int i = 0; i < n; i++ )
+				{
+				if ( match_state.Jammed() ) {
+					// std::fprintf(stderr, "jammed\n");
+					break;
+				}
+
+				bool bol = (s + offset + i) == s_orig; // only once
+				bool eol = i == n - 1;
+				// std::fprintf(stderr, "%c bol=%d eol=%d\n", s[offset + i], bol, eol);
+				if ( match_state.Match(&s[offset + i], 1, bol, eol, false /*reset*/) )
+					{
+					// std::fprintf(stderr, "match %d %d %c\n", offset, i, s[offset + i]);
+					end_of_match = i + 1;
+					}
+				}
+
+			if ( end_of_match > 0 )
+				break;
+
 			// Move on to next byte.
 			++offset;
 			--n;

--- a/testing/btest/Baseline/bifs.split_string/out
+++ b/testing/btest/Baseline/bifs.split_string/out
@@ -31,3 +31,6 @@ A
  C 
 =
  D
+test, ^est, [test]
+test, tes$, [test]
+test, ^test$, [, test, ]

--- a/testing/btest/bifs/split_string.zeek
+++ b/testing/btest/bifs/split_string.zeek
@@ -34,3 +34,25 @@ event zeek_init()
 	pat = /=/;
 	print_string_vector(split_string_all(a, pat));
 	}
+
+event zeek_init()
+	{
+	# Anchor testing.
+	local a = "test";
+	local r = split_string_n("test", /^est/, T, 1);
+	assert |r| == 1;
+	assert r[0] == "test";
+	print "test", "^est", r;
+
+	r = split_string_n("test", /tes$/, T, 1);
+	assert |r| == 1;
+	assert r[0] == "test";
+	print "test", "tes$", r;
+
+	r = split_string_n("test", /^test$/, T, 1);
+	assert |r| == 3;
+	assert r[0] == "";
+	assert r[1] == "test";
+	assert r[2] == "";
+	print "test", "^test$", r;
+	}


### PR DESCRIPTION
This allows better control of BOL and EOL. MatchPrefix() / LongestMatch() always start with BOL.

Closes #3455.

---

Including some prep work in `RE.h / RE.cc...