### PR TITLE
RE_Match_State: Do not reset current_pos for every Match() call

### DIFF
--- a/src/RE.cc
+++ b/src/RE.cc
@@ -268,6 +268,7 @@ bool RE_Match_State::Match(const u_char* bv, int n, bool bol, bool eol, bool cle
 
         // Initialize state and copy the accepting states of the start
         // state into the acceptance set.
+        current_pos = 0;
         current_state = dfa->StartState();
 
         const AcceptingSet* ac = current_state->Accept();
@@ -276,13 +277,14 @@ bool RE_Match_State::Match(const u_char* bv, int n, bool bol, bool eol, bool cle
             AddMatches(*ac, 0);
     }
 
-    else if ( clear )
+    else if ( clear ) {
+        current_pos = 0;
         current_state = dfa->StartState();
+    }
 
     if ( ! current_state )
         return false;
 
-    current_pos = 0;
 
     size_t old_matches = accepted_matches.size();
 


### PR DESCRIPTION
This seems like a bug: If one feeds one byte at a time to RE_Match_State, current_pos is being reset to `0` for every byte, possibly reporting the wrong offsets in the accepted_matches map.

---

This came up during #3458. The other candidate would be bad3d4dab35455039baf8f12205704aefafc8d63 to have `RE_Match_State::Match()` return true if there's a match at higher position in the input, but I'm not sure `Match()` was ever meant to work this way (RuleMatcher looks as if it might have been the idea, but it's not fully implemented).

@rsmmr , thoughts? :-)