### PR TITLE
Use std::move() where appropriate

### DIFF
--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -891,7 +891,7 @@ void DNS_Mgr::Event(EventHandlerPtr e, const DNS_MappingPtr& old_dm, DNS_Mapping
         event_mgr.Enqueue(e, BuildMappingVal(old_dm), BuildMappingVal(new_dm));
 }
 
-ValPtr DNS_Mgr::BuildMappingVal(const DNS_MappingPtr& dm) {
+RecordValPtr DNS_Mgr::BuildMappingVal(const DNS_MappingPtr& dm) {
     if ( ! dm_rec )
         return nullptr;
 

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -32,6 +32,7 @@ class Val;
 class ListVal;
 class TableVal;
 class StringVal;
+class RecordVal;
 
 template<class T>
 class IntrusivePtr;
@@ -39,6 +40,7 @@ using ValPtr = IntrusivePtr<Val>;
 using ListValPtr = IntrusivePtr<ListVal>;
 using TableValPtr = IntrusivePtr<TableVal>;
 using StringValPtr = IntrusivePtr<StringVal>;
+using RecordValPtr = IntrusivePtr<RecordVal>;
 
 } // namespace zeek
 
@@ -263,7 +265,7 @@ protected:
     void Event(EventHandlerPtr e, const DNS_MappingPtr& dm, ListValPtr l1, ListValPtr l2);
     void Event(EventHandlerPtr e, const DNS_MappingPtr& old_dm, DNS_MappingPtr new_dm);
 
-    ValPtr BuildMappingVal(const DNS_MappingPtr& dm);
+    RecordValPtr BuildMappingVal(const DNS_MappingPtr& dm);
 
     void CompareMappings(const DNS_MappingPtr& prev_dm, const DNS_MappingPtr& new_dm);
     ListValPtr AddrListDelta(ListValPtr al1, ListValPtr al2);

--- a/src/EventTrace.cc
+++ b/src/EventTrace.cc
@@ -844,8 +844,7 @@ void ValTraceMgr::AssessChange(const ValTrace* vt, const ValTrace* prev_vt) {
 
 void ValTraceMgr::TrackVar(const Val* v) {
     std::string base_name = IsUnsupported(v) ? "UNSUPPORTED" : "val";
-    auto val_name = "__" + base_name + std::to_string(num_vars++);
-    val_names[v] = val_name;
+    val_names[v] = "__" + base_name + std::to_string(num_vars++);
 }
 
 std::string ValTraceMgr::GenValName(const ValPtr& v) {

--- a/src/EventTrace.h
+++ b/src/EventTrace.h
@@ -151,7 +151,7 @@ public:
 // delete values.
 class DeltaSetSetEntry : public ValDelta {
 public:
-    DeltaSetSetEntry(const ValTrace* _vt, ValPtr _index) : ValDelta(_vt), index(_index) {}
+    DeltaSetSetEntry(const ValTrace* _vt, ValPtr _index) : ValDelta(_vt), index(std::move(_index)) {}
 
     std::string Generate(ValTraceMgr* vtm) const override;
     bool NeedsLHS() const override { return false; }
@@ -166,7 +166,7 @@ private:
 class DeltaSetTableEntry : public ValDelta {
 public:
     DeltaSetTableEntry(const ValTrace* _vt, ValPtr _index, ValPtr _new_val)
-        : ValDelta(_vt), index(_index), new_val(std::move(_new_val)) {}
+        : ValDelta(_vt), index(std::move(_index)), new_val(std::move(_new_val)) {}
 
     std::string Generate(ValTraceMgr* vtm) const override;
 

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -3057,7 +3057,7 @@ ListExprPtr expand_op(ListExprPtr op, const TypePtr& t) {
 TableConstructorExpr::TableConstructorExpr(ListExprPtr constructor_list,
                                            std::unique_ptr<std::vector<AttrPtr>> arg_attrs, TypePtr arg_type,
                                            AttributesPtr arg_attrs2)
-    : UnaryExpr(EXPR_TABLE_CONSTRUCTOR, expand_op(constructor_list, arg_type)) {
+    : UnaryExpr(EXPR_TABLE_CONSTRUCTOR, expand_op(std::move(constructor_list), arg_type)) {
     if ( IsError() )
         return;
 

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -2303,7 +2303,7 @@ TypePtr merge_record_types(const Type* t1, const Type* t2) {
     return make_intrusive<RecordType>(tdl3);
 }
 
-TypePtr merge_list_types(const Type* t1, const Type* t2) {
+TypeListPtr merge_list_types(const Type* t1, const Type* t2) {
     const TypeList* tl1 = t1->AsTypeList();
     const TypeList* tl2 = t2->AsTypeList();
 

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1052,8 +1052,7 @@ void RecordType::AddField(unsigned int field, const TypeDecl* td) {
 
     if ( def_expr && ! IsErrorType(type->Tag()) ) {
         if ( def_expr->Tag() == detail::EXPR_CONST ) {
-            auto v = def_expr->Eval(nullptr);
-            auto zv = ZVal(v, type);
+            auto zv = ZVal(def_expr->Eval(nullptr), type);
 
             if ( ZVal::IsManagedType(type) )
                 init = std::make_unique<detail::DirectManagedFieldInit>(zv);

--- a/src/Val.h
+++ b/src/Val.h
@@ -1563,7 +1563,7 @@ public:
      * @return  True if the element was inserted or false if the element was
      * the wrong type.
      */
-    bool Append(ValPtr element) { return Insert(Size(), element); }
+    bool Append(ValPtr element) { return Insert(Size(), std::move(element)); }
 
     // Removes an element at a specific position.
     bool Remove(unsigned int index);

--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -4,7 +4,7 @@ type ftp_port: record;
 %%{
 #include "zeek/Reporter.h"
 
-static zeek::ValPtr parse_port(const char* line)
+static zeek::RecordValPtr parse_port(const char* line)
 	{
 	auto r = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::ftp_port);
 
@@ -47,7 +47,7 @@ static zeek::ValPtr parse_port(const char* line)
 	return r;
 	}
 
-static zeek::ValPtr parse_eftp(const char* line)
+static zeek::RecordValPtr parse_eftp(const char* line)
 	{
 	auto r = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::ftp_port);
 

--- a/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
+++ b/src/analyzer/protocol/ntlm/ntlm-analyzer.pac
@@ -1,12 +1,12 @@
 %header{
-	zeek::ValPtr filetime2zeektime(uint64_t ts);
+	zeek::IntrusivePtr<zeek::TimeVal> filetime2zeektime(uint64_t ts);
 	zeek::RecordValPtr build_version_record(NTLM_Version* val);
 	zeek::RecordValPtr build_negotiate_flag_record(NTLM_Negotiate_Flags* val);
 %}
 
 %code{
 	// This is replicated from the SMB analyzer. :(
-	zeek::ValPtr filetime2zeektime(uint64_t ts)
+	zeek::IntrusivePtr<zeek::TimeVal> filetime2zeektime(uint64_t ts)
 		{
 		double secs = (ts / 10000000.0);
 

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -164,7 +164,7 @@ bool PortmapperInterp::RPC_BuildReply(RPC_CallInfo* c, BifEnum::rpc_status statu
     return true;
 }
 
-ValPtr PortmapperInterp::ExtractMapping(const u_char*& buf, int& len) {
+RecordValPtr PortmapperInterp::ExtractMapping(const u_char*& buf, int& len) {
     static auto pm_mapping = id::find_type<RecordType>("pm_mapping");
     auto mapping = make_intrusive<RecordVal>(pm_mapping);
 
@@ -181,7 +181,7 @@ ValPtr PortmapperInterp::ExtractMapping(const u_char*& buf, int& len) {
     return mapping;
 }
 
-ValPtr PortmapperInterp::ExtractPortRequest(const u_char*& buf, int& len) {
+RecordValPtr PortmapperInterp::ExtractPortRequest(const u_char*& buf, int& len) {
     static auto pm_port_request = id::find_type<RecordType>("pm_port_request");
     auto pr = make_intrusive<RecordVal>(pm_port_request);
 
@@ -198,7 +198,7 @@ ValPtr PortmapperInterp::ExtractPortRequest(const u_char*& buf, int& len) {
     return pr;
 }
 
-ValPtr PortmapperInterp::ExtractCallItRequest(const u_char*& buf, int& len) {
+RecordValPtr PortmapperInterp::ExtractCallItRequest(const u_char*& buf, int& len) {
     static auto pm_callit_request = id::find_type<RecordType>("pm_callit_request");
     auto c = make_intrusive<RecordVal>(pm_callit_request);
 

--- a/src/analyzer/protocol/rpc/Portmap.h
+++ b/src/analyzer/protocol/rpc/Portmap.h
@@ -19,9 +19,9 @@ protected:
 
     void Event(EventHandlerPtr f, ValPtr request, BifEnum::rpc_status status, ValPtr reply);
 
-    ValPtr ExtractMapping(const u_char*& buf, int& len);
-    ValPtr ExtractPortRequest(const u_char*& buf, int& len);
-    ValPtr ExtractCallItRequest(const u_char*& buf, int& len);
+    RecordValPtr ExtractMapping(const u_char*& buf, int& len);
+    RecordValPtr ExtractPortRequest(const u_char*& buf, int& len);
+    RecordValPtr ExtractCallItRequest(const u_char*& buf, int& len);
 };
 
 } // namespace detail

--- a/src/analyzer/protocol/snmp/snmp-analyzer.pac
+++ b/src/analyzer/protocol/snmp/snmp-analyzer.pac
@@ -10,7 +10,7 @@
 %header{
 zeek::AddrValPtr network_address_to_val(const ASN1Encoding* na);
 zeek::AddrValPtr network_address_to_val(const NetworkAddress* na);
-zeek::ValPtr     asn1_obj_to_val(const ASN1Encoding* obj);
+zeek::RecordValPtr asn1_obj_to_val(const ASN1Encoding* obj);
 
 zeek::RecordValPtr build_hdr(const Header* header);
 zeek::RecordValPtr build_hdrV3(const Header* header);
@@ -42,7 +42,7 @@ zeek::AddrValPtr network_address_to_val(const ASN1Encoding* na)
 	return zeek::make_intrusive<zeek::AddrVal>(ntohl(network_order));
 	}
 
-zeek::ValPtr asn1_obj_to_val(const ASN1Encoding* obj)
+zeek::RecordValPtr asn1_obj_to_val(const ASN1Encoding* obj)
 	{
 	zeek::RecordValPtr rval = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::SNMP::ObjectValue);
 	uint8 tag = obj->meta()->tag();

--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -74,7 +74,7 @@ public:
      */
     Packet(int link_type, pkt_timeval* ts, uint32_t caplen, uint32_t len, const u_char* data, bool copy = false,
            std::string tag = "") {
-        Init(link_type, ts, caplen, len, data, copy, tag);
+        Init(link_type, ts, caplen, len, data, copy, std::move(tag));
     }
 
     /**

--- a/src/packet_analysis/Component.cc
+++ b/src/packet_analysis/Component.cc
@@ -9,9 +9,8 @@
 using namespace zeek::packet_analysis;
 
 Component::Component(const std::string& name, factory_callback arg_factory, Tag::subtype_t arg_subtype)
-    : plugin::Component(plugin::component::PACKET_ANALYZER, name, arg_subtype, packet_mgr->GetTagType()) {
-    factory = arg_factory;
-}
+    : plugin::Component(plugin::component::PACKET_ANALYZER, name, arg_subtype, packet_mgr->GetTagType()),
+      factory(std::move(arg_factory)) {}
 
 void Component::Initialize() {
     InitializeTag();

--- a/src/packet_analysis/protocol/gtpv1/gtpv1-analyzer.pac
+++ b/src/packet_analysis/protocol/gtpv1/gtpv1-analyzer.pac
@@ -33,7 +33,7 @@ static zeek::ValPtr BuildIMSI(const InformationElement* ie)
 	return zeek::val_mgr->Count(ie->imsi()->value());
 	}
 
-static zeek::ValPtr BuildRAI(const InformationElement* ie)
+static zeek::RecordValPtr BuildRAI(const InformationElement* ie)
 	{
 	auto ev = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::gtp_rai);
 	ev->Assign(0, ie->rai()->mcc());
@@ -83,7 +83,7 @@ static zeek::ValPtr BuildTraceType(const InformationElement* ie)
 	return zeek::val_mgr->Count(ie->trace_type()->value());
 	}
 
-zeek::ValPtr BuildEndUserAddr(const InformationElement* ie)
+zeek::RecordValPtr BuildEndUserAddr(const InformationElement* ie)
 	{
 	auto ev = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::gtp_end_user_addr);
 	ev->Assign(0, ie->end_user_addr()->pdp_type_org());
@@ -127,7 +127,7 @@ zeek::ValPtr BuildProtoConfigOptions(const InformationElement* ie)
 	return zeek::make_intrusive<zeek::StringVal>(new zeek::String(d, len, false));
 	}
 
-zeek::ValPtr BuildGSN_Addr(const InformationElement* ie)
+zeek::RecordValPtr BuildGSN_Addr(const InformationElement* ie)
 	{
 	auto ev = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::gtp_gsn_addr);
 
@@ -153,7 +153,7 @@ zeek::ValPtr BuildMSISDN(const InformationElement* ie)
 	return zeek::make_intrusive<zeek::StringVal>(new zeek::String(d, len, false));
 	}
 
-zeek::ValPtr BuildQoS_Profile(const InformationElement* ie)
+zeek::RecordValPtr BuildQoS_Profile(const InformationElement* ie)
 	{
 	auto ev = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::gtp_qos_profile);
 
@@ -187,7 +187,7 @@ zeek::ValPtr BuildOMC_ID(const InformationElement* ie)
 	return zeek::make_intrusive<zeek::StringVal>(new zeek::String((const u_char*) d, len, false));
 	}
 
-zeek::ValPtr BuildPrivateExt(const InformationElement* ie)
+zeek::RecordValPtr BuildPrivateExt(const InformationElement* ie)
 	{
 	auto ev = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::gtp_private_extension);
 

--- a/src/packet_analysis/protocol/ip/IPBasedAnalyzer.cc
+++ b/src/packet_analysis/protocol/ip/IPBasedAnalyzer.cc
@@ -263,7 +263,9 @@ void IPBasedAnalyzer::DumpPortDebug() {
 
 TableValPtr IPBasedAnalyzer::ignore_checksums_nets_table = nullptr;
 
-void IPBasedAnalyzer::SetIgnoreChecksumsNets(TableValPtr t) { IPBasedAnalyzer::ignore_checksums_nets_table = t; }
+void IPBasedAnalyzer::SetIgnoreChecksumsNets(TableValPtr t) {
+    IPBasedAnalyzer::ignore_checksums_nets_table = std::move(t);
+}
 
 TableValPtr IPBasedAnalyzer::GetIgnoreChecksumsNets() {
     if ( ! IPBasedAnalyzer::ignore_checksums_nets_table )

--- a/src/packet_analysis/protocol/iptunnel/IPTunnel.cc
+++ b/src/packet_analysis/protocol/iptunnel/IPTunnel.cc
@@ -185,7 +185,7 @@ namespace detail {
 
 IPTunnelTimer::IPTunnelTimer(double t, IPTunnelAnalyzer::IPPair p, IPTunnelAnalyzer* analyzer)
     : Timer(t + BifConst::Tunnel::ip_tunnel_timeout, zeek::detail::TIMER_IP_TUNNEL_INACTIVITY),
-      tunnel_idx(p),
+      tunnel_idx(std::move(p)),
       analyzer(analyzer) {}
 
 void IPTunnelTimer::Dispatch(double t, bool is_expire) {

--- a/src/script_opt/IDOptInfo.h
+++ b/src/script_opt/IDOptInfo.h
@@ -71,7 +71,7 @@ public:
     // but not have an associated expression, if the point-of-definition
     // is the end of a confluence block.
     const ExprPtr& DefExprAfter() const { return def_expr; }
-    void SetDefExpr(ExprPtr e) { def_expr = e; }
+    void SetDefExpr(ExprPtr e) { def_expr = std::move(e); }
 
     // Used for debugging.
     void Dump() const;
@@ -107,7 +107,7 @@ protected:
 
 class IDInitInfo {
 public:
-    IDInitInfo(const ID* _id, ExprPtr _init, InitClass _ic) : id(_id), init(_init), ic(_ic) {}
+    IDInitInfo(const ID* _id, ExprPtr _init, InitClass _ic) : id(_id), init(std::move(_init)), ic(_ic) {}
 
     const ID* Id() const { return id; }
     const ExprPtr& Init() const { return init; }

--- a/src/script_opt/ScriptOpt.h
+++ b/src/script_opt/ScriptOpt.h
@@ -172,8 +172,8 @@ protected:
 class CoalescedScriptFunc : public ScriptFunc {
 public:
     CoalescedScriptFunc(StmtPtr merged_body, ScopePtr scope, ScriptFuncPtr orig_func)
-        : ScriptFunc(orig_func->Name(), orig_func->GetType(), {merged_body}, {0}), orig_func(orig_func) {
-        SetScope(scope);
+        : ScriptFunc(orig_func->Name(), orig_func->GetType(), {std::move(merged_body)}, {0}), orig_func(orig_func) {
+        SetScope(std::move(scope));
     };
 
     ValPtr Invoke(zeek::Args* args, Frame* parent) const override {

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -1240,9 +1240,7 @@ Supervisor::NodeConfig Supervisor::NodeConfig::FromRecord(const RecordVal* node)
 
         auto key = env_table_val->RecreateIndex(*k);
         auto name = key->Idx(0)->AsStringVal()->ToStdString();
-        auto val = v->GetVal()->AsStringVal()->ToStdString();
-
-        rval.env[name] = val;
+        rval.env[name] = v->GetVal()->AsStringVal()->ToStdString();
     }
 
     auto cluster_table_val = node->GetField("cluster")->AsTableVal();


### PR DESCRIPTION
This fixes a bunch of Coverity findings (too many to list)