### PR TITLE
CMakeLists: Fix OPENSSL_INCLUDE_DIR reference (for release/6.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,9 +287,6 @@ target_include_directories(
     zeek_dynamic_plugin_base
     INTERFACE $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
               $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
-if (OPENSSL_INCLUDE_DIR)
-    target_include_directories(zeek_dynamic_plugin_base INTERFACE "${OPENSSL_INCLUDE_DIR}")
-endif ()
 target_link_libraries(zeek_dynamic_plugin_base INTERFACE Threads::Threads)
 add_library(Zeek::DynamicPluginBase ALIAS zeek_dynamic_plugin_base)
 set_target_properties(zeek_dynamic_plugin_base PROPERTIES EXPORT_NAME DynamicPluginBase)
@@ -1032,6 +1029,9 @@ endif ()
 # system OpenSSL headers to still be picked up even if one specifies
 # --with-openssl (which may be common).
 include_directories(BEFORE ${OPENSSL_INCLUDE_DIR})
+
+# Propagate non-standard OpenSSL includes to dynamic plugins.
+target_include_directories(zeek_dynamic_plugin_base INTERFACE "${OPENSSL_INCLUDE_DIR}")
 
 # Determine if libfts is external to libc, i.e. musl
 find_package(FTS)


### PR DESCRIPTION
Seems the intention was to always add OPENSSL_INCLUDE_DIR to the zeek_dynamic_plugin_base target, but finding of the OpenSSL package and setting OPENSSL_INCLUDE_DIR happens much later, so this was never functional.

Relates to #3408 - this is the fix for Zeek 6.0.3, #3420 is the better fix for the future.