### PR TITLE
Perf fixes around FieldOffset(), EventMgr's flare and SegmentProfiler

### DIFF
--- a/src/Event.cc
+++ b/src/Event.cc
@@ -99,7 +99,6 @@ void EventMgr::QueueEvent(Event* event) {
 
     if ( ! head ) {
         head = tail = event;
-        queue_flare.Fire();
     }
     else {
         tail->SetNext(event);
@@ -177,25 +176,12 @@ void EventMgr::Describe(ODesc* d) const {
 }
 
 void EventMgr::Process() {
-    queue_flare.Extinguish();
-
     // While it semes like the most logical thing to do, we dont want
     // to call Drain() as part of this method. It will get called at
-    // the end of net_run after all of the sources have been processed
+    // the end of run_loop after all of the sources have been processed
     // and had the opportunity to spawn new events.
 }
 
-void EventMgr::InitPostScript() {
-    iosource_mgr->Register(this, true, false);
-    if ( ! iosource_mgr->RegisterFd(queue_flare.FD(), this) )
-        reporter->FatalError("Failed to register event manager FD with iosource_mgr");
-}
-
-void EventMgr::InitPostFork() {
-    // Re-initialize the flare, closing and re-opening the underlying
-    // pipe FDs. This is needed so that each Zeek process in a supervisor
-    // setup has its own pipe instead of them all sharing a single pipe.
-    queue_flare = zeek::detail::Flare{};
-}
+void EventMgr::InitPostScript() { iosource_mgr->Register(this, true, false); }
 
 } // namespace zeek

--- a/src/Event.h
+++ b/src/Event.h
@@ -106,13 +106,13 @@ public:
 
     void Describe(ODesc* d) const override;
 
-    double GetNextTimeout() override { return -1; }
+    // Let the IO loop know when there's more events to process
+    // by returning a zero-timeout.
+    double GetNextTimeout() override { return head ? 0.0 : -1.0; }
+
     void Process() override;
     const char* Tag() override { return "EventManager"; }
     void InitPostScript();
-
-    // Initialization to be done after a fork() happened.
-    void InitPostFork();
 
     uint64_t num_events_queued = 0;
     uint64_t num_events_dispatched = 0;
@@ -127,7 +127,6 @@ protected:
     double current_ts;
     RecordVal* src_val;
     bool draining;
-    detail::Flare queue_flare;
 };
 
 extern EventMgr event_mgr;

--- a/src/Stats.h
+++ b/src/Stats.h
@@ -39,13 +39,13 @@ class SegmentProfiler {
 public:
     // The constructor takes some way of identifying the segment.
     SegmentProfiler(std::shared_ptr<SegmentStatsReporter> arg_reporter, const char* arg_name)
-        : reporter(std::move(arg_reporter)), name(arg_name), loc(), initial_rusage() {
+        : reporter(std::move(arg_reporter)), name(arg_name), loc() {
         if ( reporter )
             Init();
     }
 
     SegmentProfiler(std::shared_ptr<SegmentStatsReporter> arg_reporter, const Location* arg_loc)
-        : reporter(std::move(arg_reporter)), name(), loc(arg_loc), initial_rusage() {
+        : reporter(std::move(arg_reporter)), name(), loc(arg_loc) {
         if ( reporter )
             Init();
     }

--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -139,20 +139,15 @@ void ConnSize_Analyzer::SetDurationThreshold(double duration) {
 }
 
 void ConnSize_Analyzer::UpdateConnVal(RecordVal* conn_val) {
-    // RecordType *connection_type is declared in NetVar.h
-    RecordVal* orig_endp = conn_val->GetFieldAs<RecordVal>("orig");
-    RecordVal* resp_endp = conn_val->GetFieldAs<RecordVal>("resp");
+    static const auto& conn_type = zeek::id::find_type<zeek::RecordType>("connection");
+    static const int origidx = conn_type->FieldOffset("orig");
+    static const int respidx = conn_type->FieldOffset("resp");
+    static const auto& endpoint_type = zeek::id::find_type<zeek::RecordType>("endpoint");
+    static const int pktidx = endpoint_type->FieldOffset("num_pkts");
+    static const int bytesidx = endpoint_type->FieldOffset("num_bytes_ip");
 
-    // endpoint is the RecordType from NetVar.h
-    int pktidx = id::endpoint->FieldOffset("num_pkts");
-    int bytesidx = id::endpoint->FieldOffset("num_bytes_ip");
-
-    if ( pktidx < 0 )
-        reporter->InternalError("'endpoint' record missing 'num_pkts' field");
-
-    if ( bytesidx < 0 )
-        reporter->InternalError("'endpoint' record missing 'num_bytes_ip' field");
-
+    auto* orig_endp = conn_val->GetFieldAs<RecordVal>(origidx);
+    auto* resp_endp = conn_val->GetFieldAs<RecordVal>(respidx);
     orig_endp->Assign(pktidx, orig_pkts);
     orig_endp->Assign(bytesidx, orig_bytes);
     resp_endp->Assign(pktidx, resp_pkts);

--- a/src/packet_analysis/protocol/tcp/TCPSessionAdapter.cc
+++ b/src/packet_analysis/protocol/tcp/TCPSessionAdapter.cc
@@ -1027,8 +1027,11 @@ void TCPSessionAdapter::FlipRoles() {
 }
 
 void TCPSessionAdapter::UpdateConnVal(RecordVal* conn_val) {
-    auto orig_endp_val = conn_val->GetFieldAs<RecordVal>("orig");
-    auto resp_endp_val = conn_val->GetFieldAs<RecordVal>("resp");
+    static const auto& conn_type = zeek::id::find_type<zeek::RecordType>("connection");
+    static const int origidx = conn_type->FieldOffset("orig");
+    static const int respidx = conn_type->FieldOffset("resp");
+    auto* orig_endp_val = conn_val->GetFieldAs<RecordVal>(origidx);
+    auto* resp_endp_val = conn_val->GetFieldAs<RecordVal>(respidx);
 
     orig_endp_val->Assign(0, orig->Size());
     orig_endp_val->Assign(1, orig->state);

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -506,8 +506,6 @@ SetupResult setup(int argc, char** argv, Options* zopts) {
         // If we get here, we're a supervised node that just returned
         // from CreateStem() after being forked from the stem.
         Supervisor::ThisNode()->Init(&options);
-
-        event_mgr.InitPostFork();
     }
 
     script_coverage_mgr.ReadStats();


### PR DESCRIPTION
* The `FieldOffset()` one came up when drilling into `Conn::GetVal()` and `UpdateConnVal()` being slower than needed.
* The queue_flare has always been a thorn in my eye as sometimes its overhead is significant. Jan has raised this before, too. I think we can just get rid of it - see commit description.
* Remove initital_rusage initialization from SegmentProfiler, initializing 144 bytes to zero event if segment profiling is disabled.