### PR TITLE
spicy/runtime-support: Use Vector::unsafeBegin() for args iteration

### DIFF
--- a/src/spicy/runtime-support.cc
+++ b/src/spicy/runtime-support.cc
@@ -197,7 +197,8 @@ void rt::raise_event(const EventHandlerPtr& handler, const hilti::rt::Vector<Val
 
     Args vl = Args();
     vl.reserve(args.size());
-    for ( const auto& v : args ) {
+    for ( auto it = args.unsafeBegin(); it != args.unsafeEnd(); it++ ) {
+        const auto& v = *it;
         if ( v )
             vl.emplace_back(v);
         else


### PR DESCRIPTION
Use unsafe iteration from https://github.com/zeek/spicy/pull/1609 