### PR TITLE
Some streamlining for constructing TableVal's

### DIFF
--- a/src/Type.cc
+++ b/src/Type.cc
@@ -10,6 +10,7 @@
 #include <unordered_set>
 
 #include "zeek/Attr.h"
+#include "zeek/CompHash.h"
 #include "zeek/Desc.h"
 #include "zeek/Expr.h"
 #include "zeek/Reporter.h"
@@ -478,7 +479,12 @@ TableType::TableType(TypeListPtr ind, TypePtr yield) : IndexType(TYPE_TABLE, std
             break;
         }
     }
+
+    if ( Tag() != TYPE_ERROR )
+        RegenerateHash();
 }
+
+TableType::~TableType() { delete table_hash; }
 
 bool TableType::CheckExpireFuncCompatibility(const detail::AttrPtr& attr) {
     if ( reported_error )
@@ -492,6 +498,11 @@ bool TableType::CheckExpireFuncCompatibility(const detail::AttrPtr& attr) {
 }
 
 TypePtr TableType::ShallowClone() { return make_intrusive<TableType>(indices, yield_type); }
+
+void TableType::RegenerateHash() {
+    delete table_hash;
+    table_hash = new detail::CompositeHash(GetIndices());
+}
 
 bool TableType::IsUnspecifiedTable() const {
     // Unspecified types have an empty list of indices.

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -484,7 +484,7 @@ TableType::TableType(TypeListPtr ind, TypePtr yield) : IndexType(TYPE_TABLE, std
         RegenerateHash();
 }
 
-TableType::~TableType() { delete table_hash; }
+TableType::~TableType() {}
 
 bool TableType::CheckExpireFuncCompatibility(const detail::AttrPtr& attr) {
     if ( reported_error )
@@ -499,10 +499,7 @@ bool TableType::CheckExpireFuncCompatibility(const detail::AttrPtr& attr) {
 
 TypePtr TableType::ShallowClone() { return make_intrusive<TableType>(indices, yield_type); }
 
-void TableType::RegenerateHash() {
-    delete table_hash;
-    table_hash = new detail::CompositeHash(GetIndices());
-}
+void TableType::RegenerateHash() { table_hash = std::make_unique<detail::CompositeHash>(GetIndices()); }
 
 bool TableType::IsUnspecifiedTable() const {
     // Unspecified types have an empty list of indices.

--- a/src/Type.h
+++ b/src/Type.h
@@ -4,6 +4,7 @@
 
 #include <list>
 #include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <string>
@@ -402,7 +403,7 @@ public:
     // what one gets using an empty "set()" or "table()" constructor.
     bool IsUnspecifiedTable() const;
 
-    const detail::CompositeHash* GetTableHash() const { return table_hash; }
+    const detail::CompositeHash* GetTableHash() const { return table_hash.get(); }
 
     // Called to rebuild the associated hash function when a record type
     // (that this table type depends on) gets redefined during parsing.
@@ -411,7 +412,7 @@ public:
 private:
     bool DoExpireCheck(const detail::AttrPtr& attr);
 
-    detail::CompositeHash* table_hash = nullptr;
+    std::unique_ptr<detail::CompositeHash> table_hash;
 
     // Used to prevent repeated error messages.
     bool reported_error = false;

--- a/src/Type.h
+++ b/src/Type.h
@@ -29,6 +29,7 @@ using TableValPtr = IntrusivePtr<TableVal>;
 
 namespace detail {
 
+class CompositeHash;
 class Expr;
 class ListExpr;
 class Attributes;
@@ -354,22 +355,20 @@ public:
     void DescribeReST(ODesc* d, bool roles_only = false) const override;
 
     // Returns true if this table is solely indexed by subnet.
-    bool IsSubNetIndex() const {
-        const auto& types = indices->GetTypes();
-        return types.size() == 1 && types[0]->Tag() == TYPE_SUBNET;
-    }
+    bool IsSubNetIndex() const { return is_subnet_index; }
 
     // Returns true if this table has a single index of type pattern.
-    bool IsPatternIndex() const {
-        const auto& types = indices->GetTypes();
-        return types.size() == 1 && types[0]->Tag() == TYPE_PATTERN;
-    }
+    bool IsPatternIndex() const { return is_pattern_index; }
 
     detail::TraversalCode Traverse(detail::TraversalCallback* cb) const override;
 
 protected:
     IndexType(TypeTag t, TypeListPtr arg_indices, TypePtr arg_yield_type)
-        : Type(t), indices(std::move(arg_indices)), yield_type(std::move(arg_yield_type)) {}
+        : Type(t), indices(std::move(arg_indices)), yield_type(std::move(arg_yield_type)) {
+        const auto& types = indices->GetTypes();
+        is_subnet_index = types.size() == 1 && types[0]->Tag() == TYPE_SUBNET;
+        is_pattern_index = types.size() == 1 && types[0]->Tag() == TYPE_PATTERN;
+    }
 
     ~IndexType() override = default;
 
@@ -377,11 +376,16 @@ protected:
 
     TypeListPtr indices;
     TypePtr yield_type;
+
+    bool is_subnet_index;
+    bool is_pattern_index;
 };
 
 class TableType : public IndexType {
 public:
     TableType(TypeListPtr ind, TypePtr yield);
+
+    ~TableType();
 
     /**
      * Assesses whether an &expire_func attribute's function type is compatible
@@ -398,8 +402,16 @@ public:
     // what one gets using an empty "set()" or "table()" constructor.
     bool IsUnspecifiedTable() const;
 
+    const detail::CompositeHash* GetTableHash() const { return table_hash; }
+
+    // Called to rebuild the associated hash function when a record type
+    // (that this table type depends on) gets redefined during parsing.
+    void RegenerateHash();
+
 private:
     bool DoExpireCheck(const detail::AttrPtr& attr);
+
+    detail::CompositeHash* table_hash = nullptr;
 
     // Used to prevent repeated error messages.
     bool reported_error = false;

--- a/src/Val.h
+++ b/src/Val.h
@@ -49,7 +49,6 @@ namespace detail {
 class ScriptFunc;
 class Frame;
 class PrefixTable;
-class CompositeHash;
 class HashKey;
 class TablePatternMatcher;
 
@@ -930,7 +929,7 @@ public:
 
     const PDict<TableEntryVal>* Get() const { return table_val; }
 
-    const detail::CompositeHash* GetTableHash() const { return table_hash; }
+    const detail::CompositeHash* GetTableHash() const { return table_type->GetTableHash(); }
 
     // Returns the size of the table.
     int Size() const;
@@ -1043,7 +1042,6 @@ protected:
     ValPtr DoClone(CloneState* state) override;
 
     TableTypePtr table_type;
-    detail::CompositeHash* table_hash;
     detail::AttributesPtr attrs;
     detail::ExprPtr expire_time;
     detail::ExprPtr expire_func;


### PR DESCRIPTION
Currently when a `TableVal` is constructed it creates a corresponding `CompHash` (and deletes it when destructed), even though that value is actually static for the associated `TableType`. This PR shifts its construction to the `TableType`, and also does some additional minor compute-it-once-because-it's-static tweaks.

On a good-sized DNS PCAP (500K requests), _hyperfine_ finds this shaves 2% off of execution time.