### PR TITLE
smb: Fix &read_expire not in effect due to &default=string_set() usage

### DIFF
--- a/scripts/base/protocols/smb/main.zeek
+++ b/scripts/base/protocols/smb/main.zeek
@@ -157,7 +157,7 @@ export {
 		## A set of recent files to avoid logging the same
 		## files over and over in the smb files log.
 		## This only applies to files seen in a single connection.
-		recent_files : set[string] &default=string_set() &read_expire=3min;
+		recent_files : set[string] &default=set() &read_expire=3min;
 	};
 
 	## Everything below here is used internally in the SMB scripts.


### PR DESCRIPTION
The SMB::State$recent_files field is meant to have expiring entries. However, due to usage of &default=string_set(), the &read_expire attribute is not respected causing unbounded state growth. Simply remove &default altogether.

Thanks to ya-sato on Slack for reporting!

Likely related: zeek/zeek-docs#179