### PR TITLE
Enhancements for ZAM record creation

### DIFF
--- a/src/Type.h
+++ b/src/Type.h
@@ -30,10 +30,12 @@ using TableValPtr = IntrusivePtr<TableVal>;
 
 namespace detail {
 
+class Attributes;
 class CompositeHash;
 class Expr;
 class ListExpr;
-class Attributes;
+class ZAMCompiler;
+
 using ListExprPtr = IntrusivePtr<ListExpr>;
 
 // The following tracks how to initialize a given record field.
@@ -737,6 +739,7 @@ private:
 
     class CreationInitsOptimizer;
     friend zeek::RecordVal;
+    friend zeek::detail::ZAMCompiler;
     const auto& DeferredInits() const { return deferred_inits; }
     const auto& CreationInits() const { return creation_inits; }
 

--- a/src/script_opt/ZAM/Expr.cc
+++ b/src/script_opt/ZAM/Expr.cc
@@ -1212,7 +1212,7 @@ const ZAMStmt ZAMCompiler::RecordCoerce(const NameExpr* n, const Expr* e) {
         z.aux->Add(i, map[i], nullptr);
 
     // Mark the integer entries in z.aux as not being frame slots as usual.
-    z.aux->slots = nullptr;
+    z.aux->elems_has_slots = false;
 
     if ( pfs->HasSideEffects(SideEffectsOp::CONSTRUCTION, e->GetType()) )
         z.aux->can_change_non_locals = true;

--- a/src/script_opt/ZAM/Ops.in
+++ b/src/script_opt/ZAM/Ops.in
@@ -1199,35 +1199,49 @@ eval	ConstructTableOrSetPre()
 
 direct-unary-op Record-Constructor ConstructRecord
 
-internal-op Construct-Record
-type V
+# v2 is boolean of whether to initialize fields. For this instruction,
+# it's always false.
+op Construct-Direct-Record
+type Vi
 eval	EvalConstructRecord(, i)
+
+# v2 is boolean of whether to initialize fields.
+op Construct-Known-Record
+type Vi
+eval	EvalConstructRecord(auto& map = aux->map;, map[i])
 
 macro EvalConstructRecord(map_init, map_accessor)
 	auto rt = cast_intrusive<RecordType>(z.t);
-	auto new_r = new RecordVal(rt);
+	auto new_r = new RecordVal(rt, z.v2 ? RecordVal::RV_FULL_INIT : RecordVal::RV_SLOTS_INIT);
 	auto aux = z.aux;
 	auto n = aux->n;
 	map_init
 	for ( auto i = 0; i < n; ++i )
-		{
-		auto v_i = aux->ToVal(frame, i);
-		auto ind = map_accessor;
-		if ( v_i && v_i->GetType()->Tag() == TYPE_VECTOR &&
-		     v_i->GetType<VectorType>()->IsUnspecifiedVector() )
-			{
-			const auto& t_ind = rt->GetFieldType(ind);
-			v_i->AsVectorVal()->Concretize(t_ind->Yield());
-			}
-		new_r->Assign(ind, v_i);
-		}
+		new_r->InitField(map_accessor, aux->ToZVal(frame, i));
 	auto& r = frame[z.v1].record_val;
 	Unref(r);
 	r = new_r;
 
-internal-op Construct-Known-Record
+# Special instruction for concretizing vectors that are fields in a
+# newly-constructed record. "aux" holds which fields in the record to
+# inspect.
+op Concretize-Vector-Fields
+op1-read
 type V
-eval	EvalConstructRecord(auto& map = aux->map;, map[i])
+eval	auto rt = cast_intrusive<RecordType>(z.t);
+	auto r = frame[z.v1].record_val;
+	auto aux = z.aux;
+	auto n = aux->n;
+	for ( auto i = 0; i < n; ++i )
+		{
+		auto v_i = r->GetField(aux->elems[i].IntVal());
+		ASSERT(v_i);
+		if ( v_i->GetType<VectorType>()->IsUnspecifiedVector() )
+			{
+			const auto& t_i = rt->GetFieldType(i);
+			v_i->AsVectorVal()->Concretize(t_i->Yield());
+			}
+		}
 
 direct-unary-op Vector-Constructor ConstructVector
 

--- a/src/script_opt/ZAM/Ops.in
+++ b/src/script_opt/ZAM/Ops.in
@@ -1758,21 +1758,21 @@ internal-op Event3
 type VVV
 op1-read
 eval	ValVec args(3);
+	auto& aux = z.aux;
 	args[0] = frame[z.v1].ToVal(z.t);
 	args[1] = frame[z.v2].ToVal(z.t2);
-	auto types = z.aux->types;
-	args[2] = frame[z.v3].ToVal(types[2]);
+	args[2] = frame[z.v3].ToVal(aux->elems[2].GetType());
 	QueueEvent(z.event_handler, args);
 
 internal-op Event4
 type VVVV
 op1-read
 eval	ValVec args(4);
+	auto& aux = z.aux;
 	args[0] = frame[z.v1].ToVal(z.t);
 	args[1] = frame[z.v2].ToVal(z.t2);
-	auto types = z.aux->types;
-	args[2] = frame[z.v3].ToVal(types[2]);
-	args[3] = frame[z.v4].ToVal(types[3]);
+	args[2] = frame[z.v3].ToVal(aux->elems[2].GetType());
+	args[3] = frame[z.v4].ToVal(aux->elems[3].GetType());
 	QueueEvent(z.event_handler, args);
 
 
@@ -2257,11 +2257,11 @@ eval	auto& aux = z.aux;
 		auto captures = std::make_unique<std::vector<ZVal>>();
 		for ( auto i = 0; i < aux->n; ++i )
 			{
-			auto slot = aux->slots[i];
+			auto slot = aux->elems[i].Slot();
 			if ( slot >= 0 )
 				{
-				auto& cp = frame[aux->slots[i]];
-				if ( aux->is_managed[i] )
+				auto& cp = frame[slot];
+				if ( aux->elems[i].IsManaged() )
 					zeek::Ref(cp.ManagedVal());
 				captures->push_back(cp);
 				}
@@ -2356,7 +2356,7 @@ eval	LogWritePre(frame[z.v2].ToVal(log_ID_enum_type), v3)
 internal-op Log-WriteC
 side-effects OP_LOG_WRITEC_V OP_V
 type VV
-eval	LogWritePre(z.aux->constants[0], v2)
+eval	LogWritePre(z.aux->elems[0].Constant(), v2)
 	LogWriteResPost()
 
 # Versions that discard the return value.
@@ -2371,7 +2371,7 @@ internal-op Log-WriteC
 side-effects
 op1-read
 type V
-eval	LogWritePre(z.aux->constants[0], v1)
+eval	LogWritePre(z.aux->elems[0].Constant(), v1)
 	LogWriteNoResPost()
 
 internal-op Broker-Flush-Logs
@@ -2460,23 +2460,21 @@ eval	Cat1FullVal(frame[z.v2])
 internal-op CatN
 type V
 eval	auto aux = z.aux;
-	auto slots = z.aux->slots;
 	auto& ca = aux->cat_args;
 	int n = aux->n;
 	size_t max_size = 0;
 	for ( int i = 0; i < n; ++i )
-		max_size += ca[i]->MaxSize(frame, slots[i]);
+		max_size += ca[i]->MaxSize(frame, aux->elems[i].Slot());
 	auto res = new char[max_size + /* slop */ n + 1];
 	auto res_p = res;
 	for ( int i = 0; i < n; ++i )
-		ca[i]->RenderInto(frame, slots[i], res_p);
+		ca[i]->RenderInto(frame, aux->elems[i].Slot(), res_p);
 	*res_p = '\0';
 	auto s = new String(true, reinterpret_cast<byte_vec>(res), res_p - res);
 	Cat1Op(ZVal(new StringVal(s)))
 
 macro CatNPre()
 	auto aux = z.aux;
-	auto slots = z.aux->slots;
 	auto& ca = aux->cat_args;
 
 macro CatNMid()
@@ -2491,113 +2489,113 @@ macro CatNPost()
 internal-op Cat2
 type V
 eval	CatNPre()
-	size_t max_size = ca[0]->MaxSize(frame, slots[0]);
-	max_size += ca[1]->MaxSize(frame, slots[1]);
+	size_t max_size = ca[0]->MaxSize(frame, aux->elems[0].Slot());
+	max_size += ca[1]->MaxSize(frame, aux->elems[1].Slot());
 	CatNMid()
-	ca[0]->RenderInto(frame, slots[0], res_p);
-	ca[1]->RenderInto(frame, slots[1], res_p);
+	ca[0]->RenderInto(frame, aux->elems[0].Slot(), res_p);
+	ca[1]->RenderInto(frame, aux->elems[1].Slot(), res_p);
 	CatNPost()
 
 internal-op Cat3
 type V
 eval	CatNPre()
-	size_t max_size = ca[0]->MaxSize(frame, slots[0]);
-	max_size += ca[1]->MaxSize(frame, slots[1]);
-	max_size += ca[2]->MaxSize(frame, slots[2]);
+	size_t max_size = ca[0]->MaxSize(frame, aux->elems[0].Slot());
+	max_size += ca[1]->MaxSize(frame, aux->elems[1].Slot());
+	max_size += ca[2]->MaxSize(frame, aux->elems[2].Slot());
 	CatNMid()
-	ca[0]->RenderInto(frame, slots[0], res_p);
-	ca[1]->RenderInto(frame, slots[1], res_p);
-	ca[2]->RenderInto(frame, slots[2], res_p);
+	ca[0]->RenderInto(frame, aux->elems[0].Slot(), res_p);
+	ca[1]->RenderInto(frame, aux->elems[1].Slot(), res_p);
+	ca[2]->RenderInto(frame, aux->elems[2].Slot(), res_p);
 	CatNPost()
 
 internal-op Cat4
 type V
 eval	CatNPre()
-	size_t max_size = ca[0]->MaxSize(frame, slots[0]);
-	max_size += ca[1]->MaxSize(frame, slots[1]);
-	max_size += ca[2]->MaxSize(frame, slots[2]);
-	max_size += ca[3]->MaxSize(frame, slots[3]);
+	size_t max_size = ca[0]->MaxSize(frame, aux->elems[0].Slot());
+	max_size += ca[1]->MaxSize(frame, aux->elems[1].Slot());
+	max_size += ca[2]->MaxSize(frame, aux->elems[2].Slot());
+	max_size += ca[3]->MaxSize(frame, aux->elems[3].Slot());
 	CatNMid()
-	ca[0]->RenderInto(frame, slots[0], res_p);
-	ca[1]->RenderInto(frame, slots[1], res_p);
-	ca[2]->RenderInto(frame, slots[2], res_p);
-	ca[3]->RenderInto(frame, slots[3], res_p);
+	ca[0]->RenderInto(frame, aux->elems[0].Slot(), res_p);
+	ca[1]->RenderInto(frame, aux->elems[1].Slot(), res_p);
+	ca[2]->RenderInto(frame, aux->elems[2].Slot(), res_p);
+	ca[3]->RenderInto(frame, aux->elems[3].Slot(), res_p);
 	CatNPost()
 
 internal-op Cat5
 type V
 eval	CatNPre()
-	size_t max_size = ca[0]->MaxSize(frame, slots[0]);
-	max_size += ca[1]->MaxSize(frame, slots[1]);
-	max_size += ca[2]->MaxSize(frame, slots[2]);
-	max_size += ca[3]->MaxSize(frame, slots[3]);
-	max_size += ca[4]->MaxSize(frame, slots[4]);
+	size_t max_size = ca[0]->MaxSize(frame, aux->elems[0].Slot());
+	max_size += ca[1]->MaxSize(frame, aux->elems[1].Slot());
+	max_size += ca[2]->MaxSize(frame, aux->elems[2].Slot());
+	max_size += ca[3]->MaxSize(frame, aux->elems[3].Slot());
+	max_size += ca[4]->MaxSize(frame, aux->elems[4].Slot());
 	CatNMid()
-	ca[0]->RenderInto(frame, slots[0], res_p);
-	ca[1]->RenderInto(frame, slots[1], res_p);
-	ca[2]->RenderInto(frame, slots[2], res_p);
-	ca[3]->RenderInto(frame, slots[3], res_p);
-	ca[4]->RenderInto(frame, slots[4], res_p);
+	ca[0]->RenderInto(frame, aux->elems[0].Slot(), res_p);
+	ca[1]->RenderInto(frame, aux->elems[1].Slot(), res_p);
+	ca[2]->RenderInto(frame, aux->elems[2].Slot(), res_p);
+	ca[3]->RenderInto(frame, aux->elems[3].Slot(), res_p);
+	ca[4]->RenderInto(frame, aux->elems[4].Slot(), res_p);
 	CatNPost()
 
 internal-op Cat6
 type V
 eval	CatNPre()
-	size_t max_size = ca[0]->MaxSize(frame, slots[0]);
-	max_size += ca[1]->MaxSize(frame, slots[1]);
-	max_size += ca[2]->MaxSize(frame, slots[2]);
-	max_size += ca[3]->MaxSize(frame, slots[3]);
-	max_size += ca[4]->MaxSize(frame, slots[4]);
-	max_size += ca[5]->MaxSize(frame, slots[5]);
+	size_t max_size = ca[0]->MaxSize(frame, aux->elems[0].Slot());
+	max_size += ca[1]->MaxSize(frame, aux->elems[1].Slot());
+	max_size += ca[2]->MaxSize(frame, aux->elems[2].Slot());
+	max_size += ca[3]->MaxSize(frame, aux->elems[3].Slot());
+	max_size += ca[4]->MaxSize(frame, aux->elems[4].Slot());
+	max_size += ca[5]->MaxSize(frame, aux->elems[5].Slot());
 	CatNMid()
-	ca[0]->RenderInto(frame, slots[0], res_p);
-	ca[1]->RenderInto(frame, slots[1], res_p);
-	ca[2]->RenderInto(frame, slots[2], res_p);
-	ca[3]->RenderInto(frame, slots[3], res_p);
-	ca[4]->RenderInto(frame, slots[4], res_p);
-	ca[5]->RenderInto(frame, slots[5], res_p);
+	ca[0]->RenderInto(frame, aux->elems[0].Slot(), res_p);
+	ca[1]->RenderInto(frame, aux->elems[1].Slot(), res_p);
+	ca[2]->RenderInto(frame, aux->elems[2].Slot(), res_p);
+	ca[3]->RenderInto(frame, aux->elems[3].Slot(), res_p);
+	ca[4]->RenderInto(frame, aux->elems[4].Slot(), res_p);
+	ca[5]->RenderInto(frame, aux->elems[5].Slot(), res_p);
 	CatNPost()
 
 internal-op Cat7
 type V
 eval	CatNPre()
-	size_t max_size = ca[0]->MaxSize(frame, slots[0]);
-	max_size += ca[1]->MaxSize(frame, slots[1]);
-	max_size += ca[2]->MaxSize(frame, slots[2]);
-	max_size += ca[3]->MaxSize(frame, slots[3]);
-	max_size += ca[4]->MaxSize(frame, slots[4]);
-	max_size += ca[5]->MaxSize(frame, slots[5]);
-	max_size += ca[6]->MaxSize(frame, slots[6]);
+	size_t max_size = ca[0]->MaxSize(frame, aux->elems[0].Slot());
+	max_size += ca[1]->MaxSize(frame, aux->elems[1].Slot());
+	max_size += ca[2]->MaxSize(frame, aux->elems[2].Slot());
+	max_size += ca[3]->MaxSize(frame, aux->elems[3].Slot());
+	max_size += ca[4]->MaxSize(frame, aux->elems[4].Slot());
+	max_size += ca[5]->MaxSize(frame, aux->elems[5].Slot());
+	max_size += ca[6]->MaxSize(frame, aux->elems[6].Slot());
 	CatNMid()
-	ca[0]->RenderInto(frame, slots[0], res_p);
-	ca[1]->RenderInto(frame, slots[1], res_p);
-	ca[2]->RenderInto(frame, slots[2], res_p);
-	ca[3]->RenderInto(frame, slots[3], res_p);
-	ca[4]->RenderInto(frame, slots[4], res_p);
-	ca[5]->RenderInto(frame, slots[5], res_p);
-	ca[6]->RenderInto(frame, slots[6], res_p);
+	ca[0]->RenderInto(frame, aux->elems[0].Slot(), res_p);
+	ca[1]->RenderInto(frame, aux->elems[1].Slot(), res_p);
+	ca[2]->RenderInto(frame, aux->elems[2].Slot(), res_p);
+	ca[3]->RenderInto(frame, aux->elems[3].Slot(), res_p);
+	ca[4]->RenderInto(frame, aux->elems[4].Slot(), res_p);
+	ca[5]->RenderInto(frame, aux->elems[5].Slot(), res_p);
+	ca[6]->RenderInto(frame, aux->elems[6].Slot(), res_p);
 	CatNPost()
 
 internal-op Cat8
 type V
 eval	CatNPre()
-	size_t max_size = ca[0]->MaxSize(frame, slots[0]);
-	max_size += ca[1]->MaxSize(frame, slots[1]);
-	max_size += ca[2]->MaxSize(frame, slots[2]);
-	max_size += ca[3]->MaxSize(frame, slots[3]);
-	max_size += ca[4]->MaxSize(frame, slots[4]);
-	max_size += ca[5]->MaxSize(frame, slots[5]);
-	max_size += ca[6]->MaxSize(frame, slots[6]);
-	max_size += ca[7]->MaxSize(frame, slots[7]);
+	size_t max_size = ca[0]->MaxSize(frame, aux->elems[0].Slot());
+	max_size += ca[1]->MaxSize(frame, aux->elems[1].Slot());
+	max_size += ca[2]->MaxSize(frame, aux->elems[2].Slot());
+	max_size += ca[3]->MaxSize(frame, aux->elems[3].Slot());
+	max_size += ca[4]->MaxSize(frame, aux->elems[4].Slot());
+	max_size += ca[5]->MaxSize(frame, aux->elems[5].Slot());
+	max_size += ca[6]->MaxSize(frame, aux->elems[6].Slot());
+	max_size += ca[7]->MaxSize(frame, aux->elems[7].Slot());
 	CatNMid()
-	ca[0]->RenderInto(frame, slots[0], res_p);
-	ca[1]->RenderInto(frame, slots[1], res_p);
-	ca[2]->RenderInto(frame, slots[2], res_p);
-	ca[3]->RenderInto(frame, slots[3], res_p);
-	ca[4]->RenderInto(frame, slots[4], res_p);
-	ca[5]->RenderInto(frame, slots[5], res_p);
-	ca[6]->RenderInto(frame, slots[6], res_p);
-	ca[7]->RenderInto(frame, slots[7], res_p);
+	ca[0]->RenderInto(frame, aux->elems[0].Slot(), res_p);
+	ca[1]->RenderInto(frame, aux->elems[1].Slot(), res_p);
+	ca[2]->RenderInto(frame, aux->elems[2].Slot(), res_p);
+	ca[3]->RenderInto(frame, aux->elems[3].Slot(), res_p);
+	ca[4]->RenderInto(frame, aux->elems[4].Slot(), res_p);
+	ca[5]->RenderInto(frame, aux->elems[5].Slot(), res_p);
+	ca[6]->RenderInto(frame, aux->elems[6].Slot(), res_p);
+	ca[7]->RenderInto(frame, aux->elems[7].Slot(), res_p);
 	CatNPost()
 
 internal-op Analyzer--Name

--- a/src/script_opt/ZAM/ZInst.h
+++ b/src/script_opt/ZAM/ZInst.h
@@ -298,6 +298,65 @@ private:
     void InitConst(const ConstExpr* ce);
 };
 
+// Class for tracking one element of auxiliary information. This can be an
+// integer, often specifying a frame slot, or a Val representing a constant.
+// The class also tracks any associated type and caches whether it's "managed".
+class AuxElem {
+public:
+    AuxElem() {}
+
+    // Different ways of setting the specifics of the element.
+    void SetInt(int _i) { i = _i; }
+    void SetInt(int _i, TypePtr _t) {
+        i = _i;
+        SetType(_t);
+    }
+    void SetSlot(int slot) { i = slot; }
+    void SetConstant(ValPtr _c) {
+        c = std::move(_c);
+        // c might be null in some contexts.
+        if ( c ) {
+            SetType(c->GetType());
+            zc = ZVal(c, t);
+        }
+    }
+
+    // Returns the element as a Val object.
+    ValPtr ToVal(const ZVal* frame) const {
+        if ( c )
+            return c;
+        else
+            return frame[i].ToVal(t);
+    }
+
+    // Returns the element as a ZVal object.
+    ZVal ToZVal(const ZVal* frame) const {
+        ZVal zv = c ? zc : frame[i];
+        if ( is_managed )
+            Ref(zv.ManagedVal());
+        return zv;
+    }
+
+    int Slot() const { return i; }
+    int IntVal() const { return i; }
+    const ValPtr& Constant() const { return c; }
+    ZVal ZConstant() const { return zc; }
+    const TypePtr& GetType() const { return t; }
+    bool IsManaged() const { return is_managed; }
+
+private:
+    void SetType(TypePtr _t) {
+        t = std::move(_t);
+        is_managed = t ? ZVal::IsManagedType(t) : false;
+    }
+
+    int i = -1; // -1 = "not a slot"
+    ValPtr c;
+    ZVal zc;
+    TypePtr t;
+    bool is_managed = false;
+};
+
 // Auxiliary information, used when the fixed ZInst layout lacks
 // sufficient expressiveness to represent all of the elements that
 // an instruction needs.
@@ -307,53 +366,41 @@ public:
     // tracking slots, constants, and types.
     ZInstAux(int _n) {
         n = _n;
-        if ( n > 0 ) {
-            slots = ints = new int[n];
-            constants = new ValPtr[n];
-            types = new TypePtr[n];
-            is_managed = new bool[n];
-        }
+        if ( n > 0 )
+            elems = new AuxElem[n];
     }
 
     ~ZInstAux() {
-        delete[] ints;
-        delete[] constants;
-        delete[] types;
-        delete[] is_managed;
+        delete[] elems;
         delete[] cat_args;
     }
 
-    // Returns the i'th element of the parallel arrays as a ValPtr.
-    ValPtr ToVal(const ZVal* frame, int i) const {
-        if ( constants[i] )
-            return constants[i];
-        else
-            return frame[slots[i]].ToVal(types[i]);
-    }
+    // Returns the i'th element of the elements as a ValPtr.
+    ValPtr ToVal(const ZVal* frame, int i) const { return elems[i].ToVal(frame); }
+    ZVal ToZVal(const ZVal* frame, int i) const { return elems[i].ToZVal(frame); }
 
-    // Returns the parallel arrays as a ListValPtr.
+    // Returns the elements as a ListValPtr.
     ListValPtr ToListVal(const ZVal* frame) const {
         auto lv = make_intrusive<ListVal>(TYPE_ANY);
         for ( auto i = 0; i < n; ++i )
-            lv->Append(ToVal(frame, i));
+            lv->Append(elems[i].ToVal(frame));
 
         return lv;
     }
 
-    // Converts the parallel arrays to a ListValPtr suitable for
-    // use as indices for indexing a table or set.  "offset" specifies
-    // which index we're looking for (there can be a bunch for
-    // constructors), and "width" the number of elements in a single
-    // index.
+    // Converts the elements to a ListValPtr suitable for use as indices
+    // for indexing a table or set.  "offset" specifies which index we're
+    // looking for (there can be a bunch for constructors), and "width"
+    // the number of elements in a single index.
     ListValPtr ToIndices(const ZVal* frame, int offset, int width) const {
         auto lv = make_intrusive<ListVal>(TYPE_ANY);
         for ( auto i = 0; i < 0 + width; ++i )
-            lv->Append(ToVal(frame, offset + i));
+            lv->Append(elems[offset + i].ToVal(frame));
 
         return lv;
     }
 
-    // Returns the parallel arrays converted to a vector of ValPtr's.
+    // Returns the elements converted to a vector of ValPtr's.
     const ValVec& ToValVec(const ZVal* frame) {
         vv.clear();
         FillValVec(vv, frame);
@@ -361,49 +408,26 @@ public:
     }
 
     // Populates the given vector of ValPtr's with the conversion
-    // of the parallel arrays.
+    // of the elements.
     void FillValVec(ValVec& vec, const ZVal* frame) const {
         for ( auto i = 0; i < n; ++i )
-            vec.push_back(ToVal(frame, i));
+            vec.push_back(elems[i].ToVal(frame));
     }
 
-    // When building up a ZInstAux, sets one element of the parallel
-    // arrays to a given frame slot and type.
-    void Add(int i, int slot, TypePtr t) {
-        ints[i] = slot;
-        constants[i] = nullptr;
-        types[i] = t;
-        is_managed[i] = t ? ZVal::IsManagedType(t) : false;
-    }
+    // When building up a ZInstAux, sets one element to a given frame slot
+    // and type.
+    void Add(int i, int slot, TypePtr t) { elems[i].SetInt(slot, t); }
 
     // Same but for constants.
-    void Add(int i, ValPtr c) {
-        ints[i] = -1;
-        constants[i] = c;
-        types[i] = nullptr;
-        is_managed[i] = false;
-    }
+    void Add(int i, ValPtr c) { elems[i].SetConstant(c); }
 
     // Member variables.  We could add accessors for manipulating
     // these (and make the variables private), but for convenience we
     // make them directly available.
 
-    // These are parallel arrays, used to build up lists of values.
-    // Each element is either an integer or a constant.  Usually the
-    // integer is a frame slot (in which case "slots" points to "ints";
-    // if not, it's nil).
-    //
-    // We track associated types, too, enabling us to use
-    // ZVal::ToVal to convert frame slots or constants to ValPtr's;
-    // and, as a performance optimization, whether those types
-    // indicate the slot needs to be managed.
-
-    int n;                // size of arrays
-    int* slots = nullptr; // either nil or points to ints
-    int* ints = nullptr;
-    ValPtr* constants = nullptr;
-    TypePtr* types = nullptr;
-    bool* is_managed = nullptr;
+    int n; // size of elements
+    AuxElem* elems = nullptr;
+    bool elems_has_slots = true;
 
     // Ingredients associated with lambdas ...
     ScriptFuncPtr primary_func;

--- a/src/script_opt/ZAM/ZInst.h
+++ b/src/script_opt/ZAM/ZInst.h
@@ -418,6 +418,9 @@ public:
     // and type.
     void Add(int i, int slot, TypePtr t) { elems[i].SetInt(slot, t); }
 
+    // Same, but for non-slot integers.
+    void Add(int i, int v_i) { elems[i].SetInt(v_i); }
+
     // Same but for constants.
     void Add(int i, ValPtr c) { elems[i].SetConstant(c); }
 


### PR DESCRIPTION
The heart of this PR is streamlining of ZAM's record creation, the most significant elements being support for direct `ZVal`-based field initialization, and skipping of default field construction if not needed. In addition, the construction now separates out concretization of "unspecified" vectors (a rare case) from the main construction. 

Doing this requires some tweaking of the `RecordVal` constructor, in particular for it to now have three modes (fully create; initialize the "slots" in its underlying `ZVal` vector but not their values; no initialization) as opposed to the previous two modes (first and last of those). I also took the opportunity to tidy up some of ZAM's internals a tad, condensing a bunch of parallel arrays into a single array that tracks multiple values.

_hyperfine_ isn't great in providing consistent numbers for just how much improvement this reaps, but for my large DNS PCAP trace it consistently ranks these changes as a tad better than without them.