### PR TITLE
Avoid extra copies in threading_field_to_data

### DIFF
--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -1154,13 +1154,17 @@ broker::data threading_field_to_data(const threading::Field* f) {
     return broker::vector({name, secondary, type, subtype, optional});
 }
 
-threading::Field* data_to_threading_field(broker::data d) {
+threading::Field* data_to_threading_field(const broker::data& d) {
     if ( ! holds_alternative<broker::vector>(d) )
         return nullptr;
 
     auto& v = get<broker::vector>(d);
+
+    if ( v.size() < 5 )
+        return nullptr;
+
     auto name = get_if<std::string>(&v[0]);
-    auto secondary = v[1];
+    const auto& secondary = v[1];
     auto type = get_if<broker::count>(&v[2]);
     auto subtype = get_if<broker::count>(&v[3]);
     auto optional = get_if<broker::boolean>(&v[4]);

--- a/src/broker/Data.h
+++ b/src/broker/Data.h
@@ -101,7 +101,7 @@ broker::data threading_field_to_data(const threading::Field* f);
  * @return a pointer to a new zeek::threading::Value or a nullptr if the conversion was not
  * possible.
  */
-threading::Field* data_to_threading_field(broker::data d);
+threading::Field* data_to_threading_field(const broker::data& d);
 
 /**
  * A Zeek value which wraps a Broker data value.


### PR DESCRIPTION
Passing the `broker::data` paramter for `threading_field_to_data` by value forces copies. However, the function only needs const access to its parameter. Hence, taking the parameter as const-ref is the logical choice and avoids unnecessary copies of individual data fields.