### PR TITLE
Backward compatibility for OpaqueVal serialization

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,39 @@ Breaking Changes
   values as well as the LDAP message identifier. The value within the LDAP logs
   will be the most recently observed one.
 
+- Zeek will no longer use the virtual member function pair ``DoSerialize`` and
+  ``DoUnserialize`` for subtypes of ``OpaqueVal`` (or ``BloomFilter``). Instead,
+  Zeek will call these virtual member functions:
+
+    * ``std::optional<BrokerData> OpaqueVal::DoSerializeData() const``
+    * ``bool OpaqueVal::DoUnserializeData(BrokerDataView data)``
+
+  When overriding ``DoSerializeData()``, return ``std::nullopt`` (or a
+  default-constructed ``optional``) for values that cannot be serialized.
+  Otherwise, the canonical way to create a ``BrokerData`` for serialization is
+  by using a ``BrokerListBuilder``. For example, creating a ``BrokerData`` that
+  contains ``true`` and the count ``42`` could be implemented as follows:
+
+    BrokerListBuilder builder;
+    builder.Add(true);
+    builder.AddCount(42u);
+    return std::move(builder).Build();
+
+  Please refer to the respective class documentation for a full list of member
+  functions on ``BrokerListBuilder`` and ``BrokerDataView``.
+
+  For plugins that are using the macro ``DECLARE_OPAQUE_VALUE`` to generate the
+  function prototypes for the serialization functions: please use
+  ``DECLARE_OPAQUE_VALUE_DATA`` instead to generate prototypes for the new API.
+
+  Please note that old code overriding ``DoSerialize`` and ``DoUnserialize``
+  will not break immediately. The default implementations for the new functions
+  will call the old signatures and convert the results. However, we are listing
+  this change as a breaking change since we cannot raise a deprecation warning
+  for overriding the old member functions. Thus, any code still depending on the
+  old signature will break without prior compiler warning when removing the old
+  functions eventually (scheduled for 7.1).
+
 New Functionality
 -----------------
 

--- a/src/OpaqueVal.h
+++ b/src/OpaqueVal.h
@@ -94,7 +94,7 @@ private:
 /**
  * Legacy macro to insert into an OpaqueVal-derived class's declaration. Overrides the "old" serialization methods
  * DoSerialize and DoUnserialize.
- * @deprecated Use DECLARE_OPAQUE_VALUE_DATA instead.
+ * @deprecated Use DECLARE_OPAQUE_VALUE_DATA instead. Remove in v7.1.
  */
 #define DECLARE_OPAQUE_VALUE(T)                                                                                        \
     friend class zeek::OpaqueMgr::Register<T>;                                                                         \
@@ -169,7 +169,7 @@ protected:
     friend class OpaqueMgr;
 
     /**
-     * @deprecated Override DoSerializeData instead.
+     * @deprecated Override DoSerializeData instead. Remove in v7.1.
      */
     virtual broker::expected<broker::data> DoSerialize() const;
 
@@ -183,7 +183,7 @@ protected:
     virtual std::optional<BrokerData> DoSerializeData() const;
 
     /**
-     * @deprecated Override DoUnserializeData instead.
+     * @deprecated Override DoUnserializeData instead. Remove in v7.1.
      */
     virtual bool DoUnserialize(const broker::data& data);
 

--- a/src/OpaqueVal.h
+++ b/src/OpaqueVal.h
@@ -111,8 +111,8 @@ private:
 #define DECLARE_OPAQUE_VALUE_V2(T)                                                                                     \
     friend class zeek::OpaqueMgr::Register<T>;                                                                         \
     friend zeek::IntrusivePtr<T> zeek::make_intrusive<T>();                                                            \
-    std::optional<zeek::BrokerData> DoSerializeData() const override;                                                      \
-    bool DoUnserializeData(zeek::BrokerDataView data) override;                                                            \
+    std::optional<zeek::BrokerData> DoSerializeData() const override;                                                  \
+    bool DoUnserializeData(zeek::BrokerDataView data) override;                                                        \
     const char* OpaqueName() const override { return #T; }                                                             \
     static zeek::OpaqueValPtr OpaqueInstantiate() { return zeek::make_intrusive<T>(); }
 
@@ -143,7 +143,7 @@ public:
     /**
      * @copydoc Serialize
      */
-     std::optional<BrokerData> SerializeData() const;
+    std::optional<BrokerData> SerializeData() const;
 
     /**
      * Reinstantiates a value from its serialized Broker representation.

--- a/src/OpaqueVal.h
+++ b/src/OpaqueVal.h
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #endif
 
+#include <broker/expected.hh>
 #include <paraglob/paraglob.h>
 #include <sys/types.h> // for u_char
 #include <optional>
@@ -17,6 +18,10 @@
 #include "zeek/telemetry/Counter.h"
 #include "zeek/telemetry/Gauge.h"
 #include "zeek/telemetry/Histogram.h"
+
+namespace broker {
+class data;
+}
 
 namespace zeek {
 
@@ -86,12 +91,28 @@ private:
     std::unordered_map<std::string, Factory*> _types;
 };
 
-/** Macro to insert into an OpaqueVal-derived class's declaration. */
+/**
+ * Legacy macro to insert into an OpaqueVal-derived class's declaration. Overrides the "old" serialization methods
+ * DoSerialize and DoUnserialize.
+ * @deprecated Use DECLARE_OPAQUE_VALUE_V2 instead.
+ */
 #define DECLARE_OPAQUE_VALUE(T)                                                                                        \
     friend class zeek::OpaqueMgr::Register<T>;                                                                         \
     friend zeek::IntrusivePtr<T> zeek::make_intrusive<T>();                                                            \
-    std::optional<BrokerData> DoSerialize() const override;                                                            \
-    bool DoUnserialize(BrokerDataView data) override;                                                                  \
+    broker::expected<broker::data> DoSerialize() const override;                                                       \
+    bool DoUnserialize(const broker::data& data) override;                                                             \
+    const char* OpaqueName() const override { return #T; }                                                             \
+    static zeek::OpaqueValPtr OpaqueInstantiate() { return zeek::make_intrusive<T>(); }
+
+/**
+ * Macro to insert into an OpaqueVal-derived class's declaration. Overrides the "new" serialization methods
+ * DoSerializeData and DoUnserializeData.
+ */
+#define DECLARE_OPAQUE_VALUE_V2(T)                                                                                     \
+    friend class zeek::OpaqueMgr::Register<T>;                                                                         \
+    friend zeek::IntrusivePtr<T> zeek::make_intrusive<T>();                                                            \
+    std::optional<zeek::BrokerData> DoSerializeData() const override;                                                      \
+    bool DoUnserializeData(zeek::BrokerDataView data) override;                                                            \
     const char* OpaqueName() const override { return #T; }                                                             \
     static zeek::OpaqueValPtr OpaqueInstantiate() { return zeek::make_intrusive<T>(); }
 
@@ -117,7 +138,12 @@ public:
      * @return the broker representation, or an error if serialization
      * isn't supported or failed.
      */
-    std::optional<BrokerData> Serialize() const;
+    [[deprecated("use SerializeData instead")]] broker::expected<broker::data> Serialize() const;
+
+    /**
+     * @copydoc Serialize
+     */
+     std::optional<BrokerData> SerializeData() const;
 
     /**
      * Reinstantiates a value from its serialized Broker representation.
@@ -125,16 +151,26 @@ public:
      * @param data Broker representation as returned by *Serialize()*.
      * @return unserialized instances with reference count at +1
      */
-    static OpaqueValPtr Unserialize(BrokerDataView data);
+    [[deprecated("use UnserializeData instead")]] static OpaqueValPtr Unserialize(const broker::data& data);
 
     /**
      * @copydoc Unserialize
      */
-    static OpaqueValPtr Unserialize(BrokerListView data);
+    static OpaqueValPtr UnserializeData(BrokerDataView data);
+
+    /**
+     * @copydoc Unserialize
+     */
+    static OpaqueValPtr UnserializeData(BrokerListView data);
 
 protected:
     friend class Val;
     friend class OpaqueMgr;
+
+    /**
+     * @deprecated Override DoSerializeData instead.
+     */
+    virtual broker::expected<broker::data> DoSerialize() const;
 
     /**
      * Must be overridden to provide a serialized version of the derived
@@ -143,7 +179,12 @@ protected:
      * @return the serialized data or an error if serialization
      * isn't supported or failed.
      */
-    virtual std::optional<BrokerData> DoSerialize() const = 0;
+    virtual std::optional<BrokerData> DoSerializeData() const;
+
+    /**
+     * @deprecated Override DoUnserializeData instead.
+     */
+    virtual bool DoUnserialize(const broker::data& data);
 
     /**
      * Must be overridden to recreate the derived class' state from a
@@ -151,7 +192,7 @@ protected:
      *
      * @return true if successful.
      */
-    virtual bool DoUnserialize(BrokerDataView data) = 0;
+    virtual bool DoUnserializeData(BrokerDataView data);
 
     /**
      * Internal helper for the serialization machinery. Automatically
@@ -248,7 +289,7 @@ protected:
     bool DoFeed(const void* data, size_t size) override;
     StringValPtr DoGet() override;
 
-    DECLARE_OPAQUE_VALUE(MD5Val)
+    DECLARE_OPAQUE_VALUE_V2(MD5Val)
 private:
     StatePtr ctx = nullptr;
 };
@@ -276,7 +317,7 @@ protected:
     bool DoFeed(const void* data, size_t size) override;
     StringValPtr DoGet() override;
 
-    DECLARE_OPAQUE_VALUE(SHA1Val)
+    DECLARE_OPAQUE_VALUE_V2(SHA1Val)
 private:
     StatePtr ctx = nullptr;
 };
@@ -304,7 +345,7 @@ protected:
     bool DoFeed(const void* data, size_t size) override;
     StringValPtr DoGet() override;
 
-    DECLARE_OPAQUE_VALUE(SHA256Val)
+    DECLARE_OPAQUE_VALUE_V2(SHA256Val)
 private:
     StatePtr ctx = nullptr;
 };
@@ -319,7 +360,7 @@ public:
 protected:
     friend class Val;
 
-    DECLARE_OPAQUE_VALUE(EntropyVal)
+    DECLARE_OPAQUE_VALUE_V2(EntropyVal)
 private:
     detail::RandTest state;
 };
@@ -349,7 +390,7 @@ protected:
     friend class Val;
     BloomFilterVal();
 
-    DECLARE_OPAQUE_VALUE(BloomFilterVal)
+    DECLARE_OPAQUE_VALUE_V2(BloomFilterVal)
 private:
     // Disable.
     BloomFilterVal(const BloomFilterVal&);
@@ -378,7 +419,7 @@ public:
 protected:
     CardinalityVal();
 
-    DECLARE_OPAQUE_VALUE(CardinalityVal)
+    DECLARE_OPAQUE_VALUE_V2(CardinalityVal)
 private:
     TypePtr type;
     detail::CompositeHash* hash;
@@ -395,7 +436,7 @@ public:
 protected:
     ParaglobVal() : OpaqueVal(paraglob_type) {}
 
-    DECLARE_OPAQUE_VALUE(ParaglobVal)
+    DECLARE_OPAQUE_VALUE_V2(ParaglobVal)
 
 private:
     std::unique_ptr<paraglob::Paraglob> internal_paraglob;
@@ -419,8 +460,8 @@ protected:
     explicit TelemetryVal(telemetry::DblHistogram);
     explicit TelemetryVal(telemetry::DblHistogramFamily);
 
-    std::optional<BrokerData> DoSerialize() const override;
-    bool DoUnserialize(BrokerDataView data) override;
+    std::optional<BrokerData> DoSerializeData() const override;
+    bool DoUnserializeData(BrokerDataView data) override;
 };
 
 template<class Handle>

--- a/src/OpaqueVal.h
+++ b/src/OpaqueVal.h
@@ -94,7 +94,7 @@ private:
 /**
  * Legacy macro to insert into an OpaqueVal-derived class's declaration. Overrides the "old" serialization methods
  * DoSerialize and DoUnserialize.
- * @deprecated Use DECLARE_OPAQUE_VALUE_V2 instead.
+ * @deprecated Use DECLARE_OPAQUE_VALUE_DATA instead.
  */
 #define DECLARE_OPAQUE_VALUE(T)                                                                                        \
     friend class zeek::OpaqueMgr::Register<T>;                                                                         \
@@ -108,7 +108,7 @@ private:
  * Macro to insert into an OpaqueVal-derived class's declaration. Overrides the "new" serialization methods
  * DoSerializeData and DoUnserializeData.
  */
-#define DECLARE_OPAQUE_VALUE_V2(T)                                                                                     \
+#define DECLARE_OPAQUE_VALUE_DATA(T)                                                                                   \
     friend class zeek::OpaqueMgr::Register<T>;                                                                         \
     friend zeek::IntrusivePtr<T> zeek::make_intrusive<T>();                                                            \
     std::optional<zeek::BrokerData> DoSerializeData() const override;                                                  \
@@ -138,7 +138,7 @@ public:
      * @return the broker representation, or an error if serialization
      * isn't supported or failed.
      */
-    [[deprecated("use SerializeData instead")]] broker::expected<broker::data> Serialize() const;
+    [[deprecated("Remove in v7.1: use SerializeData instead")]] broker::expected<broker::data> Serialize() const;
 
     /**
      * @copydoc Serialize
@@ -151,7 +151,8 @@ public:
      * @param data Broker representation as returned by *Serialize()*.
      * @return unserialized instances with reference count at +1
      */
-    [[deprecated("use UnserializeData instead")]] static OpaqueValPtr Unserialize(const broker::data& data);
+    [[deprecated("Remove in v7.1: use UnserializeData instead")]] static OpaqueValPtr Unserialize(
+        const broker::data& data);
 
     /**
      * @copydoc Unserialize
@@ -289,7 +290,7 @@ protected:
     bool DoFeed(const void* data, size_t size) override;
     StringValPtr DoGet() override;
 
-    DECLARE_OPAQUE_VALUE_V2(MD5Val)
+    DECLARE_OPAQUE_VALUE_DATA(MD5Val)
 private:
     StatePtr ctx = nullptr;
 };
@@ -317,7 +318,7 @@ protected:
     bool DoFeed(const void* data, size_t size) override;
     StringValPtr DoGet() override;
 
-    DECLARE_OPAQUE_VALUE_V2(SHA1Val)
+    DECLARE_OPAQUE_VALUE_DATA(SHA1Val)
 private:
     StatePtr ctx = nullptr;
 };
@@ -345,7 +346,7 @@ protected:
     bool DoFeed(const void* data, size_t size) override;
     StringValPtr DoGet() override;
 
-    DECLARE_OPAQUE_VALUE_V2(SHA256Val)
+    DECLARE_OPAQUE_VALUE_DATA(SHA256Val)
 private:
     StatePtr ctx = nullptr;
 };
@@ -360,7 +361,7 @@ public:
 protected:
     friend class Val;
 
-    DECLARE_OPAQUE_VALUE_V2(EntropyVal)
+    DECLARE_OPAQUE_VALUE_DATA(EntropyVal)
 private:
     detail::RandTest state;
 };
@@ -390,7 +391,7 @@ protected:
     friend class Val;
     BloomFilterVal();
 
-    DECLARE_OPAQUE_VALUE_V2(BloomFilterVal)
+    DECLARE_OPAQUE_VALUE_DATA(BloomFilterVal)
 private:
     // Disable.
     BloomFilterVal(const BloomFilterVal&);
@@ -419,7 +420,7 @@ public:
 protected:
     CardinalityVal();
 
-    DECLARE_OPAQUE_VALUE_V2(CardinalityVal)
+    DECLARE_OPAQUE_VALUE_DATA(CardinalityVal)
 private:
     TypePtr type;
     detail::CompositeHash* hash;
@@ -436,7 +437,7 @@ public:
 protected:
     ParaglobVal() : OpaqueVal(paraglob_type) {}
 
-    DECLARE_OPAQUE_VALUE_V2(ParaglobVal)
+    DECLARE_OPAQUE_VALUE_DATA(ParaglobVal)
 
 private:
     std::unique_ptr<paraglob::Paraglob> internal_paraglob;

--- a/src/broker/Data.h
+++ b/src/broker/Data.h
@@ -125,7 +125,7 @@ public:
 protected:
     DataVal() : OpaqueVal(opaque_of_data_type) {}
 
-    DECLARE_OPAQUE_VALUE_V2(zeek::Broker::detail::DataVal)
+    DECLARE_OPAQUE_VALUE_DATA(zeek::Broker::detail::DataVal)
 };
 
 /**
@@ -222,7 +222,7 @@ public:
 protected:
     SetIterator() : zeek::OpaqueVal(opaque_of_set_iterator) {}
 
-    DECLARE_OPAQUE_VALUE_V2(zeek::Broker::detail::SetIterator)
+    DECLARE_OPAQUE_VALUE_DATA(zeek::Broker::detail::SetIterator)
 };
 
 class TableIterator : public zeek::OpaqueVal {
@@ -238,7 +238,7 @@ public:
 protected:
     TableIterator() : zeek::OpaqueVal(opaque_of_table_iterator) {}
 
-    DECLARE_OPAQUE_VALUE_V2(zeek::Broker::detail::TableIterator)
+    DECLARE_OPAQUE_VALUE_DATA(zeek::Broker::detail::TableIterator)
 };
 
 class VectorIterator : public zeek::OpaqueVal {
@@ -254,7 +254,7 @@ public:
 protected:
     VectorIterator() : zeek::OpaqueVal(opaque_of_vector_iterator) {}
 
-    DECLARE_OPAQUE_VALUE_V2(zeek::Broker::detail::VectorIterator)
+    DECLARE_OPAQUE_VALUE_DATA(zeek::Broker::detail::VectorIterator)
 };
 
 class RecordIterator : public zeek::OpaqueVal {
@@ -270,7 +270,7 @@ public:
 protected:
     RecordIterator() : zeek::OpaqueVal(opaque_of_record_iterator) {}
 
-    DECLARE_OPAQUE_VALUE_V2(zeek::Broker::detail::RecordIterator)
+    DECLARE_OPAQUE_VALUE_DATA(zeek::Broker::detail::RecordIterator)
 };
 
 } // namespace zeek::Broker::detail

--- a/src/broker/Data.h
+++ b/src/broker/Data.h
@@ -125,7 +125,7 @@ public:
 protected:
     DataVal() : OpaqueVal(opaque_of_data_type) {}
 
-    DECLARE_OPAQUE_VALUE(zeek::Broker::detail::DataVal)
+    DECLARE_OPAQUE_VALUE_V2(zeek::Broker::detail::DataVal)
 };
 
 /**
@@ -222,7 +222,7 @@ public:
 protected:
     SetIterator() : zeek::OpaqueVal(opaque_of_set_iterator) {}
 
-    DECLARE_OPAQUE_VALUE(zeek::Broker::detail::SetIterator)
+    DECLARE_OPAQUE_VALUE_V2(zeek::Broker::detail::SetIterator)
 };
 
 class TableIterator : public zeek::OpaqueVal {
@@ -238,7 +238,7 @@ public:
 protected:
     TableIterator() : zeek::OpaqueVal(opaque_of_table_iterator) {}
 
-    DECLARE_OPAQUE_VALUE(zeek::Broker::detail::TableIterator)
+    DECLARE_OPAQUE_VALUE_V2(zeek::Broker::detail::TableIterator)
 };
 
 class VectorIterator : public zeek::OpaqueVal {
@@ -254,7 +254,7 @@ public:
 protected:
     VectorIterator() : zeek::OpaqueVal(opaque_of_vector_iterator) {}
 
-    DECLARE_OPAQUE_VALUE(zeek::Broker::detail::VectorIterator)
+    DECLARE_OPAQUE_VALUE_V2(zeek::Broker::detail::VectorIterator)
 };
 
 class RecordIterator : public zeek::OpaqueVal {
@@ -270,20 +270,33 @@ public:
 protected:
     RecordIterator() : zeek::OpaqueVal(opaque_of_record_iterator) {}
 
-    DECLARE_OPAQUE_VALUE(zeek::Broker::detail::RecordIterator)
+    DECLARE_OPAQUE_VALUE_V2(zeek::Broker::detail::RecordIterator)
 };
 
 } // namespace zeek::Broker::detail
 
 namespace zeek {
 
+class BrokerData;
+class BrokerDataView;
 class BrokerListView;
+
+} // namespace zeek
+
+namespace zeek::detail {
+
+class BrokerDataAccess;
+
+} // namespace zeek::detail
+
+namespace zeek {
 
 /**
  * Non-owning reference (view) to a Broker data value.
  */
 class BrokerDataView {
 public:
+    friend class zeek::detail::BrokerDataAccess;
     friend class zeek::Broker::detail::DataVal;
     friend class zeek::Broker::detail::SetIterator;
     friend class zeek::Broker::detail::TableIterator;
@@ -294,7 +307,7 @@ public:
 
     BrokerDataView(const BrokerDataView&) noexcept = default;
 
-    explicit BrokerDataView(broker::data* value) noexcept : value_(value) { assert(value != nullptr); }
+    explicit BrokerDataView(const broker::data* value) noexcept : value_(value) { assert(value != nullptr); }
 
     /**
      * Checks whether the value represents the `nil` value.
@@ -399,7 +412,7 @@ public:
     friend std::string to_string(const BrokerDataView& data) { return broker::to_string(*data.value_); }
 
 private:
-    broker::data* value_;
+    const broker::data* value_;
 };
 
 /**
@@ -423,11 +436,13 @@ template<typename... Args>
  */
 class BrokerListView {
 public:
+    friend class zeek::detail::BrokerDataAccess;
+
     BrokerListView() = delete;
 
     BrokerListView(const BrokerListView&) noexcept = default;
 
-    explicit BrokerListView(broker::vector* values) noexcept : values_(values) { assert(values != nullptr); }
+    explicit BrokerListView(const broker::vector* values) noexcept : values_(values) { assert(values != nullptr); }
 
     /**
      * Returns a view to the first element.
@@ -460,10 +475,8 @@ public:
     [[nodiscard]] size_t IsEmpty() const noexcept { return values_->empty(); }
 
 private:
-    broker::vector* values_;
+    const broker::vector* values_;
 };
-
-class BrokerDataAccess;
 
 class BrokerListBuilder;
 
@@ -472,10 +485,10 @@ class BrokerListBuilder;
  */
 class BrokerData {
 public:
-    friend class BrokerDataAccess;
     friend class BrokerListBuilder;
     friend class zeek::Broker::Manager;
     friend class zeek::Broker::detail::StoreHandleVal;
+    friend class zeek::detail::BrokerDataAccess;
 
     BrokerData() = default;
 
@@ -651,3 +664,18 @@ private:
 };
 
 } // namespace zeek
+
+namespace zeek::detail {
+
+class BrokerDataAccess {
+public:
+    static broker::data& Unbox(BrokerData& data) { return data.value_; }
+
+    static const broker::data& Unbox(const BrokerData& data) { return data.value_; }
+
+    static broker::data&& Unbox(BrokerData&& data) { return std::move(data.value_); }
+
+    static const broker::data& Unbox(const BrokerDataView& data) { return *data.value_; }
+};
+
+} // namespace zeek::detail

--- a/src/broker/Store.cc
+++ b/src/broker/Store.cc
@@ -40,12 +40,12 @@ void StoreHandleVal::ValDescribe(ODesc* d) const {
 
 IMPLEMENT_OPAQUE_VALUE(StoreHandleVal)
 
-std::optional<BrokerData> StoreHandleVal::DoSerialize() const {
+std::optional<BrokerData> StoreHandleVal::DoSerializeData() const {
     // Cannot serialize.
     return std::nullopt;
 }
 
-bool StoreHandleVal::DoUnserialize(BrokerDataView) {
+bool StoreHandleVal::DoUnserializeData(BrokerDataView) {
     // Cannot unserialize.
     return false;
 }

--- a/src/broker/Store.h
+++ b/src/broker/Store.h
@@ -127,7 +127,7 @@ public:
 protected:
     IntrusivePtr<Val> DoClone(CloneState* state) override { return {NewRef{}, this}; }
 
-    DECLARE_OPAQUE_VALUE_V2(StoreHandleVal)
+    DECLARE_OPAQUE_VALUE_DATA(StoreHandleVal)
 };
 
 // Helper function to construct a broker backend type from script land.

--- a/src/broker/Store.h
+++ b/src/broker/Store.h
@@ -127,7 +127,7 @@ public:
 protected:
     IntrusivePtr<Val> DoClone(CloneState* state) override { return {NewRef{}, this}; }
 
-    DECLARE_OPAQUE_VALUE(StoreHandleVal)
+    DECLARE_OPAQUE_VALUE_V2(StoreHandleVal)
 };
 
 // Helper function to construct a broker backend type from script land.

--- a/src/broker/data.bif
+++ b/src/broker/data.bif
@@ -44,7 +44,7 @@ function Broker::__data_type%(d: Broker::Data%): Broker::DataType
 # For testing only.
 function Broker::__opaque_clone_through_serialization%(d: any%): any
 	%{
-	auto x = d->AsOpaqueVal()->Serialize();
+	auto x = d->AsOpaqueVal()->SerializeData();
 
 	if ( ! x )
 		{
@@ -52,7 +52,7 @@ function Broker::__opaque_clone_through_serialization%(d: any%): any
         	return zeek::val_mgr->False();
 		}
 
-	return OpaqueVal::Unserialize(x->AsView());
+	return OpaqueVal::UnserializeData(x->AsView());
 	%}
 
 function Broker::__set_create%(%): Broker::Data

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -552,7 +552,7 @@ ValPtr X509Val::DoClone(CloneState* state) {
 
 IMPLEMENT_OPAQUE_VALUE(X509Val)
 
-std::optional<BrokerData> X509Val::DoSerialize() const {
+std::optional<BrokerData> X509Val::DoSerializeData() const {
     unsigned char* buf = nullptr;
     int length = i2d_X509(certificate, &buf);
 
@@ -565,7 +565,7 @@ std::optional<BrokerData> X509Val::DoSerialize() const {
     return std::move(result);
 }
 
-bool X509Val::DoUnserialize(BrokerDataView data) {
+bool X509Val::DoUnserializeData(BrokerDataView data) {
     if ( ! data.IsString() )
         return false;
 

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -184,7 +184,7 @@ protected:
      */
     X509Val();
 
-    DECLARE_OPAQUE_VALUE_V2(X509Val)
+    DECLARE_OPAQUE_VALUE_DATA(X509Val)
 private:
     ::X509* certificate; // the wrapped certificate
 };

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -184,7 +184,7 @@ protected:
      */
     X509Val();
 
-    DECLARE_OPAQUE_VALUE(X509Val)
+    DECLARE_OPAQUE_VALUE_V2(X509Val)
 private:
     ::X509* certificate; // the wrapped certificate
 };

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -56,7 +56,7 @@ public:
 
 protected:
     explicit LogDelayTokenVal() : LogDelayTokenVal(0) {}
-    DECLARE_OPAQUE_VALUE(LogDelayTokenVal)
+    DECLARE_OPAQUE_VALUE_V2(LogDelayTokenVal)
 
 private:
     DelayTokenType token;
@@ -67,9 +67,9 @@ ValPtr LogDelayTokenVal::DoClone(CloneState* state) {
 }
 
 // Delay tokens are only valid on the same worker.
-std::optional<BrokerData> LogDelayTokenVal::DoSerialize() const { return std::nullopt; }
+std::optional<BrokerData> LogDelayTokenVal::DoSerializeData() const { return std::nullopt; }
 
-bool LogDelayTokenVal::DoUnserialize(BrokerDataView) { return false; }
+bool LogDelayTokenVal::DoUnserializeData(BrokerDataView) { return false; }
 
 IMPLEMENT_OPAQUE_VALUE(LogDelayTokenVal)
 

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -56,7 +56,7 @@ public:
 
 protected:
     explicit LogDelayTokenVal() : LogDelayTokenVal(0) {}
-    DECLARE_OPAQUE_VALUE_V2(LogDelayTokenVal)
+    DECLARE_OPAQUE_VALUE_DATA(LogDelayTokenVal)
 
 private:
     DelayTokenType token;

--- a/src/probabilistic/BloomFilter.h
+++ b/src/probabilistic/BloomFilter.h
@@ -105,8 +105,11 @@ public:
      */
     virtual std::string InternalState() const = 0;
 
-    std::optional<BrokerData> Serialize() const;
-    static std::unique_ptr<BloomFilter> Unserialize(BrokerDataView data);
+    [[deprecated("use SerializeData instead")]] broker::expected<broker::data> Serialize() const;
+    [[deprecated("use UnserializeData instead")]] static std::unique_ptr<BloomFilter> Unserialize(
+        const broker::data& data);
+    std::optional<BrokerData> SerializeData() const;
+    static std::unique_ptr<BloomFilter> UnserializeData(BrokerDataView data);
 
 protected:
     /**
@@ -121,8 +124,10 @@ protected:
      */
     explicit BloomFilter(const detail::Hasher* hasher);
 
-    virtual std::optional<BrokerData> DoSerialize() const = 0;
-    virtual bool DoUnserialize(BrokerDataView data) = 0;
+    virtual broker::expected<broker::data> DoSerialize() const;
+    virtual bool DoUnserialize(const broker::data& data);
+    virtual std::optional<BrokerData> DoSerializeData() const;
+    virtual bool DoUnserializeData(BrokerDataView data);
     virtual BloomFilterType Type() const = 0;
 
     const detail::Hasher* hasher;
@@ -201,8 +206,8 @@ protected:
     void Add(const zeek::detail::HashKey* key) override;
     bool Decrement(const zeek::detail::HashKey* key) override;
     size_t Count(const zeek::detail::HashKey* key) const override;
-    std::optional<BrokerData> DoSerialize() const override;
-    bool DoUnserialize(BrokerDataView data) override;
+    std::optional<BrokerData> DoSerializeData() const override;
+    bool DoUnserializeData(BrokerDataView data) override;
     BloomFilterType Type() const override { return BloomFilterType::Basic; }
 
 private:
@@ -264,8 +269,8 @@ protected:
     void Add(const zeek::detail::HashKey* key) override;
     bool Decrement(const zeek::detail::HashKey* key) override;
     size_t Count(const zeek::detail::HashKey* key) const override;
-    std::optional<BrokerData> DoSerialize() const override;
-    bool DoUnserialize(BrokerDataView data) override;
+    std::optional<BrokerData> DoSerializeData() const override;
+    bool DoUnserializeData(BrokerDataView data) override;
     BloomFilterType Type() const override { return BloomFilterType::Counting; }
 
 private:

--- a/src/probabilistic/BloomFilter.h
+++ b/src/probabilistic/BloomFilter.h
@@ -105,8 +105,8 @@ public:
      */
     virtual std::string InternalState() const = 0;
 
-    [[deprecated("use SerializeData instead")]] broker::expected<broker::data> Serialize() const;
-    [[deprecated("use UnserializeData instead")]] static std::unique_ptr<BloomFilter> Unserialize(
+    [[deprecated("Remove in v7.1: use SerializeData instead")]] broker::expected<broker::data> Serialize() const;
+    [[deprecated("Remove in v7.1: use UnserializeData instead")]] static std::unique_ptr<BloomFilter> Unserialize(
         const broker::data& data);
     std::optional<BrokerData> SerializeData() const;
     static std::unique_ptr<BloomFilter> UnserializeData(BrokerDataView data);

--- a/src/probabilistic/Topk.cc
+++ b/src/probabilistic/Topk.cc
@@ -360,7 +360,7 @@ void TopkVal::IncrementCounter(Element* e, unsigned int count) {
 
 IMPLEMENT_OPAQUE_VALUE(TopkVal)
 
-std::optional<BrokerData> TopkVal::DoSerialize() const {
+std::optional<BrokerData> TopkVal::DoSerializeData() const {
     BrokerListBuilder builder;
     builder.Reserve(8);
 
@@ -399,7 +399,7 @@ std::optional<BrokerData> TopkVal::DoSerialize() const {
     return std::move(builder).Build();
 }
 
-bool TopkVal::DoUnserialize(BrokerDataView data) {
+bool TopkVal::DoUnserializeData(BrokerDataView data) {
     if ( ! data.IsList() )
         return false;
 

--- a/src/probabilistic/Topk.h
+++ b/src/probabilistic/Topk.h
@@ -132,7 +132,7 @@ public:
      */
     ValPtr DoClone(CloneState* state) override;
 
-    DECLARE_OPAQUE_VALUE(TopkVal)
+    DECLARE_OPAQUE_VALUE_V2(TopkVal)
 
 protected:
     /**

--- a/src/probabilistic/Topk.h
+++ b/src/probabilistic/Topk.h
@@ -132,7 +132,7 @@ public:
      */
     ValPtr DoClone(CloneState* state) override;
 
-    DECLARE_OPAQUE_VALUE_V2(TopkVal)
+    DECLARE_OPAQUE_VALUE_DATA(TopkVal)
 
 protected:
     /**


### PR DESCRIPTION
External plugins depend on the API for `OpaqueVal`. This set of changes brings back the previous signature for the `Serialize` and `Unserialize` member functions. The new set of functions that operate on the recently added `BrokerData` API were renamed accordingly and use a `Data` suffix to distinguish between the old and new interface.

For the transition period, `OpaqueVal` now has two "sets" of serialization functions: old and new (using the suffix). By default, the new functions call the old API and then convert to the new types. Hence, plugins that override the old set of member functions will continue to work. New code should only override the new set of functions.

Since the macro `DECLARE_OPAQUE_VALUE` (a convenience macro for adding a default set of member functions to a subtype of `OpaqueVal`) might be used by 3rd parties, the macro has been "restored" to its previous behavior, i.e., it will override the old set of member functions. The new macro `DECLARE_OPAQUE_VALUE_V2` is similar but overrides the new set of functions instead.

The class `BloomFilter` uses the same member function signatures as `OpaqueVal` for serialization. Hence, the same old/new split was implemented to keep the APIs consistent.