### PR TITLE
Known: Keep &create_expire on local tables/sets valid

### DIFF
--- a/scripts/policy/protocols/conn/known-hosts.zeek
+++ b/scripts/policy/protocols/conn/known-hosts.zeek
@@ -121,7 +121,7 @@ event Cluster::node_up(name: string, id: string)
 		return;
 
 	# Drop local suppression cache on workers to force HRW key repartitioning.
-	Known::hosts = set();
+	clear_table(Known::hosts);
 	}
 
 event Cluster::node_down(name: string, id: string)
@@ -133,7 +133,7 @@ event Cluster::node_down(name: string, id: string)
 		return;
 
 	# Drop local suppression cache on workers to force HRW key repartitioning.
-	Known::hosts = set();
+	clear_table(Known::hosts);
 	}
 
 event Known::host_found(info: HostsInfo)

--- a/scripts/policy/protocols/conn/known-services.zeek
+++ b/scripts/policy/protocols/conn/known-services.zeek
@@ -187,7 +187,7 @@ event Cluster::node_up(name: string, id: string)
 		return;
 
 	# Drop local suppression cache on workers to force HRW key repartitioning.
-	Known::services = table();
+	clear_table(Known::services);
 	}
 
 event Cluster::node_down(name: string, id: string)
@@ -199,7 +199,7 @@ event Cluster::node_down(name: string, id: string)
 		return;
 
 	# Drop local suppression cache on workers to force HRW key repartitioning.
-	Known::services = table();
+	clear_table(Known::services);
 	}
 
 event service_info_commit(info: ServicesInfo)

--- a/scripts/policy/protocols/ssl/known-certs.zeek
+++ b/scripts/policy/protocols/ssl/known-certs.zeek
@@ -146,7 +146,7 @@ event Cluster::node_up(name: string, id: string)
 		return;
 
 	# Drop local suppression cache on workers to force HRW key repartitioning.
-	Known::certs = table();
+	clear_table(Known::certs);
 	}
 
 event Cluster::node_down(name: string, id: string)
@@ -158,7 +158,7 @@ event Cluster::node_down(name: string, id: string)
 		return;
 
 	# Drop local suppression cache on workers to force HRW key repartitioning.
-	Known::certs = table();
+	clear_table(Known::certs);
 	}
 
 event ssl_established(c: connection) &priority=3


### PR DESCRIPTION
After switching the known scripts away from broker stores, the
&create_expire value of the local tables/sets of the known scripts
wasn't in effect due to Cluster::node_up() and Cluster::node_down()
re-assigning these without keeping the &create_expire attribute
intact. This broke the "log hosts every 24h" behavior.

Closes #3540