### PR TITLE
Session/Conn: Follow-up fix for hist_seen and history lift

### DIFF
--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -58,9 +58,6 @@ Connection::Connection(const detail::ConnKey& k, double t, const ConnTuple* id, 
 
     finished = 0;
 
-    hist_seen = 0;
-    history = "";
-
     adapter = nullptr;
     primary_PIA = nullptr;
 

--- a/src/session/Session.cc
+++ b/src/session/Session.cc
@@ -58,6 +58,7 @@ Session::Session(double t, EventHandlerPtr timeout_event, EventHandlerPtr status
     timers_canceled = 0;
     inactivity_timeout = 0;
     installed_status_timer = 0;
+    hist_seen = 0;
 }
 
 void Session::Event(EventHandlerPtr f, analyzer::Analyzer* analyzer, const char* name) {


### PR DESCRIPTION
Borked in commit b4e86f28b8adcbd45b9008dfa1818c6eb2fbb4d0.

We don't need to initialize std::string explicitly either.

Thanks coverity!