### PR TITLE
Squeeze a bit more performance out of the ends_with bif

### DIFF
--- a/src/strings.bif
+++ b/src/strings.bif
@@ -1366,9 +1366,15 @@ function ends_with%(str: string, sub: string%) : bool
 	if ( sub->Len() > str->Len() )
 		return zeek::val_mgr->Bool(false);
 
-	string s = str->ToStdString();
-	string sub_s = sub->ToStdString();
-	return zeek::val_mgr->Bool(s.rfind(sub_s) == (s.size() - sub_s.size()));
+	auto sub_s = sub->ToStdStringView();
+	auto s = str->ToStdStringView();
+
+	// Create a string_view that only looks at the end of the string being searched
+	// with the same number of characters as the search string. This avoids possible
+	// pathological searches of big strings if the search string doesn't exist.
+	auto end_s = std::string_view{s.data() + s.size() - sub_s.size(), sub_s.size()};
+
+	return zeek::val_mgr->Bool(end_s == sub_s);
 	%}
 
 ## Returns whether a string consists entirely of digits.

--- a/testing/btest/Baseline/bifs.string_utils/out
+++ b/testing/btest/Baseline/bifs.string_utils/out
@@ -41,6 +41,7 @@ starts_with bro: 1
 starts_with ids: 0
 ends_with ids: 1
 ends_with bro: 0
+ends_with containing null: 1
 
 Transformations
 ---------------

--- a/testing/btest/bifs/string_utils.zeek
+++ b/testing/btest/bifs/string_utils.zeek
@@ -1,4 +1,4 @@
-# @TEST-EXEC: zeek -b %INPUT >out
+# @TEST-EXEC: zeek -b %INPUT >out 2>&1
 # @TEST-EXEC: btest-diff out
 
 event zeek_init()
@@ -51,6 +51,7 @@ event zeek_init()
 	print fmt("starts_with ids: %d", starts_with(s3, "ghi"));
 	print fmt("ends_with ids: %d", ends_with(s3, "ghi"));
 	print fmt("ends_with bro: %d", ends_with(s3, "abc"));
+	print fmt("ends_with containing null: %d", ends_with("a\x00\x00b", "\x00b"));
 	print "";
 
 	print "Transformations";


### PR DESCRIPTION
Thanks to @JustinAzoff for pointing this one out and @awelzel for the possible optimized implementation. The previous implementation created two full std::string objects for every comparison, copying both strings every time. This avoids that by using string_view and only comparing the last part of the string to be searched.

```
Benchmark 1: ./src/zeek -b t.zeek
  Time (mean ± σ):     20.876 s ±  0.298 s    [User: 20.818 s, System: 0.060 s]
  Range (min … max):   20.408 s … 21.390 s    10 runs

Benchmark 2: ./src/zeek.new -b t.zeek
  Time (mean ± σ):     19.889 s ±  0.121 s    [User: 19.835 s, System: 0.057 s]
  Range (min … max):   19.654 s … 20.035 s    10 runs

Benchmark 3: ./src/zeek.rfind -b t.zeek
  Time (mean ± σ):     20.471 s ±  0.117 s    [User: 20.411 s, System: 0.062 s]
  Range (min … max):   20.226 s … 20.699 s    10 runs

Summary
  './src/zeek.new -b t.zeek' ran
    1.03 ± 0.01 times faster than './src/zeek.rfind -b t.zeek'
    1.05 ± 0.02 times faster than './src/zeek -b t.zeek'
```

Also included in the benchmark above is a version that uses `rfind` with string_views instead. It's still slower.