### PR TITLE
More std::string_view usage in various BIFs

### DIFF
--- a/src/strings.bif
+++ b/src/strings.bif
@@ -1355,8 +1355,14 @@ function rfind_str%(str: string, sub: string, start: count &default=0, end: int 
 ##
 function starts_with%(str: string, sub: string%) : bool
 	%{
-	string s = str->ToStdString();
-	return zeek::val_mgr->Bool(s.find(sub->ToStdString()) == 0);
+	if ( sub->Len() > str->Len() )
+		return zeek::val_mgr->Bool(false);
+
+	auto sub_s = sub->ToStdStringView();
+	auto s = str->ToStdStringView();
+	auto start_s = std::string_view{s.data(), sub_s.size()};
+
+	return zeek::val_mgr->Bool(start_s == sub_s);
 	%}
 
 ## Returns whether a string ends with a substring.

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -1247,8 +1247,8 @@ function reverse%(str: string%) : string
 ##
 function count_substr%(str: string, sub: string%) : count
 	%{
-	string s = str->ToStdString();
-	string sub_s = sub->ToStdString();
+	auto s = str->ToStdStringView();
+	auto sub_s = sub->ToStdStringView();
 
 	size_t count = 0;
 	size_t pos = s.find(sub_s);

--- a/src/strings.bif
+++ b/src/strings.bif
@@ -1562,8 +1562,8 @@ function remove_prefix%(str: string, sub: string%) : string
 	// This could just use repeated calls to lstrip(), except for a couple of reasons:
 	// 1) lstrip() creates a StringVal at the end, and that would mean repeated recreation of objects
 	// 2) lstrip() searches for any character in the string, not the string as a whole.
-	string s = str->ToStdString();
-	string sub_s = sub->ToStdString();
+	auto s = str->ToStdStringView();
+	auto sub_s = sub->ToStdStringView();
 
 	size_t pos = s.find(sub_s);
 	if ( pos != 0 )
@@ -1584,11 +1584,14 @@ function remove_prefix%(str: string, sub: string%) : string
 function remove_suffix%(str: string, sub: string%) : string
 	%{
 	// See the note in removeprefix for why this doesn't just call rstrip.
-	string s = str->ToStdString();
-	string sub_s = sub->ToStdString();
+	auto s = str->ToStdStringView();
+	auto sub_s = sub->ToStdStringView();
 
 	size_t pos = s.rfind(sub_s);
 	size_t next_pos = s.size() - sub_s.size();
+
+	if ( pos != next_pos )
+		return zeek::IntrusivePtr<zeek::StringVal>(NewRef{}, str);
 
 	while ( pos == next_pos )
 		{

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -1986,7 +1986,7 @@ function enum_names%(et: any%): string_set
 
 	if ( et->GetType()->Tag() == TYPE_STRING )
 		{
-		const auto& id = zeek::detail::global_scope()->Find(et->AsStringVal()->ToStdString());
+		const auto& id = zeek::detail::global_scope()->Find(et->AsStringVal()->ToStdStringView());
 		if ( id && id->IsType() )
 			t = id->GetType();
 		}
@@ -2184,7 +2184,7 @@ function global_options%(%): string_set
 ##          the string ``"<unknown id>"`` or ``"<no ID value>"`` is returned.
 function lookup_ID%(id: string%) : any
 	%{
-	const auto& i = zeek::detail::global_scope()->Find(id->CheckString());
+	const auto& i = zeek::detail::global_scope()->Find(id->ToStdStringView());
 	if ( ! i )
 		return zeek::make_intrusive<zeek::StringVal>("<unknown id>");
 
@@ -2214,7 +2214,7 @@ function record_fields%(rec: any%): record_field_table
 
 	if ( rec->GetType()->Tag() == zeek::TYPE_STRING )
 		{
-		const auto& id = zeek::detail::global_scope()->Find(rec->AsStringVal()->ToStdString());
+		const auto& id = zeek::detail::global_scope()->Find(rec->AsStringVal()->ToStdStringView());
 
 		if ( ! id || ! id->IsType() || id->GetType()->Tag() != zeek::TYPE_RECORD )
 			{
@@ -5106,7 +5106,7 @@ function from_json%(s: string, t: any, key_func: string_mapper &default=from_jso
 ## Returns: a compressed version of the input path.
 function compress_path%(dir: string%): string
 	%{
-	return zeek::make_intrusive<zeek::StringVal>(zeek::util::detail::normalize_path(dir->ToStdString()));
+	return zeek::make_intrusive<zeek::StringVal>(zeek::util::detail::normalize_path(dir->ToStdStringView()));
 	%}
 
 ## Returns true if the given tag belongs to a protocol analyzer.

--- a/testing/btest/Baseline/bifs.string_utils/out
+++ b/testing/btest/Baseline/bifs.string_utils/out
@@ -49,10 +49,12 @@ swap_case 'aBc': AbC
 to_title 'bro is a very neat ids': 'Bro Is A Very Neat Ids'
 to_title '   ': '   '
 to_title '  a   c  ': '  A   C  '
-remove_prefix 'ananab'/'an' : ab
-remove_prefix 'anatnab'/'an': atnab
+remove_prefix 'banana'/'ba' : nana
+remove_prefix 'bantana'/'ba': ntana
+remove_prefix 'bantana'/'ab': bantana
 remove_suffix 'banana'/'na' : ba
 remove_suffix 'bantana'/'na': banta
+remove_suffix 'bantana'/'an': bantana
 
 find_str/rfind_str (input string 'abcdefghi')
 -----------------------------------------------------

--- a/testing/btest/bifs/string_utils.zeek
+++ b/testing/btest/bifs/string_utils.zeek
@@ -60,10 +60,12 @@ event zeek_init()
 	print fmt("to_title 'bro is a very neat ids': '%s'", to_title("bro is a very neat ids"));
 	print fmt("to_title '   ': '%s'", to_title("   "));
 	print fmt("to_title '  a   c  ': '%s'", to_title("  a   c  "));
-	print fmt("remove_prefix 'ananab'/'an' : %s", remove_prefix("ananab", "an"));
-	print fmt("remove_prefix 'anatnab'/'an': %s", remove_prefix("anatnab", "an"));
+	print fmt("remove_prefix 'banana'/'ba' : %s", remove_prefix("banana", "ba"));
+	print fmt("remove_prefix 'bantana'/'ba': %s", remove_prefix("bantana", "ba"));
+	print fmt("remove_prefix 'bantana'/'ab': %s", remove_prefix("bantana", "ab"));
 	print fmt("remove_suffix 'banana'/'na' : %s", remove_suffix("banana", "na"));
 	print fmt("remove_suffix 'bantana'/'na': %s", remove_suffix("bantana", "na"));
+	print fmt("remove_suffix 'bantana'/'an': %s", remove_suffix("bantana", "an"));
 	print "";
 
 	print fmt("find_str/rfind_str (input string '%s')", s3);


### PR DESCRIPTION
This is a follow-on to https://github.com/zeek/zeek/pull/3554 that switches to using `ToStdStringView()` for more BIFs that were previously calling `ToStdString()`.

In strings.bif:
- The actual work for the `starts_with` and `ends_with` BIFs are moved out into separate utility methods so they can be reused more easily in other BIFs.
- `starts_with` changes to closely match the `ends_with` changes from https://github.com/zeek/zeek/pull/3554.
- `remove_prefix` and `remove_suffix` were both heavily reworked to just call the two new utility methods.
- `count_substr` just had a direct function call change.

In zeek.bif:
- `Scope::Find()` takes a string_view argument so we can just pass that in instead of calling `ToStdString()` and then having it be converted as part of the function call.

Some perf numbers:

- `starts_with`:
```
event zeek_init() {
	local x = 0;
	while (++x < 5000000) {
		starts_with("sdf.fasdfa.asfs.dfas.fsfdsf.com", "abcde");
	}
}

Benchmark 1: ./src/zeek.master -b ~/Desktop/t.zeek
  Time (mean ± σ):     15.907 s ±  0.063 s    [User: 15.687 s, System: 0.203 s]
  Range (min … max):   15.830 s … 16.030 s    10 runs
 
Benchmark 2: ./src/zeek -b ~/Desktop/t.zeek
  Time (mean ± σ):     14.455 s ±  0.033 s    [User: 14.229 s, System: 0.207 s]
  Range (min … max):   14.401 s … 14.525 s    10 runs
 
Summary
  ./src/zeek -b ~/Desktop/t.zeek ran
    1.10 ± 0.01 times faster than ./src/zeek.master -b ~/Desktop/t.zeek
```

- `remove_prefix`:
```
event zeek_init() {
	local x = 0;
	while (++x < 5000000) {
		remove_prefix("abcabcabcabcabcabcabcabcabcabc", "abc");
	}
}

Benchmark 1: ./src/zeek.master -b ~/Desktop/t.zeek
  Time (mean ± σ):     23.462 s ±  0.052 s    [User: 23.243 s, System: 0.201 s]
  Range (min … max):   23.410 s … 23.568 s    10 runs
 
Benchmark 2: ./src/zeek -b ~/Desktop/t.zeek
  Time (mean ± σ):     25.367 s ±  0.032 s    [User: 25.128 s, System: 0.219 s]
  Range (min … max):   25.306 s … 25.425 s    10 runs
 
Summary
  ./src/zeek.master -b ~/Desktop/t.zeek ran
    1.08 ± 0.00 times faster than ./src/zeek -b ~/Desktop/t.zeek
```

- `remove_suffix`:
```
event zeek_init() {
	local x = 0;
	while (++x < 5000000) {
		remove_suffix("abcabcabcabcabcabcabcabcabcabc", "abc");
	}
}

Benchmark 1: ./src/zeek.master -b ~/Desktop/t.zeek
  Time (mean ± σ):     38.084 s ±  0.109 s    [User: 37.797 s, System: 0.265 s]
  Range (min … max):   37.905 s … 38.224 s    10 runs
 
Benchmark 2: ./src/zeek -b ~/Desktop/t.zeek
  Time (mean ± σ):     25.462 s ±  0.098 s    [User: 25.211 s, System: 0.228 s]
  Range (min … max):   25.348 s … 25.652 s    10 runs
 
Summary
  ./src/zeek -b ~/Desktop/t.zeek ran
    1.50 ± 0.01 times faster than ./src/zeek.master -b ~/Desktop/t.zeek
```