### PR TITLE
Enable darwin builds for zeek-security repo

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,7 +52,6 @@ builds_only_if_template: &BUILDS_ONLY_IF_TEMPLATE
   # - Always build master and release/* builds from the main repo
   only_if: >
     ( $CIRRUS_CRON == '' ) &&
-    ( $CIRRUS_REPO_NAME != 'zeek-security' || $CIRRUS_OS != "darwin" ) &&
     ( ( $CIRRUS_PR != '' && $CIRRUS_BRANCH !=~ 'dependabot/.*' ) ||
     ( ( $CIRRUS_REPO_NAME == 'zeek' || $CIRRUS_REPO_NAME == 'zeek-security' ) &&
       (


### PR DESCRIPTION
We had previously disabled these builds for the zeek-security repo since we were using freely-provided credits from Cirrus for that repo. The only x86_64 darwin builds were eating a ton of them. We've since switched over to the ARM builds which are much more efficient, and we're also not using free credits for our builds anymore.

This PR re-enables them. No changes for the public repos will be visible, but I'm opening a PR anyways for any possible discussion. I'll pull this into the 6.0 and 6.1 release branches as well once it's approved and merged.