### PR TITLE
RFC: Helpers for raw Val* to IntrusivePtr conversions

### DIFF
--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -2545,7 +2545,7 @@ ValPtr IndexExpr::Fold(Val* v1, Val* v2) const {
 
         case TYPE_TABLE:
             if ( is_pattern_table )
-                return v1->AsTableVal()->LookupPattern({NewRef{}, v2->AsListVal()->Idx(0)->AsStringVal()});
+                return v1->AsTableVal()->LookupPattern(as_ptr<StringVal>(v2->AsListVal()->Idx(0)));
 
             v = v1->AsTableVal()->FindOrDefault({NewRef{}, v2});
             break;

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -3436,7 +3436,7 @@ ValPtr ArithCoerceExpr::Fold(Val* v) const {
         if ( type->Tag() == TYPE_VECTOR )
             t = t->AsVectorType()->Yield();
 
-        return FoldSingleVal({NewRef{}, v}, t);
+        return FoldSingleVal(to_ptr(v), t);
     }
 
     VectorVal* vv = v->AsVectorVal();
@@ -3562,7 +3562,7 @@ RecordCoerceExpr::RecordCoerceExpr(ExprPtr arg_op, RecordTypePtr r) : UnaryExpr(
 
 ValPtr RecordCoerceExpr::Fold(Val* v) const {
     if ( same_type(GetType(), Op()->GetType()) )
-        return IntrusivePtr{NewRef{}, v};
+        return to_ptr(v);
 
     auto rt = cast_intrusive<RecordType>(GetType());
     return coerce_to_record(rt, v, map);
@@ -3870,9 +3870,9 @@ ValPtr InExpr::Fold(Val* v1, Val* v2) const {
         const auto& table_type = table_val->GetType<zeek::TableType>();
         // Special table[pattern] / set[pattern] in expression.
         if ( table_type->IsPatternIndex() && v1->GetType()->Tag() == TYPE_STRING )
-            res = table_val->MatchPattern({NewRef{}, v1->AsStringVal()});
+            res = table_val->MatchPattern(to_ptr<StringVal>(v1));
         else
-            res = (bool)v2->AsTableVal()->Find({NewRef{}, v1});
+            res = (bool)v2->AsTableVal()->Find(to_ptr(v1));
     }
 
     return val_mgr->Bool(res);
@@ -3989,7 +3989,7 @@ ValPtr CallExpr::Eval(Frame* f) const {
         if ( trigger::Trigger* trigger = f->GetTrigger() ) {
             if ( Val* v = trigger->Lookup((void*)this) ) {
                 DBG_LOG(DBG_NOTIFIERS, "%s: provides cached function result", trigger->Name());
-                return {NewRef{}, v};
+                return to_ptr(v);
             }
         }
     }

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -2301,7 +2301,7 @@ ValPtr TableVal::Remove(const detail::HashKey& k, bool* iterators_invalidated) {
     return va;
 }
 
-ListValPtr TableVal::ToListVal(TypeTag t) const {
+ListValPtr TableVal::ToListVal(zeek::TypeTag t) const {
     auto l = make_intrusive<ListVal>(t);
 
     for ( const auto& tble : *table_val ) {

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1221,12 +1221,11 @@ PatternVal::PatternVal(RE_Matcher* re) : Val(base_type(TYPE_PATTERN)) { re_val =
 PatternVal::~PatternVal() { delete re_val; }
 
 bool PatternVal::AddTo(Val* v, bool /* is_first_init */) const {
-    if ( v->GetType()->Tag() != TYPE_PATTERN ) {
+    auto pv = try_to_ptr<PatternVal>(v);
+    if ( ! pv ) {
         v->Error("not a pattern");
         return false;
     }
-
-    PatternVal* pv = v->AsPatternVal();
 
     RE_Matcher* re = new RE_Matcher(AsPattern()->PatternText());
     re->AddPat(pv->AsPattern()->PatternText());
@@ -1737,12 +1736,11 @@ ValPtr TableVal::SizeVal() const { return val_mgr->Count(Size()); }
 bool TableVal::AddTo(Val* val, bool is_first_init) const { return AddTo(val, is_first_init, true); }
 
 bool TableVal::AddTo(Val* val, bool is_first_init, bool propagate_ops) const {
-    if ( val->GetType()->Tag() != TYPE_TABLE ) {
+    auto t = try_to_ptr<TableVal>(val);
+    if ( ! t ) {
         val->Error("not a table");
         return false;
     }
-
-    TableVal* t = val->AsTableVal();
 
     if ( ! same_type(type, t->GetType()) ) {
         type->Error("table type clash", t->GetType().get());
@@ -1774,12 +1772,11 @@ bool TableVal::AddTo(Val* val, bool is_first_init, bool propagate_ops) const {
 }
 
 bool TableVal::RemoveFrom(Val* val) const {
-    if ( val->GetType()->Tag() != TYPE_TABLE ) {
+    auto t = try_to_ptr<TableVal>(val);
+    if ( ! t ) {
         val->Error("not a table");
         return false;
     }
-
-    TableVal* t = val->AsTableVal();
 
     if ( ! same_type(type, t->GetType()) ) {
         type->Error("table type clash", t->GetType().get());
@@ -3263,12 +3260,11 @@ bool VectorVal::Remove(unsigned int index) {
 }
 
 bool VectorVal::AddTo(Val* val, bool /* is_first_init */) const {
-    if ( val->GetType()->Tag() != TYPE_VECTOR ) {
+    auto v = try_to_ptr<VectorVal>(val);
+    if ( ! v ) {
         val->Error("not a vector");
         return false;
     }
-
-    VectorVal* v = val->AsVectorVal();
 
     if ( ! same_type(type, v->GetType()) ) {
         type->Error("vector type clash", v->GetType().get());

--- a/src/analyzer/Manager.cc
+++ b/src/analyzer/Manager.cc
@@ -356,7 +356,7 @@ void Manager::ScheduleAnalyzer(const IPAddr& orig, const IPAddr& resp, uint16_t 
 }
 
 void Manager::ScheduleAnalyzer(const IPAddr& orig, const IPAddr& resp, PortVal* resp_p, Val* analyzer, double timeout) {
-    EnumValPtr ev{NewRef{}, analyzer->AsEnumVal()};
+    auto ev = to_ptr<EnumVal>(analyzer);
     return ScheduleAnalyzer(orig, resp, resp_p->Port(), resp_p->PortType(), zeek::Tag(std::move(ev)), timeout);
 }
 

--- a/src/logging/logging.bif
+++ b/src/logging/logging.bif
@@ -71,39 +71,11 @@ function Log::__flush%(id: Log::ID%): bool
 	return zeek::val_mgr->Bool(result);
 	%}
 
-%%{
-namespace
-	{
-	zeek::EnumValPtr enum_ref(zeek::Val *v)
-		{
-		if ( v->GetType()->Tag() != zeek::TYPE_ENUM )
-			{
-			zeek::emit_builtin_error("not an enum");
-			return nullptr;
-			}
-
-		return zeek::IntrusivePtr<zeek::EnumVal>{zeek::NewRef{}, v->AsEnumVal()};
-		}
-	}
-
-	// Create intrusive pointer adopting reference.
-	zeek::RecordValPtr record_ref(zeek::Val *v)
-		{
-		if ( v->GetType()->Tag() != zeek::TYPE_RECORD )
-			{
-			zeek::emit_builtin_error("not a record");
-			return nullptr;
-			}
-
-		return zeek::IntrusivePtr<zeek::RecordVal>{zeek::NewRef{}, v->AsRecordVal()};
-		}
-%%}
-
 function Log::__delay%(id: Log::ID, rec: any, post_delay_cb: PostDelayCallback%): Log::DelayToken
         %{
-        auto idptr = enum_ref(id);
-        auto recptr = record_ref(rec);
-        if ( ! idptr || ! recptr )
+        auto idptr = to_ptr<EnumVal>(id);
+        auto recptr = try_to_ptr<RecordVal>(rec);
+        if ( ! recptr )
                 return zeek::val_mgr->Bool(false);
 
         static auto empty_post_delay_cb_ptr = zeek::id::find_func("Log::empty_post_delay_cb");
@@ -117,9 +89,9 @@ function Log::__delay%(id: Log::ID, rec: any, post_delay_cb: PostDelayCallback%)
 
 function Log::__delay_finish%(id: Log::ID, rec: any, token: Log::DelayToken%): bool
         %{
-        auto idptr = enum_ref(id);
-        auto recptr = record_ref(rec);
-        if ( ! idptr || ! recptr )
+        auto idptr = to_ptr<EnumVal>(id);
+        auto recptr = try_to_ptr<RecordVal>(rec);
+        if ( ! recptr )
                 return zeek::val_mgr->Bool(false);
 
         bool result = zeek::log_mgr->DelayFinish(std::move(idptr), std::move(recptr), {zeek::NewRef{}, token});
@@ -128,29 +100,20 @@ function Log::__delay_finish%(id: Log::ID, rec: any, token: Log::DelayToken%): b
 
 function Log::__set_max_delay_interval%(id: Log::ID, max_delay: interval%): bool
         %{
-        auto idptr = enum_ref(id);
-        if ( ! idptr )
-                return zeek::val_mgr->Bool(false);
-
+        auto idptr = to_ptr<EnumVal>(id);
         bool result = zeek::log_mgr->SetMaxDelayInterval(idptr, max_delay);
         return zeek::val_mgr->Bool(result);
         %}
 
 function Log::__set_max_delay_queue_size%(id: Log::ID, max_queue_size: count%): bool
         %{
-        auto idptr = enum_ref(id);
-        if ( ! idptr )
-                return zeek::val_mgr->Bool(false);
-
+        auto idptr = to_ptr<EnumVal>(id);
         bool result = zeek::log_mgr->SetMaxDelayQueueSize(idptr, max_queue_size);
         return zeek::val_mgr->Bool(result);
         %}
 
 function Log::__get_delay_queue_size%(id: Log::ID%): int
         %{
-        auto idptr = enum_ref(id);
-        if ( ! idptr )
-                return zeek::val_mgr->Bool(false);
-
+        auto idptr = to_ptr<EnumVal>(id);
         return zeek::val_mgr->Int(zeek::log_mgr->GetDelayQueueSize(idptr));
         %}

--- a/src/mmdb.bif
+++ b/src/mmdb.bif
@@ -12,7 +12,7 @@
 ## .. zeek:see:: lookup_autonomous_system
 function mmdb_open_location_db%(f: string%) : bool
 	%{
-	return zeek::mmdb_open_location_db(StringValPtr(NewRef(), f));
+	return zeek::mmdb_open_location_db(to_ptr(f));
 	%}
 
 ## Initializes MMDB for later use of lookup_autonomous_system.
@@ -25,7 +25,7 @@ function mmdb_open_location_db%(f: string%) : bool
 ## .. zeek:see:: lookup_autonomous_system
 function mmdb_open_asn_db%(f: string%) : bool
 	%{
-	return zeek::mmdb_open_asn_db(StringValPtr(NewRef(), f));
+	return zeek::mmdb_open_asn_db(to_ptr(f));
 	%}
 
 ## Performs a geo-lookup of an IP address.
@@ -38,7 +38,7 @@ function mmdb_open_asn_db%(f: string%) : bool
 ## .. zeek:see:: lookup_autonomous_system
 function lookup_location%(a: addr%) : geo_location
 	%{
-	return zeek::mmdb_lookup_location(AddrValPtr(NewRef(), a));
+	return zeek::mmdb_lookup_location(to_ptr(a));
 	%}
 
 ## Performs an lookup of AS number & organization of an IP address.
@@ -51,5 +51,5 @@ function lookup_location%(a: addr%) : geo_location
 ## .. zeek:see:: lookup_location
 function lookup_autonomous_system%(a: addr%) : geo_autonomous_system
 	%{
-	return zeek::mmdb_lookup_autonomous_system(AddrValPtr(NewRef(), a));
+	return zeek::mmdb_lookup_autonomous_system(to_ptr(a));
 	%}


### PR DESCRIPTION
I've been dabbling a bit with ideas for helpers to get from `Val*` to `AbcValPtr`, or from a "typed Val pointer", like `AddrVal*`, to an `AddrValPtr`. This mostly comes up in the context of BiFs, where Bifcl generates a preamble of raw pointers, but certain Zeek APIs are now using IntrusivePtr.

One pattern in Bifs with `any` parameters, the safe pattern is something like:
```
Val* v = ...;
if ( v->GetType()->Tag() == TYPE_RECORD )
    // bail
auto rv =  IntrusivePtr{NewRef{}, v->AsRecordVal()};
```

The other pattern is the following, which causes an abort if v isn't a RecordVal.
```
auto rv = IntrusivePtr{NewRef{}, v->AsRecordVal()};
```

The other, to get from a `AddrVal*` to an AddrValPtr is usually:
```
AddrVal* ap = ...;
auto av = zeek::IntrusivePtr{zeek::NewRef{}, ap};
```



---
This PR proposes `try_to_ptr()` and `to_ptr()` helpers to contain the above logic, so it's visually not too nosiy. For the 3 examples above - the PR contains a few examples for usages.

```
auto rv = try_to_ptr<RecordVal>(v)
if ( ! rv )
   // bail

auto rv = as_ptr<RecordVal>(v);  // fatal error if v isn't a RecordVal

auto av = to_ptr(ap);  // type of av automatically IntrusivePtr<AddrVal>;
```

Given I have no gut feeling for C++'sh things and naming is difficult, happy to hear any feedback. I've not worried about performance at all, there might be an extra ref-count increment here and there. This doesn't need to go in and happy for critcial feedback, it's just that I find some of the code around these conversions repetitive/clumsy. It could be argued Bifcl should generate a ValPtr preamble, too :man_shrugging: , but unsure we'll have that in the near future.