### PR TITLE
Make sure Spicy symbols are available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -959,8 +959,10 @@ if (NOT DISABLE_SPICY)
         # instead explicitly branch on `BINARY_PACKAGING_MODE` here.
         if (BINARY_PACKAGING_MODE)
             hilti_link_object_libraries_in_tree(zeek_exe PRIVATE)
+            spicy_link_object_libraries_in_tree(zeek_exe PRIVATE)
         else ()
             hilti_link_libraries_in_tree(zeek_exe PRIVATE)
+            spicy_link_libraries_in_tree(zeek_exe PRIVATE)
         endif ()
 
         set(HAVE_SPICY yes)


### PR DESCRIPTION
The Spicy/HILTI runtime libraries are modelled as object libraries and linked into the `spicy` and `hilti` libraries. These libraries are then linked into `zeek_objs` which is another object library linked into the `zeek` executable (target `zeek_exe`). On some platforms this transitive link of object libraries is broken with `--binary-package` which causes creation of static archives, even with our minimum required CMake version which already contains many fixes for object libraries.

With this patch we now explicitly linked the Spicy/HILTI runtime libraries into `zeek_exe`.

Closes #3177.