### PR TITLE
testing/scripts: Use sed -E everywhere

### DIFF
--- a/testing/scripts/diff-clean-doctest
+++ b/testing/scripts/diff-clean-doctest
@@ -5,13 +5,6 @@
 # - The version number, which becomes "x.y.z"
 # - Spacing in the report, which we normalize to single spaces
 
-# Get us "modern" regexps with sed.
-if [ $(uname) == "Linux" ]; then
-    sed="sed -r"
-else
-    sed="sed -E"
-fi
-
-$sed -e 's/[0-9]+ skipped/XX skipped/g' |
-    $sed -e 's/"[0-9]+\.[0-9]+\.[0-9]+"/"x.y.z"/g' |
-    $sed -e 's/ {2,}/ /g'
+sed -E -e 's/[0-9]+ skipped/XX skipped/g' |
+    sed -E -e 's/"[0-9]+\.[0-9]+\.[0-9]+"/"x.y.z"/g' |
+    sed -E -e 's/ {2,}/ /g'

--- a/testing/scripts/diff-remove-abspath
+++ b/testing/scripts/diff-remove-abspath
@@ -2,12 +2,6 @@
 #
 # Replace absolute paths with the basename.
 
-if [ $(uname) == "Linux" ]; then
-    sed="sed -r"
-else
-    sed="sed -E"
-fi
-
-$sed 's#/+#/#g' |
-    $sed 's#[^( ]*testing_btest#<___>testing_btest#' |
-    $sed 's#([a-zA-Z]:)?/([^	 :/]{1,}/){1,}([^	 :/]{1,})#<...>/\3#g'
+sed -E 's#/+#/#g' |
+    sed -E 's#[^( ]*testing_btest#<___>testing_btest#' |
+    sed -E 's#([a-zA-Z]:)?/([^	 :/]{1,}/){1,}([^	 :/]{1,})#<...>/\3#g'

--- a/testing/scripts/diff-remove-openclose-timestamps
+++ b/testing/scripts/diff-remove-openclose-timestamps
@@ -2,11 +2,4 @@
 #
 # Replace timestamps in the #start/end markers in logs.
 
-# Get us "modern" regexps with sed.
-if [ $(uname) == "Linux" ]; then
-    sed="sed -r"
-else
-    sed="sed -E"
-fi
-
-$sed 's/^ *#(open|close).(19|20)..-..-..-..-..-..$/#\1 XXXX-XX-XX-XX-XX-XX/g'
+sed -E 's/^ *#(open|close).(19|20)..-..-..-..-..-..$/#\1 XXXX-XX-XX-XX-XX-XX/g'

--- a/testing/scripts/diff-remove-spicy-abspath
+++ b/testing/scripts/diff-remove-spicy-abspath
@@ -3,10 +3,4 @@
 # Replace absolute paths in Spicy error message with the basename. This is more
 # restrictive than diff-remove-abspath to avoid catching other stuff.
 
-if [ $(uname) == "Linux" ]; then
-    sed="sed -r"
-else
-    sed="sed -E"
-fi
-
-$sed 's#/([^:/]{1,}/){1,}([^:/]{1,}\.spicy[:,])#<...>/\2#g'
+sed -E 's#/([^:/]{1,}/){1,}([^:/]{1,}\.spicy[:,])#<...>/\2#g'

--- a/testing/scripts/diff-remove-timestamps
+++ b/testing/scripts/diff-remove-timestamps
@@ -2,11 +2,4 @@
 #
 # Replace anything which looks like timestamps with XXXs (including the #start/end markers in logs).
 
-# Get us "modern" regexps with sed.
-if [ $(uname) == "Linux" ]; then
-    sed="sed -r"
-else
-    sed="sed -E"
-fi
-
-$sed -e 's/(^|[^0-9])([0-9]{9,10}\.[0-9]{1,8})/\1XXXXXXXXXX.XXXXXX/g' -e 's/^ *#(open|close).(19|20)..-..-..-..-..-..$/#\1 XXXX-XX-XX-XX-XX-XX/g'
+sed -E -e 's/(^|[^0-9])([0-9]{9,10}\.[0-9]{1,8})/\1XXXXXXXXXX.XXXXXX/g' -e 's/^ *#(open|close).(19|20)..-..-..-..-..-..$/#\1 XXXX-XX-XX-XX-XX-XX/g'

--- a/testing/scripts/spicy/canonify-zeek-log
+++ b/testing/scripts/spicy/canonify-zeek-log
@@ -2,13 +2,6 @@
 #
 # Remove unstable pieces in Zeek logs.
 
-# Get us "modern" regexps with sed.
-if [ $(uname) == "Linux" ]; then
-    sed="sed -r"
-else
-    sed="sed -E"
-fi
-
-${sed} 's/^ *#(open|close).(19|20)..-..-..-..-..-..$/#\1 XXXX-XX-XX-XX-XX-XX/g' |
+sed -E 's/^ *#(open|close).(19|20)..-..-..-..-..-..$/#\1 XXXX-XX-XX-XX-XX-XX/g' |
     $(dirname $0)/diff-remove-timestamps |
     $(dirname $0)/diff-remove-abspath

--- a/testing/scripts/spicy/canonify-zeek-log-sorted
+++ b/testing/scripts/spicy/canonify-zeek-log-sorted
@@ -2,14 +2,7 @@
 #
 # Remove unstable pieces in Zeek logs.
 
-# Get us "modern" regexps with sed.
-if [ $(uname) == "Linux" ]; then
-    sed="sed -r"
-else
-    sed="sed -E"
-fi
-
-${sed} 's/^ *#(open|close).(19|20)..-..-..-..-..-..$/#\1 XXXX-XX-XX-XX-XX-XX/g' |
+sed -E 's/^ *#(open|close).(19|20)..-..-..-..-..-..$/#\1 XXXX-XX-XX-XX-XX-XX/g' |
     $(dirname $0)/diff-sort |
     $(dirname $0)/diff-remove-timestamps |
     $(dirname $0)/diff-remove-abspath

--- a/testing/scripts/spicy/diff-remove-abspath
+++ b/testing/scripts/spicy/diff-remove-abspath
@@ -2,11 +2,5 @@
 #
 # Replace absolute paths with the basename.
 
-if [ $(uname) == "Linux" ]; then
-    sed="sed -r"
-else
-    sed="sed -E"
-fi
-
-$sed 's#/+#/#g' |
-    $sed 's#/([^	 :/]{1,}/){1,}([^	 :/]{1,})#<...>/\2#g'
+sed -E 's#/+#/#g' |
+    sed -E 's#/([^	 :/]{1,}/){1,}([^	 :/]{1,})#<...>/\2#g'

--- a/testing/scripts/spicy/diff-remove-timestamps
+++ b/testing/scripts/spicy/diff-remove-timestamps
@@ -2,11 +2,4 @@
 #
 # Replace anything which looks like timestamps with XXXs (including the #start/end markers in logs).
 
-# Get us "modern" regexps with sed.
-if [ $(uname) == "Linux" ]; then
-    sed="sed -r"
-else
-    sed="sed -E"
-fi
-
-$sed -e 's/(^|[^0-9])([0-9]{9,10}\.[0-9]{1,8})/\1XXXXXXXXXX.XXXXXX/g' -e 's/^ *#(open|close).(19|20)..-..-..-..-..-../#\1 XXXX-XX-XX-XX-XX-XX/g'
+sed -E 's/(^|[^0-9])([0-9]{9,10}\.[0-9]{1,8})/\1XXXXXXXXXX.XXXXXX/g' -e 's/^ *#(open|close).(19|20)..-..-..-..-..-../#\1 XXXX-XX-XX-XX-XX-XX/g'


### PR DESCRIPTION
I'm always a bit worried to use sed -E anywhere, because the canonifiers give the impression it won't work everywhere consistently. My manpage says sed -E should be preferred for portability, so lets remove the sed -r / sed -E differentiation assuming it's just a thing from the past.