### PR TITLE
Complete association of location information with AST nodes / ZAM generated code

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -22,8 +22,6 @@ namespace zeek {
 template<class T>
 class IntrusivePtr;
 
-using ObjPtr = IntrusivePtr<Obj>;
-
 namespace detail {
 
 class Frame;
@@ -1794,28 +1792,8 @@ inline bool is_vector(const ExprPtr& e) { return is_vector(e.get()); }
 
 // True if the given Expr* has a list type
 inline bool is_list(Expr* e) { return e->GetType()->Tag() == TYPE_LIST; }
+
 inline bool is_list(const ExprPtr& e) { return is_list(e.get()); }
-
-// Helper functions for setting the location of an expression (usually newly
-// created) to match that of the associated object, returning the expression
-// for convenience.
-inline ExprPtr with_location_of(ExprPtr e, const Obj* o) {
-    e->SetLocationInfo(o->GetLocationInfo());
-    return e;
-}
-
-inline ExprPtr with_location_of(ExprPtr e, const ObjPtr& o) { return with_location_of(e, o.get()); }
-
-// Versions that preserve the expression as a ListExpr.
-inline ListExprPtr with_location_of(ListExprPtr e, const ObjPtr& o) {
-    (void)with_location_of(e, o.get());
-    return e;
-}
-
-inline ListExprPtr with_location_of(ListExprPtr e, const Obj* o) {
-    e->SetLocationInfo(o->GetLocationInfo());
-    return e;
-}
 
 } // namespace detail
 } // namespace zeek

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -680,8 +680,10 @@ StmtPtr ScriptFunc::AddInits(StmtPtr body, const std::vector<IDPtr>& inits) {
     if ( inits.empty() )
         return body;
 
-    auto stmt_series = make_intrusive<StmtList>();
-    stmt_series->Stmts().push_back(make_intrusive<InitStmt>(inits));
+    auto stmt_series = with_location_of(make_intrusive<StmtList>(), body);
+    auto init = with_location_of(make_intrusive<InitStmt>(inits), body);
+
+    stmt_series->Stmts().push_back(std::move(init));
     stmt_series->Stmts().push_back(std::move(body));
 
     return stmt_series;

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -49,6 +49,13 @@ inline void set_location(const Location start, const Location end) {
     end_location = end;
 }
 
+// Helper for updating e's location to the one used by o, returning e.
+template<typename T, typename U>
+T with_location_of(T e, const U& o) {
+    e->SetLocationInfo(o->GetLocationInfo());
+    return e;
+}
+
 } // namespace detail
 
 class Obj {

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -780,25 +780,4 @@ protected:
     int expected_len;
 };
 
-// Helper functions for setting the location of a statement (usually newly
-// created) to match that of the associated object, returning the statement
-// for convenience.
-inline StmtPtr with_location_of(StmtPtr s, const Obj* o) {
-    s->SetLocationInfo(o->GetLocationInfo());
-    return s;
-}
-
-inline StmtPtr with_location_of(StmtPtr s, const ObjPtr& o) { return with_location_of(s, o.get()); }
-
-// Versions that preserve the statement as a StmtList.
-inline IntrusivePtr<StmtList> with_location_of(IntrusivePtr<StmtList> s, const ObjPtr& o) {
-    (void)with_location_of(s, o.get());
-    return s;
-}
-
-inline IntrusivePtr<StmtList> with_location_of(IntrusivePtr<StmtList> s, const Obj* o) {
-    s->SetLocationInfo(o->GetLocationInfo());
-    return s;
-}
-
 } // namespace zeek::detail

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -658,7 +658,7 @@ private:
 
     // The current instance of the lambda.  Created by Instantiate(),
     // for immediate use via calls to Cond() etc.
-    ConstExprPtr curr_lambda;
+    ExprPtr curr_lambda;
 
     // Arguments to use when calling the lambda to either evaluate
     // the conditional, or execute the body or the timeout statement.
@@ -712,8 +712,9 @@ private:
 // an already-reduced state.
 class CatchReturnStmt : public Stmt {
 public:
-    explicit CatchReturnStmt(StmtPtr block, NameExprPtr ret_var);
+    explicit CatchReturnStmt(ScriptFuncPtr sf, StmtPtr block, NameExprPtr ret_var);
 
+    const ScriptFuncPtr& Func() const { return sf; }
     StmtPtr Block() const { return block; }
 
     // This returns a bare pointer rather than a NameExprPtr only
@@ -743,6 +744,9 @@ public:
     TraversalCode Traverse(TraversalCallback* cb) const override;
 
 protected:
+    // The inlined function.
+    ScriptFuncPtr sf;
+
     // The inlined function body.
     StmtPtr block;
 
@@ -775,5 +779,26 @@ public:
 protected:
     int expected_len;
 };
+
+// Helper functions for setting the location of a statement (usually newly
+// created) to match that of the associated object, returning the statement
+// for convenience.
+inline StmtPtr with_location_of(StmtPtr s, const Obj* o) {
+    s->SetLocationInfo(o->GetLocationInfo());
+    return s;
+}
+
+inline StmtPtr with_location_of(StmtPtr s, const ObjPtr& o) { return with_location_of(s, o.get()); }
+
+// Versions that preserve the statement as a StmtList.
+inline IntrusivePtr<StmtList> with_location_of(IntrusivePtr<StmtList> s, const ObjPtr& o) {
+    (void)with_location_of(s, o.get());
+    return s;
+}
+
+inline IntrusivePtr<StmtList> with_location_of(IntrusivePtr<StmtList> s, const Obj* o) {
+    s->SetLocationInfo(o->GetLocationInfo());
+    return s;
+}
 
 } // namespace zeek::detail

--- a/src/script_opt/Expr.cc
+++ b/src/script_opt/Expr.cc
@@ -348,10 +348,10 @@ ExprPtr Expr::AssignToTemporary(ExprPtr e, Reducer* c, StmtPtr& red_stmt) {
     auto result_tmp = c->GenTemporaryExpr(GetType(), e);
 
     auto a_e = make_intrusive<AssignExpr>(result_tmp->MakeLvalue(), e, false, nullptr, nullptr, false);
+    a_e->SetLocationInfo(GetLocationInfo());
     a_e->SetIsTemp();
-    a_e->SetOriginal(ThisPtr());
 
-    auto a_e_s = make_intrusive<ExprStmt>(a_e);
+    auto a_e_s = with_location_of(make_intrusive<ExprStmt>(a_e), this);
     red_stmt = MergeStmts(red_stmt, a_e_s);
 
     // Important: our result is not result_tmp, but a duplicate of it.
@@ -366,7 +366,7 @@ ExprPtr Expr::TransformMe(ExprPtr new_me, Reducer* c, StmtPtr& red_stmt) {
     if ( new_me == this )
         return new_me;
 
-    new_me->SetOriginal(ThisPtr());
+    new_me->SetLocationInfo(GetLocationInfo());
 
     // Unlike for Stmt's, we assume that new_me has already
     // been reduced, so no need to do so further.
@@ -377,7 +377,7 @@ StmtPtr Expr::MergeStmts(StmtPtr s1, StmtPtr s2, StmtPtr s3) const {
     int nums = (s1 != nullptr) + (s2 != nullptr) + (s3 != nullptr);
 
     if ( nums > 1 )
-        return make_intrusive<StmtList>(s1, s2, s3);
+        return with_location_of(make_intrusive<StmtList>(s1, s2, s3), this);
     else if ( s1 )
         return s1;
     else if ( s2 )
@@ -402,7 +402,11 @@ ValPtr Expr::MakeZero(TypeTag t) const {
     }
 }
 
-ConstExprPtr Expr::MakeZeroExpr(TypeTag t) const { return make_intrusive<ConstExpr>(MakeZero(t)); }
+ConstExprPtr Expr::MakeZeroExpr(TypeTag t) const {
+    auto z = make_intrusive<ConstExpr>(MakeZero(t));
+    z->SetLocationInfo(GetLocationInfo());
+    return z;
+}
 
 ExprPtr NameExpr::Duplicate() { return SetSucc(new NameExpr(id, in_const_init)); }
 
@@ -569,17 +573,15 @@ ExprPtr IncrExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     StmtPtr target_stmt;
     target = target->ReduceToSingleton(c, target_stmt);
 
-    auto incr_const = make_intrusive<ConstExpr>(val_mgr->Count(1));
-    incr_const->SetOriginal(ThisPtr());
+    auto incr_const = with_location_of(make_intrusive<ConstExpr>(val_mgr->Count(1)), this);
 
     ExprPtr incr_expr;
 
     if ( Tag() == EXPR_INCR )
-        incr_expr = make_intrusive<AddExpr>(target, incr_const);
+        incr_expr = with_location_of(make_intrusive<AddExpr>(target, incr_const), this);
     else
-        incr_expr = make_intrusive<SubExpr>(target, incr_const);
+        incr_expr = with_location_of(make_intrusive<SubExpr>(target, incr_const), this);
 
-    incr_expr->SetOriginal(ThisPtr());
     StmtPtr incr_stmt;
     auto incr_expr2 = incr_expr->Reduce(c, incr_stmt);
 
@@ -594,21 +596,19 @@ ExprPtr IncrExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
         auto dup1 = orig_target->GetOp1()->Duplicate();
         auto dup2 = orig_target->GetOp2()->Duplicate();
         auto index = dup2->AsListExprPtr();
-        orig_target = make_intrusive<IndexExpr>(dup1, index);
+        orig_target = with_location_of(make_intrusive<IndexExpr>(dup1, index), this);
     }
 
     else if ( orig_target->Tag() == EXPR_FIELD ) {
         auto dup1 = orig_target->GetOp1()->Duplicate();
         auto field_name = orig_target->AsFieldExpr()->FieldName();
-        orig_target = make_intrusive<FieldExpr>(dup1, field_name);
+        orig_target = with_location_of(make_intrusive<FieldExpr>(dup1, field_name), this);
     }
 
     else
         reporter->InternalError("confused in IncrExpr::Reduce");
 
-    auto assign = make_intrusive<AssignExpr>(orig_target, rhs, false, nullptr, nullptr, false);
-
-    orig_target->SetOriginal(ThisPtr());
+    auto assign = with_location_of(make_intrusive<AssignExpr>(orig_target, rhs, false, nullptr, nullptr, false), this);
 
     // First reduce it regularly, so it can transform into $= or
     // such as needed.  Then reduce that to a singleton to provide
@@ -628,7 +628,7 @@ ExprPtr IncrExpr::ReduceToSingleton(Reducer* c, StmtPtr& red_stmt) {
 
     if ( target->Tag() == EXPR_NAME && IsIntegral(target->GetType()->Tag()) ) {
         ExprPtr incr_expr = Duplicate();
-        red_stmt = make_intrusive<ExprStmt>(incr_expr)->Reduce(c);
+        red_stmt = with_location_of(make_intrusive<ExprStmt>(incr_expr), this)->Reduce(c);
 
         StmtPtr targ_red_stmt;
         auto targ_red = target->Reduce(c, targ_red_stmt);
@@ -719,9 +719,7 @@ ExprPtr AddExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
 
 ExprPtr AddExpr::BuildSub(const ExprPtr& op1, const ExprPtr& op2) {
     auto rhs = op2->GetOp1();
-    auto sub = make_intrusive<SubExpr>(op1, rhs);
-    sub->SetOriginal(ThisPtr());
-    return sub;
+    return with_location_of(make_intrusive<SubExpr>(op1, rhs), this);
 }
 
 ExprPtr AddToExpr::Duplicate() {
@@ -767,10 +765,8 @@ ExprPtr AddToExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
             red_stmt = MergeStmts(red_stmt1, red_stmt2);
 
             if ( tag == TYPE_VECTOR && (! IsVector(op2->GetType()->Tag()) || ! same_type(t, op2->GetType())) ) {
-                auto append = make_intrusive<AppendToExpr>(op1->Duplicate(), op2);
-                append->SetOriginal(ThisPtr());
-
-                auto append_stmt = make_intrusive<ExprStmt>(append);
+                auto append = with_location_of(make_intrusive<AppendToExpr>(op1->Duplicate(), op2), this);
+                auto append_stmt = with_location_of(make_intrusive<ExprStmt>(append), this);
 
                 red_stmt = MergeStmts(red_stmt, append_stmt);
 
@@ -782,8 +778,9 @@ ExprPtr AddToExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
 
         default: {
             auto rhs = op1->AsRefExprPtr()->GetOp1();
-            auto do_incr = make_intrusive<AddExpr>(rhs->Duplicate(), op2);
-            auto assign = make_intrusive<AssignExpr>(op1, do_incr, false, nullptr, nullptr, false);
+            auto do_incr = with_location_of(make_intrusive<AddExpr>(rhs->Duplicate(), op2), this);
+            auto assign =
+                with_location_of(make_intrusive<AssignExpr>(op1, do_incr, false, nullptr, nullptr, false), this);
 
             return assign->ReduceToSingleton(c, red_stmt);
         }
@@ -791,7 +788,7 @@ ExprPtr AddToExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
 }
 
 ExprPtr AddToExpr::ReduceToSingleton(Reducer* c, StmtPtr& red_stmt) {
-    auto at_stmt = make_intrusive<ExprStmt>(Duplicate());
+    auto at_stmt = with_location_of(make_intrusive<ExprStmt>(Duplicate()), this);
     red_stmt = at_stmt->Reduce(c);
     return op1;
 }
@@ -814,8 +811,7 @@ ExprPtr SubExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
 
     if ( op2->Tag() == EXPR_NEGATE ) {
         auto rhs = op2->GetOp1();
-        auto add = make_intrusive<AddExpr>(op1, rhs);
-        add->SetOriginal(ThisPtr());
+        auto add = with_location_of(make_intrusive<AddExpr>(op1, rhs), this);
         return add->Reduce(c, red_stmt);
     }
 
@@ -864,14 +860,14 @@ ExprPtr RemoveFromExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     }
 
     auto lhs = op1->AsRefExprPtr()->GetOp1();
-    auto do_decr = make_intrusive<SubExpr>(lhs->Duplicate(), op2);
-    auto assign = make_intrusive<AssignExpr>(op1, do_decr, false, nullptr, nullptr, false);
+    auto do_decr = with_location_of(make_intrusive<SubExpr>(lhs->Duplicate(), op2), this);
+    auto assign = with_location_of(make_intrusive<AssignExpr>(op1, do_decr, false, nullptr, nullptr, false), this);
 
     return assign->Reduce(c, red_stmt);
 }
 
 ExprPtr RemoveFromExpr::ReduceToSingleton(Reducer* c, StmtPtr& red_stmt) {
-    auto rf_stmt = make_intrusive<ExprStmt>(Duplicate());
+    auto rf_stmt = with_location_of(make_intrusive<ExprStmt>(Duplicate()), this);
     red_stmt = rf_stmt->Reduce(c);
     return op1;
 }
@@ -970,13 +966,13 @@ static bool is_pattern_cascade(const ExprPtr& e, IDPtr& id, std::vector<ConstExp
 
 // Given a set of pattern constants, returns a disjunction that
 // includes all of them.
-static ExprPtr build_disjunction(std::vector<ConstExprPtr>& patterns) {
+static ExprPtr build_disjunction(std::vector<ConstExprPtr>& patterns, const Obj* obj) {
     ASSERT(patterns.size() > 1);
 
     ExprPtr e = patterns[0];
 
     for ( auto& p : patterns )
-        e = make_intrusive<BitExpr>(EXPR_OR, e, p);
+        e = with_location_of(make_intrusive<BitExpr>(EXPR_OR, e, p), obj);
 
     return e;
 }
@@ -1005,9 +1001,9 @@ ExprPtr BoolExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     IDPtr common_id = nullptr;
     std::vector<ConstExprPtr> patterns;
     if ( tag == EXPR_OR_OR && is_pattern_cascade(ThisPtr(), common_id, patterns) ) {
-        auto new_pat = build_disjunction(patterns);
-        auto new_id = make_intrusive<NameExpr>(common_id);
-        auto new_node = make_intrusive<InExpr>(new_pat, new_id);
+        auto new_pat = build_disjunction(patterns, this);
+        auto new_id = with_location_of(make_intrusive<NameExpr>(common_id), this);
+        auto new_node = with_location_of(make_intrusive<InExpr>(new_pat, new_id), this);
         return new_node->Reduce(c, red_stmt);
     }
 
@@ -1052,16 +1048,15 @@ ExprPtr BoolExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     }
 
     auto else_val = is_and ? val_mgr->False() : val_mgr->True();
-    ExprPtr else_e = make_intrusive<ConstExpr>(else_val);
+    ExprPtr else_e = with_location_of(make_intrusive<ConstExpr>(else_val), this);
 
     ExprPtr cond;
     if ( is_and )
-        cond = make_intrusive<CondExpr>(op1, op2, else_e);
+        cond = with_location_of(make_intrusive<CondExpr>(op1, op2, else_e), this);
     else
-        cond = make_intrusive<CondExpr>(op1, else_e, op2);
+        cond = with_location_of(make_intrusive<CondExpr>(op1, else_e, op2), this);
 
     auto cond_red = cond->ReduceToSingleton(c, red_stmt);
-
     return TransformMe(cond_red, c, red_stmt);
 }
 
@@ -1118,8 +1113,7 @@ ExprPtr BitExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
         auto n = op1->AsNameExpr();
 
         if ( Tag() == EXPR_XOR ) {
-            auto zero = make_intrusive<ConstExpr>(val_mgr->Count(0));
-            zero->SetOriginal(ThisPtr());
+            auto zero = with_location_of(make_intrusive<ConstExpr>(val_mgr->Count(0)), this);
             return zero->Reduce(c, red_stmt);
         }
 
@@ -1141,8 +1135,7 @@ bool EqExpr::WillTransform(Reducer* c) const { return GetType()->Tag() == TYPE_B
 ExprPtr EqExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     if ( GetType()->Tag() == TYPE_BOOL && same_singletons(op1, op2) ) {
         bool t = Tag() == EXPR_EQ;
-        auto res = make_intrusive<ConstExpr>(val_mgr->Bool(t));
-        res->SetOriginal(ThisPtr());
+        auto res = with_location_of(make_intrusive<ConstExpr>(val_mgr->Bool(t)), this);
         return res->Reduce(c, red_stmt);
     }
 
@@ -1161,8 +1154,7 @@ ExprPtr RelExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     if ( GetType()->Tag() == TYPE_BOOL ) {
         if ( same_singletons(op1, op2) ) {
             bool t = Tag() == EXPR_GE || Tag() == EXPR_LE;
-            auto res = make_intrusive<ConstExpr>(val_mgr->Bool(t));
-            res->SetOriginal(ThisPtr());
+            auto res = with_location_of(make_intrusive<ConstExpr>(val_mgr->Bool(t)), this);
             return res->Reduce(c, red_stmt);
         }
 
@@ -1248,7 +1240,7 @@ ExprPtr CondExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
             return op1;
 
         // Instead we have "var ? F : T".
-        return make_intrusive<NotExpr>(op1);
+        return TransformMe(make_intrusive<NotExpr>(op1), c, red_stmt);
     }
 
     if ( c->Optimizing() )
@@ -1288,11 +1280,12 @@ StmtPtr CondExpr::ReduceToSingletons(Reducer* c) {
 
     if ( red2_stmt || red3_stmt ) {
         if ( ! red2_stmt )
-            red2_stmt = make_intrusive<NullStmt>();
+            red2_stmt = with_location_of(make_intrusive<NullStmt>(), this);
         if ( ! red3_stmt )
-            red3_stmt = make_intrusive<NullStmt>();
+            red3_stmt = with_location_of(make_intrusive<NullStmt>(), this);
 
-        if_else = make_intrusive<IfStmt>(op1->Duplicate(), std::move(red2_stmt), std::move(red3_stmt));
+        if_else = with_location_of(make_intrusive<IfStmt>(op1->Duplicate(), std::move(red2_stmt), std::move(red3_stmt)),
+                                   this);
     }
 
     return MergeStmts(red1_stmt, if_else);
@@ -1343,7 +1336,7 @@ StmtPtr RefExpr::ReduceToLHS(Reducer* c) {
     }
 
     auto red_stmt1 = op->ReduceToSingletons(c);
-    auto op_ref = make_intrusive<RefExpr>(op);
+    auto op_ref = with_location_of(make_intrusive<RefExpr>(op), this);
 
     StmtPtr red_stmt2;
     op = AssignToTemporary(op_ref, c, red_stmt2);
@@ -1428,9 +1421,9 @@ ExprPtr AssignExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     if ( val ) {
         // These are reduced to the assignment followed by
         // the assignment value.
-        auto assign_val = make_intrusive<ConstExpr>(val);
+        auto assign_val = with_location_of(make_intrusive<ConstExpr>(val), this);
         val = nullptr;
-        red_stmt = make_intrusive<ExprStmt>(ThisPtr());
+        red_stmt = with_location_of(make_intrusive<ExprStmt>(ThisPtr()), this);
         return assign_val;
     }
 
@@ -1443,6 +1436,8 @@ ExprPtr AssignExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     StmtPtr rhs_reduce;
 
     if ( lhs_is_any != rhs_is_any ) {
+        auto op2_orig = op2;
+
         ExprPtr red_rhs = op2->ReduceToSingleton(c, rhs_reduce);
 
         if ( lhs_is_any ) {
@@ -1453,11 +1448,13 @@ ExprPtr AssignExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
         }
         else
             op2 = make_intrusive<CoerceFromAnyExpr>(red_rhs, t1);
+
+        op2->SetLocationInfo(op2_orig->GetLocationInfo());
     }
 
     if ( t1->Tag() == TYPE_VECTOR && t1->Yield()->Tag() != TYPE_ANY && t2->Yield() && t2->Yield()->Tag() == TYPE_ANY ) {
         ExprPtr red_rhs = op2->ReduceToSingleton(c, rhs_reduce);
-        op2 = make_intrusive<CoerceFromAnyVecExpr>(red_rhs, t1);
+        op2 = with_location_of(make_intrusive<CoerceFromAnyVecExpr>(red_rhs, t1), op2);
     }
 
     auto lhs_ref = op1->AsRefExprPtr();
@@ -1511,10 +1508,12 @@ ExprPtr AssignExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
 
         loop_over_list(lhs_list, i) {
             auto rhs_dup = rhs_e->Duplicate();
-            auto rhs = make_intrusive<AnyIndexExpr>(rhs_dup, i);
+            auto rhs = with_location_of(make_intrusive<AnyIndexExpr>(rhs_dup, i), this);
             auto lhs = lhs_list[i]->ThisPtr();
+            lhs->SetLocationInfo(GetLocationInfo());
             auto assign = make_intrusive<AssignExpr>(lhs, rhs, false, nullptr, nullptr, false);
-            auto assign_stmt = make_intrusive<ExprStmt>(assign);
+
+            auto assign_stmt = with_location_of(make_intrusive<ExprStmt>(assign), this);
             red_stmt = MergeStmts(red_stmt, assign_stmt);
         }
 
@@ -1562,11 +1561,11 @@ ExprPtr AssignExpr::ReduceToSingleton(Reducer* c, StmtPtr& red_stmt) {
         Internal("Confusion in AssignExpr::ReduceToSingleton");
 
     ExprPtr assign_expr = Duplicate();
-    auto ae_stmt = make_intrusive<ExprStmt>(assign_expr);
+    auto ae_stmt = with_location_of(make_intrusive<ExprStmt>(assign_expr), this);
     red_stmt = ae_stmt->Reduce(c);
 
     if ( val )
-        return make_intrusive<ConstExpr>(val);
+        return TransformMe(make_intrusive<ConstExpr>(val), c, red_stmt);
 
     auto lhs = op1->AsRefExprPtr()->GetOp1();
     StmtPtr lhs_stmt;
@@ -1884,7 +1883,7 @@ ExprPtr ArithCoerceExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
 
         if ( IsArithmetic(t->Tag()) || IsArithmetic(ct->Tag()) ) {
             if ( auto v = FoldSingleVal(cv, t) )
-                return make_intrusive<ConstExpr>(v);
+                return TransformMe(make_intrusive<ConstExpr>(v), c, red_stmt);
             // else there was a coercion error, fall through
         }
     }
@@ -1926,7 +1925,7 @@ ExprPtr RecordCoerceExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     if ( WillTransform(c) ) {
         auto rt = cast_intrusive<RecordType>(type);
         auto rc_op = op->AsRecordConstructorExpr();
-        auto known_constr = make_intrusive<RecordConstructorExpr>(rt, rc_op->Op());
+        auto known_constr = with_location_of(make_intrusive<RecordConstructorExpr>(rt, rc_op->Op()), this);
         auto red_e = known_constr->Reduce(c, red_stmt);
         return TransformMe(std::move(red_e), c, red_stmt);
     }
@@ -1960,7 +1959,7 @@ ExprPtr VectorCoerceExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
         auto op1_list = op->GetOp1();
         ASSERT(op1_list->Tag() == EXPR_LIST);
         auto empty_list = cast_intrusive<ListExpr>(op1_list);
-        auto new_me = make_intrusive<VectorConstructorExpr>(empty_list, type);
+        auto new_me = with_location_of(make_intrusive<VectorConstructorExpr>(empty_list, type), this);
         auto red_e = new_me->Reduce(c, red_stmt);
         return TransformMe(std::move(red_e), c, red_stmt);
     }
@@ -2039,7 +2038,7 @@ bool InExpr::HasReducedOps(Reducer* c) const { return op1->HasReducedOps(c) && o
 
 ExprPtr InExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     if ( op2->Tag() == EXPR_SET_CONSTRUCTOR && op2->GetOp1()->AsListExpr()->HasConstantOps() )
-        op2 = make_intrusive<ConstExpr>(op2->Eval(nullptr));
+        op2 = with_location_of(make_intrusive<ConstExpr>(op2->Eval(nullptr)), this);
 
     return BinaryExpr::Reduce(c, red_stmt);
 }
@@ -2290,9 +2289,9 @@ ExprPtr CastExpr::Duplicate() { return SetSucc(new CastExpr(op->Duplicate(), typ
 
 ExprPtr IsExpr::Duplicate() { return SetSucc(new IsExpr(op->Duplicate(), t)); }
 
-InlineExpr::InlineExpr(ListExprPtr arg_args, std::vector<IDPtr> arg_params, std ::vector<bool> arg_param_is_modified,
-                       StmtPtr arg_body, int _frame_offset, TypePtr ret_type)
-    : Expr(EXPR_INLINE), args(std::move(arg_args)), body(std::move(arg_body)) {
+InlineExpr::InlineExpr(ScriptFuncPtr arg_sf, ListExprPtr arg_args, std::vector<IDPtr> arg_params,
+                       std ::vector<bool> arg_param_is_modified, StmtPtr arg_body, int _frame_offset, TypePtr ret_type)
+    : Expr(EXPR_INLINE), sf(std::move(arg_sf)), args(std::move(arg_args)), body(std::move(arg_body)) {
     params = std::move(arg_params);
     param_is_modified = std::move(arg_param_is_modified);
     frame_offset = _frame_offset;
@@ -2335,7 +2334,7 @@ ValPtr InlineExpr::Eval(Frame* f) const {
 ExprPtr InlineExpr::Duplicate() {
     auto args_d = args->Duplicate()->AsListExprPtr();
     auto body_d = body->Duplicate();
-    return SetSucc(new InlineExpr(args_d, params, param_is_modified, body_d, frame_offset, type));
+    return SetSucc(new InlineExpr(sf, args_d, params, param_is_modified, body_d, frame_offset, type));
 }
 
 bool InlineExpr::IsReduced(Reducer* c) const { return NonReduced(this); }
@@ -2349,18 +2348,20 @@ ExprPtr InlineExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
 
     auto args_list = args->Exprs();
     auto ret_val = c->PushInlineBlock(type);
+    if ( ret_val )
+        ret_val->SetLocationInfo(GetLocationInfo());
 
     loop_over_list(args_list, i) {
         StmtPtr arg_red_stmt;
         auto red_i = args_list[i]->Reduce(c, arg_red_stmt);
-        auto assign_stmt = c->GenParam(params[i], red_i, param_is_modified[i]);
+        auto assign_stmt = with_location_of(c->GenParam(params[i], red_i, param_is_modified[i]), this);
         red_stmt = MergeStmts(red_stmt, arg_red_stmt, assign_stmt);
     }
 
     body = body->Reduce(c);
     c->PopInlineBlock();
 
-    auto catch_ret = make_intrusive<CatchReturnStmt>(body, ret_val);
+    auto catch_ret = with_location_of(make_intrusive<CatchReturnStmt>(sf, body, ret_val), this);
 
     red_stmt = MergeStmts(red_stmt, catch_ret);
 
@@ -2448,7 +2449,7 @@ ExprPtr AppendToExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
 }
 
 ExprPtr AppendToExpr::ReduceToSingleton(Reducer* c, StmtPtr& red_stmt) {
-    auto at_stmt = make_intrusive<ExprStmt>(Duplicate());
+    auto at_stmt = with_location_of(make_intrusive<ExprStmt>(Duplicate()), this);
     red_stmt = at_stmt->Reduce(c);
     return op1->AsRefExprPtr()->GetOp1();
 }
@@ -2496,10 +2497,10 @@ ExprPtr IndexAssignExpr::ReduceToSingleton(Reducer* c, StmtPtr& red_stmt) {
     StmtPtr op1_red_stmt;
     op1 = op1->Reduce(c, op1_red_stmt);
 
-    auto assign_stmt = make_intrusive<ExprStmt>(Duplicate());
+    auto assign_stmt = with_location_of(make_intrusive<ExprStmt>(Duplicate()), this);
 
     auto index = op2->AsListExprPtr();
-    auto res = make_intrusive<IndexExpr>(GetOp1(), index, false);
+    auto res = with_location_of(make_intrusive<IndexExpr>(GetOp1(), index, false), this);
     auto final_res = res->ReduceToSingleton(c, red_stmt);
 
     red_stmt = MergeStmts(op1_red_stmt, assign_stmt, red_stmt);
@@ -2597,9 +2598,9 @@ ExprPtr FieldLHSAssignExpr::ReduceToSingleton(Reducer* c, StmtPtr& red_stmt) {
     StmtPtr op1_red_stmt;
     op1 = op1->Reduce(c, op1_red_stmt);
 
-    auto assign_stmt = make_intrusive<ExprStmt>(Duplicate());
+    auto assign_stmt = with_location_of(make_intrusive<ExprStmt>(Duplicate()), this);
 
-    auto field_res = make_intrusive<FieldExpr>(op1, field_name);
+    auto field_res = with_location_of(make_intrusive<FieldExpr>(op1, field_name), this);
     StmtPtr field_res_stmt;
     auto res = field_res->ReduceToSingleton(c, field_res_stmt);
 

--- a/src/script_opt/Stmt.cc
+++ b/src/script_opt/Stmt.cc
@@ -23,11 +23,8 @@ StmtPtr Stmt::Reduce(Reducer* c) {
     if ( repl )
         return repl;
 
-    if ( c->ShouldOmitStmt(this) ) {
-        auto null = make_intrusive<NullStmt>();
-        null->SetOriginal(this_ptr);
-        return null;
-    }
+    if ( c->ShouldOmitStmt(this) )
+        return with_location_of(make_intrusive<NullStmt>(), this);
 
     c->SetCurrStmt(this);
 
@@ -39,7 +36,7 @@ StmtPtr Stmt::TransformMe(StmtPtr new_me, Reducer* c) {
 
     // Set the original prior to reduction, to support "original chains"
     // to ultimately resolve back to the source statement.
-    new_me->SetOriginal(ThisPtr());
+    new_me->SetLocationInfo(GetLocationInfo());
     return new_me->Reduce(c);
 }
 
@@ -62,8 +59,8 @@ StmtPtr ExprListStmt::DoReduce(Reducer* c) {
     if ( ! c->Optimizing() && IsReduced(c) )
         return ThisPtr();
 
-    auto new_l = make_intrusive<ListExpr>();
-    auto s = make_intrusive<StmtList>();
+    auto new_l = with_location_of(make_intrusive<ListExpr>(), this);
+    auto s = with_location_of(make_intrusive<StmtList>(), this);
 
     ExprPList& e = l->Exprs();
     for ( auto& expr : e ) {
@@ -97,9 +94,7 @@ StmtPtr ExprListStmt::DoReduce(Reducer* c) {
 StmtPtr PrintStmt::Duplicate() { return SetSucc(new PrintStmt(l->Duplicate()->AsListExprPtr())); }
 
 StmtPtr PrintStmt::DoSubclassReduce(ListExprPtr singletons, Reducer* c) {
-    auto new_me = make_intrusive<PrintStmt>(singletons);
-    new_me->SetOriginal(ThisPtr());
-    return new_me;
+    return with_location_of(make_intrusive<PrintStmt>(singletons), this);
 }
 
 StmtPtr ExprStmt::Duplicate() { return SetSucc(new ExprStmt(e ? e->Duplicate() : nullptr)); }
@@ -201,7 +196,7 @@ StmtPtr IfStmt::DoReduce(Reducer* c) {
         auto b = e->GetOp2();
 
         auto s1_dup = s1 ? s1->Duplicate() : nullptr;
-        s2 = make_intrusive<IfStmt>(b, s1_dup, s2);
+        s2 = with_location_of(make_intrusive<IfStmt>(b, s1_dup, s2), s2);
         e = a;
 
         auto res = DoReduce(c);
@@ -218,7 +213,7 @@ StmtPtr IfStmt::DoReduce(Reducer* c) {
         auto b = e->GetOp2();
 
         auto s2_dup = s2 ? s2->Duplicate() : nullptr;
-        s1 = make_intrusive<IfStmt>(b, s1, s2_dup);
+        s1 = with_location_of(make_intrusive<IfStmt>(b, s1, s2_dup), s1);
         e = a;
 
         auto res = DoReduce(c);
@@ -239,10 +234,12 @@ StmtPtr IfStmt::DoReduce(Reducer* c) {
         e = e->ReduceToConditional(c, cond_red_stmt);
 
         if ( red_e_stmt && cond_red_stmt )
-            red_e_stmt = make_intrusive<StmtList>(red_e_stmt, cond_red_stmt);
+            red_e_stmt = with_location_of(make_intrusive<StmtList>(red_e_stmt, cond_red_stmt), this);
         else if ( cond_red_stmt )
             red_e_stmt = cond_red_stmt;
     }
+
+    StmtPtr sl;
 
     if ( e->IsConst() ) {
         auto c_e = e->AsConstExprPtr();
@@ -251,14 +248,14 @@ StmtPtr IfStmt::DoReduce(Reducer* c) {
         if ( c->Optimizing() )
             return t ? s1 : s2;
 
-        if ( t )
-            return TransformMe(make_intrusive<StmtList>(red_e_stmt, s1), c);
-        else
-            return TransformMe(make_intrusive<StmtList>(red_e_stmt, s2), c);
+        sl = make_intrusive<StmtList>(red_e_stmt, t ? s1 : s2);
     }
 
-    if ( red_e_stmt )
-        return TransformMe(make_intrusive<StmtList>(red_e_stmt, ThisPtr()), c);
+    else if ( red_e_stmt )
+        sl = make_intrusive<StmtList>(red_e_stmt, ThisPtr());
+
+    if ( sl )
+        return TransformMe(sl, c);
 
     return ThisPtr();
 }
@@ -339,9 +336,9 @@ bool SwitchStmt::IsReduced(Reducer* r) const {
 StmtPtr SwitchStmt::DoReduce(Reducer* rc) {
     if ( cases->length() == 0 )
         // Degenerate.
-        return make_intrusive<NullStmt>();
+        return TransformMe(make_intrusive<NullStmt>(), rc);
 
-    auto s = make_intrusive<StmtList>();
+    auto s = with_location_of(make_intrusive<StmtList>(), this);
     StmtPtr red_e_stmt;
 
     if ( rc->Optimizing() )
@@ -381,11 +378,8 @@ StmtPtr SwitchStmt::DoReduce(Reducer* rc) {
         c->UpdateBody(c->Body()->Reduce(rc));
     }
 
-    if ( ! s->Stmts().empty() ) {
-        StmtPtr me = ThisPtr();
-        auto pre_and_me = make_intrusive<StmtList>(s, me);
-        return TransformMe(pre_and_me, rc);
-    }
+    if ( ! s->Stmts().empty() )
+        return TransformMe(make_intrusive<StmtList>(s, ThisPtr()), rc);
 
     return ThisPtr();
 }
@@ -429,10 +423,8 @@ StmtPtr AddDelStmt::DoReduce(Reducer* c) {
 
     auto red_e_stmt = e->ReduceToSingletons(c);
 
-    if ( red_e_stmt ) {
-        auto s = make_intrusive<StmtList>(red_e_stmt, ThisPtr());
-        return TransformMe(s, c);
-    }
+    if ( red_e_stmt )
+        return TransformMe(make_intrusive<StmtList>(red_e_stmt, ThisPtr()), c);
 
     else
         return ThisPtr();
@@ -457,10 +449,8 @@ StmtPtr EventStmt::DoReduce(Reducer* c) {
         event_expr = ee_red->AsEventExprPtr();
         e = event_expr;
 
-        if ( red_e_stmt ) {
-            auto s = make_intrusive<StmtList>(red_e_stmt, ThisPtr());
-            return TransformMe(s, c);
-        }
+        if ( red_e_stmt )
+            return TransformMe(make_intrusive<StmtList>(red_e_stmt, ThisPtr()), c);
     }
 
     return ThisPtr();
@@ -490,7 +480,7 @@ StmtPtr WhileStmt::DoReduce(Reducer* c) {
             if ( ! c->IsPruning() ) {
                 // See comment below for the particulars
                 // of this constructor.
-                stmt_loop_condition = make_intrusive<ExprStmt>(STMT_EXPR, loop_condition);
+                stmt_loop_condition = with_location_of(make_intrusive<ExprStmt>(STMT_EXPR, loop_condition), this);
                 return ThisPtr();
             }
         }
@@ -503,7 +493,7 @@ StmtPtr WhileStmt::DoReduce(Reducer* c) {
     // We use the more involved ExprStmt constructor here to bypass
     // its check for whether the expression is being ignored, since
     // we're not actually creating an ExprStmt for execution.
-    stmt_loop_condition = make_intrusive<ExprStmt>(STMT_EXPR, loop_condition);
+    stmt_loop_condition = with_location_of(make_intrusive<ExprStmt>(STMT_EXPR, loop_condition), this);
 
     if ( loop_cond_pred_stmt )
         loop_cond_pred_stmt = loop_cond_pred_stmt->Reduce(c);
@@ -606,10 +596,8 @@ StmtPtr ReturnStmt::DoReduce(Reducer* c) {
         StmtPtr red_e_stmt;
         e = e->ReduceToSingleton(c, red_e_stmt);
 
-        if ( red_e_stmt ) {
-            auto s = make_intrusive<StmtList>(red_e_stmt, ThisPtr());
-            return TransformMe(s, c);
-        }
+        if ( red_e_stmt )
+            return TransformMe(make_intrusive<StmtList>(red_e_stmt, ThisPtr()), c);
     }
 
     return ThisPtr();
@@ -829,7 +817,7 @@ StmtPtr AssertStmt::Duplicate() { return SetSucc(new AssertStmt(cond->Duplicate(
 
 bool AssertStmt::IsReduced(Reducer* c) const { return false; }
 
-StmtPtr AssertStmt::DoReduce(Reducer* c) { return make_intrusive<NullStmt>(); }
+StmtPtr AssertStmt::DoReduce(Reducer* c) { return TransformMe(make_intrusive<NullStmt>(), c); }
 
 bool WhenInfo::HasUnreducedIDs(Reducer* c) const {
     for ( auto& cp : *cl ) {
@@ -891,18 +879,17 @@ StmtPtr WhenStmt::DoReduce(Reducer* c) {
         auto new_e = e->ReduceToSingleton(c, red_e_stmt);
         wi->SetTimeoutExpr(new_e);
 
-        if ( red_e_stmt ) {
-            auto s = make_intrusive<StmtList>(red_e_stmt, ThisPtr());
-            return TransformMe(std::move(s), c);
-        }
+        if ( red_e_stmt )
+            return TransformMe(make_intrusive<StmtList>(red_e_stmt, ThisPtr()), c);
     }
 
     return ThisPtr();
 }
 
-CatchReturnStmt::CatchReturnStmt(StmtPtr _block, NameExprPtr _ret_var) : Stmt(STMT_CATCH_RETURN) {
-    block = _block;
-    ret_var = _ret_var;
+CatchReturnStmt::CatchReturnStmt(ScriptFuncPtr _sf, StmtPtr _block, NameExprPtr _ret_var) : Stmt(STMT_CATCH_RETURN) {
+    sf = std::move(_sf);
+    block = std::move(_block);
+    ret_var = std::move(_ret_var);
 }
 
 ValPtr CatchReturnStmt::Exec(Frame* f, StmtFlowType& flow) {
@@ -929,7 +916,7 @@ bool CatchReturnStmt::IsPure() const {
 StmtPtr CatchReturnStmt::Duplicate() {
     auto rv_dup = ret_var->Duplicate();
     auto rv_dup_ptr = rv_dup->AsNameExprPtr();
-    return SetSucc(new CatchReturnStmt(block->Duplicate(), rv_dup_ptr));
+    return SetSucc(new CatchReturnStmt(sf, block->Duplicate(), rv_dup_ptr));
 }
 
 StmtPtr CatchReturnStmt::DoReduce(Reducer* c) {
@@ -945,14 +932,14 @@ StmtPtr CatchReturnStmt::DoReduce(Reducer* c) {
             if ( ret_var )
                 reporter->InternalError("inlining inconsistency: no return value");
 
-            return make_intrusive<NullStmt>();
+            return TransformMe(make_intrusive<NullStmt>(), c);
         }
 
         auto rv_dup = ret_var->Duplicate();
         auto ret_e_dup = ret_e->Duplicate();
 
-        auto assign = make_intrusive<AssignExpr>(rv_dup, ret_e_dup, false);
-        assign_stmt = make_intrusive<ExprStmt>(assign);
+        auto assign = with_location_of(make_intrusive<AssignExpr>(rv_dup, ret_e_dup, false), this);
+        assign_stmt = with_location_of(make_intrusive<ExprStmt>(assign), this);
 
         if ( ret_e_dup->Tag() == EXPR_CONST ) {
             auto ce = ret_e_dup->AsConstExpr();

--- a/src/script_opt/UseDefs.cc
+++ b/src/script_opt/UseDefs.cc
@@ -87,7 +87,7 @@ bool UseDefs::RemoveUnused(int iter) {
                 // with one that only includes the actually
                 // used identifiers.
 
-                auto new_init = make_intrusive<InitStmt>(used_ids);
+                auto new_init = with_location_of(make_intrusive<InitStmt>(used_ids), s);
                 rc->AddStmtToReplace(s, std::move(new_init));
             }
 

--- a/src/script_opt/ZAM/Stmt.cc
+++ b/src/script_opt/ZAM/Stmt.cc
@@ -11,6 +11,7 @@ namespace zeek::detail {
 
 const ZAMStmt ZAMCompiler::CompileStmt(const Stmt* s) {
     curr_stmt = const_cast<Stmt*>(s)->ThisPtr();
+    ASSERT(curr_stmt->Tag() == STMT_NULL || curr_stmt->GetLocationInfo()->first_line != 0);
 
     switch ( s->Tag() ) {
         case STMT_PRINT: return CompilePrint(static_cast<const PrintStmt*>(s));

--- a/src/script_opt/ZAM/ZBody.cc
+++ b/src/script_opt/ZAM/ZBody.cc
@@ -195,7 +195,7 @@ void ZBody::SetInsts(vector<ZInstI*>& instsI) {
         auto& iI = *instsI[i];
         insts_copy[i] = iI;
         if ( iI.stmt ) {
-            auto l = iI.stmt->Original()->GetLocationInfo();
+            auto l = iI.stmt->GetLocationInfo();
             if ( l != &no_location )
                 insts_copy[i].loc = std::make_shared<Location>(l->filename, l->first_line, l->last_line,
                                                                l->first_column, l->last_column);


### PR DESCRIPTION
ZAM script optimization creates a bunch of new AST nodes derived from the original AST. To tie these to the correct location information, ZAM introduced the notion of the "original" node associated with a new node (for both `Stmt` and `Expr` objects). Doing this at the node-level was handy during earlier development when debugging ZAM's AST transformations. However, now that those are solid, the associations are overly complex (all that's fundamentally needed these days is the location information), and also incomplete (some new nodes wind up having `no_location` for their location).

This PR removes the notion of "original" node and replaces it with a simple mechanism for derived nodes to use to mirror the location information of their source nodes. The changes are lengthy mainly because they fix up a bunch of instances where a new node did not in fact correctly track its source. (The PR includes an `ASSERT` in the ZAM compiler that ensures that every non-trivial node has a non-trivial location associated with it.)

There are also a couple of secondary changes similar in spirit: (1) for inlined functions, tracking their original names, (2) for specialized ZAM instructions that replace certain BiFs, tracking the original function call to the BiF.

(All of this is preparation for work-in-progress on ZAM supporting generating fine-grained flame graphs for profiling execution.)