### PR TITLE
Force Windows CI to use OpenSSL 3.1.1

### DIFF
--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -22,7 +22,7 @@ RUN choco install -y --no-progress sed
 RUN choco install -y --no-progress winflexbison3
 RUN choco install -y --no-progress msysgit
 RUN choco install -y --no-progress python
-RUN choco install -y --no-progress openssl
+RUN choco install -y --no-progress openssl --version=3.1.1
 
 # Set working environment.
 SHELL [ "cmd", "/c" ]


### PR DESCRIPTION
There's something wrong with chocolatey's OpenSSL 3.2.0 package that causes cmake to not be able to find libcrypto even though it's clearly in the directory. Pinning to 3.1.1 fixes the build issue.