### PR TITLE
Pull in variant-enabled Broker

### DIFF
--- a/testing/btest/Baseline/scripts.base.frameworks.telemetry.internal-metrics/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.telemetry.internal-metrics/out
@@ -18,8 +18,8 @@ Telemetry::INT_GAUGE, broker, buffered-messages, [type], [data], 0.0
 count_value, 0
 Telemetry::INT_GAUGE, broker, buffered-messages, [type], [command], 0.0
 count_value, 0
-Telemetry::INT_GAUGE, broker, buffered-messages, [type], [routing-update], 1.0
-count_value, 1
+Telemetry::INT_GAUGE, broker, buffered-messages, [type], [routing-update], 0.0
+count_value, 0
 Telemetry::INT_GAUGE, broker, buffered-messages, [type], [ping], 0.0
 count_value, 0
 Telemetry::INT_GAUGE, broker, buffered-messages, [type], [pong], 0.0


### PR DESCRIPTION
Switch the Broker submodule to a version with `broker::variant` enabled and provide new overloads for `broker::variant` in the Broker manager.

@timwoj, @ckreibich: should we find some issue with `broker::variant` in the mix that we can't fix quickly, all we need to do is point the Broker submodule back to the current version. How do you guys think we should deal with Broker in the meantime? Point Zeek to a branch until we're confident enough to merge Broker upstream?