### PR TITLE
spicy/diff-remove-timestamp: Fix missing -e

### DIFF
--- a/testing/scripts/spicy/diff-remove-timestamps
+++ b/testing/scripts/spicy/diff-remove-timestamps
@@ -2,4 +2,4 @@
 #
 # Replace anything which looks like timestamps with XXXs (including the #start/end markers in logs).
 
-sed -E 's/(^|[^0-9])([0-9]{9,10}\.[0-9]{1,8})/\1XXXXXXXXXX.XXXXXX/g' -e 's/^ *#(open|close).(19|20)..-..-..-..-..-../#\1 XXXX-XX-XX-XX-XX-XX/g'
+sed -E -e 's/(^|[^0-9])([0-9]{9,10}\.[0-9]{1,8})/\1XXXXXXXXXX.XXXXXX/g' -e 's/^ *#(open|close).(19|20)..-..-..-..-..-../#\1 XXXX-XX-XX-XX-XX-XX/g'


### PR DESCRIPTION
This got lost when converting to sed -E.