### PR TITLE
Do not default to proxy nodes in `Broker::PoolSpec`

### DIFF
--- a/scripts/base/frameworks/cluster/pools.zeek
+++ b/scripts/base/frameworks/cluster/pools.zeek
@@ -23,7 +23,7 @@ export {
 	## A pool specification.
 	type PoolSpec: record {
 		## A topic string that can be used to reach all nodes within a pool.
-		topic: string &default = "";
+		topic: string;
 		## The type of nodes that are contained within the pool.
 		node_type: Cluster::NodeType;
 		## The maximum number of nodes that may belong to the pool.

--- a/scripts/base/frameworks/cluster/pools.zeek
+++ b/scripts/base/frameworks/cluster/pools.zeek
@@ -25,7 +25,7 @@ export {
 		## A topic string that can be used to reach all nodes within a pool.
 		topic: string &default = "";
 		## The type of nodes that are contained within the pool.
-		node_type: Cluster::NodeType &default = Cluster::PROXY;
+		node_type: Cluster::NodeType;
 		## The maximum number of nodes that may belong to the pool.
 		## If not set, then all available nodes will be added to the pool,
 		## else the cluster framework will automatically limit the pool
@@ -43,7 +43,7 @@ export {
 	## A pool used for distributing data/work among a set of cluster nodes.
 	type Pool: record {
 		## The specification of the pool that was used when registering it.
-		spec: PoolSpec &default = PoolSpec();
+		spec: PoolSpec;
 		## Nodes in the pool, indexed by their name (e.g. "manager").
 		nodes: PoolNodeTable &default = PoolNodeTable();
 		## A list of nodes in the pool in a deterministic order.


### PR DESCRIPTION
This requires pool creation to spell out a spec explicitly, which the only code using these types already does. There's no reason for pools to automatically refer to proxies.

I came upon this via @ynadji's comment on proxies in the extracted Zeekygen docs [on Slack](https://zeekorg.slack.com/archives/CSZBXF6TH/p1706892270800569) — this change will help with that too.