### PR TITLE
Stmt: Introduce STMT_EXTERN

### DIFF
--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -52,6 +52,7 @@ const char* stmt_name(StmtTag t) {
         "ZAM",
         "null",
         "assert",
+        "extern",
     };
 
     return stmt_names[int(t)];

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -55,6 +55,12 @@ const char* stmt_name(StmtTag t) {
         "extern",
     };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    if ( int(t) == STMT_ANY )
+        return "any";
+#pragma GCC diagnostic pop
+
     return stmt_names[int(t)];
 }
 

--- a/src/StmtEnums.h
+++ b/src/StmtEnums.h
@@ -31,7 +31,8 @@ enum StmtTag {
     STMT_ZAM,           // a ZAM function body
     STMT_NULL,
     STMT_ASSERT,
-#define NUM_STMTS (int(STMT_ASSERT) + 1)
+    STMT_EXTERN, // for custom Stmt subclasses provided by plugins
+#define NUM_STMTS (int(STMT_EXTERN) + 1)
 };
 
 enum StmtFlowType {

--- a/src/StmtEnums.h
+++ b/src/StmtEnums.h
@@ -6,7 +6,7 @@ namespace zeek::detail {
 
 // These are in a separate file to break circular dependences
 enum StmtTag {
-    STMT_ANY = -1,
+    STMT_ANY [[deprecated("Remove in v7.1 - Unused and plugins should use STMT_EXTERN.")]] = -1,
     STMT_ALARM, // Does no longer exist but kept to create enums consistent.
     STMT_PRINT,
     STMT_EVENT,


### PR DESCRIPTION
It's currently possible for plugin's to implement their own statement
subclasses and override the Exec() implementation. This has been leveraged
by ZeekJS [1] and zeek-perf-support [2] as well as a private WASM plugin.
All of these used STMT_ANY as the tag of their own statement subclasses.

With STMT_EXTERN, we make the possibility to add external code into the AST
somewhat more supported. It's all in detail space and plugin authors have
no guarantee for stability, but it seems such a powerful extension point
that IMO we should keep it.

I'm conscious there's the broader topic how this interacts with ZAM
optimization like in-lining or rewriting of statements. However, this
already applies to the STMT_ANY usage of the mentioned plugins.

[1] https://github.com/corelight/zeekjs
[2] https://github.com/zeek/zeek-perf-support
