### PR TITLE
Update vcpkg to get C-Ares 1.26.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,11 +19,17 @@ cmake-build-*
 # clangd
 .cache
 
-out/
-
 # Visual Studio
 .vs/
 .vscode/
+out/
 CMakeSettings.json
+
+# Emacs temporary files
+*~
+
+# Vim temporary files
+*.swp
+*.swo
 
 src/include


### PR DESCRIPTION
This also updates the .gitignore file with suggestions from https://github.com/zeek/zeek/pull/3601