### PR TITLE
Do not use snprintf() for hex printing

### DIFF
--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -196,16 +196,20 @@ const RecordValPtr& Connection::GetVal() {
         const int l2_len = sizeof(orig_l2_addr);
         char null[l2_len]{};
 
-        if ( memcmp(&orig_l2_addr, &null, l2_len) != 0 )
-            orig_endp->Assign(5, fmt_mac(orig_l2_addr, l2_len));
+        if ( memcmp(&orig_l2_addr, &null, l2_len) != 0 ) {
+            auto [mac_bytes, mac_len] = fmt_mac_bytes(orig_l2_addr, l2_len);
+            orig_endp->Assign(5, new String(true, mac_bytes.release(), mac_len));
+        }
 
         auto resp_endp = make_intrusive<RecordVal>(id::endpoint);
         resp_endp->Assign(0, 0);
         resp_endp->Assign(1, 0);
         resp_endp->Assign(4, resp_flow_label);
 
-        if ( memcmp(&resp_l2_addr, &null, l2_len) != 0 )
-            resp_endp->Assign(5, fmt_mac(resp_l2_addr, l2_len));
+        if ( memcmp(&resp_l2_addr, &null, l2_len) != 0 ) {
+            auto [mac_bytes, mac_len] = fmt_mac_bytes(resp_l2_addr, l2_len);
+            resp_endp->Assign(5, new String(true, mac_bytes.release(), mac_len));
+        }
 
         conn_val->Assign(0, std::move(id_val));
         conn_val->Assign(1, std::move(orig_endp));

--- a/src/digest.h
+++ b/src/digest.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <sys/types.h> // for u_char
+#include <zeek/util.h>
 #include <cstdint>
 #include <cstdio>
 
@@ -41,7 +42,8 @@ enum HashAlgorithm { Hash_MD5, Hash_SHA1, Hash_SHA224, Hash_SHA256, Hash_SHA384,
 inline const char* digest_print(const u_char* digest, size_t n) {
     static char buf[ZEEK_DIGEST_PRINT_LENGTH];
     for ( size_t i = 0; i < n; ++i )
-        snprintf(buf + i * 2, 3, "%02x", digest[i]);
+        zeek::util::bytetohex(digest[i], &buf[i * 2]);
+    buf[2 * n] = '\0';
     return buf;
 }
 

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -207,11 +207,28 @@ extern const char* fmt_conn_id(const uint32_t* src_addr, uint32_t src_port, cons
  * an empty string.
  *
  * @param m EUI-48 or EUI-64 MAC address to format, as a char array
- * @param len Number of bytes valid starting at *n*. This must be at
- *            least 8 for a valid address.
+ * @param len Number of bytes valid starting at *m*. This must be at
+ *            least 6 for a valid address.
  * @return A string of the formatted MAC. Passes ownership to caller.
  */
 extern std::string fmt_mac(const unsigned char* m, int len);
+
+/**
+ * Given a MAC address, formats it in hex as 00:de:ad:be:ef.
+ * Supports both EUI-48 and EUI-64. If it's neither, returns
+ * an empty buffer.
+ *
+ * This method returns a unique pointer to a buffer that is
+ * null terminated. It can, for example, be directly passed
+ * to a zeek::String instance.
+ *
+ * @param m EUI-48 or EUI-64 MAC address to format, as a char array
+ * @param len Number of bytes valid starting at *m*. This must be at
+ *            least 6 for a valid address.
+ * @return A pair consisting of a uint8_t buffer and its string length.
+ *         The buffer is null terminated and its actual length is + 1.
+ */
+extern std::pair<std::unique_ptr<uint8_t[]>, int> fmt_mac_bytes(const unsigned char* m, int len);
 
 // Read 4 bytes from data and return in network order.
 extern uint32_t extract_uint32(const u_char* data);

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -1546,7 +1546,7 @@ function cat%(...%): string
 	for ( const auto& a : @ARG@ )
 		a->Describe(&d);
 
-	String* s = new String(1, d.TakeBytes(), d.Len());
+	String* s = new String(true, d.TakeBytes(), d.Len());
 	s->SetUseFreeToDelete(true);
 
 	return zeek::make_intrusive<zeek::StringVal>(s);
@@ -1583,7 +1583,7 @@ function cat_sep%(sep: string, def: string, ...%): string
 		v->Describe(&d);
 		}
 
-	String* s = new String(1, d.TakeBytes(), d.Len());
+	String* s = new String(true, d.TakeBytes(), d.Len());
 	s->SetUseFreeToDelete(true);
 
 	return zeek::make_intrusive<zeek::StringVal>(s);
@@ -1658,7 +1658,7 @@ function fmt%(...%): string
 		return zeek::val_mgr->EmptyString();
 		}
 
-	String* s = new String(1, d.TakeBytes(), d.Len());
+	String* s = new String(true, d.TakeBytes(), d.Len());
 	s->SetUseFreeToDelete(true);
 
 	return zeek::make_intrusive<zeek::StringVal>(s);
@@ -1873,7 +1873,7 @@ function type_name%(t: any%): string
 	zeek::ODesc d;
 	t->GetType()->Describe(&d);
 
-	String* s = new String(1, d.TakeBytes(), d.Len());
+	String* s = new String(true, d.TakeBytes(), d.Len());
 	s->SetUseFreeToDelete(true);
 
 	return zeek::make_intrusive<zeek::StringVal>(s);

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -3175,14 +3175,16 @@ function bytestring_to_hexstr%(bytestring: string%): string
 	%{
 	zeek_uint_t len = bytestring->AsString()->Len();
 	const u_char* bytes = bytestring->AsString()->Bytes();
-	auto hextr_buf = std::make_unique<char[]>((2 * len) + 1);
-	auto hexstr = hextr_buf.get();
+	auto hexstr_buf = std::make_unique<char[]>((2 * len) + 1);
+	auto hexstr = hexstr_buf.get();
 
-	hexstr[0] = 0;
 	for ( zeek_uint_t i = 0; i < len; ++i )
-		snprintf(hexstr + (2 * i), 3, "%.2hhx", bytes[i]);
+		zeek::util::bytetohex(bytes[i], &hexstr[2 * i]);
+	hexstr[2 * len] = 0;
 
-	return zeek::make_intrusive<zeek::StringVal>(hexstr);
+	// Adopt the memory...
+	String* s = new String(true, reinterpret_cast<uint8_t*>(hexstr_buf.release()), 2 * len);
+	return zeek::make_intrusive<zeek::StringVal>(s);
 	%}
 
 ## Converts a hex-string into its binary representation.


### PR DESCRIPTION
I've been staring at native/script flamegraphs for the zeek-perf-support demo a bit and snprintf() showing up caught my eye. bytestring_to_hexstr() also has an extra copy of the resulting string that can be removed. Tested with pure SSL traffic, looks to be around ~3% so seems worth doing.

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|                    
| `taskset -c 0,1 zeek  -C -r ./much-alexa-https-top-100.pcap -f "port 443" Log::default_writer=Log::WRITER_NONE` | 5.201 ± 0.037 | 5.156 | 5.270 | 1.00 |
| `taskset -c 0,1 /opt/zeek-dev-prod/bin/zeek  -C -r ./much-alexa-https-top-100.pcap -f "port 443" Log::default_writer=Log::WRITER_NONE` | 5.392 ± 0.034 | 5.349 | 5.455 | 1.04 ± 0.01 |
