### PR TITLE
Avoid src/spicy ccache busting on Zeek version bumps

### DIFF
--- a/src/spicy/file-analyzer.cc
+++ b/src/spicy/file-analyzer.cc
@@ -87,11 +87,7 @@ bool FileAnalyzer::Process(int len, const u_char* data) {
         file->FileEvent(Spicy::max_file_depth_exceeded, {file_val, analyzer_args, val_mgr->Count(_state.file().depth)});
 
         auto tag = spicy_mgr->tagForFileAnalyzer(_state.file().analyzer->Tag());
-#if ZEEK_VERSION_NUMBER >= 50200
         AnalyzerViolation("maximal file depth exceeded", reinterpret_cast<const char*>(data), len, tag);
-#else
-        // We don't have an an appropriate way to report this with older Zeeks.
-#endif
         return false;
     }
 
@@ -101,11 +97,7 @@ bool FileAnalyzer::Process(int len, const u_char* data) {
     } catch ( const hilti::rt::RuntimeError& e ) {
         STATE_DEBUG_MSG(hilti::rt::fmt("error during parsing, triggering analyzer violation: %s", e.what()));
         auto tag = spicy_mgr->tagForFileAnalyzer(_state.file().analyzer->Tag());
-#if ZEEK_VERSION_NUMBER >= 50200
         AnalyzerViolation(e.what(), reinterpret_cast<const char*>(data), len, tag);
-#else
-        // We don't have an an appropriate way to report this with older Zeeks.
-#endif
     } catch ( const hilti::rt::Exception& e ) {
         STATE_DEBUG_MSG(e.what());
         spicy_mgr->analyzerError(_state.file().analyzer, e.description(),
@@ -122,11 +114,7 @@ void FileAnalyzer::Finish() {
     } catch ( const hilti::rt::RuntimeError& e ) {
         STATE_DEBUG_MSG(hilti::rt::fmt("error during parsing, triggering analyzer violation: %s", e.what()));
         auto tag = spicy_mgr->tagForFileAnalyzer(_state.file().analyzer->Tag());
-#if ZEEK_VERSION_NUMBER >= 50200
         AnalyzerViolation(e.what(), "", 0, tag);
-#else
-        // We don't have an an appropriate way to report this with older Zeeks.
-#endif
     } catch ( const hilti::rt::Exception& e ) {
         spicy_mgr->analyzerError(_state.file().analyzer, e.description(),
                                  e.location()); // this sets Zeek to skip sending any further input

--- a/src/spicy/runtime-support.h
+++ b/src/spicy/runtime-support.h
@@ -772,11 +772,7 @@ inline void set_record_field(RecordVal* rval, const IntrusivePtr<RecordType>& rt
     if constexpr ( NoConversionNeeded::value )
         rval->Assign(idx, x);
     else if constexpr ( IsSignedInteger::value )
-#if ZEEK_VERSION_NUMBER >= 50200
         rval->Assign(idx, static_cast<int64_t>(x.Ref()));
-#else
-        rval->Assign(idx, static_cast<int>(x.Ref()));
-#endif
     else if constexpr ( IsUnsignedInteger::value )
         rval->Assign(idx, static_cast<uint64_t>(x.Ref()));
     else if constexpr ( std::is_same_v<T, hilti::rt::Bytes> )

--- a/src/spicy/spicyz/CMakeLists.txt
+++ b/src/spicy/spicyz/CMakeLists.txt
@@ -3,7 +3,7 @@
 configure_file(config.h.in config.h)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h DESTINATION include/zeek/spicy/spicyz)
 
-add_executable(spicyz driver.cc glue-compiler.cc main.cc)
+add_executable(spicyz driver.cc glue-compiler.cc main.cc zeek-version.cc)
 target_compile_options(spicyz PRIVATE "-Wall")
 target_compile_features(spicyz PRIVATE "${ZEEK_CXX_STD}")
 set_target_properties(spicyz PROPERTIES CXX_EXTENSIONS OFF)

--- a/src/spicy/spicyz/config.h.in
+++ b/src/spicy/spicyz/config.h.in
@@ -58,10 +58,7 @@ inline const auto CxxZeekIncludesDirectories() {
 
 // Version of Spicy that we are compiling against.
 #cmakedefine SPICY_VERSION_NUMBER ${SPICY_VERSION_NUMBER}
-#cmakedefine ZEEK_VERSION_NUMBER ${ZEEK_VERSION_NUMBER}
 
-inline const auto SpicyVersion = "${SPICY_VERSION_LONG}";
-inline const auto ZeekVersion = "${ZEEK_VERSION_FULL}";
 inline const auto InstallPrefix = path("${CMAKE_INSTALL_PREFIX}");
 
 } // namespace zeek::spicy::configuration

--- a/src/spicy/spicyz/main.cc
+++ b/src/spicy/spicyz/main.cc
@@ -8,6 +8,7 @@
 #include "config.h"
 #include "driver.h"
 #include "glue-compiler.h"
+#include "zeek-version.h"
 
 using namespace zeek::spicy;
 
@@ -194,9 +195,9 @@ static hilti::Result<Nothing> parseOptions(int argc, char** argv, hilti::driver:
                 compiler_options->keep_tmps = true;
                 break;
 
-            case 'v': std::cout << configuration::ZeekVersion << std::endl; return Nothing();
+            case 'v': std::cout << configuration::ZeekVersionString() << std::endl; return Nothing();
 
-            case 'V': std::cout << ZEEK_VERSION_NUMBER << std::endl; return Nothing();
+            case 'V': std::cout << configuration::ZeekVersionNumber() << std::endl; return Nothing();
 
             case 'z': {
                 if ( auto zcfg = getenv("ZEEK_CONFIG"); zcfg && *zcfg )
@@ -245,7 +246,8 @@ static hilti::Result<Nothing> parseOptions(int argc, char** argv, hilti::driver:
 }
 
 int main(int argc, char** argv) {
-    Driver driver(std::make_unique<GlueCompiler>(), "", configuration::LibraryPath(), ZEEK_VERSION_NUMBER);
+    Driver driver(std::make_unique<GlueCompiler>(), "", configuration::LibraryPath(),
+                  configuration::ZeekVersionNumber());
 
     hilti::driver::Options driver_options;
     driver_options.execute_code = true;

--- a/src/spicy/spicyz/zeek-version.cc
+++ b/src/spicy/spicyz/zeek-version.cc
@@ -1,0 +1,11 @@
+// See the file "COPYING" in the main distribution directory for copyright.
+
+#include "zeek-version.h"
+
+#include "zeek/zeek-version.h"
+
+using namespace zeek::spicy;
+
+int configuration::ZeekVersionNumber() { return ZEEK_VERSION_NUMBER; }
+
+const char* configuration::ZeekVersionString() { return VERSION; }

--- a/src/spicy/spicyz/zeek-version.h
+++ b/src/spicy/spicyz/zeek-version.h
@@ -1,0 +1,10 @@
+// See the file "COPYING" in the main distribution directory for copyright.
+
+#pragma once
+
+namespace zeek::spicy::configuration {
+
+int ZeekVersionNumber();
+const char* ZeekVersionString();
+
+} // namespace zeek::spicy::configuration


### PR DESCRIPTION
As mentioned in the issue, bumping `VERSION` results in most of src/spicy being rebuilt for no good reason. Avoid this by removing the version numbers from spicyz/config.h.

Could see the two API functions also in zeek/util.cc, but wasn't sure if that's really worth it (requires library in cmake, etc etc).

Feedback welcome.

Closes #3139.