### PR TITLE
RE/Specific_RE_Matcher: Make Compile() return false for syntax errors

### DIFF
--- a/src/re-parse.y
+++ b/src/re-parse.y
@@ -9,10 +9,10 @@
 #include "zeek/EquivClass.h"
 #include "zeek/Reporter.h"
 
-int csize = 256;
-int syntax_error = 0;
 
 namespace zeek::detail {
+	constexpr int csize = 256;
+	bool re_syntax_error = 0;
 	int cupper(int sym);
 	int clower(int sym);
 }
@@ -230,7 +230,7 @@ ccl		:  ccl TOK_CHAR '-' TOK_CHAR
 
 ccl_expr:	   TOK_CCE
 			{
-			for ( int c = 0; c < csize; ++c )
+			for ( int c = 0; c < zeek::detail::csize; ++c )
 				if ( isascii(c) && $1(c) )
 					zeek::detail::curr_ccl->Add(c);
 			}
@@ -265,7 +265,7 @@ int clower(int sym)
 
 void synerr(const char str[])
 	{
-	syntax_error = true;
+	zeek::detail::re_syntax_error = true;
 	zeek::reporter->Error("%s (compiling pattern /%s/)", str, RE_parse_input);
 	}
 

--- a/src/re-scan.l
+++ b/src/re-scan.l
@@ -149,9 +149,13 @@ CCL_EXPR	("[:"[[:alpha:]]+":]")
 }
 
 <SC_QUOTE>{
-	[^"\n]$		zeek::detail::synerr("missing quote"); return '"';
 	[^"\n]		yylval.int_val = yytext[0]; return TOK_CHAR;
 	\"		BEGIN(INITIAL); return '"';
+	<<EOF>>		{
+			zeek::detail::synerr("missing quote");
+			BEGIN(INITIAL);
+			return '"';
+			}
 }
 
 <SC_FIRST_CCL>{
@@ -164,8 +168,8 @@ CCL_EXPR	("[:"[[:alpha:]]+":]")
 	-/[^\]\n]	return '-';
 	[^\]\n]		yylval.int_val = yytext[0]; return TOK_CHAR;
 	"]"		BEGIN(INITIAL); return ']';
-	[^\]]$		{
-			zeek::detail::synerr("bad character class");
+	<<EOF>>		{
+			zeek::detail::synerr("unterminated character class");
 			BEGIN(INITIAL);
 			return ']';
 			}


### PR DESCRIPTION
When creating RE_Matcher instances at runtime and verifying the pattern
compiles via Compile(), the syntax_error flag wasn't respected and
Compile() would return true even for some invalid regular expressions.

For example, compiling /a{1,b}/, Compile() would return true even though
it produced a reporter error while parsing complaining about b not
being valid.

This patch improves the error handling, so that calling Compile() returns
false whenever zeek::detail::synerr() was called while a pattern was
parsed. The use-case is creation of patterns at runtime based on
JavaScript strings. These might be entered or received at runtime via
an API. This change allows to be a bit more robust to detect invalid
input and raising exceptions to notify the user.

This also move syntax_error and csize out of global scope.

If RE_Matcher was to be used as an actual API, we likely should squelch
the reporter errors and mark it as not thread safe, but this is a small
step forward.