### PR TITLE
Add community contributions for the 6.2 timeframe to NEWS. [skip ci]

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,6 +55,10 @@ Deprecated Functionality
 Zeek 6.2.0
 ==========
 
+We would like to thank Anthony Verez (netantho), Bijoy Das (mute019), Jan
+Grashöfer (J-Gras), Matti Bispham (mbispham), Phil Rzewski (philrz), and
+xb-anssi for their contributions to this release.
+
 Breaking Changes
 ----------------
 


### PR DESCRIPTION
Let's start listing these. This list includes external contributions across `zeek/zeek` and its submodules during the 6.2 timeframe. I will cherry-pick into `release/6.2` when merging.