### PR TITLE
Add a CI test with the same options as we used for binary builds.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,7 @@ memory: &MEMORY 16GB
 config: &CONFIG --build-type=release --disable-broker-tests --prefix=$CIRRUS_WORKING_DIR/install --ccache --enable-werror
 no_spicy_config: &NO_SPICY_CONFIG --build-type=release --disable-broker-tests --disable-spicy --prefix=$CIRRUS_WORKING_DIR/install --ccache --enable-werror
 static_config: &STATIC_CONFIG --build-type=release --disable-broker-tests --enable-static-broker --enable-static-binpac --prefix=$CIRRUS_WORKING_DIR/install --ccache --enable-werror
+binary_config: &BINARY_CONFIG --prefix=$CIRRUS_WORKING_DIR/install --libdir=$CIRRUS_WORKING_DIR/install/lib --binary-package --enable-static-broker --enable-static-binpac --disable-broker-tests --build-type=Release --ccache --enable-werror
 asan_sanitizer_config: &ASAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=address --enable-fuzzers --enable-coverage --disable-spicy --ccache --enable-werror
 ubsan_sanitizer_config: &UBSAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=undefined --enable-fuzzers --disable-spicy --ccache --enable-werror
 tsan_sanitizer_config: &TSAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=thread --enable-fuzzers --disable-spicy --ccache --enable-werror
@@ -231,6 +232,20 @@ debian12_static_task:
   << : *SKIP_TASK_ON_PR
   env:
     ZEEK_CI_CONFIGURE_FLAGS: *STATIC_CONFIG
+
+debian12_binary_task:
+  container:
+    # Just use a recent/common distro to run binary mode compile test.
+    # As of 2024-03, the used configure flags are equivalent to the flags
+    # that we use to create binary packages.
+    # Just use a recent/common distro to run a static compile test.
+    # Debian 12 (bookworm) EOL: TBD
+    dockerfile: ci/debian-12/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+  env:
+    ZEEK_CI_CONFIGURE_FLAGS: *BINARY_CONFIG
 
 debian11_task:
   container:


### PR DESCRIPTION
We already do have a test that check static builds, but none that tests the exact same build flags we use for binary builds on OBS. This commit fixes this oversight.

Related to GH-3647