### PR TITLE
Bump Spicy to latest version reworking AST memory management.

### DIFF
--- a/src/spicy/spicyz/driver.cc
+++ b/src/spicy/spicyz/driver.cc
@@ -263,7 +263,7 @@ std::vector<std::pair<TypeInfo, hilti::ID>> Driver::exportedTypes() const {
     return result;
 }
 
-void Driver::hookNewASTPreCompilation(const hilti::Plugin& plugin, const std::shared_ptr<hilti::ASTRoot>& root) {
+void Driver::hookNewASTPreCompilation(const hilti::Plugin& plugin, hilti::ASTRoot* root) {
     auto v = VisitorTypes(this, _glue.get(), false);
     hilti::visitor::visit(v, root, ".spicy");
 
@@ -281,7 +281,7 @@ void Driver::hookNewASTPreCompilation(const hilti::Plugin& plugin, const std::sh
     }
 }
 
-bool Driver::hookNewASTPostCompilation(const hilti::Plugin& plugin, const std::shared_ptr<hilti::ASTRoot>& root) {
+bool Driver::hookNewASTPostCompilation(const hilti::Plugin& plugin, hilti::ASTRoot* root) {
     if ( plugin.component != "Spicy" )
         return false;
 
@@ -305,9 +305,7 @@ bool Driver::hookNewASTPostCompilation(const hilti::Plugin& plugin, const std::s
     return true;
 }
 
-hilti::Result<hilti::Nothing> Driver::hookCompilationFinished(const std::shared_ptr<hilti::ASTRoot>& root) {
-    return _error;
-}
+hilti::Result<hilti::Nothing> Driver::hookCompilationFinished(hilti::ASTRoot* root) { return _error; }
 
 void Driver::hookInitRuntime() { ::spicy::rt::init(); }
 

--- a/src/spicy/spicyz/driver.h
+++ b/src/spicy/spicyz/driver.h
@@ -31,9 +31,9 @@ namespace zeek::spicy {
 class GlueCompiler;
 
 struct TypeInfo {
-    hilti::ID id;                        /**< fully-qualified name of the type */
-    hilti::QualifiedTypePtr type;        /**< the type itself */
-    hilti::declaration::Linkage linkage; /**< linkage of of the type's declaration */
+    hilti::ID id;                         /**< fully-qualified name of the type */
+    hilti::QualifiedType* type = nullptr; /**< the type itself */
+    hilti::declaration::Linkage linkage;  /**< linkage of of the type's declaration */
     bool is_resolved = false; /**< true if we are far enough in processing that the type has been fully resolved */
     hilti::ID module_id;      /**< name of module type is defined in */
     hilti::rt::filesystem::path module_path; /**< path of module that type is defined in */
@@ -175,13 +175,13 @@ protected:
     virtual void hookNewType(const TypeInfo& ti) {}
 
     /** Overridden from HILTI driver. */
-    void hookNewASTPreCompilation(const hilti::Plugin& plugin, const std::shared_ptr<hilti::ASTRoot>& root) override;
+    void hookNewASTPreCompilation(const hilti::Plugin& plugin, hilti::ASTRoot* root) override;
 
     /** Overridden from HILTI driver. */
-    bool hookNewASTPostCompilation(const hilti::Plugin& plugin, const std::shared_ptr<hilti::ASTRoot>& root) override;
+    bool hookNewASTPostCompilation(const hilti::Plugin& plugin, hilti::ASTRoot* root) override;
 
     /** Overridden from HILTI driver. */
-    hilti::Result<hilti::Nothing> hookCompilationFinished(const std::shared_ptr<hilti::ASTRoot>& root) override;
+    hilti::Result<hilti::Nothing> hookCompilationFinished(hilti::ASTRoot* root) override;
 
     /** Overridden from HILTI driver. */
     void hookInitRuntime() override;

--- a/src/spicy/spicyz/glue-compiler.h
+++ b/src/spicy/spicyz/glue-compiler.h
@@ -101,7 +101,7 @@ struct SpicyModule {
     std::set<hilti::rt::filesystem::path> evts; /**< EVT files that refer to this module. */
 
     // Generated code.
-    hilti::ModulePtr spicy_module; /**< the ``BroHooks_*.spicy`` module. */
+    hilti::declaration::Module* spicy_module = nullptr; /**< the ``BroHooks_*.spicy`` module. */
 };
 
 /** Representation of an event parsed from an EVT file. */
@@ -119,7 +119,7 @@ struct Event {
     // Computed information.
     hilti::ID hook;                               /**< The name of the hook triggering the event. */
     hilti::ID unit;                               /**< The fully qualified name of the unit type. */
-    ::spicy::type::UnitPtr unit_type;             /**< The Spicy type of referenced unit. */
+    ::spicy::type::Unit* unit_type = nullptr;     /**< The Spicy type of referenced unit. */
     hilti::ID unit_module_id;                     /**< The name of the module the referenced unit is defined in. */
     hilti::rt::filesystem::path unit_module_path; /**< The path of the module that the referenced unit is defined in. */
     std::shared_ptr<glue::SpicyModule>
@@ -128,8 +128,8 @@ struct Event {
     // TODO: The following aren't set yet.
 
     // Code generation.
-    ::spicy::type::unit::item::UnitHookPtr spicy_hook;         /**< The generated Spicy hook. */
-    std::shared_ptr<hilti::declaration::Function> hilti_raise; /**< The generated HILTI raise() function. */
+    ::spicy::type::unit::item::UnitHook* spicy_hook = nullptr; /**< The generated Spicy hook. */
+    hilti::declaration::Function* hilti_raise = nullptr;       /**< The generated HILTI raise() function. */
     std::vector<ExpressionAccessor> expression_accessors; /**< One HILTI function per expression to access the value. */
 };
 
@@ -212,21 +212,21 @@ public:
      */
     ExportedField exportForField(const hilti::ID& zeek_id, const hilti::ID& field_id) const;
 
-    using ZeekTypeCache = std::map<hilti::ID, hilti::ExpressionPtr>;
+    using ZeekTypeCache = std::map<hilti::ID, hilti::Expression*>;
 
     /**
      * Generates code to convert a HILTI type to a corresponding Zeek type at
      * runtime. The code is added to the given body.
      */
-    hilti::Result<hilti::Nothing> createZeekType(const hilti::QualifiedTypePtr& t, const hilti::ID& id,
+    hilti::Result<hilti::Nothing> createZeekType(hilti::QualifiedType* t, const hilti::ID& id,
                                                  ::spicy::Builder* builder, ZeekTypeCache* cache) const;
 
     /** Return type for `recordField()`. */
     struct RecordField {
-        hilti::ID id;                 /**< name of record field */
-        hilti::QualifiedTypePtr type; /**< Spicy-side type object */
-        bool is_optional;             /**< true if field is optional */
-        bool is_anonymous;            /**< true if field is annymous */
+        hilti::ID id;                         /**< name of record field */
+        hilti::QualifiedType* type = nullptr; /**< Spicy-side type object */
+        bool is_optional;                     /**< true if field is optional */
+        bool is_anonymous;                    /**< true if field is annymous */
     };
 
     /**


### PR DESCRIPTION
Includes the necessary Zeek-side changes.

Goes with https://github.com/zeek/spicy/pull/1691.
