### PR TITLE
Remove variant from StdFunctionStmt

### DIFF
--- a/src/Func.cc
+++ b/src/Func.cc
@@ -129,7 +129,7 @@ void Func::AddBody(const detail::FunctionIngredients& ingr, detail::StmtPtr new_
 void Func::AddBody(detail::StmtPtr new_body, const std::vector<detail::IDPtr>& new_inits, size_t new_frame_size,
                    int priority) {
     std::set<EventGroupPtr> groups;
-    AddBody(new_body, new_inits, new_frame_size, priority, groups);
+    AddBody(std::move(new_body), new_inits, new_frame_size, priority, groups);
 }
 
 void Func::AddBody(detail::StmtPtr new_body, size_t new_frame_size) {
@@ -143,7 +143,7 @@ void Func::AddBody(detail::StmtPtr /* new_body */, const std::vector<detail::IDP
     Internal("Func::AddBody called");
 }
 
-void Func::AddBody(detail::StdFunctionStmt::FunctionVariant body, int priority) {
+void Func::AddBody(std::function<void(const zeek::Args&, detail::StmtFlowType&)> body, int priority) {
     auto stmt = zeek::make_intrusive<detail::StdFunctionStmt>(std::move(body));
     AddBody(stmt, {}, priority);
 }

--- a/src/Func.h
+++ b/src/Func.h
@@ -114,7 +114,7 @@ public:
     void AddBody(detail::StmtPtr new_body, const std::vector<detail::IDPtr>& new_inits, size_t new_frame_size,
                  int priority = 0);
     void AddBody(detail::StmtPtr new_body, size_t new_frame_size);
-    void AddBody(detail::StdFunctionStmt::FunctionVariant body, int priority = 0);
+    void AddBody(std::function<void(const zeek::Args&, detail::StmtFlowType&)> body, int priority = 0);
 
     virtual void SetScope(detail::ScopePtr newscope);
     virtual detail::ScopePtr GetScope() const { return scope; }

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -2087,12 +2087,9 @@ TraversalCode WhenStmt::Traverse(TraversalCallback* cb) const {
 ValPtr StdFunctionStmt::Exec(Frame* f, StmtFlowType& flow) {
     zeek::Args args = *f->GetFuncArgs();
 
-    if ( func.index() == 0 ) {
-        flow = FLOW_NEXT;
-        std::get<0>(func)(args);
-    }
-    else
-        std::get<1>(func)(args, flow);
+    // Set this to NEXT by default. The function can override that if it wants.
+    flow = FLOW_NEXT;
+    func(args, flow);
 
     return nullptr;
 }

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -784,9 +784,8 @@ protected:
 // to directly all a C++ method.
 class StdFunctionStmt : public Stmt {
 public:
-    using FunctionVariant =
-        std::variant<std::function<void(const zeek::Args&)>, std::function<void(const zeek::Args&, StmtFlowType&)>>;
-    StdFunctionStmt(FunctionVariant f) : Stmt(STMT_STD_FUNCTION), func(std::move(f)) {}
+    StdFunctionStmt(std::function<void(const zeek::Args&, StmtFlowType&)> f)
+        : Stmt(STMT_STD_FUNCTION), func(std::move(f)) {}
 
     ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 
@@ -798,7 +797,7 @@ public:
     TraversalCode Traverse(TraversalCallback* cb) const override { return TC_CONTINUE; }
 
 private:
-    FunctionVariant func;
+    std::function<void(const zeek::Args&, StmtFlowType&)> func;
 };
 
 } // namespace zeek::detail

--- a/testing/btest/plugins/protocol-plugin/src/Foo.cc
+++ b/testing/btest/plugins/protocol-plugin/src/Foo.cc
@@ -15,17 +15,17 @@ Foo::Foo(zeek::Connection* conn) : zeek::analyzer::tcp::TCP_ApplicationAnalyzer(
 
     auto handler = zeek::event_registry->Lookup("connection_established");
     if ( handler ) {
-        handler->GetFunc()->AddBody([](const zeek::Args& args) {
+        handler->GetFunc()->AddBody([](const zeek::Args& args, zeek::detail::StmtFlowType& flow) {
             printf("c++ connection_established lambda handler, received %zu arguments\n", args.size());
         });
 
-        handler->GetFunc()->AddBody(std::bind(&Foo::ConnectionEstablishedHandler, this, _1));
+        handler->GetFunc()->AddBody(std::bind(&Foo::ConnectionEstablishedHandler, this, _1, _2));
     }
 }
 
 Foo::~Foo() { delete interp; }
 
-void Foo::ConnectionEstablishedHandler(const zeek::Args& args) {
+void Foo::ConnectionEstablishedHandler(const zeek::Args& args, zeek::detail::StmtFlowType& flow) {
     printf("c++ connection_established member handler, received %zu arguments\n", args.size());
 }
 

--- a/testing/btest/plugins/protocol-plugin/src/Foo.h
+++ b/testing/btest/plugins/protocol-plugin/src/Foo.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "Stmt.h"
 #include "analyzer/protocol/pia/PIA.h"
 #include "analyzer/protocol/tcp/TCP.h"
 
@@ -23,7 +24,7 @@ public:
     virtual void EndpointEOF(bool is_orig);
 
     static zeek::analyzer::Analyzer* Instantiate(zeek::Connection* conn) { return new Foo(conn); }
-    void ConnectionEstablishedHandler(const zeek::Args& args);
+    void ConnectionEstablishedHandler(const zeek::Args& args, zeek::detail::StmtFlowType& flow);
 
 protected:
     binpac::Foo::Foo_Conn* interp;


### PR DESCRIPTION
The variant ended up conflicting with std::bind, which resulted in failures on the btest invoking it. Change back to a single function that takes a flow, and default it to a value in Exec.