### PR TITLE
CI: Specify the xcode version of the macOS Sonoma instance

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -339,7 +339,7 @@ alpine_task:
 # We aim to support both the current and previous macOS release.
 macos_sonoma_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-base:latest
+    image: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_ENVIRONMENT


### PR DESCRIPTION
A recent update to the base image by Cirrus caused our build to break. https://github.com/cirruslabs/cirrus-ci-docs/issues/1272 says that it's a problem with the base OS itself, and they recommended we try to xcode image instead.