### PR TITLE
fix: set SignatureFile.full_path if invalid

### DIFF
--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -241,8 +241,8 @@ bool RuleMatcher::ReadFiles(const std::vector<SignatureFile>& files) {
         // if load is relative to the load location, and we don't have a valid full_path
         // let's fix it by setting the full_path to load location and relative path
         if ( f.file.find("./") == 0 && (! f.full_path.has_value() || f.full_path == "") ) {
-          auto full_path = std::string(f.load_location.filename) + "/" + f.file);
-          f.full_path = util::detail::normalize_path(full_path);
+            auto full_path = std::string(f.load_location.filename) + "/" + f.file;
+            f.full_path = util::detail::normalize_path(full_path);
         }
 
         if ( ! f.full_path )

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -238,6 +238,13 @@ bool RuleMatcher::ReadFiles(const std::vector<SignatureFile>& files) {
     parse_error = false;
 
     for ( auto f : files ) {
+        // if load is relative to the load location, and we don't have a valid full_path
+        // let's fix it by setting the full_path to load location and relative path
+        if ( f.file.find("./") == 0 && (! f.full_path.has_value() || f.full_path == "") ) {
+          auto full_path = std::string(f.load_location.filename) + "/" + f.file);
+          f.full_path = util::detail::normalize_path(full_path);
+        }
+
         if ( ! f.full_path )
             f.full_path = util::find_file(f.file, util::zeek_path(), ".sig");
 

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -240,7 +240,7 @@ bool RuleMatcher::ReadFiles(const std::vector<SignatureFile>& files) {
     for ( auto f : files ) {
         // if load is relative to the load location, and we don't have a valid full_path
         // let's fix it by setting the full_path to load location and relative path
-        if ( f.file.find("./") == 0 && (! f.full_path.has_value() || f.full_path == "") ) {
+        if ( f.file.find("./") == 0 && f.load_location.filename && (! f.full_path.has_value() || f.full_path == "") ) {
             auto full_path = std::string(f.load_location.filename) + "/" + f.file;
             f.full_path = util::detail::normalize_path(full_path);
         }


### PR DESCRIPTION
This sets SignatureFile::full_path member variable to the full path if SignatureFile::file member is relative and full_path is invalid. This uses the SignatureFile::load_location to derive the full path from the file path relative to the load_location.

This is needed when the full_path is passed in to either HookLoadFile and/or HookLoadFileExtended.