### PR TITLE
Improving ZAM's estimation of profiling overheads

### DIFF
--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -325,6 +325,8 @@ static void init_options() {
         // the usual "-O ZAM" profile. But if they have, honor those.
         if ( ! analysis_options.gen_ZAM_code )
             analysis_options.gen_ZAM = true;
+
+        estimate_ZAM_profiling_overhead();
     }
 
     if ( analysis_options.gen_ZAM ) {

--- a/src/script_opt/ZAM/Ops.in
+++ b/src/script_opt/ZAM/Ops.in
@@ -1232,11 +1232,12 @@ eval	auto rt = cast_intrusive<RecordType>(z.t);
 	auto n = aux->n;
 	for ( auto i = 0; i < n; ++i )
 		{
-		auto v_i = r->GetField(aux->elems[i].IntVal());
+		auto ind = aux->elems[i].IntVal();
+		auto v_i = r->GetField(ind);
 		ASSERT(v_i);
 		if ( v_i->GetType<VectorType>()->IsUnspecifiedVector() )
 			{
-			const auto& t_i = rt->GetFieldType(i);
+			const auto& t_i = rt->GetFieldType(ind);
 			v_i->AsVectorVal()->Concretize(t_i->Yield());
 			}
 		}

--- a/src/script_opt/ZAM/Profile.h
+++ b/src/script_opt/ZAM/Profile.h
@@ -35,6 +35,9 @@ private:
     std::shared_ptr<ZAMLocInfo> parent;
 };
 
+// Computes the approximate overhead of ZAM CPU and memory profiling.
+extern void estimate_ZAM_profiling_overhead();
+
 // Reports a profile of the different ZAM operations (instructions)
 // that executed.
 extern void report_ZOP_profile();


### PR DESCRIPTION
This PR started off as monthly script-optimization maintenance (per the branch name), but it turned out that nothing was needed for either ZAM or compile-to-C++, other than this improvement to how ZAM estimates profiling overhead.

The estimate is important because not taking the overhead into account can significantly skew conclusions about which ZAM instructions are consuming the most CPU time, biasing towards those executed very frequently even if they're in fact inexpensive. Previously, ZAM used as its estimates the average of a bunch of calls made to the relevant function (either getting CPU time, or getting memory usage). I found that on some Linux systems these estimates could vary a great deal (e.g., 30+% difference), which skewed A/B comparisons of resource consumption that I was making. The alternative implemented here is to look at the _minimum_ rather than the _average_, as the former is robust against inflation due to outlier spikes. However, the minimums still need to be accumulated over a window to ensure they don't fly under the measurement precision and come out as 0. The new estimator function takes both a total number of calls to measure and a window over which to take measurements to then use to find the minimum seen across any window. Testing on MacOS and Linux shows this to be quite stable, with < 1% fluctuations.

Because overhead measurement takes non-trivial time and is only useful for ZAM profiling, this PR also changes things to only compute the measurement if ZAM profiling is in use.

Finally, in https://github.com/zeek/zeek/pull/3644 there was discussion of using `clock_gettime(CLOCK_THREAD_CPUTIME_ID, ...)` as a way to get cleaner CPU times. I tried this under Linux but it didn't make any difference, the averages still exhibited considerable spikes.