### PR TITLE
Raise configure error message for unsupported archives

### DIFF
--- a/configure
+++ b/configure
@@ -145,6 +145,25 @@ Zeek. To check out the required subdirectories, please execute:
     exit 1
 fi
 
+if [ ! -e "$sourcedir/cmake/COPYING" ] && [ ! -d "$sourcedir/.git" ]; then
+    echo "\
+You seem to be missing the content of the cmake directory.
+
+This typically means that you downloaded a non-release archive from github.
+These archives do not contain all required files.
+
+If you want to download the current release of Zeek, please download a full
+archive using one of the links at https://zeek.org/get-zeek/.
+
+If you want to get the current development version of Zeek, please use git to
+clone our repository.
+
+See https://docs.zeek.org/en/master/install.html#retrieving-the-sources for
+instructions.
+" >&2
+    exit 1
+fi
+
 # Function to append a CMake cache entry definition to the
 # CMakeCacheEntries variable.
 #   $1 is the cache entry variable name

--- a/configure
+++ b/configure
@@ -133,8 +133,9 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
 
 sourcedir="$(cd "$(dirname "$0")" && pwd)"
 
-if [ ! -e "$sourcedir/cmake/COPYING" ] && [ -d "$sourcedir/.git" ]; then
-    echo "\
+if [ ! -e "$sourcedir/cmake/COPYING" ]; then
+    if [ -d "$sourcedir/.git" ]; then
+        echo "\
 You seem to be missing the content of the cmake directory.
 
 This typically means that you performed a non-recursive git clone of
@@ -142,11 +143,8 @@ Zeek. To check out the required subdirectories, please execute:
 
   ( cd $sourcedir && git submodule update --recursive --init )
 " >&2
-    exit 1
-fi
-
-if [ ! -e "$sourcedir/cmake/COPYING" ] && [ ! -d "$sourcedir/.git" ]; then
-    echo "\
+    else
+        echo "\
 You seem to be missing the content of the cmake directory.
 
 This typically means that you downloaded a non-release archive from github.
@@ -161,6 +159,7 @@ clone our repository.
 See https://docs.zeek.org/en/master/install.html#retrieving-the-sources for
 instructions.
 " >&2
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
Github lets users download archives of our repos. These do not contain the necessary submodules. We regularly encounter users who stumble across this.

We already do have an error message that is raised when a non-recursive git checkout was done. This commit adds an error message for a non-git download that does not contain the necessary files.