### PR TITLE
CI: Fix installation of python package on macOS

### DIFF
--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -8,7 +8,12 @@ set -x
 brew update
 brew upgrade cmake
 brew install openssl@3 swig bison flex ccache libmaxminddb
-python3 -m pip install --user websockets
+
+if [ $(sw_vers -productVersion | cut -d '.' -f 1) -lt 14 ]; then
+    python3 -m pip install --upgrade pip
+fi
+
+python3 -m pip install --user --break-system-packages websockets
 
 # Brew doesn't create the /opt/homebrew/opt/openssl symlink if you install
 # openssl@1.1, only with 3.0. Create the symlink if it doesn't exist.

--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -14,11 +14,3 @@ if [ $(sw_vers -productVersion | cut -d '.' -f 1) -lt 14 ]; then
 fi
 
 python3 -m pip install --user --break-system-packages websockets
-
-# Brew doesn't create the /opt/homebrew/opt/openssl symlink if you install
-# openssl@1.1, only with 3.0. Create the symlink if it doesn't exist.
-#if [ ! -e /opt/homebrew/opt/openssl ]; then
-#    if [ -d /opt/homebrew/opt/openssl@1.1 ]; then
-#        ln -s /opt/homebrew/opt/openssl@1.1 /opt/homebrew/opt/openssl
-#    fi
-#fi


### PR DESCRIPTION
The macOS Sonoma image updated to a version of python that cares about `--break-system-packages`, similar to all of the Linux images which did the same a while back. This fixes the install failure in the same way as those.