### PR TITLE
Don't attempt to stop or flush disabled writer frontends

### DIFF
--- a/src/logging/WriterFrontend.cc
+++ b/src/logging/WriterFrontend.cc
@@ -133,6 +133,11 @@ WriterFrontend::~WriterFrontend() {
 }
 
 void WriterFrontend::Stop() {
+    if ( disabled ) {
+        CleanupWriteBuffer();
+        return;
+    }
+
     FlushWriteBuffer();
     SetDisable();
 
@@ -204,6 +209,11 @@ void WriterFrontend::Write(int arg_num_fields, Value** vals) {
 }
 
 void WriterFrontend::FlushWriteBuffer() {
+    if ( disabled ) {
+        CleanupWriteBuffer();
+        return;
+    }
+
     if ( ! write_buffer_pos )
         // Nothing to do.
         return;
@@ -259,6 +269,18 @@ void WriterFrontend::DeleteVals(int num_fields, Value** vals) {
         delete vals[i];
 
     delete[] vals;
+}
+
+void WriterFrontend::CleanupWriteBuffer() {
+    if ( ! write_buffer || write_buffer_pos == 0 )
+        return;
+
+    for ( int j = 0; j < write_buffer_pos; j++ )
+        DeleteVals(num_fields, write_buffer[j]);
+
+    delete[] write_buffer;
+    write_buffer = nullptr;
+    write_buffer_pos = 0;
 }
 
 } // namespace zeek::logging

--- a/src/logging/WriterFrontend.h
+++ b/src/logging/WriterFrontend.h
@@ -206,6 +206,9 @@ protected:
     static const int WRITER_BUFFER_SIZE = 1000;
     int write_buffer_pos;             // Position of next write in buffer.
     threading::Value*** write_buffer; // Buffer of size WRITER_BUFFER_SIZE.
+
+private:
+    void CleanupWriteBuffer();
 };
 
 } // namespace zeek::logging


### PR DESCRIPTION
When a writer fails to start up, the backend tells the frontend to disable itself via a call to `WriterFrontend::SetDisable()`. The backend may be marked invalid and deleted by the threading manager at that point, but the pointer is still valid in the frontend. Most operations in the frontend check for this state before they try to do anything, but `Stop()` and `FlushWriteBuffer()` both don't. If they attempt to use the backend once it's been deleted, it runs into a use-after-free and crashes.

Fixes #3662 