### PR TITLE
Check for valid identifier in WhenStmt::Describe

### DIFF
--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -2029,7 +2029,10 @@ void WhenStmt::StmtDescribe(ODesc* d) const {
             if ( c.IsDeepCopy() )
                 d->Add("copy ");
 
-            d->Add(c.Id()->Name());
+            if ( c.Id() )
+                d->Add(c.Id()->Name());
+            else
+                d->Add("<error>");
         }
         d->Add("]");
     }

--- a/testing/btest/Baseline/language.when-local-function-capture-error/out
+++ b/testing/btest/Baseline/language.when-local-function-capture-error/out
@@ -1,0 +1,2 @@
+error in /Users/tim/Desktop/projects/zeek-master/testing/btest/.tmp/language.when-local-function-capture-error/when-local-function-capture-error.zeek, line 9: no such local identifier: z
+error in /Users/tim/Desktop/projects/zeek-master/testing/btest/.tmp/language.when-local-function-capture-error/when-local-function-capture-error.zeek, lines 12-16: y is used inside "when" statement but not captured (when [x, <error>](T == T) { print hmm?, x, y} timeout 100.0 msecs { print timeout})

--- a/testing/btest/language/when-local-function-capture-error.zeek
+++ b/testing/btest/language/when-local-function-capture-error.zeek
@@ -1,0 +1,17 @@
+# @TEST-DOC: Tests that a capture in a function that doesn't exist doesn't crash
+# @TEST-EXEC-FAIL: zeek -b %INPUT >out 2>&1
+# @TeST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff out
+
+function f() {
+        local x = 1;
+        local y = 2;
+
+        when [x, z] ( T == T )
+                {
+                print "hmm?", x, y;
+                }
+        timeout 100msec
+                {
+                print "timeout";
+                }
+}


### PR DESCRIPTION
Fixes #3456

I tried adding the test to language.when-capture-errors, but it didn't want to trigger as part of that. It would only trigger when it was in a file by itself.