### PR TITLE
Bump Spicy to latest `main`

### DIFF
--- a/src/analyzer/protocol/quic/QUIC.spicy
+++ b/src/analyzer/protocol/quic/QUIC.spicy
@@ -280,7 +280,7 @@ public type LongHeaderPacket = unit {
 };
 
 # A QUIC Frame.
-public type Frame = unit(header: LongHeaderPacket, from_client: bool, inout crypto_sink: sink) {
+public type Frame = unit(header: LongHeaderPacket, from_client: bool, crypto_sink: sink&) {
   frame_type : uint8 &convert=cast<FrameType>($$);
 
   # TODO: add other FrameTypes as well
@@ -289,7 +289,7 @@ public type Frame = unit(header: LongHeaderPacket, from_client: bool, inout cryp
     FrameType::ACK2 -> b: ACKPayload;
     FrameType::CRYPTO -> c: CRYPTOPayload(from_client) {
       # Have the sink re-assemble potentially out-of-order cryptodata
-      crypto_sink.write(self.c.cryptodata, self.c.offset.result);
+      (*crypto_sink).write(self.c.cryptodata, self.c.offset.result);
     }
     FrameType::CONNECTION_CLOSE1 -> : ConnectionClosePayload(header);
 @if SPICY_VERSION >= 10800
@@ -447,7 +447,7 @@ type CryptoBuffer = unit() {
 #
 # A UDP datagram contains one or more QUIC packets.
 ##############
-type Packet = unit(from_client: bool, inout context: ConnectionIDInfo&) {
+type Packet = unit(from_client: bool, context: ConnectionIDInfo&) {
   var decrypted_data: bytes;
   var full_packet: bytes;
   var start: iterator<stream>;
@@ -459,10 +459,10 @@ type Packet = unit(from_client: bool, inout context: ConnectionIDInfo&) {
   on %init {
 @if SPICY_VERSION >= 10800
     if ( ! context?.ssl_handle ) {
-      context.ssl_handle = zeek::protocol_handle_get_or_create("SSL");
+      (*context).ssl_handle = zeek::protocol_handle_get_or_create("SSL");
     }
 @else
-    if ( ! context.did_ssl_begin ) {
+    if ( ! (context).did_ssl_begin ) {
       zeek::protocol_begin("SSL");
       context.did_ssl_begin = True;
     }
@@ -492,14 +492,14 @@ type Packet = unit(from_client: bool, inout context: ConnectionIDInfo&) {
         # If we see a retry packet from the responder, reset the decryption
         # context such that the next DCID from the client is used for decryption.
         if ( self.long_header.is_retry ) {
-          context.client_initial_processed = False;
-          context.server_initial_processed = False;
-          context.initial_destination_conn_id = b"";
+          (*context).client_initial_processed = False;
+          (*context).server_initial_processed = False;
+          (*context).initial_destination_conn_id = b"";
 
           # Allow re-opening the SSL analyzer the next time around.
 @if SPICY_VERSION >= 10800
           zeek::protocol_handle_close(context.ssl_handle);
-          unset context.ssl_handle;
+          unset (*context).ssl_handle;
 @else
           zeek::protocol_end();
           context.did_ssl_begin = False;
@@ -514,8 +514,8 @@ type Packet = unit(from_client: bool, inout context: ConnectionIDInfo&) {
     self.crypto_sink.connect(self.crypto_buffer);
 
     if ( from_client ) {
-      context.server_cid_len = self.long_header.dest_conn_id_len;
-      context.client_cid_len = self.long_header.src_conn_id_len;
+      (*context).server_cid_len = self.long_header.dest_conn_id_len;
+      (*context).client_cid_len = self.long_header.src_conn_id_len;
 
       # This means that here, we can try to decrypt the initial packet!
       # All data is accessible via the `long_header` unit
@@ -531,12 +531,12 @@ type Packet = unit(from_client: bool, inout context: ConnectionIDInfo&) {
       # Assuming that the client set up the connection, this can be considered the first
       # received Initial from the client. So disable change of ConnectionID's afterwards
       if ( |context.initial_destination_conn_id| == 0 ) {
-        context.initial_destination_conn_id = self.long_header.dest_conn_id;
+        (*context).initial_destination_conn_id = self.long_header.dest_conn_id;
       }
 
     } else {
-      context.server_cid_len = self.long_header.src_conn_id_len;
-      context.client_cid_len = self.long_header.dest_conn_id_len;
+      (*context).server_cid_len = self.long_header.src_conn_id_len;
+      (*context).client_cid_len = self.long_header.dest_conn_id_len;
 
       self.decrypted_data = decrypt_crypto_payload(
         self.long_header.version,
@@ -587,9 +587,9 @@ type Packet = unit(from_client: bool, inout context: ConnectionIDInfo&) {
       # Stop decryption attempts after processing the very first INITIAL
       # INITIAL packet for which we forwarded data to the SSL analyzer.
       if ( from_client )
-        context.client_initial_processed = True;
+        (*context).client_initial_processed = True;
       else
-        context.server_initial_processed = True;
+        (*context).server_initial_processed = True;
 
       # Take buffered crypto data as confirmation signal.
       spicy::accept_input();


### PR DESCRIPTION
The new reference parameter handling requires slight adjustments to the QUIC analyzer. These changes make it incompatible with earlier versions, but since this analyzer is in tree we do not need to worry about this (we leave cleanup of the remaining `SPICY_VERSION` checks for later).