### PR TITLE
fix for ZAM optimization of "while" loops

### DIFF
--- a/src/script_opt/Stmt.cc
+++ b/src/script_opt/Stmt.cc
@@ -469,6 +469,11 @@ bool WhileStmt::IsReduced(Reducer* c) const {
 }
 
 StmtPtr WhileStmt::DoReduce(Reducer* c) {
+    if ( loop_cond_pred_stmt )
+        // Important to do this before updating the loop_condition, since
+        // changes to the predecessor statement can alter the condition.
+        loop_cond_pred_stmt = loop_cond_pred_stmt->Reduce(c);
+
     if ( c->Optimizing() )
         loop_condition = c->OptExpr(loop_condition);
     else {
@@ -490,9 +495,6 @@ StmtPtr WhileStmt::DoReduce(Reducer* c) {
     // its check for whether the expression is being ignored, since
     // we're not actually creating an ExprStmt for execution.
     stmt_loop_condition = with_location_of(make_intrusive<ExprStmt>(STMT_EXPR, loop_condition), this);
-
-    if ( loop_cond_pred_stmt )
-        loop_cond_pred_stmt = loop_cond_pred_stmt->Reduce(c);
 
     return ThisPtr();
 }
@@ -680,7 +682,7 @@ StmtPtr StmtList::DoReduce(Reducer* c) {
 bool StmtList::ReduceStmt(unsigned int& s_i, std::vector<StmtPtr>& f_stmts, Reducer* c) {
     bool did_change = false;
     auto& stmt_i = stmts[s_i];
-    auto old_stmt = stmt_i.get();
+    auto old_stmt = stmt_i;
 
     auto stmt = stmt_i->Reduce(c);
 


### PR DESCRIPTION
In some testing this morning I ran across a ZAM problem rooted in the order of how it optimizes the conditions in `while` loops. This simple PR fixes the problem, and also adds a memory-management tidiness (that I thought I'd done previously but I guess it was lost).