### PR TITLE
Gracefully handle empty shadow files

### DIFF
--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -118,7 +118,7 @@ static std::optional<LeftoverLog> parse_shadow_log(const std::string& fname) {
     auto sfname = prefix_basename_with(fname, shadow_file_prefix);
     string default_ext = "." + Ascii::LogExt();
     if ( BifConst::LogAscii::gzip_level > 0 )
-	default_ext += ".gz";
+        default_ext += ".gz";
 
     LeftoverLog rval = {};
     rval.filename = fname;
@@ -169,11 +169,11 @@ static std::optional<LeftoverLog> parse_shadow_log(const std::string& fname) {
     auto sf_lines = util::tokenize_string(sf_view, '\n');
 
     if ( sf_lines.size() < 2 ) {
-        reporter->Warning("Found leftover log, '%s', but the associated shadow "
-                          " file, '%s', required to process it is invalid: using default "
-                          " for extension (%s) and post_proc_func",
-                          rval.filename.data(), rval.shadow_filename.data(),
-                          default_ext.data());
+        reporter->Warning(
+            "Found leftover log, '%s', but the associated shadow "
+            " file, '%s', required to process it is invalid: using default "
+            " for extension (%s) and post_proc_func",
+            rval.filename.data(), rval.shadow_filename.data(), default_ext.data());
     }
     else {
         rval.extension = sf_lines[0];

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -116,10 +116,14 @@ TEST_CASE("writers.ascii prefix_basename_with") {
 
 static std::optional<LeftoverLog> parse_shadow_log(const std::string& fname) {
     auto sfname = prefix_basename_with(fname, shadow_file_prefix);
+    string default_ext = "." + Ascii::LogExt();
+    if ( BifConst::LogAscii::gzip_level > 0 )
+	default_ext += ".gz";
 
     LeftoverLog rval = {};
     rval.filename = fname;
     rval.shadow_filename = std::move(sfname);
+    rval.extension = default_ext;
 
     auto sf_stream = fopen(rval.shadow_filename.data(), "r");
 
@@ -165,15 +169,16 @@ static std::optional<LeftoverLog> parse_shadow_log(const std::string& fname) {
     auto sf_lines = util::tokenize_string(sf_view, '\n');
 
     if ( sf_lines.size() < 2 ) {
-        rval.error = util::
-            fmt("Found leftover log, '%s', but the associated shadow "
-                " file, '%s', required to process it is invalid",
-                rval.filename.data(), rval.shadow_filename.data());
-        return rval;
+        reporter->Warning("Found leftover log, '%s', but the associated shadow "
+                          " file, '%s', required to process it is invalid: using default "
+                          " for extension (%s) and post_proc_func",
+                          rval.filename.data(), rval.shadow_filename.data(),
+                          default_ext.data());
     }
-
-    rval.extension = sf_lines[0];
-    rval.post_proc_func = sf_lines[1];
+    else {
+        rval.extension = sf_lines[0];
+        rval.post_proc_func = sf_lines[1];
+    }
 
     struct stat st;
 


### PR DESCRIPTION
When a shadow file is empty/missing during rotation, Zeek aborts with an error message, but if the shadow file was empty, it will still be there after the restart. That causes an endless restart loop. This solution gracefully handles the rotation in such cases using the default file extension and post processing function.