### PR TITLE
Avoid calling typecasts in Val when we have direct access to the underlying value object

### DIFF
--- a/src/Val.cc
+++ b/src/Val.cc
@@ -742,22 +742,18 @@ StringVal::~StringVal() { delete string_val; }
 
 ValPtr StringVal::SizeVal() const { return val_mgr->Count(string_val->Len()); }
 
-int StringVal::Len() const { return AsString()->Len(); }
+int StringVal::Len() const { return string_val->Len(); }
 
-const u_char* StringVal::Bytes() const { return AsString()->Bytes(); }
+const u_char* StringVal::Bytes() const { return string_val->Bytes(); }
 
-const char* StringVal::CheckString() const { return AsString()->CheckString(); }
+const char* StringVal::CheckString() const { return string_val->CheckString(); }
 
-std::pair<const char*, size_t> StringVal::CheckStringWithSize() const { return AsString()->CheckStringWithSize(); }
+std::pair<const char*, size_t> StringVal::CheckStringWithSize() const { return string_val->CheckStringWithSize(); }
 
-string StringVal::ToStdString() const {
-    auto* bs = AsString();
-    return {(char*)bs->Bytes(), static_cast<size_t>(bs->Len())};
-}
+string StringVal::ToStdString() const { return {(char*)string_val->Bytes(), static_cast<size_t>(string_val->Len())}; }
 
 string_view StringVal::ToStdStringView() const {
-    auto* bs = AsString();
-    return {(char*)bs->Bytes(), static_cast<size_t>(bs->Len())};
+    return {(char*)string_val->Bytes(), static_cast<size_t>(string_val->Len())};
 }
 
 StringVal* StringVal::ToUpper() {
@@ -1223,7 +1219,7 @@ bool PatternVal::AddTo(Val* v, bool /* is_first_init */) const {
 
     PatternVal* pv = v->AsPatternVal();
 
-    RE_Matcher* re = new RE_Matcher(AsPattern()->PatternText());
+    RE_Matcher* re = new RE_Matcher(re_val->PatternText());
     re->AddPat(pv->AsPattern()->PatternText());
     re->Compile();
 
@@ -1233,7 +1229,7 @@ bool PatternVal::AddTo(Val* v, bool /* is_first_init */) const {
 }
 
 void PatternVal::SetMatcher(RE_Matcher* re) {
-    delete AsPattern();
+    delete re_val;
     re_val = re;
 }
 
@@ -1243,7 +1239,7 @@ bool PatternVal::MatchAnywhere(const String* s) const { return re_val->MatchAnyw
 
 void PatternVal::ValDescribe(ODesc* d) const {
     d->Add("/");
-    d->Add(AsPattern()->PatternText());
+    d->Add(re_val->PatternText());
     d->Add("/");
 }
 
@@ -2668,7 +2664,6 @@ ValPtr TableVal::DoClone(CloneState* state) {
     auto tv = make_intrusive<TableVal>(table_type, init_attrs);
     state->NewClone(this, tv);
 
-    const PDict<TableEntryVal>* tbl = AsTable();
     for ( const auto& tble : *table_val ) {
         auto key = tble.GetHashKey();
         auto* val = tble.value;


### PR DESCRIPTION
There are a number of places in the Val.cc file where we call an `As...` method inside a `Val` implementation but the `Val` being implemented already has access to the raw object. This causes an unnecessary `static_cast` from one of the set of `UNDERLYING_ACCESSOR_DEF` macros defined in Val.h. This PR fixes these cases to use the raw object directly instead.

I'm opening this as a draft to get results from the benchmarker service before asking for reviews.