### PR TITLE
Label zeekygen warnings as such

### DIFF
--- a/src/zeekygen/Manager.cc
+++ b/src/zeekygen/Manager.cc
@@ -25,7 +25,7 @@ static void DbgAndWarn(const char* msg) {
         // be confusing.
         return;
 
-    reporter->Warning("%s", msg);
+    reporter->Warning("[zeekygen] %s", msg);
     DBG_LOG(DBG_ZEEKYGEN, "%s", msg);
 }
 


### PR DESCRIPTION
Label warnings from zeekygen as such which makes them much easier to filter out, if desired.