### PR TITLE
Fix ICMP caplen violations that could trigger out-of-bounds buffer access in rule matching

### DIFF
--- a/src/packet_analysis/protocol/icmp/ICMP.cc
+++ b/src/packet_analysis/protocol/icmp/ICMP.cc
@@ -92,11 +92,14 @@ void ICMPAnalyzer::DeliverPacket(Connection* c, double t, bool is_orig, int rema
     c->SetLastTime(run_state::current_timestamp);
     adapter->InitEndpointMatcher(ip.get(), len, is_orig);
 
-    // Move past common portion of ICMP header.
+    // Move past common portion of ICMP header. BuildConnTuple() verified that
+    // the header is fully present.
     data += 8;
     remaining -= 8;
     len -= 8;
 
+    // The ICMP session adapter only uses len to signal endpoint activity, so
+    // caplen vs len does not matter.
     adapter->UpdateLength(is_orig, len);
 
     if ( ip->NextProto() == IPPROTO_ICMP )
@@ -112,12 +115,12 @@ void ICMPAnalyzer::DeliverPacket(Connection* c, double t, bool is_orig, int rema
     // handling those properly.
     pkt->session = c;
 
-    ForwardPacket(len, data, pkt);
+    ForwardPacket(std::min(len, remaining), data, pkt);
 
     if ( remaining >= len )
         adapter->ForwardPacket(len, data, is_orig, -1, ip.get(), remaining);
 
-    adapter->MatchEndpoint(data, len, is_orig);
+    adapter->MatchEndpoint(data, std::min(len, remaining), is_orig);
 }
 
 void ICMPAnalyzer::NextICMP4(double t, const struct icmp* icmpp, int len, int caplen, const u_char*& data,


### PR DESCRIPTION
I considered adding a testcase based on the reproducer in the issue, but it feels odd to add something that technically relies on libpcap's buffer sizing to trigger. Holler if you disagree, though.

I looked at the other IP-based packet parsers and didn't see obviously similar patterns. Not directly related, but I came across this while digging through the code: it looks suspicious that [RuleMatcher::InitEndpoint()](https://github.com/zeek/zeek/blob/master/src/RuleMatcher.cc#L679-L768) has a `caplen` argument but never uses it.

Resolves #3671.
