### PR TITLE
Move packet_analysis::Dispatcher to detail namespace

### DIFF
--- a/src/packet_analysis/Analyzer.h
+++ b/src/packet_analysis/Analyzer.h
@@ -266,7 +266,7 @@ private:
     const AnalyzerPtr& DetectInnerAnalyzer(size_t len, const uint8_t* data, Packet* packet) const;
 
     zeek::Tag tag;
-    Dispatcher dispatcher;
+    detail::Dispatcher dispatcher;
     AnalyzerPtr default_analyzer = nullptr;
     bool enabled = true;
 

--- a/src/packet_analysis/Dispatcher.cc
+++ b/src/packet_analysis/Dispatcher.cc
@@ -8,7 +8,7 @@
 #include "zeek/Reporter.h"
 #include "zeek/packet_analysis/Analyzer.h"
 
-namespace zeek::packet_analysis {
+namespace zeek::packet_analysis::detail {
 
 Dispatcher::~Dispatcher() { FreeValues(); }
 
@@ -80,4 +80,4 @@ void Dispatcher::DumpDebug() const {
 #endif
 }
 
-} // namespace zeek::packet_analysis
+} // namespace zeek::packet_analysis::detail

--- a/src/packet_analysis/Dispatcher.h
+++ b/src/packet_analysis/Dispatcher.h
@@ -12,6 +12,8 @@ namespace zeek::packet_analysis {
 class Analyzer; // Forward declaration for Value
 using AnalyzerPtr = std::shared_ptr<zeek::packet_analysis::Analyzer>;
 
+namespace detail {
+
 /**
  * The Dispatcher class manages identifier-to-analyzer mappings.
  */
@@ -62,4 +64,5 @@ private:
     inline uint32_t GetHighestIdentifier() const { return lowest_identifier + table.size() - 1; }
 };
 
+} // namespace detail
 } // namespace zeek::packet_analysis

--- a/src/packet_analysis/Manager.cc
+++ b/src/packet_analysis/Manager.cc
@@ -37,9 +37,9 @@ void Manager::InitPostScript(const std::string& unprocessed_output_file) {
 
     auto pkt_profile_file = id::find_val("pkt_profile_file");
 
-    if ( detail::pkt_profile_mode && detail::pkt_profile_freq > 0 && pkt_profile_file )
-        pkt_profiler =
-            new detail::PacketProfiler(detail::pkt_profile_mode, detail::pkt_profile_freq, pkt_profile_file->AsFile());
+    if ( zeek::detail::pkt_profile_mode && zeek::detail::pkt_profile_freq > 0 && pkt_profile_file )
+        pkt_profiler = new zeek::detail::PacketProfiler(zeek::detail::pkt_profile_mode, zeek::detail::pkt_profile_freq,
+                                                        pkt_profile_file->AsFile());
 
     unknown_sampling_rate = id::find_val("UnknownProtocol::sampling_rate")->AsCount();
     unknown_sampling_threshold = id::find_val("UnknownProtocol::sampling_threshold")->AsCount();
@@ -215,7 +215,7 @@ bool Manager::PermitUnknownProtocol(const std::string& analyzer, uint32_t protoc
     ++count;
 
     if ( count == 1 )
-        detail::timer_mgr->Add(new UnknownProtocolTimer(run_state::network_time, p, unknown_sampling_duration));
+        zeek::detail::timer_mgr->Add(new UnknownProtocolTimer(run_state::network_time, p, unknown_sampling_duration));
 
     if ( count < unknown_sampling_threshold )
         return true;

--- a/src/packet_analysis/Manager.h
+++ b/src/packet_analysis/Manager.h
@@ -164,9 +164,9 @@ public:
      */
     void ResetUnknownProtocolTimer(const std::string& analyzer, uint32_t protocol);
 
-    detail::PacketFilter* GetPacketFilter(bool init = true) {
+    zeek::detail::PacketFilter* GetPacketFilter(bool init = true) {
         if ( ! pkt_filter && init )
-            pkt_filter = new detail::PacketFilter(detail::packet_filter_default);
+            pkt_filter = new zeek::detail::PacketFilter(zeek::detail::packet_filter_default);
         return pkt_filter;
     }
 
@@ -203,8 +203,8 @@ private:
     AnalyzerPtr root_analyzer = nullptr;
 
     uint64_t num_packets_processed = 0;
-    detail::PacketProfiler* pkt_profiler = nullptr;
-    detail::PacketFilter* pkt_filter = nullptr;
+    zeek::detail::PacketProfiler* pkt_profiler = nullptr;
+    zeek::detail::PacketFilter* pkt_filter = nullptr;
 
     using UnknownProtocolPair = std::pair<std::string, uint32_t>;
     std::map<UnknownProtocolPair, uint64_t> unknown_protocols;

--- a/src/packet_analysis/protocol/icmp/ICMP.cc
+++ b/src/packet_analysis/protocol/icmp/ICMP.cc
@@ -280,8 +280,8 @@ zeek::RecordValPtr ICMPAnalyzer::ExtractICMP4Context(int len, const u_char*& dat
 
         if ( ! bad_hdr_len )
             bad_checksum = ! run_state::current_pkt->l4_checksummed &&
-                           (detail::in_cksum(reinterpret_cast<const uint8_t*>(ip_hdr->IP4_Hdr()),
-                                             static_cast<int>(ip_hdr_len)) != 0xffff);
+                           (zeek::detail::in_cksum(reinterpret_cast<const uint8_t*>(ip_hdr->IP4_Hdr()),
+                                                   static_cast<int>(ip_hdr_len)) != 0xffff);
         else
             bad_checksum = false;
 

--- a/src/packet_analysis/protocol/icmp/ICMPSessionAdapter.h
+++ b/src/packet_analysis/protocol/icmp/ICMPSessionAdapter.h
@@ -22,7 +22,7 @@ public:
     void MatchEndpoint(const u_char* data, int len, bool is_orig);
 
 private:
-    detail::RuleMatcherState matcher_state;
+    zeek::detail::RuleMatcherState matcher_state;
     int request_len = -1;
     int reply_len = -1;
 };

--- a/src/packet_analysis/protocol/ip/IPBasedAnalyzer.cc
+++ b/src/packet_analysis/protocol/ip/IPBasedAnalyzer.cc
@@ -27,7 +27,7 @@ bool IPBasedAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* pkt
         return false;
 
     const std::shared_ptr<IP_Hdr>& ip_hdr = pkt->ip_hdr;
-    detail::ConnKey key(tuple);
+    zeek::detail::ConnKey key(tuple);
 
     Connection* conn = session_mgr->FindConnection(key);
 
@@ -140,7 +140,7 @@ bool IPBasedAnalyzer::IsLikelyServerPort(uint32_t port) const {
     return port_cache.find(port) != port_cache.end();
 }
 
-zeek::Connection* IPBasedAnalyzer::NewConn(const ConnTuple* id, const detail::ConnKey& key, const Packet* pkt) {
+zeek::Connection* IPBasedAnalyzer::NewConn(const ConnTuple* id, const zeek::detail::ConnKey& key, const Packet* pkt) {
     int src_h = ntohs(id->src_port);
     int dst_h = ntohs(id->dst_port);
     bool flip = false;

--- a/src/packet_analysis/protocol/ip/IPBasedAnalyzer.h
+++ b/src/packet_analysis/protocol/ip/IPBasedAnalyzer.h
@@ -185,7 +185,7 @@ private:
      * @param key A connection ID key generated from the ID.
      * @param pkt The packet associated with the new connection.
      */
-    zeek::Connection* NewConn(const ConnTuple* id, const detail::ConnKey& key, const Packet* pkt);
+    zeek::Connection* NewConn(const ConnTuple* id, const zeek::detail::ConnKey& key, const Packet* pkt);
 
     void BuildSessionAnalyzerTree(Connection* conn);
 

--- a/src/packet_analysis/protocol/tcp/TCP.cc
+++ b/src/packet_analysis/protocol/tcp/TCP.cc
@@ -148,7 +148,7 @@ const struct tcphdr* TCPAnalyzer::ExtractTCP_Header(const u_char*& data, int& le
 
 bool TCPAnalyzer::ValidateChecksum(const IP_Hdr* ip, const struct tcphdr* tp, analyzer::tcp::TCP_Endpoint* endpoint,
                                    int len, int caplen, TCPSessionAdapter* adapter) {
-    if ( ! run_state::current_pkt->l4_checksummed && ! detail::ignore_checksums &&
+    if ( ! run_state::current_pkt->l4_checksummed && ! zeek::detail::ignore_checksums &&
          ! GetIgnoreChecksumsNets()->Contains(ip->IPHeaderSrcAddr()) && caplen >= len &&
          ! endpoint->ValidChecksum(tp, len, ip->IP4_Hdr()) ) {
         adapter->Weird("bad_TCP_checksum");

--- a/src/packet_analysis/protocol/tcp/TCPSessionAdapter.cc
+++ b/src/packet_analysis/protocol/tcp/TCPSessionAdapter.cc
@@ -23,8 +23,8 @@ using namespace zeek::packet_analysis::TCP;
 
 TCPSessionAdapter::TCPSessionAdapter(Connection* conn) : packet_analysis::IP::SessionAdapter("TCP", conn) {
     // Set a timer to eventually time out this connection.
-    ADD_ANALYZER_TIMER(&TCPSessionAdapter::ExpireTimer, run_state::network_time + detail::tcp_SYN_timeout, false,
-                       detail::TIMER_TCP_EXPIRE);
+    ADD_ANALYZER_TIMER(&TCPSessionAdapter::ExpireTimer, run_state::network_time + zeek::detail::tcp_SYN_timeout, false,
+                       zeek::detail::TIMER_TCP_EXPIRE);
 
     deferred_gen_event = close_deferred = 0;
 
@@ -529,8 +529,8 @@ void TCPSessionAdapter::Process(bool is_orig, const struct tcphdr* tp, int len, 
     if ( flags.FIN() ) {
         ++endpoint->FIN_cnt;
 
-        if ( endpoint->FIN_cnt >= detail::tcp_storm_thresh &&
-             run_state::current_timestamp < endpoint->last_time + detail::tcp_storm_interarrival_thresh )
+        if ( endpoint->FIN_cnt >= zeek::detail::tcp_storm_thresh &&
+             run_state::current_timestamp < endpoint->last_time + zeek::detail::tcp_storm_interarrival_thresh )
             Weird("FIN_storm");
 
         endpoint->FIN_seq = rel_seq + seg_len;
@@ -539,8 +539,8 @@ void TCPSessionAdapter::Process(bool is_orig, const struct tcphdr* tp, int len, 
     if ( flags.RST() ) {
         ++endpoint->RST_cnt;
 
-        if ( endpoint->RST_cnt >= detail::tcp_storm_thresh &&
-             run_state::current_timestamp < endpoint->last_time + detail::tcp_storm_interarrival_thresh )
+        if ( endpoint->RST_cnt >= zeek::detail::tcp_storm_thresh &&
+             run_state::current_timestamp < endpoint->last_time + zeek::detail::tcp_storm_interarrival_thresh )
             Weird("RST_storm");
 
         // This now happens often enough that it's
@@ -717,8 +717,8 @@ void TCPSessionAdapter::UpdateInactiveState(double t, analyzer::tcp::TCP_Endpoin
                 endpoint->SetState(analyzer::tcp::TCP_ENDPOINT_SYN_SENT);
 
             if ( zeek::detail::tcp_attempt_delay )
-                ADD_ANALYZER_TIMER(&TCPSessionAdapter::AttemptTimer, t + detail::tcp_attempt_delay, true,
-                                   detail::TIMER_TCP_ATTEMPT);
+                ADD_ANALYZER_TIMER(&TCPSessionAdapter::AttemptTimer, t + zeek::detail::tcp_attempt_delay, true,
+                                   zeek::detail::TIMER_TCP_ATTEMPT);
         }
         else {
             if ( flags.ACK() ) {
@@ -1205,7 +1205,7 @@ void TCPSessionAdapter::ConnectionClosed(analyzer::tcp::TCP_Endpoint* endpoint, 
 
     if ( DEBUG_tcp_connection_close ) {
         DEBUG_MSG("%.6f close_complete=%d tcp_close_delay=%f\n", run_state::network_time, close_complete,
-                  detail::tcp_close_delay);
+                  zeek::detail::tcp_close_delay);
     }
 
     if ( close_complete ) {

--- a/src/packet_analysis/protocol/udp/UDP.cc
+++ b/src/packet_analysis/protocol/udp/UDP.cc
@@ -37,7 +37,7 @@ zeek::analyzer::pia::PIA* UDPAnalyzer::MakePIA(Connection* conn) { return new an
 void UDPAnalyzer::Initialize() {
     IPBasedAnalyzer::Initialize();
 
-    const auto& id = detail::global_scope()->Find("PacketAnalyzer::VXLAN::vxlan_ports");
+    const auto& id = zeek::detail::global_scope()->Find("PacketAnalyzer::VXLAN::vxlan_ports");
 
     if ( ! (id && id->GetVal()) )
         reporter->FatalError("PacketAnalyzer::VXLAN::vxlan_ports not defined");
@@ -204,8 +204,8 @@ void UDPAnalyzer::DeliverPacket(Connection* c, double t, bool is_orig, int remai
 }
 
 bool UDPAnalyzer::ValidateChecksum(const IP_Hdr* ip, const udphdr* up, int len) {
-    auto sum = detail::ip_in_cksum(ip->IP4_Hdr(), ip->SrcAddr(), ip->DstAddr(), IPPROTO_UDP,
-                                   reinterpret_cast<const uint8_t*>(up), len);
+    auto sum = zeek::detail::ip_in_cksum(ip->IP4_Hdr(), ip->SrcAddr(), ip->DstAddr(), IPPROTO_UDP,
+                                         reinterpret_cast<const uint8_t*>(up), len);
 
     return sum == 0xffff;
 }


### PR DESCRIPTION
This PR moves the `packet_analysis::Dispatcher` class under a new `packet_analysis::detail` namespace, where it should have existed in the first place. There's nothing in the that class that should have a stable API. Unfortunately, introducing this namespace breaks the build in a few places due to the compiler not recognizing the difference between the various `detail` namespaces, so fixes are included to be more explicit about which are used.

Fixes #3417 