### PR TITLE
Fix cid propagation into files.log

### DIFF
--- a/scripts/base/frameworks/files/main.zeek
+++ b/scripts/base/frameworks/files/main.zeek
@@ -603,7 +603,7 @@ event file_state_remove(f: fa_file) &priority=-10
 		# by reference in Log::write() rather than by copy.
 		local info = |f$conns| > 1 ? copy(f$info) : f$info;
 		info$uid = c$uid;
-		info$id = cid;
+		info$id = c$id;
 		Log::write(Files::LOG, info);
 		}
 	}


### PR DESCRIPTION
Changes to the connection id were not propagated to files.log in all cases.

Fixes GH-3700

I did not add a test case as this is highly specific and did not seem worthwhile in this case - but I am happy to add it if so desired.