### PR TITLE
Constify classes in RuleMatcher, fixes c++20 build failure

### DIFF
--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -143,7 +143,7 @@ RuleHdrTest::~RuleHdrTest() {
     delete ruleset;
 }
 
-bool RuleHdrTest::operator==(const RuleHdrTest& h) {
+bool RuleHdrTest::operator==(const RuleHdrTest& h) const {
     if ( prot != h.prot || offset != h.offset || size != h.size || comp != h.comp ||
          vals->length() != h.vals->length() )
         return false;
@@ -158,7 +158,7 @@ bool RuleHdrTest::operator==(const RuleHdrTest& h) {
     return true;
 }
 
-void RuleHdrTest::PrintDebug() {
+void RuleHdrTest::PrintDebug() const {
     static const char* str_comp[] = {"<=", ">=", "<", ">", "==", "!="};
     static const char* str_prot[] = {"", "ip", "ipv6", "icmp", "icmpv6", "tcp", "udp", "next", "ipsrc", "ipdst"};
 
@@ -1013,7 +1013,7 @@ void RuleMatcher::ClearFileMagicState(RuleFileMagicState* state) const {
         matcher->state->Clear();
 }
 
-void RuleMatcher::PrintDebug() {
+void RuleMatcher::PrintDebug() const {
     for ( const auto& rule : rules )
         rule->PrintDebug();
 
@@ -1027,7 +1027,7 @@ static inline void indent(int level) {
         fputc(' ', stderr);
 }
 
-void RuleMatcher::PrintTreeDebug(RuleHdrTest* node) {
+void RuleMatcher::PrintTreeDebug(RuleHdrTest* node) const {
     for ( int i = 0; i < Rule::TYPES; ++i ) {
         indent(node->level);
         loop_over_list(node->psets[i], j) {
@@ -1055,7 +1055,7 @@ void RuleMatcher::PrintTreeDebug(RuleHdrTest* node) {
     }
 }
 
-void RuleMatcher::GetStats(Stats* stats, RuleHdrTest* hdr_test) {
+void RuleMatcher::GetStats(Stats* stats, RuleHdrTest* hdr_test) const {
     if ( ! hdr_test ) {
         stats->matchers = 0;
         stats->dfa_states = 0;
@@ -1089,7 +1089,7 @@ void RuleMatcher::GetStats(Stats* stats, RuleHdrTest* hdr_test) {
         GetStats(stats, h);
 }
 
-void RuleMatcher::DumpStats(File* f) {
+void RuleMatcher::DumpStats(File* f) const {
     Stats stats;
     GetStats(&stats);
 
@@ -1102,7 +1102,7 @@ void RuleMatcher::DumpStats(File* f) {
     DumpStateStats(f, root);
 }
 
-void RuleMatcher::DumpStateStats(File* f, RuleHdrTest* hdr_test) {
+void RuleMatcher::DumpStateStats(File* f, RuleHdrTest* hdr_test) const {
     if ( ! hdr_test )
         return;
 

--- a/src/RuleMatcher.h
+++ b/src/RuleMatcher.h
@@ -84,7 +84,7 @@ public:
     RuleHdrTest(Prot arg_prot, Comp arg_comp, std::vector<IPPrefix> arg_v);
     ~RuleHdrTest();
 
-    void PrintDebug();
+    void PrintDebug() const;
 
 private:
     // The constructor does not copy those attributes which are set
@@ -93,7 +93,7 @@ private:
     // should be const, but lists don't have const version
 
     // Likewise, the operator== checks only for same test semantics.
-    bool operator==(const RuleHdrTest& h);
+    bool operator==(const RuleHdrTest& h) const;
 
     Prot prot;
     Comp comp;
@@ -282,7 +282,7 @@ public:
     // Reset the state of the pattern matcher for this endpoint.
     void ClearEndpointState(RuleEndpointState* state);
 
-    void PrintDebug();
+    void PrintDebug() const;
 
     // Interface to parser
     void AddRule(Rule* rule);
@@ -309,8 +309,8 @@ public:
 
     Val* BuildRuleStateValue(const Rule* rule, const RuleEndpointState* state) const;
 
-    void GetStats(Stats* stats, RuleHdrTest* hdr_test = nullptr);
-    void DumpStats(File* f);
+    void GetStats(Stats* stats, RuleHdrTest* hdr_test = nullptr) const;
+    void DumpStats(File* f) const;
 
 private:
     // Delete node and all children.
@@ -346,9 +346,9 @@ private:
     // Evaluate all rule conditions except patterns and "header".
     bool EvalRuleConditions(Rule* r, RuleEndpointState* state, const u_char* data, int len, bool eos);
 
-    void PrintTreeDebug(RuleHdrTest* node);
+    void PrintTreeDebug(RuleHdrTest* node) const;
 
-    void DumpStateStats(File* f, RuleHdrTest* hdr_test);
+    void DumpStateStats(File* f, RuleHdrTest* hdr_test) const;
 
     static bool AllRulePatternsMatched(const Rule* r, MatchPos matchpos, const AcceptingMatchSet& ams);
 


### PR DESCRIPTION
These changes came out of my branch where I'm getting everything to build with C++20, but there's no reason they can't go directly into master now. The original build failure was because `operator==` wasn't marked const. The rest are just some extra similar fixes.