### PR TITLE
Clarify membership in the `Site::private_address_space` prefix list.

### DIFF
--- a/scripts/base/utils/site.zeek
+++ b/scripts/base/utils/site.zeek
@@ -7,7 +7,11 @@ module Site;
 export {
 	## A list of subnets that are considered private address space.
 	##
-	## By default, it has address blocks defined by IANA as not being routable over the Internet.
+	## By default, it has address blocks defined by IANA as not being
+	## routable over the Internet. Some address blocks are reserved for
+	## purposes inconsistent with the address architecture (such as
+	## 5f00::/16), making them neither clearly private nor routable. We do
+	## not include such blocks in this list.
 	##
 	## See the `IPv4 Special-Purpose Address Registry <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_
 	## and the `IPv6 Special-Purpose Address Registry <https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml>`_


### PR DESCRIPTION
IANA's IPv6 special-purpose address registry now has members that technically meet the definition of not being globally reachable, but don't imply operating locally. An example: https://datatracker.ietf.org/doc/draft-ietf-6man-sids/06/

This change just explains that distinction.