### PR TITLE
CI: Replace Ubuntu 23.10 with Ubuntu 24.04

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -384,7 +384,7 @@ freebsd13_task:
 asan_sanitizer_task:
   container:
     # Just uses a recent/common distro to run memory error/leak checks.
-    dockerfile: ci/ubuntu-20.04/Dockerfile
+    dockerfile: ci/ubuntu-22.04/Dockerfile
     << : *RESOURCES_TEMPLATE
 
   << : *CI_TEMPLATE
@@ -393,12 +393,12 @@ asan_sanitizer_task:
   env:
     CXXFLAGS: -DZEEK_DICT_DEBUG
     ZEEK_CI_CONFIGURE_FLAGS: *ASAN_SANITIZER_CONFIG
-    ASAN_OPTIONS: detect_leaks=1
+    ASAN_OPTIONS: detect_leaks=1:detect_odr_violation=0
 
 ubsan_sanitizer_task:
   container:
     # Just uses a recent/common distro to run undefined behavior checks.
-    dockerfile: ci/ubuntu-20.04/Dockerfile
+    dockerfile: ci/ubuntu-22.04/Dockerfile
     << : *RESOURCES_TEMPLATE
 
   << : *CI_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -269,16 +269,16 @@ opensuse_tumbleweed_task:
   << : *CI_TEMPLATE
 #  << : *SKIP_TASK_ON_PR
 
-ubuntu23_task:
+ubuntu24_task:
   container:
-    # Ubuntu 23.10 EOL: July 2024
-    dockerfile: ci/ubuntu-23.10/Dockerfile
+    # Ubuntu 24.04 EOL: Jun 2029
+    dockerfile: ci/ubuntu-24.04/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
 ubuntu22_task:
   container:
-    # Ubuntu 22.04 EOL: April 2027
+    # Ubuntu 22.04 EOL: June 2027
     dockerfile: ci/ubuntu-22.04/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230828
+ENV DOCKERFILE_VERSION 20240508
 
 RUN apt-get update && apt-get -y install \
     bc \


### PR DESCRIPTION
Ubuntu 24.04 came out in April 2024, and replaces Ubuntu 23.10 as the next LTS. This also updates the asan and ubsan jobs to use Ubuntu 22. They were previously on Ubuntu 20.