### PR TITLE
CI: Use clang-18 on Ubuntu 24 to run sanitizer builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -384,13 +384,15 @@ freebsd13_task:
 asan_sanitizer_task:
   container:
     # Just uses a recent/common distro to run memory error/leak checks.
-    dockerfile: ci/ubuntu-22.04/Dockerfile
+    dockerfile: ci/ubuntu-24.04/Dockerfile
     << : *RESOURCES_TEMPLATE
 
   << : *CI_TEMPLATE
   test_fuzzers_script: ./ci/test-fuzzers.sh
   coverage_script: ./ci/upload-coverage.sh
   env:
+    CC: clang-18
+    CXX: clang++-18
     CXXFLAGS: -DZEEK_DICT_DEBUG
     ZEEK_CI_CONFIGURE_FLAGS: *ASAN_SANITIZER_CONFIG
     ASAN_OPTIONS: detect_leaks=1:detect_odr_violation=0
@@ -398,33 +400,37 @@ asan_sanitizer_task:
 ubsan_sanitizer_task:
   container:
     # Just uses a recent/common distro to run undefined behavior checks.
-    dockerfile: ci/ubuntu-22.04/Dockerfile
+    dockerfile: ci/ubuntu-24.04/Dockerfile
     << : *RESOURCES_TEMPLATE
 
   << : *CI_TEMPLATE
   << : *SKIP_TASK_ON_PR
   test_fuzzers_script: ./ci/test-fuzzers.sh
   env:
+    CC: clang-18
+    CXX: clang++-18
     CXXFLAGS: -DZEEK_DICT_DEBUG
     ZEEK_CI_CONFIGURE_FLAGS: *UBSAN_SANITIZER_CONFIG
     ZEEK_TAILORED_UB_CHECKS: 1
     UBSAN_OPTIONS: print_stacktrace=1
 
-# tsan_sanitizer_task:
-#   container:
-#     # Just uses a recent/common distro to run memory error/leak checks.
-#     dockerfile: ci/ubuntu-22.04/Dockerfile
-#     << : *RESOURCES_TEMPLATE
+tsan_sanitizer_task:
+  container:
+    # Just uses a recent/common distro to run memory error/leak checks.
+    dockerfile: ci/ubuntu-24.04/Dockerfile
+    << : *RESOURCES_TEMPLATE
 
-#   << : *CI_TEMPLATE
-#   << : *SKIP_TASK_ON_PR
-#   env:
-#     ZEEK_CI_CONFIGURE_FLAGS: *TSAN_SANITIZER_CONFIG
-#     ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1
-#     # If this is defined directly in the environment, configure fails to find
-#     # OpenSSL. Instead we define it with a different name and then give it
-#     # the correct name in the testing scripts.
-#     ZEEK_TSAN_OPTIONS: suppressions=/zeek/ci/tsan_suppressions.txt
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+  env:
+    CC: clang-18
+    CXX: clang++-18
+    ZEEK_CI_CONFIGURE_FLAGS: *TSAN_SANITIZER_CONFIG
+    ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1
+    # If this is defined directly in the environment, configure fails to find
+    # OpenSSL. Instead we define it with a different name and then give it
+    # the correct name in the testing scripts.
+    ZEEK_TSAN_OPTIONS: suppressions=/zeek/ci/tsan_suppressions.txt
 
 windows_task:
   # 2 hour timeout just for potential of building Docker image taking a while

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get -y install \
     bison \
     bsdmainutils \
     ccache \
+    clang-18 \
+    clang++-18 \
     cmake \
     curl \
     flex \


### PR DESCRIPTION
https://github.com/zeek/zeek/issues/3308 is still broken with the default GCC on Ubuntu 24, but tsan works fine with Clang 18+. This PR adds Clang 18 to Ubuntu 24 and switches all of the sanitizer builds use it. I opted to switch all of them for consistency instead of just the tsan build.

Fixes #3308