### PR TITLE
CI: Add missing lcov package to ubuntu 24 Dockerfile

### DIFF
--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get -y install \
     g++ \
     gcc \
     git \
+    lcov \
     libkrb5-dev \
     libmaxminddb-dev \
     libpcap-dev \


### PR DESCRIPTION
The asan build failed after moving it to Ubuntu 24.04 and merging that PR to master because the `lcov` package is needed for coverage. This was missed during the PR cycle because coverage only runs on master builds.