### PR TITLE
Fix coverage builds on CI, part 2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -392,7 +392,7 @@ asan_sanitizer_task:
 
   << : *CI_TEMPLATE
   test_fuzzers_script: ./ci/test-fuzzers.sh
-#  coverage_script: ./ci/upload-coverage.sh
+  coverage_script: ./ci/upload-coverage.sh
   env:
     CXXFLAGS: -DZEEK_DICT_DEBUG
     ZEEK_CI_CONFIGURE_FLAGS: *ASAN_SANITIZER_CONFIG

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -394,8 +394,6 @@ asan_sanitizer_task:
   test_fuzzers_script: ./ci/test-fuzzers.sh
 #  coverage_script: ./ci/upload-coverage.sh
   env:
-    CC: clang-18
-    CXX: clang++-18
     CXXFLAGS: -DZEEK_DICT_DEBUG
     ZEEK_CI_CONFIGURE_FLAGS: *ASAN_SANITIZER_CONFIG
     ASAN_OPTIONS: detect_leaks=1:detect_odr_violation=0

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ config: &CONFIG --build-type=release --disable-broker-tests --prefix=$CIRRUS_WOR
 no_spicy_config: &NO_SPICY_CONFIG --build-type=release --disable-broker-tests --disable-spicy --prefix=$CIRRUS_WORKING_DIR/install --ccache --enable-werror
 static_config: &STATIC_CONFIG --build-type=release --disable-broker-tests --enable-static-broker --enable-static-binpac --prefix=$CIRRUS_WORKING_DIR/install --ccache --enable-werror
 binary_config: &BINARY_CONFIG --prefix=$CIRRUS_WORKING_DIR/install --libdir=$CIRRUS_WORKING_DIR/install/lib --binary-package --enable-static-broker --enable-static-binpac --disable-broker-tests --build-type=Release --ccache --enable-werror
-asan_sanitizer_config: &ASAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=address --enable-fuzzers --enable-coverage --disable-spicy --ccache --enable-werror
+asan_sanitizer_config: &ASAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=address --enable-fuzzers --enable-coverage --disable-spicy --ccache
 ubsan_sanitizer_config: &UBSAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=undefined --enable-fuzzers --disable-spicy --ccache --enable-werror
 tsan_sanitizer_config: &TSAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=thread --enable-fuzzers --disable-spicy --ccache --enable-werror
 

--- a/ci/upload-coverage.sh
+++ b/ci/upload-coverage.sh
@@ -11,11 +11,6 @@ if [ "${CIRRUS_REPO_FULL_NAME}" != "zeek/zeek" ]; then
     exit 0
 fi
 
-if [ "${CIRRUS_BRANCH}" != "master" ]; then
-    echo "Coverage upload skipped for non-master branches"
-    exit 0
-fi
-
 cd testing/coverage
 make coverage
 make coveralls

--- a/testing/coverage/code_coverage.sh
+++ b/testing/coverage/code_coverage.sh
@@ -90,9 +90,11 @@ function check_group_coverage {
             TOTAL=$(echo $(grep "$i" $DATA | cut -f 3) | tr " " "+" | bc)
         fi
 
-        PERCENTAGE=$(echo "scale=3;100*$RUN/$TOTAL" | bc | tr "\n" " ")
-        printf "%-50s\t%12s\t%6s %%\n" "$i" "$RUN/$TOTAL" $PERCENTAGE |
-            sed 's|#|/|g' >>$OUTPUT
+        if [ $TOTAL -ne 0 ]; then
+            PERCENTAGE=$(echo "scale=3;100*$RUN/$TOTAL" | bc | tr "\n" " ")
+            printf "%-50s\t%12s\t%6s %%\n" "$i" "$RUN/$TOTAL" $PERCENTAGE |
+                sed 's|#|/|g' >>$OUTPUT
+        fi
     done
 }
 

--- a/testing/coverage/lcov_html.sh
+++ b/testing/coverage/lcov_html.sh
@@ -131,6 +131,11 @@ if [ $HTML_REPORT -eq 1 ]; then
     echo -n "Creating HTML files... "
     verify_run "genhtml --ignore-errors empty -o $COVERAGE_HTML_DIR $COVERAGE_FILE"
 else
+    if [ "${CIRRUS_BRANCH}" != "master" ]; then
+        echo "Coverage upload skipped for non-master branches"
+        exit 0
+    fi
+
     # The data we send to coveralls has a lot of duplicate files in it because of the
     # zeek symlink in the src directory. Run a script that cleans that up.
     echo -n "Cleaning coverage data for Coveralls..."

--- a/testing/coverage/lcov_html.sh
+++ b/testing/coverage/lcov_html.sh
@@ -123,13 +123,13 @@ verify_run "lcov --no-external --capture --directory . --output-file $COVERAGE_F
 # Zeek coverage numbers.
 for TARGET in $REMOVE_TARGETS; do
     echo -n "Getting rid of $TARGET files from tracefile... "
-    verify_run "lcov --remove $COVERAGE_FILE $TARGET --output-file $COVERAGE_FILE"
+    verify_run "lcov --ignore-errors unused,empty --remove $COVERAGE_FILE $TARGET --output-file $COVERAGE_FILE"
 done
 
 # 6. Create HTML files or Coveralls report
 if [ $HTML_REPORT -eq 1 ]; then
     echo -n "Creating HTML files... "
-    verify_run "genhtml -o $COVERAGE_HTML_DIR $COVERAGE_FILE"
+    verify_run "genhtml --ignore-errors empty -o $COVERAGE_HTML_DIR $COVERAGE_FILE"
 else
     # The data we send to coveralls has a lot of duplicate files in it because of the
     # zeek symlink in the src directory. Run a script that cleans that up.

--- a/testing/coverage/lcov_html.sh
+++ b/testing/coverage/lcov_html.sh
@@ -93,7 +93,7 @@ fi
 
 # Files and directories that will be removed from the counts in step 5. Directories
 # need to be surrounded by escaped wildcards.
-REMOVE_TARGETS="*.yy *.ll *.y *.l \*/bro.dir/\* *.bif \*/zeek.dir/\* \*/src/3rdparty/\* \*/src/zeek/3rdparty/\* \*/auxil/\* \*/build/zeek/3rdparty/\*"
+REMOVE_TARGETS="*.yy *.ll *.y *.l *.bif \*/zeek.dir/\* \*/src/3rdparty/\* \*/src/zeek/3rdparty/\* \*/auxil/\* \*/build/zeek/3rdparty/\*"
 
 # 1. Move to base dir, create tmp dir
 cd ../../


### PR DESCRIPTION
This has a couple of minor fixes in it, including a related PR in the cmake repo.

The major part of this switches our ASan build back to GCC. When building with clang-18, the coverage data generated doesn't match the versions expected by `gcov` and `lcov` which we use to generate the files for Coveralls. I looked into switching over to use `llvm-cov` instead as well. The main issue I ran into there is that instead of storing `.gcda/.gcno/.gcov` files alongside the object files in the build directory as `gcov` does, `llvm-cov` wants you to pass a path to store the profile files for each execution of a binary and then run commands to merge them together. It ends up fairly complicated, when our setup currently just works correctly with GCC.