### PR TITLE
Update reporter.bif to describe special case of errors in init

### DIFF
--- a/src/reporter.bif
+++ b/src/reporter.bif
@@ -43,8 +43,9 @@ function Reporter::warning%(msg: string%): bool
 	return zeek::val_mgr->True();
 	%}
 
-## Generates a non-fatal error indicative of a definite problem that should
-## be addressed. Program execution does not terminate.
+## Generates a usually non-fatal error indicative of a definite problem that
+## should be addressed. Program execution does not terminate unless the error
+## is reported during initialization (e.g., :zeek:see:`zeek_init`).
 ##
 ## msg: The error message to report.
 ##


### PR DESCRIPTION
Originally proposed in zeek/zeek-docs#257, but reverted via 9f9ebde62380a3012a1471d9ff1c1c91c7aa69da.