### PR TITLE
Change prometheus test to check for require jq

### DIFF
--- a/testing/btest/scripts/policy/frameworks/telemetry/prometheus.zeek
+++ b/testing/btest/scripts/policy/frameworks/telemetry/prometheus.zeek
@@ -2,6 +2,7 @@
 # Note compilable to C++ due to globals being initialized to a record that
 # has an opaque type as a field.
 # @TEST-REQUIRES: test "${ZEEK_USE_CPP}" != "1"
+# @TEST-REQUIRES: which jq
 #
 # @TEST-PORT: BROKER_PORT1
 # @TEST-PORT: BROKER_PORT2


### PR DESCRIPTION
The prometheus test currently expects that `jq` is installed on the system and fails if it isn't. It's installed on all of the CI hosts, but may not be on user systems. Change the test to check for `jq` and bail out if it's not there.