### PR TITLE
Check for 'zeekctl check' before trying to start up prometheus

### DIFF
--- a/src/telemetry/Manager.cc
+++ b/src/telemetry/Manager.cc
@@ -70,16 +70,18 @@ void Manager::InitPostScript() {
             }
         }
 
-        try {
-            prometheus_exposer = std::make_unique<prometheus::Exposer>(prometheus_url, 2, callbacks);
+        if ( ! getenv("ZEEKCTL_CHECK_CONFIG") ) {
+            try {
+                prometheus_exposer = std::make_unique<prometheus::Exposer>(prometheus_url, 2, callbacks);
 
-            // CivetWeb stores a copy of the callbacks, so we're safe to delete the pointer here
-            delete callbacks;
-        } catch ( const CivetException& exc ) {
-            reporter->FatalError("Failed to setup Prometheus endpoint: %s\n", exc.what());
+                // CivetWeb stores a copy of the callbacks, so we're safe to delete the pointer here
+                delete callbacks;
+            } catch ( const CivetException& exc ) {
+                reporter->FatalError("Failed to setup Prometheus endpoint: %s\n", exc.what());
+            }
+
+            prometheus_exposer->RegisterCollectable(prometheus_registry);
         }
-
-        prometheus_exposer->RegisterCollectable(prometheus_registry);
     }
 
 #ifdef HAVE_PROCESS_STAT_METRICS


### PR DESCRIPTION
`zeekctl check` runs all of the `InitPostScript` methods before exiting. This means that if the cluster is already running and prometheus is already initialized, it'll try to start up the underlying webserver a second time and fail due to the ports being in use. Check for one of the environment variables set during `check` before trying to initialize it.

Fixes #3771 