### PR TITLE
Update zeekctl submodule

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,12 @@ Breaking Changes
   instruments are not. ``Histogram`` instruments don't have the concept of
   summing.
 
+- Zeekctl now sets `FileExtract::prefix` to `spool/extract_files/<node>` to avoid
+  deletion of extracted files when stopping worker nodes. To revert to the
+  previous behavior, set `FileExtractDir` to an empty string in `zeekctl.cfg`.
+
+  If you never enabled Zeek's file extraction functionality, there's no impact.
+
 New Functionality
 -----------------
 


### PR DESCRIPTION
To integrate `ExtractFileDir` option into zeekctl.cfg: https://github.com/zeek/zeekctl/pull/67 