### PR TITLE
Fix coverage builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -397,6 +397,8 @@ asan_sanitizer_task:
     CXXFLAGS: -DZEEK_DICT_DEBUG
     ZEEK_CI_CONFIGURE_FLAGS: *ASAN_SANITIZER_CONFIG
     ASAN_OPTIONS: detect_leaks=1:detect_odr_violation=0
+    # Use absolute paths for coverage files.
+    CCACHE_BASEDIR:
 
 ubsan_sanitizer_task:
   container:


### PR DESCRIPTION
This does two things:
* Compile coverage builds with with `-fprofile-update=atomic` to avoid negative counters
* Unset CCACHE_BASEDIR from the asan_sanitizer task to avoid cmake rewriting everything as relative paths and confusing our gcov setup (we only ever compile in `/zeek` in CI, so CCACHE_BASEDIR usage isn't really useful generally).

Goes with https://github.com/zeek/cmake/pull/112