### PR TITLE
threading/MsgThread: Decouple IO source and thread

### DIFF
--- a/src/threading/Manager.cc
+++ b/src/threading/Manager.cc
@@ -58,8 +58,12 @@ void Manager::Terminate() {
         delete *i;
     }
 
+    for ( auto* iosource : io_sources )
+        delete iosource;
+
     all_threads.clear();
     msg_threads.clear();
+    io_sources.clear();
     terminating = false;
 }
 
@@ -71,9 +75,10 @@ void Manager::AddThread(BasicThread* thread) {
         StartHeartbeatTimer();
 }
 
-void Manager::AddMsgThread(MsgThread* thread) {
+void Manager::AddMsgThread(MsgThread* thread, iosource::IOSource* iosource) {
     DBG_LOG(DBG_THREADING, "%s is a MsgThread ...", thread->Name());
     msg_threads.push_back(thread);
+    io_sources.push_back(iosource);
 }
 
 void Manager::KillThreads() {
@@ -115,6 +120,16 @@ void Manager::SendHeartbeats() {
 
         t->Join();
         delete t;
+    }
+
+    for ( auto it = io_sources.begin(); it != io_sources.end(); /**/ ) {
+        auto* src = *it;
+        if ( ! src->IsOpen() ) {
+            delete src;
+            it = io_sources.erase(it);
+        }
+        else
+            ++it;
     }
 }
 

--- a/src/threading/Manager.h
+++ b/src/threading/Manager.h
@@ -121,8 +121,9 @@ protected:
      * MsgThread constructor makes sure to do so.
      *
      * @param thread The thread.
+     * @param iosource The IO source of the thread.
      */
-    void AddMsgThread(MsgThread* thread);
+    void AddMsgThread(MsgThread* thread, iosource::IOSource* iosource);
 
     void Flush();
 
@@ -142,6 +143,9 @@ private:
 
     using msg_thread_list = std::list<MsgThread*>;
     msg_thread_list msg_threads;
+
+    using io_source_list = std::list<iosource::IOSource*>;
+    io_source_list io_sources;
 
     bool did_process; // True if the last Process() found some work to do.
     double next_beat; // Timestamp when the next heartbeat will be sent.

--- a/src/threading/MsgThread.cc
+++ b/src/threading/MsgThread.cc
@@ -165,6 +165,72 @@ bool ReporterMessage::Process() {
     return true;
 }
 
+
+// This is the IO source used by MsgThread.
+//
+// The lifetime of the IO source is decoupled from
+// the thread. The thread may be terminated prior
+// to the IO source being properly unregistered and
+// forgotten by the IO manager. Specifically the
+// threading manager would delete an IO source which
+// the IO manager still believed to be ready.
+//
+// See issue #3682 for more details.
+class MsgThread_IOSource : public iosource::IOSource {
+public:
+    explicit MsgThread_IOSource(MsgThread* thread) : thread(thread) {
+        if ( ! iosource_mgr->RegisterFd(flare.FD(), this) )
+            reporter->FatalError("Failed to register MsgThread fd with iosource_mgr");
+
+        SetClosed(false);
+    }
+
+    ~MsgThread_IOSource() {
+        if ( IsOpen() ) {
+            if ( thread )
+                reporter->Warning("Have thread %s set in MsgThread_IOSource", thread->Name());
+
+            if ( ! iosource_mgr->UnregisterFd(flare.FD(), this) )
+                reporter->FatalError("Failed to unregister MsgThread fd from iosource_mgr");
+        }
+    }
+
+    void Process() override {
+        flare.Extinguish();
+
+        if ( thread )
+            thread->Process();
+        else {
+            // When there's no thread anymore, unregister
+            // this source from the IO manager and mark
+            // it as closed. The threading manager will then
+            // reap it during heartbeat processing or shutdown.
+            if ( ! iosource_mgr->UnregisterFd(flare.FD(), this) )
+                reporter->FatalError("Failed to unregister MsgThread fd from iosource_mgr");
+
+            SetClosed(true);
+        }
+    }
+
+    const char* Tag() override { return thread ? thread->Name() : "<MsgThread_IOSource orphan>"; }
+
+    double GetNextTimeout() override { return -1; }
+
+    void Fire() { flare.Fire(); };
+
+    // Fire the flare one more time so that
+    // the IO manager will call Process() and
+    // SetClosed(true).
+    void Close() {
+        thread = nullptr;
+        flare.Fire();
+    }
+
+private:
+    MsgThread* thread = nullptr;
+    zeek::detail::Flare flare;
+};
+
 } // namespace detail
 
 ////// Methods.
@@ -179,18 +245,20 @@ MsgThread::MsgThread() : BasicThread(), queue_in(this, nullptr), queue_out(nullp
     child_finished = false;
     child_sent_finish = false;
     failed = false;
-    thread_mgr->AddMsgThread(this);
 
-    if ( ! iosource_mgr->RegisterFd(flare.FD(), this) )
-        reporter->FatalError("Failed to register MsgThread fd with iosource_mgr");
-
-    SetClosed(false);
+    io_source = new detail::MsgThread_IOSource(this);
+    thread_mgr->AddMsgThread(this, io_source);
 }
 
 MsgThread::~MsgThread() {
-    // Unregister this thread from the iosource manager so it doesn't wake
-    // up the main poll anymore.
-    iosource_mgr->UnregisterFd(flare.FD(), this);
+    // Unregister this thread from the IO source so we don't
+    // get Process() callbacks anymore. The IO source is
+    // freed by separately by the threading manager after its
+    // last Process() invocation.
+    if ( io_source ) {
+        io_source->Close();
+        io_source = nullptr;
+    }
 }
 
 void MsgThread::OnSignalStop() {
@@ -253,7 +321,13 @@ void MsgThread::OnWaitForStop() {
 }
 
 void MsgThread::OnKill() {
-    SetClosed(true);
+    // Ensure the IO source is closed and won't call Process() on this
+    // thread anymore. The thread got killed, so the threading manager will
+    // remove it forcefully soon.
+    if ( io_source ) {
+        io_source->Close();
+        io_source = nullptr;
+    }
 
     // Send a message to unblock the reader if its currently waiting for
     // input. This is just an optimization to make it terminate more
@@ -345,7 +419,8 @@ void MsgThread::SendOut(BasicOutputMessage* msg, bool force) {
 
     ++cnt_sent_out;
 
-    flare.Fire();
+    if ( io_source )
+        io_source->Fire();
 }
 
 void MsgThread::SendEvent(const char* name, const int num_vals, Value** vals) {
@@ -418,8 +493,6 @@ void MsgThread::GetStats(Stats* stats) {
 }
 
 void MsgThread::Process() {
-    flare.Extinguish();
-
     while ( HasOut() ) {
         Message* msg = RetrieveOut();
         assert(msg);

--- a/src/threading/MsgThread.h
+++ b/src/threading/MsgThread.h
@@ -27,6 +27,8 @@ class FinishMessage;
 class FinishedMessage;
 class KillMeMessage;
 
+class MsgThread_IOSource;
+
 } // namespace detail
 
 /**
@@ -40,7 +42,7 @@ class KillMeMessage;
  * that happens, the thread stops accepting any new messages, finishes
  * processes all remaining ones still in the queue, and then exits.
  */
-class MsgThread : public BasicThread, public iosource::IOSource {
+class MsgThread : public BasicThread {
 public:
     /**
      * Constructor. It automatically registers the thread with the
@@ -208,19 +210,13 @@ public:
      */
     void GetStats(Stats* stats);
 
-    /**
-     * Overridden from iosource::IOSource.
-     */
-    void Process() override;
-    const char* Tag() override { return Name(); }
-    double GetNextTimeout() override { return -1; }
-
 protected:
     friend class Manager;
     friend class detail::HeartbeatMessage;
     friend class detail::FinishMessage;
     friend class detail::FinishedMessage;
     friend class detail::KillMeMessage;
+    friend class detail::MsgThread_IOSource;
 
     /**
      * Pops a message sent by the child from the child-to-main queue.
@@ -285,6 +281,11 @@ protected:
      * or nullptr if nothing is available.
      */
     virtual const zeek::detail::Location* GetLocationInfo() const { return nullptr; }
+
+    /**
+     * Process() forwarded by MsgThread_IOSource.
+     */
+    void Process();
 
 private:
     /**
@@ -362,7 +363,7 @@ private:
     bool child_sent_finish; // Child thread asked to be finished.
     bool failed;            // Set to true when a command failed.
 
-    zeek::detail::Flare flare;
+    detail::MsgThread_IOSource* io_source = nullptr; // IO source registered with the IO manager.
 };
 
 /**


### PR DESCRIPTION
A MsgThread acting as an IO source itself can result in the scenario where the threading manager's heartbeat timer deletes a terminated MsgThread instance, but at the same time this instance is in the list of ready IO sources as determined by the IO loop in the current iteration.

Fix this by decoupling the IO source from the thread and clean them up separately. The threading manager now also tracks MsgThread IO sources and deletes them only when they've been closed and therefore unregistered from the IO loop. Unregistration only happens during Process() which should have the necessary guarantees.

Fixes #3682