### PR TITLE
Remove internal `Supervisor::ClusterEndpoint` struct

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -151,6 +151,10 @@ Changed Functionality
   it aligns with the same requirement for traditional analyzers and
   enables customizing file handles for protocol-specific semantics.
 
+- The Supervisor's API now returns NodeConfig records with a cluster table whose
+  ClusterEndpoints have a port value of 0/unknown, rather than 0/tcp, to
+  indicate that the node in question has no listening port.
+
 Removed Functionality
 ---------------------
 

--- a/scripts/base/frameworks/cluster/supervisor.zeek
+++ b/scripts/base/frameworks/cluster/supervisor.zeek
@@ -1,0 +1,57 @@
+##! Cluster-related functionality specific to running under the Supervisor
+##! framework.
+
+@load base/frameworks/supervisor/api
+
+module Cluster::Supervisor;
+
+export {
+	## Populates the current node's :zeek:id:`Cluster::nodes` table from the
+	## supervisor's node configuration in :zeek:id:`Supervisor::NodeConfig`.
+	##
+	## Returns: true if initialization completed, false otherwise.
+	global __init_cluster_nodes: function(): bool;
+}
+
+function __init_cluster_nodes(): bool
+	{
+	local config = Supervisor::node();
+
+	if ( |config$cluster| == 0 )
+		return F;
+
+	local rolemap: table[Supervisor::ClusterRole] of Cluster::NodeType = {
+		[Supervisor::LOGGER] = Cluster::LOGGER,
+		[Supervisor::MANAGER] = Cluster::MANAGER,
+		[Supervisor::PROXY] = Cluster::PROXY,
+		[Supervisor::WORKER] = Cluster::WORKER,
+	};
+
+	local manager_name = "";
+	local cnode: Cluster::Node;
+	local typ: Cluster::NodeType = Cluster::NONE;
+
+	for ( node_name, endp in config$cluster )
+		{
+		if ( endp$role == Supervisor::MANAGER )
+			manager_name = node_name;
+		}
+
+	for ( node_name, endp in config$cluster )
+		{
+		if ( endp$role in rolemap )
+			typ = rolemap[endp$role];
+
+		cnode = [$node_type=typ, $ip=endp$host, $p=endp$p];
+@pragma push ignore-deprecations
+		if ( endp?$interface )
+			cnode$interface = endp$interface;
+@pragma pop ignore-deprecations
+		if ( |manager_name| > 0 && cnode$node_type != Cluster::MANAGER )
+			cnode$manager = manager_name;
+
+		Cluster::nodes[node_name] = cnode;
+		}
+
+	return T;
+	}

--- a/scripts/policy/frameworks/management/agent/main.zeek
+++ b/scripts/policy/frameworks/management/agent/main.zeek
@@ -625,10 +625,9 @@ function get_nodes_request_finish(areq: Management::Request::Request)
 			if ( node in g_nodes )
 				cns$state = g_nodes[node]$state;
 
-			# The supervisor's responses use 0/tcp (not 0/unknown)
-			# when indicating an unused port because its internal
-			# serialization always assumes TCP.
-			if ( sns$node$cluster[node]$p != 0/tcp )
+			# The supervisor's responses use 0/unknown to indicate
+			# unused ports. (Prior to Zeek 7 this used to be 0/tcp.)
+			if ( sns$node$cluster[node]$p != 0/unknown )
 				cns$p = sns$node$cluster[node]$p;
 			}
 		else

--- a/src/supervisor/Supervisor.h
+++ b/src/supervisor/Supervisor.h
@@ -111,35 +111,6 @@ public:
     };
 
     /**
-     * Configuration options that influence how a Supervised Zeek node
-     * integrates into the normal Zeek Cluster Framework.
-     */
-    struct ClusterEndpoint {
-        /**
-         * The node's role within the cluster.  E.g. manager, logger, worker.
-         */
-        BifEnum::Supervisor::ClusterRole role;
-        /**
-         * The TCP port number at which the cluster node listens for connections.
-         */
-        int port;
-        /**
-         * The host/IP at which the cluster node is listening for connections.
-         */
-        std::string host;
-        /**
-         * The interface name from which the node read/analyze packets.
-         * Typically used by worker nodes.
-         */
-        std::optional<std::string> interface;
-        /**
-         * The PCAP file name from which the node read/analyze packets.
-         * Typically used by worker nodes.
-         */
-        std::optional<std::string> pcap_file;
-    };
-
-    /**
      * Configuration options that influence behavior of a Supervised Zeek node.
      */
     struct NodeConfig {
@@ -233,15 +204,16 @@ public:
          */
         std::vector<std::string> addl_user_scripts;
         /**
-         * Environment variables and values  to define in the node.
+         * Environment variables and values to define in the node.
          */
         std::map<std::string, std::string> env;
         /**
-         * The Cluster Layout definition.  Each node in the Cluster Framework
-         * knows about the full, static cluster topology to which it belongs.
-         * Entries in the map use node names for keys.
+         * The cluster layout definition.  Each node in the Cluster Framework
+         * knows the full, static cluster topology to which it belongs.  The
+         * layout is encoded as the JSON map resulting from ToJSON() on the
+         * corresponding cluster table in the script layer's NodeConfig record.
          */
-        std::map<std::string, ClusterEndpoint> cluster;
+        std::string cluster;
     };
 
     /**

--- a/src/supervisor/supervisor.bif
+++ b/src/supervisor/supervisor.bif
@@ -14,7 +14,6 @@ enum ClusterRole %{
 	WORKER,
 %}
 
-type Supervisor::ClusterEndpoint: record;
 type Supervisor::Status: record;
 type Supervisor::NodeConfig: record;
 type Supervisor::NodeStatus: record;
@@ -64,14 +63,6 @@ function Supervisor::__restart%(node: string%): bool
 
 	auto rval = zeek::supervisor_mgr->Restart(node->CheckString());
 	return zeek::val_mgr->Bool(rval);
-	%}
-
-function Supervisor::__init_cluster%(%): bool
-	%{
-	if ( zeek::Supervisor::ThisNode() )
-		return zeek::val_mgr->Bool(zeek::Supervisor::ThisNode()->InitCluster());
-
-	return zeek::val_mgr->Bool(false);
 	%}
 
 function Supervisor::__is_supervised%(%): bool

--- a/testing/btest/Baseline/coverage.init-default/missing_loads
+++ b/testing/btest/Baseline/coverage.init-default/missing_loads
@@ -5,6 +5,7 @@
 -./frameworks/cluster/nodes/proxy.zeek
 -./frameworks/cluster/nodes/worker.zeek
 -./frameworks/cluster/setup-connections.zeek
+-./frameworks/cluster/supervisor.zeek
 -./frameworks/intel/cluster.zeek
 -./frameworks/netcontrol/cluster.zeek
 -./frameworks/openflow/cluster.zeek


### PR DESCRIPTION
This implements the brief discussion we had [here](https://zeekorg.slack.com/archives/CTGDG83B8/p1711501157059819). Removing that internal struct removes one place in which we need to keep changes to `Cluster::Node` consistent. This would be nice to get in prior to my upcoming change to add the metrics port, since it'll mean a smaller changeset.

I tried this in a couple of ways. One alternative was to keep the internal representation as a `RecordValPtr` to the script-layer `ClusterEndpoint` instance throughout (instead of keeping a JSON string), but that does not work because the stem doesn't have the corresponding script-layer context at the time it receives the serialized `NodeConfig`. I rather like that the meat of the mapping logic now lives in the script layer. 