### PR TITLE
coverage/lcov_html: Allow missing coveralls token

### DIFF
--- a/testing/coverage/lcov_html.sh
+++ b/testing/coverage/lcov_html.sh
@@ -63,15 +63,14 @@ while (("$#")); do
             fi
             ;;
         --coveralls)
-            if [ ${#2} -eq 0 ]; then
-                echo "ERROR: Coveralls repo token must be passed with --coveralls argument."
-                echo
-                usage
-            fi
-
             HTML_REPORT=0
-            COVERALLS_REPO_TOKEN=$2
-            shift 2
+            if [ ${#2} -eq 0 ]; then
+                echo "WARN: No coveralls token, running coveralls-lcov --dry-run."
+                shift 1
+            else
+                COVERALLS_REPO_TOKEN=$2
+                shift 2
+            fi
             ;;
         --help)
             usage
@@ -131,19 +130,19 @@ if [ $HTML_REPORT -eq 1 ]; then
     echo -n "Creating HTML files... "
     verify_run "genhtml --ignore-errors empty -o $COVERAGE_HTML_DIR $COVERAGE_FILE"
 else
-    if [ "${CIRRUS_BRANCH}" != "master" ]; then
-        echo "Coverage upload skipped for non-master branches"
-        exit 0
-    fi
-
     # The data we send to coveralls has a lot of duplicate files in it because of the
     # zeek symlink in the src directory. Run a script that cleans that up.
     echo -n "Cleaning coverage data for Coveralls..."
     COVERAGE_FILE_CLEAN="${COVERAGE_FILE}.clean"
     verify_run "testing/coverage/coverage_cleanup.py ${COVERAGE_FILE} > ${COVERAGE_FILE_CLEAN} 2>&1"
 
-    echo -n "Reporting to Coveralls..."
-    coveralls_cmd="coveralls-lcov -t ${COVERALLS_REPO_TOKEN}"
+    if [ "${CIRRUS_BRANCH}" == "master" ] && [ -n "${COVERALLS_REPO_TOKEN}" ]; then
+        echo -n "Reporting to Coveralls..."
+        coveralls_cmd="coveralls-lcov -t ${COVERALLS_REPO_TOKEN}"
+    else
+        echo "Reporting to Coveralls in --dry-run mode"
+        coveralls_cmd="coveralls-lcov --dry-run"
+    fi
 
     # If we're being called by Cirrus, add some additional information to the output.
     if [ -n "${CIRRUS_BUILD_ID}" ]; then


### PR DESCRIPTION
This is a fixup for 0cd023b83919fca7bfac55e75a41f724e820fd26 which currently causes ASAN coverage builds to fail for non-master branches when due to a missing COVERALLS_REPO_TOKEN.

Instead of bailing out for non-master branches, pass `--dry-run` to the coveralls-lcov invocation to test more of the script.