### PR TITLE
mkdir() BiF optionally generates error on failure

### DIFF
--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -4393,13 +4393,15 @@ function flush_all%(%): bool
 ##
 ## f: The directory name.
 ##
+## err_on_fail: Emits an error message when true, the default value is false.
+##
 ## Returns: True if the operation succeeds or if *f* already exists,
 ##          and false if the file creation fails.
 ##
 ## .. zeek:see:: active_file open_for_append close write_file
 ##              get_file_name set_buf flush_all enable_raw_output
 ##              rmdir unlink rename
-function mkdir%(f: string%): bool
+function mkdir%(f: string, err_on_fail: bool &default=F%): bool
 	%{
 	const char* filename = f->CheckString();
 
@@ -4412,7 +4414,8 @@ function mkdir%(f: string%): bool
 		     && S_ISDIR(filestat.st_mode) )
 			return zeek::val_mgr->True();
 
-		zeek::emit_builtin_error(zeek::util::fmt("cannot create directory '%s': %s", filename,
+        else if ( err_on_fail )
+		    zeek::emit_builtin_error(zeek::util::fmt("cannot create directory '%s': %s", filename,
 		                                         strerror(error)));
 		return zeek::val_mgr->False();
 		}


### PR DESCRIPTION

Addresses #3595.  

I added an extra argument to the BiF mkdir() called err_on_fail and it defaults to false.  It could default to true, but I reason that if folks want all the noise of diagnostics, they can ask for it.  That may be wrongheaded of me, so, if desired I can swap out the default value easily.  

While I was in the zeek.bif, I noticed that the BiF functions: rmdir, unlink, and rename behave like mkdir.  It may be worthwhile having those functions do as mkdir does.  I could add that on to this PR or have it in a separate one; however you all like to organize things.