### PR TITLE
Fix for --display-cmake option in configure

### DIFF
--- a/configure
+++ b/configure
@@ -458,6 +458,19 @@ if [ -z "$CMakeCommand" ]; then
     fi
 fi
 
+echo "Using $(cmake --version | head -1)"
+echo
+if [ -n "$CMakeGenerator" ]; then
+    cmake="${CMakeCommand} -G ${CMakeGenerator} ${CMakeCacheEntries} ${sourcedir}"
+else
+    cmake="${CMakeCommand} ${CMakeCacheEntries} ${sourcedir}"
+fi
+
+if [ "${display_cmake}" = 1 ]; then
+    echo "${cmake}"
+    exit 0
+fi
+
 if [ -d $builddir ]; then
     # If build directory exists, check if it has a CMake cache
     if [ -f $builddir/CMakeCache.txt ]; then
@@ -473,19 +486,6 @@ fi
 echo "Build Directory : $builddir"
 echo "Source Directory: $sourcedir"
 cd $builddir
-
-echo "Using $(cmake --version | head -1)"
-echo
-if [ -n "$CMakeGenerator" ]; then
-    cmake="${CMakeCommand} -G ${CMakeGenerator} ${CMakeCacheEntries} ${sourcedir}"
-else
-    cmake="${CMakeCommand} ${CMakeCacheEntries} ${sourcedir}"
-fi
-
-if [ "${display_cmake}" = 1 ]; then
-    echo "${cmake}"
-    exit 0
-fi
 
 eval ${cmake} 2>&1
 


### PR DESCRIPTION
Fixes  #3767

The configure script was setting up the build tree before checking if --display-cmake was set. It looks like it was as simple as moving that build tree setup further down the script.