### PR TITLE
CI: Use ccache and a single CPU when building spicy analyzers for btests

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -59,7 +59,9 @@ function run_btests {
 
     pushd testing/btest
 
-    ZEEK_PROFILER_FILE=$(pwd)/.tmp/script-coverage/XXXXXX \
+    HILTI_CXX_COMPILER_LAUNCHER=ccache \
+        HILTI_JIT_PARALLELISM=1 \
+        ZEEK_PROFILER_FILE=$(pwd)/.tmp/script-coverage/XXXXXX \
         ${BTEST} -z ${ZEEK_CI_BTEST_RETRIES} -d -A -x btest-results.xml -j ${ZEEK_CI_BTEST_JOBS} || result=1
     make coverage
     prep_artifacts


### PR DESCRIPTION
Some of the CI tasks are struggling with OOM issues when running tests. @bbannier dug a bit and it appears that the spicy jobs are causing extra load by using the maximum number of CPUs. This is compounded by the fact that we run as many btest jobs as we can, up to the number of CPUs. This PR tries to reduce the load first by using ccache for spicy builds, and second by only using a single CPU for the spicy plugin builds.