### PR TITLE
testing/btest: Default to HILTI_JIT_PARALLELISM=1

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -59,9 +59,7 @@ function run_btests {
 
     pushd testing/btest
 
-    HILTI_CXX_COMPILER_LAUNCHER=ccache \
-        HILTI_JIT_PARALLELISM=1 \
-        ZEEK_PROFILER_FILE=$(pwd)/.tmp/script-coverage/XXXXXX \
+    ZEEK_PROFILER_FILE=$(pwd)/.tmp/script-coverage/XXXXXX \
         ${BTEST} -z ${ZEEK_CI_BTEST_RETRIES} -d -A -x btest-results.xml -j ${ZEEK_CI_BTEST_JOBS} || result=1
     make coverage
     prep_artifacts

--- a/testing/btest/btest.cfg
+++ b/testing/btest/btest.cfg
@@ -14,6 +14,7 @@ MinVersion  = 0.63
 [environment]
 ZEEKPATH=`bash -c %(testbase)s/../../%(build_dir)s/zeek-path-dev`
 HILTI_CXX_COMPILER_LAUNCHER=`f=%(testbase)s/../../%(build_dir)s/CMakeCache.txt && grep -q '^ENABLE_CCACHE:BOOL=true' $f && sed -n 's/^CCACHE_PROGRAM:FILEPATH=\(.*\)$/\1/p' $f`
+HILTI_JIT_PARALLELISM=`bash -c 'echo ${HILTI_JIT_PARALLELISM:-1}'`
 ZEEK_SEED_FILE=%(testbase)s/random.seed
 ZEEK_PLUGIN_PATH=
 TZ=UTC


### PR DESCRIPTION
Follow up for #3820 to make setting applicable for manual `btest -j` invocations.