### PR TITLE
Do not emit hook files for builtin modules

### DIFF
--- a/src/spicy/spicyz/driver.cc
+++ b/src/spicy/spicyz/driver.cc
@@ -4,10 +4,8 @@
 
 #include <getopt.h>
 
-#include <algorithm>
 #include <memory>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -37,11 +35,14 @@ struct VisitorTypes : public spicy::visitor::PreOrder {
         : driver(driver), glue(glue), is_resolved(is_resolved) {}
 
     void operator()(hilti::declaration::Module* n) final {
-        if ( n->uid().in_memory ) {
-            // Ignore modules built by us in memory.
+        // Ignore modules built by us in memory, or builtin modules which
+        // never contain implementations of hooks for user types.
+        if ( n->uid().in_memory ||
+             (module == "hilti" || module == "spicy" || module == "spicy_rt" || module == "zeek_rt") ) {
             module = {};
             return;
         }
+
 
         module = n->scopeID();
         path = n->uid().path;


### PR DESCRIPTION
We would previously emit a C++ file with hooks for at least the builtin `spicy` module even though that module like any other builtin module never contains implementations of hooks for types in user code.

This patch adds a blocklist of builtin modules which are skipped for generating hook files.