### PR TITLE
Fix warning about grealpath when running 'make dist' on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD=build
 REPO=$$(cd $(CURDIR) && basename $$(git config --get remote.origin.url | sed 's/^[^:]*://g'))
 VERSION_FULL=$(REPO)-$$(cd $(CURDIR) && cat VERSION)
 GITDIR=$$(test -f .git && echo $$(cut -d" " -f2 .git) || echo .git)
-REALPATH=$$($$(realpath --relative-to=$(pwd) . >/dev/null 2>&1) && echo 'realpath' || echo 'grealpath')
+REALPATH=$$($$(realpath --relative-to=$(shell pwd) . >/dev/null 2>&1) && echo 'realpath' || echo 'grealpath')
 
 all: configured
 	$(MAKE) -C $(BUILD) $@


### PR DESCRIPTION
This fixes the following error if you run `make dist` on Linux:

```
tim@nuc release-7.0% make dist
error: cannot run grealpath: No such file or directory
fatal: run_command returned non-zero status for auxil/bifcl
.
error: cannot run grealpath: No such file or directory
fatal: run_command returned non-zero status for auxil/bifcl
.
```