### PR TITLE
Bump auxil/spicy to latest development snapshot

### DIFF
--- a/src/analyzer/protocol/finger/finger.spicy
+++ b/src/analyzer/protocol/finger/finger.spicy
@@ -15,7 +15,7 @@ public type Request  = unit {
 
     switch {
         -> : /\/W/ { self.whois = True; }
-        -> void;
+        -> : void;
     };
 
     : OptionalWhiteSpace;

--- a/src/analyzer/protocol/syslog/syslog.spicy
+++ b/src/analyzer/protocol/syslog/syslog.spicy
@@ -7,7 +7,7 @@ import spicy;
 public type Message = unit {
     switch {
         -> prio: Priority;
-        -> void;
+        -> : void;
     };
 
     msg: bytes &eod;

--- a/src/spicy/spicyz/glue-compiler.cc
+++ b/src/spicy/spicyz/glue-compiler.cc
@@ -1375,7 +1375,7 @@ bool GlueCompiler::CreateSpicyHook(glue::Event* ev) {
 
     auto attrs = builder()->attributeSet({builder()->attribute("&priority", builder()->integer(ev->priority))});
     auto parameters = hilti::util::transform(ev->parameters, [](const auto& p) { return p.get(); });
-    auto unit_hook = builder()->declarationHook(parameters, body.block(), ::spicy::Engine::All, attrs, meta);
+    auto unit_hook = builder()->declarationHook(parameters, body.block(), attrs, meta);
     auto hook_decl = builder()->declarationUnitHook(ev->hook, unit_hook, meta);
     ev->spicy_module->spicy_module->add(context(), hook_decl);
 


### PR DESCRIPTION
This patch bump Spicy to the latest development snapshot. This introduces a backwards-incompatible change in that it removes support for a never officially supported syntax to specify unit fields (so I would argue: not strictly a breaking change).