### PR TITLE
telemetry: Deprecate prometheus.zeek policy script

### DIFF
--- a/scripts/base/frameworks/telemetry/__load__.zeek
+++ b/scripts/base/frameworks/telemetry/__load__.zeek
@@ -1,3 +1,1 @@
 @load ./main
-
-@load base/frameworks/cluster

--- a/scripts/base/frameworks/telemetry/main.zeek
+++ b/scripts/base/frameworks/telemetry/main.zeek
@@ -5,9 +5,27 @@
 ##! enabled by setting :zeek:see:`Telemetry::metrics_port`.
 
 @load base/misc/version
+@load base/frameworks/cluster
+
 @load base/frameworks/telemetry/options
 
 module Telemetry;
+
+# In a cluster configuration, open the port number for metrics
+# from the cluster node configuration for exporting data to
+# Prometheus.
+#
+# The manager node will also provide a ``/services.json`` endpoint
+# for the HTTP Service Discovery system in Prometheus to use for
+# configuration. This endpoint will include information for all of
+# the other nodes in the cluster.
+@if ( Cluster::is_enabled() )
+redef Telemetry::metrics_endpoint_name = Cluster::node;
+
+@if ( Cluster::local_node_metrics_port() != 0/unknown )
+redef Telemetry::metrics_port = Cluster::local_node_metrics_port();
+@endif
+@endif
 
 export {
 	## Alias for a vector of label values.

--- a/scripts/policy/frameworks/telemetry/prometheus.zeek
+++ b/scripts/policy/frameworks/telemetry/prometheus.zeek
@@ -1,19 +1,2 @@
-##! In a cluster configuration, open the port number for metrics
-##! from the cluster node configuration for exporting data to
-##! Prometheus.
-##!
-##! The manager node will also provide a ``/services.json`` endpoint
-##! for the HTTP Service Discovery system in Prometheus to use for
-##! configuration. This endpoint will include information for all of
-##! the other nodes in the cluster.
-@load base/frameworks/cluster
-
-@if ( Cluster::is_enabled() )
-
-redef Telemetry::metrics_endpoint_name = Cluster::node;
-
-@if ( Cluster::local_node_metrics_port() != 0/unknown )
-redef Telemetry::metrics_port = Cluster::local_node_metrics_port();
-@endif
-
-@endif
+@deprecated "Remove in v7.1: Cluster nodes now implicitly listen on metrics port if set in cluster-layout."
+@load base/frameworks/telemetry

--- a/scripts/site/local.zeek
+++ b/scripts/site/local.zeek
@@ -94,10 +94,6 @@ redef digest_salt = "Please change this value.";
 # telemetry_histogram.log.
 @load frameworks/telemetry/log
 
-# Enable Prometheus metrics scraping in the cluster: each Zeek node will listen
-# on the metrics port defined in its Cluster::nodes entry.
-# @load frameworks/telemetry/prometheus
-
 # Uncomment the following line to enable detection of the heartbleed attack. Enabling
 # this might impact performance a bit.
 # @load policy/protocols/ssl/heartbleed

--- a/testing/btest/coverage/bare-mode-errors.test
+++ b/testing/btest/coverage/bare-mode-errors.test
@@ -9,4 +9,4 @@
 #
 # @TEST-EXEC: test -d $DIST/scripts
 # @TEST-EXEC: for script in `find $DIST/scripts/ -name \*\.zeek`; do zeek -b --parse-only $script >>errors 2>&1; done
-# @TEST-EXEC: TEST_DIFF_CANONIFIER="grep -v -e 'load-balancing.zeek.*deprecated script loaded' | $SCRIPTS/diff-remove-abspath | $SCRIPTS/diff-sort" btest-diff errors
+# @TEST-EXEC: TEST_DIFF_CANONIFIER="grep -v -e 'load-balancing.zeek.*deprecated script loaded' | grep -v -e 'prometheus.zeek.*deprecated script loaded' | $SCRIPTS/diff-remove-abspath | $SCRIPTS/diff-sort" btest-diff errors

--- a/testing/btest/coverage/test-all-policy-cluster.test
+++ b/testing/btest/coverage/test-all-policy-cluster.test
@@ -9,7 +9,7 @@
 # @TEST-EXEC: CLUSTER_NODE=logger-1 zeek %INPUT
 # @TEST-EXEC: CLUSTER_NODE=proxy-1 zeek %INPUT
 # @TEST-EXEC: CLUSTER_NODE=worker-1 zeek %INPUT
-# @TEST-EXEC: TEST_DIFF_CANONIFIER='grep -v "load-balancing.zeek.*deprecated script" | $SCRIPTS/diff-remove-abspath' btest-diff .stderr
+# @TEST-EXEC: TEST_DIFF_CANONIFIER='grep -v "load-balancing.zeek.*deprecated script" | grep -v "prometheus.zeek.*deprecated script" | $SCRIPTS/diff-remove-abspath' btest-diff .stderr
 
 @load base/frameworks/cluster
 @load misc/loaded-scripts

--- a/testing/btest/scripts/policy/frameworks/telemetry/prometheus.zeek
+++ b/testing/btest/scripts/policy/frameworks/telemetry/prometheus.zeek
@@ -55,7 +55,6 @@ done
 @TEST-END-FILE
 
 @load policy/frameworks/cluster/experimental
-@load policy/frameworks/telemetry/prometheus
 @load base/frameworks/telemetry
 
 # So the cluster nodes don't terminate right away.


### PR DESCRIPTION
With Cluster::Node$metrics_port being optional, there's not really a need for the extra script. New rule, if a metrics_port is set, the node will attempt to listen on it.

Users can still redef Telemetry::metrics_port *after* base/frameworks/telemetry was loaded to change the port defined in cluster-layout.zeek.