### PR TITLE
CI: Use 16GB of memory for FreeBSD builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,8 +35,7 @@ macos_environment: &MACOS_ENVIRONMENT
 
 freebsd_resources_template: &FREEBSD_RESOURCES_TEMPLATE
   cpu: 8
-  # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
-  memory: 8GB
+  memory: *MEMORY
   # For greediness, see https://medium.com/cirruslabs/introducing-greedy-container-instances-29aad06dc2b4
   greedy: true
 


### PR DESCRIPTION
I don't remember why we were setting this to 8GB. There was probably a limitation on those VMs when we first started using Cirrus and we never went back to fix it. This will hopefully help with the number of "Context cancelled" errors that we get from the FreeBSD builds. According to the memory graphs for the FreeBSD builds we weren't bumping against the old 8GB limit, but Fedor suggested we try upping the memory on our builds.