### PR TITLE
Don't install empty ZAM directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -636,6 +636,8 @@ install(
     # https://gitlab.kitware.com/cmake/cmake/-/issues/17122 Exclude the ones that
     # this affects explicitly.
     PATTERN "script_opt/CPP/maint" EXCLUDE
+    PATTERN "script_opt/ZAM/maint" EXCLUDE
+    PATTERN "script_opt/ZAM/OPs" EXCLUDE
     PATTERN "fuzzers/corpora" EXCLUDE)
 
 install(


### PR DESCRIPTION
These directories are empty at install time and shouldn't be installed. They're causing issues for the FreeBSD packaging scripts. Thanks @leres for the note about them.