### PR TITLE
broker: Deprecate MakeEvent(ValPList*)

### DIFF
--- a/src/Span.h
+++ b/src/Span.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <array>
 #include <cstddef>
 #include <iterator>
 #include <type_traits>
@@ -127,9 +126,6 @@ private:
 
 template<class T>
 Span(T*, size_t) -> Span<T>;
-
-template<class Iter>
-Span(Iter, Iter) -> Span<typename std::iterator_traits<Iter>::value_type>;
 
 template<class T, size_t N>
 Span(T (&)[N]) -> Span<T>;

--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -14,6 +14,7 @@
 #include <unordered_map>
 
 #include "zeek/IntrusivePtr.h"
+#include "zeek/Span.h"
 #include "zeek/broker/Data.h"
 #include "zeek/iosource/IOSource.h"
 #include "zeek/logging/WriterBackend.h"
@@ -262,7 +263,27 @@ public:
      * @return an `Event` record value.  If an invalid event or arguments
      * were supplied the optional "name" field will not be set.
      */
-    RecordVal* MakeEvent(ValPList* args, zeek::detail::Frame* frame);
+    [[deprecated("Remove in v8.1: Use the ArgsSpan version instead")]] RecordVal* MakeEvent(ValPList* args,
+                                                                                            zeek::detail::Frame* frame);
+
+    using ArgsSpan = Span<const ValPtr>;
+
+    /**
+     * Create an `Event` record value from an event and its arguments.
+     * @param args A span pointing at the event arguments.
+     * @return an `Event` record value.  If an invalid event or arguments
+     * were supplied the optional "name" field will not be set.
+     */
+    zeek::RecordValPtr MakeEvent(ArgsSpan args);
+
+    /**
+     * Create an `Event` record value from an event and its arguments.
+     * @param args A span pointing at the event arguments.
+     * @param frame the calling frame, used to report location info upon error
+     * @return an `Event` record value.  If an invalid event or arguments
+     * were supplied the optional "name" field will not be set.
+     */
+    zeek::RecordValPtr MakeEvent(ArgsSpan args, zeek::detail::Frame* frame);
 
     /**
      * Register interest in peer event messages that use a certain topic prefix.

--- a/src/broker/messaging.bif
+++ b/src/broker/messaging.bif
@@ -5,8 +5,15 @@
 #include <set>
 #include <string>
 
+#include "zeek/Span.h"
 #include "zeek/broker/Manager.h"
 #include "zeek/logging/Manager.h"
+
+namespace {
+
+using ArgsSpan = zeek::Span<const zeek::ValPtr>;
+
+}
 
 static bool is_string_set(const zeek::Type* type)
 	{
@@ -46,7 +53,7 @@ std::set<std::string> val_to_topic_set(zeek::Val* val)
 	return rval;
 	}
 
-static bool publish_event_args(zeek::ValPList& args, const zeek::String* topic,
+static bool publish_event_args(ArgsSpan args, const zeek::String* topic,
                                zeek::detail::Frame* frame)
 	{
 	zeek::Broker::Manager::ScriptScopeGuard ssg;
@@ -57,9 +64,8 @@ static bool publish_event_args(zeek::ValPList& args, const zeek::String* topic,
 		                                      args[0]->AsRecordVal());
 	else
 		{
-		auto ev = zeek::broker_mgr->MakeEvent(&args, frame);
-		rval = zeek::broker_mgr->PublishEvent(topic->CheckString(), ev);
-		Unref(ev);
+		auto ev = zeek::broker_mgr->MakeEvent(args, frame);
+		rval = zeek::broker_mgr->PublishEvent(topic->CheckString(), ev->AsRecordVal());
 		}
 
 	return rval;
@@ -92,13 +98,9 @@ type Broker::Event: record;
 function Broker::make_event%(...%): Broker::Event
 	%{
 	zeek::Broker::Manager::ScriptScopeGuard ssg;
-	const auto& bif_args = @ARGS@;
-	ValPList args(bif_args->size());
 
-	for ( auto i = 0u; i < bif_args->size(); ++i )
-		args.push_back((*bif_args)[i].get());
-
-	return RecordValPtr{zeek::AdoptRef{}, zeek::broker_mgr->MakeEvent(&args, frame)};
+	auto ev = zeek::broker_mgr->MakeEvent(ArgsSpan{*@ARGS@});
+	return zeek::cast_intrusive<RecordVal>(ev);
 	%}
 
 ## Publishes an event at a given topic.
@@ -112,13 +114,8 @@ function Broker::make_event%(...%): Broker::Event
 ## Returns: true if the message is sent.
 function Broker::publish%(topic: string, ...%): bool
 	%{
-	const auto& bif_args = @ARGS@;
-	ValPList args(bif_args->size() - 1);
-
-	for ( auto i = 1u; i < bif_args->size(); ++i )
-		args.push_back((*bif_args)[i].get());
-
-	auto rval = publish_event_args(args, topic->AsString(), frame);
+	auto rval = publish_event_args(ArgsSpan{*@ARGS@}.subspan(1),
+	                               topic->AsString(), frame);
 	return zeek::val_mgr->Bool(rval);
 	%}
 
@@ -208,13 +205,8 @@ function Cluster::publish_rr%(pool: Pool, key: string, ...%): bool
 	if ( ! topic->AsString()->Len() )
 		return zeek::val_mgr->False();
 
-	const auto& bif_args = @ARGS@;
-	ValPList args(bif_args->size() - 2);
-
-	for ( auto i = 2u; i < bif_args->size(); ++i )
-		args.push_back((*bif_args)[i].get());
-
-	auto rval = publish_event_args(args, topic->AsString(), frame);
+	auto rval = publish_event_args(ArgsSpan{*@ARGS@}.subspan(2),
+	                               topic->AsString(), frame);
 	return zeek::val_mgr->Bool(rval);
 	%}
 
@@ -251,12 +243,7 @@ function Cluster::publish_hrw%(pool: Pool, key: any, ...%): bool
 	if ( ! topic->AsString()->Len() )
 		return zeek::val_mgr->False();
 
-	const auto& bif_args = @ARGS@;
-	ValPList args(bif_args->size() - 2);
-
-	for ( auto i = 2u; i < bif_args->size(); ++i )
-		args.push_back((*bif_args)[i].get());
-
-	auto rval = publish_event_args(args, topic->AsString(), frame);
+	auto rval = publish_event_args(ArgsSpan{*@ARGS@}.subspan(2),
+	                               topic->AsString(), frame);
 	return zeek::val_mgr->Bool(rval);
 	%}


### PR DESCRIPTION
The variadic broker messaging BIFs currently convert `@ARGS@` into a ValPList before passing it on to MakeEvent(). This appears historic plumbing. Implement the same functionality using iterators and do the extra copying in the now deprecated MakeEvent(ValPList*).

Further, make passing a frame optional as not all callers may have one available.


---

@Neverlord / @timwoj - I've been staring a lot at some of the variadic BiFs used by broker and wanted to see if you have opinions about moving to a model where the BiF arguments are passed as two iterators rather than the ValPList (which seems somewhat historic).

Basically, replace:
```
RecordVal* MakeEvent(
        ValPList* args, zeek::detail::Frame* frame);
```
with
```
zeek::RecordValPtr MakeEvent(ArgsIt first, ArgsIt last, zeek::detail::Frame* frame);
```

where `ArgsIt` is std::vector<ValPtr>::const_iterator. As `@ARGS@` in BiFs is a `std::vector<ValPtr>`. Switching to iterators allows slicing without copying (though maybe there's a better pattern than that?)