### PR TITLE
ci/ubuntu-24.04: Use ccache 4.10.2

### DIFF
--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20240528
+ENV DOCKERFILE_VERSION 20240807
 
 RUN apt-get update && apt-get -y install \
     bc \
@@ -41,3 +41,25 @@ RUN apt-get update && apt-get -y install \
 
 RUN pip3 install --break-system-packages junit2html
 RUN gem install coveralls-lcov
+
+# Download a newer pre-built ccache version that recognizes -fprofile-update=atomic
+# which is used when building with --coverage.
+#
+# This extracts the tarball into /opt/ccache-<version>-<platform> and
+# symlinks the executable to /usr/local/bin/ccache.
+#
+# See: https://ccache.dev/download.html
+ENV CCACHE_VERSION=4.10.2
+ENV CCACHE_PLATFORM=linux-x86_64
+ENV CCACHE_URL=https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-${CCACHE_PLATFORM}.tar.xz
+ENV CCACHE_SHA256=80cab87bd510eca796467aee8e663c398239e0df1c4800a0b5dff11dca0b4f18
+RUN cd /opt \
+    && if [ "$(uname -p)" != "x86_64" ]; then echo "cannot use ccache pre-built for x86_64!" >&2; exit 1 ; fi \
+    && curl -L --fail --max-time 30 $CCACHE_URL -o ccache.tar.xz \
+    && sha256sum ./ccache.tar.xz >&2 \
+    && echo "${CCACHE_SHA256} ccache.tar.xz" | sha256sum -c - \
+    && tar xvf ./ccache.tar.xz \
+    && ln -s $(pwd)/ccache-${CCACHE_VERSION}-${CCACHE_PLATFORM}/ccache /usr/local/bin/ccache \
+    && test "$(command -v ccache)" = "/usr/local/bin/ccache" \
+    && test "$(ccache --print-version)" = "${CCACHE_VERSION}" \
+    && rm ./ccache.tar.xz


### PR DESCRIPTION
The ccache version shipped with Ubuntu 24.04 does not yet recognize --fprofile-update=atomic, install one that does.

Now that the asan_sanitizer build also includes building Spicy and running the spicyz test suite, ccache is quite important.

Reference ccache/ccache#1408 and zeek/zeek#3777.