### PR TITLE
btest: Skip core.script-args under TSAN

### DIFF
--- a/testing/btest/core/script-args.zeek
+++ b/testing/btest/core/script-args.zeek
@@ -2,6 +2,10 @@
 # the script differently, leading to complaints that there are no scripts.
 # @TEST-REQUIRES: test "${ZEEK_USE_CPP}" != "1"
 
+# TSAN may re-execute the executable when the memory layout doesn't fullfill
+# requirements, causing argument confusion when that happens (see #3774).
+# @TEST-REQUIRES: ! have-tsan
+
 # @TEST-EXEC: printf '#!' > test.zeek
 # @TEST-EXEC: printf "$BUILD/src/zeek -b --\n" >> test.zeek
 # @TEST-EXEC: cat %INPUT >> test.zeek

--- a/testing/scripts/have-tsan
+++ b/testing/scripts/have-tsan
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if grep -q "ZEEK_SANITIZERS:STRING=.*thread.*" "${BUILD}"/CMakeCache.txt; then
+    exit 0
+fi
+
+exit 1


### PR DESCRIPTION
TSAN may re-execute the executable when the memory layout doesn't fullfill requirements, causing argument confusion when that happens.

Closes #3774.