### PR TITLE
rule-parse: Remove id_to_str() lookup to squelch coverity warning

### DIFF
--- a/src/rule-parse.y
+++ b/src/rule-parse.y
@@ -196,12 +196,7 @@ rule_attr:
 			if ( is_event($2) )
 				current_rule->AddAction(new zeek::detail::RuleActionEvent(nullptr, $2));
 			else
-				{
-				const char *msg = id_to_str($2);
-				if ( ! zeek::util::streq(msg, "<error>") )
-					zeek::reporter->Error("Identifier %s is not an event (%s:%d)", id_to_str($2),
-					                      current_rule_file, rules_line_number+1);
-				}
+				rules_error("identifier is not an event", $2);
 			}
 
 	|	TOK_EVENT TOK_IDENT TOK_STRING

--- a/testing/btest/Baseline/signatures.custom-event-errors/.stderr
+++ b/testing/btest/Baseline/signatures.custom-event-errors/.stderr
@@ -5,4 +5,6 @@ warning in <...>/custom-event-errors.zeek, line 9: Wrong number of arguments for
 error: wrong event parameters for 'wrong_signature3'
 warning in <...>/custom-event-errors.zeek, line 11: Type mismatch in function argument #1. Expected string, got count. (event(state:signature_state, msg:count, data:string))
 error: wrong event parameters for 'wrong_signature4'
-error: Error in signature (./id.sig:19): unknown script-level identifier (non_existing_event)
+error: Error in signature (./id.sig:19): identifier is not an event (non_existing_event)
+error: Error in signature (./id.sig:24): identifier is not an event (cat)
+error: Error in signature (./id.sig:29): identifier is not an event (ignore_checksums)

--- a/testing/btest/signatures/custom-event-errors.zeek
+++ b/testing/btest/signatures/custom-event-errors.zeek
@@ -23,6 +23,16 @@ signature udp-proto4 {
   ip-proto == 17
   event non_existing_event
 }
+
+signature udp-proto5 {
+  ip-proto == 17
+  event cat  # builtin function
+}
+
+signature udp-proto6 {
+  ip-proto == 17
+  event ignore_checksums  # variable
+}
 @TEST-END-FILE
 
 event wrong_signature2(state: signature_state, data: string) { }


### PR DESCRIPTION
Coverity didn't like that id_to_str() allocates memory and we didn't free it. Remote its usage wholesale.