### PR TITLE
-O gen-C++ initialization improvements (and some other tweaks)

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -474,7 +474,16 @@ public:
 
     // Optimization-related:
     ExprPtr Duplicate() override;
-    ValPtr FoldVal() const override { return val; }
+
+    ValPtr FoldVal() const override {
+        if ( type->Tag() == TYPE_OPAQUE )
+            // Aggressive constant propagation can lead to the appearance of
+            // opaque "constants". Don't consider these as foldable because
+            // they're problematic to generate independently.
+            return nullptr;
+
+        return val;
+    }
 
 protected:
     void ExprDescribe(ODesc* d) const override;

--- a/src/Func.h
+++ b/src/Func.h
@@ -291,6 +291,9 @@ protected:
      */
     virtual void SetCaptures(Frame* f);
 
+    // Captures when using ZVal block instead of a Frame.
+    std::unique_ptr<std::vector<ZVal>> captures_vec;
+
 private:
     size_t frame_size = 0;
 
@@ -303,9 +306,6 @@ private:
     Frame* captures_frame = nullptr;
 
     OffsetMap* captures_offset_mapping = nullptr;
-
-    // Captures when using ZVal block instead of a Frame.
-    std::unique_ptr<std::vector<ZVal>> captures_vec;
 
     // The most recently added/updated body ...
     StmtPtr current_body;

--- a/src/Func.h
+++ b/src/Func.h
@@ -211,6 +211,15 @@ public:
         return *captures_vec;
     }
 
+    /**
+     * Set the set of ZVal's used for captures.
+     *
+     * Used for script optimization purposes.
+     *
+     * @param cv The value used for captures_vec.
+     */
+    void SetCapturesVec(std::unique_ptr<std::vector<ZVal>> cv) { captures_vec = std::move(cv); }
+
     // Same definition as in Frame.h.
     using OffsetMap = std::unordered_map<std::string, int>;
 
@@ -291,9 +300,6 @@ protected:
      */
     virtual void SetCaptures(Frame* f);
 
-    // Captures when using ZVal block instead of a Frame.
-    std::unique_ptr<std::vector<ZVal>> captures_vec;
-
 private:
     size_t frame_size = 0;
 
@@ -306,6 +312,9 @@ private:
     Frame* captures_frame = nullptr;
 
     OffsetMap* captures_offset_mapping = nullptr;
+
+    // Captures when using ZVal block instead of a Frame.
+    std::unique_ptr<std::vector<ZVal>> captures_vec;
 
     // The most recently added/updated body ...
     StmtPtr current_body;

--- a/src/Type.h
+++ b/src/Type.h
@@ -35,6 +35,7 @@ class CompositeHash;
 class Expr;
 class ListExpr;
 class ZAMCompiler;
+class CPPRuntime;
 
 using ExprPtr = IntrusivePtr<Expr>;
 using ListExprPtr = IntrusivePtr<ListExpr>;
@@ -752,6 +753,7 @@ private:
     class CreationInitsOptimizer;
     friend zeek::RecordVal;
     friend zeek::detail::ZAMCompiler;
+    friend zeek::detail::CPPRuntime;
     const auto& DeferredInits() const { return deferred_inits; }
     const auto& CreationInits() const { return creation_inits; }
 

--- a/src/script_opt/CPP/Compile.h
+++ b/src/script_opt/CPP/Compile.h
@@ -143,6 +143,7 @@ public:
     // cohort associated with a given type.
     int TypeOffset(const TypePtr& t) { return GI_Offset(RegisterType(t)); }
     int TypeCohort(const TypePtr& t) { return GI_Cohort(RegisterType(t)); }
+    int TypeFinalCohort(const TypePtr& t) { return GI_FinalCohort(RegisterType(t)); }
 
     // Tracks a Zeek ValPtr used as a constant value.  These occur
     // in two contexts: directly as constant expressions, and indirectly
@@ -963,6 +964,7 @@ private:
     // associated with an initialization.
     int GI_Offset(const std::shared_ptr<CPP_InitInfo>& gi) const { return gi ? gi->Offset() : -1; }
     int GI_Cohort(const std::shared_ptr<CPP_InitInfo>& gi) const { return gi ? gi->InitCohort() : 0; }
+    int GI_FinalCohort(const std::shared_ptr<CPP_InitInfo>& gi) const { return gi ? gi->FinalInitCohort() : 0; }
 
     // Generate code to initialize the mappings for record field
     // offsets for field accesses into regions of records that

--- a/src/script_opt/CPP/Compile.h
+++ b/src/script_opt/CPP/Compile.h
@@ -385,6 +385,10 @@ private:
     std::string LocalName(const ID* l) const;
     std::string LocalName(const IDPtr& l) const { return LocalName(l.get()); }
 
+    // The same, but for a capture.
+    std::string CaptureName(const ID* l) const;
+    std::string CaptureName(const IDPtr& l) const { return CaptureName(l.get()); }
+
     // Returns a canonicalized name, with various non-alphanumeric
     // characters stripped or transformed, and guaranteed not to
     // conflict with C++ keywords.
@@ -585,8 +589,11 @@ private:
     // Maps function names to events relevant to them.
     std::unordered_map<std::string, std::vector<std::string>> body_events;
 
+    // Full type of the function we're currently compiling.
+    FuncTypePtr func_type;
+
     // Return type of the function we're currently compiling.
-    TypePtr ret_type = nullptr;
+    TypePtr ret_type;
 
     // Internal name of the function we're currently compiling.
     std::string body_name;
@@ -697,6 +704,8 @@ private:
     void GenValueSwitchStmt(const Expr* e, const case_list* cases);
 
     void GenWhenStmt(const WhenStmt* w);
+    void GenWhenStmt(const WhenInfo* wi, const std::string& when_lambda, const Location* loc,
+                     std::vector<std::string> local_aggrs);
     void GenForStmt(const ForStmt* f);
     void GenForOverTable(const ExprPtr& tbl, const IDPtr& value_var, const IDPList* loop_vars);
     void GenForOverVector(const ExprPtr& tbl, const IDPtr& value_var, const IDPList* loop_vars);
@@ -771,6 +780,7 @@ private:
     std::string GenSizeExpr(const Expr* e, GenType gt);
     std::string GenScheduleExpr(const Expr* e);
     std::string GenLambdaExpr(const Expr* e);
+    std::string GenLambdaExpr(const Expr* e, std::string capture_args);
     std::string GenIsExpr(const Expr* e, GenType gt);
 
     std::string GenArithCoerceExpr(const Expr* e, GenType gt);

--- a/src/script_opt/CPP/Driver.cc
+++ b/src/script_opt/CPP/Driver.cc
@@ -37,11 +37,12 @@ void CPPCompile::Compile(bool report_uncompilable) {
     // previously compiled instances of those if present.
     for ( auto& func : funcs ) {
         const auto& f = func.Func();
+        auto& body = func.Body();
 
         auto& ofiles = analysis_options.only_files;
         auto allow_cond = analysis_options.allow_cond;
 
-        string fn = func.Body()->GetLocationInfo()->filename;
+        string fn = body->GetLocationInfo()->filename;
 
         if ( ! allow_cond && ! func.ShouldSkip() && ! ofiles.empty() && files_with_conditionals.count(fn) > 0 ) {
             if ( report_uncompilable )
@@ -184,8 +185,8 @@ void CPPCompile::GenProlog() {
     Emit("namespace CPP_%s { // %s\n", Fmt(total_hash), string(working_dir));
 
     // The following might-or-might-not wind up being populated/used.
-    Emit("std::vector<int> field_mapping;");
-    Emit("std::vector<int> enum_mapping;");
+    Emit("std::vector<zeek_int_t> field_mapping;");
+    Emit("std::vector<zeek_int_t> enum_mapping;");
     NL();
 
     const_info[TYPE_BOOL] = CreateConstInitInfo("Bool", "ValPtr", "bool");

--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -1248,7 +1248,7 @@ string CPPCompile::GenEnum(const TypePtr& t, const ValPtr& ev) {
 
     if ( ! et->HasRedefs() )
         // Can use direct access.
-        return std::to_string(v);
+        return "zeek_int_t(" + std::to_string(v) + ")";
 
     // Need to dynamically map the access.
     int mapping_slot;

--- a/src/script_opt/CPP/Func.h
+++ b/src/script_opt/CPP/Func.h
@@ -8,9 +8,7 @@
 #include "zeek/Func.h"
 #include "zeek/script_opt/ProfileFunc.h"
 
-namespace zeek {
-
-namespace detail {
+namespace zeek::detail {
 
 // A subclass of Func used for lambdas that the compiler creates for
 // complex initializations (expressions used in type attributes).
@@ -42,11 +40,6 @@ public:
 
     const std::string& Name() { return name; }
 
-    // Sets/returns a hash associated with this statement.  A value
-    // of 0 means "not set".
-    p_hash_type GetHash() const { return hash; }
-    void SetHash(p_hash_type h) { hash = h; }
-
     // The following only get defined by lambda bodies.
     virtual void SetLambdaCaptures(Frame* f) {}
     virtual std::vector<ValPtr> SerializeLambdaCaptures() const { return std::vector<ValPtr>{}; }
@@ -64,7 +57,6 @@ protected:
     TraversalCode Traverse(TraversalCallback* cb) const override { return TC_CONTINUE; }
 
     std::string name;
-    p_hash_type hash = 0ULL;
 
     // A pseudo AST "call" node, used to support error localization.
     CallExprPtr ce;
@@ -117,6 +109,4 @@ extern std::unordered_map<p_hash_type, void (*)()> standalone_callbacks;
 // Callbacks to finalize initialization of standalone compiled scripts.
 extern std::vector<void (*)()> standalone_finalizations;
 
-} // namespace detail
-
-} // namespace zeek
+} // namespace zeek::detail

--- a/src/script_opt/CPP/Func.h
+++ b/src/script_opt/CPP/Func.h
@@ -77,7 +77,6 @@ protected:
     // Methods related to sending lambdas via Broker.
     std::optional<BrokerData> SerializeCaptures() const override;
     void SetCaptures(Frame* f) override;
-    void SetCapturesVec(std::unique_ptr<std::vector<ZVal>> _captures_vec) { captures_vec = std::move(_captures_vec); }
 
     FuncPtr DoClone() override;
 

--- a/src/script_opt/CPP/Func.h
+++ b/src/script_opt/CPP/Func.h
@@ -77,6 +77,7 @@ protected:
     // Methods related to sending lambdas via Broker.
     std::optional<BrokerData> SerializeCaptures() const override;
     void SetCaptures(Frame* f) override;
+    void SetCapturesVec(std::unique_ptr<std::vector<ZVal>> _captures_vec) { captures_vec = std::move(_captures_vec); }
 
     FuncPtr DoClone() override;
 

--- a/src/script_opt/CPP/Inits.cc
+++ b/src/script_opt/CPP/Inits.cc
@@ -166,7 +166,7 @@ void CPPCompile::InitializeConsts() {
     StartBlock();
 
     for ( const auto& c : consts )
-        Emit("CPP_ValElem(%s, %s),", TypeTagName(c.first), Fmt(c.second));
+        Emit("{%s, %s},", TypeTagName(c.first), Fmt(c.second));
 
     EndBlock(true);
 }

--- a/src/script_opt/CPP/InitsInfo.h
+++ b/src/script_opt/CPP/InitsInfo.h
@@ -133,10 +133,10 @@ public:
     // Sets the associated C++ type.
     virtual void SetCPPType(std::string ct) { CPP_type = std::move(ct); }
 
-    // Whether this initializer is in terms of compound objects. Used
+    // Whether this initializer is in terms of compound vectors. Used
     // for avoiding compiler warnings about singleton initializations in
     // braces.
-    virtual bool IsCompound() const { return false; }
+    virtual bool UsesCompoundVectors() const { return false; }
 
     // Returns the type associated with the table used for initialization
     // (i.e., this is the type of the global returned by InitializersName()).
@@ -146,9 +146,11 @@ public:
     void AddInstance(std::shared_ptr<CPP_InitInfo> g);
 
     // Emit code to populate the table used to initialize this collection.
-    void GenerateInitializers(CPPCompile* c);
+    virtual void GenerateInitializers(CPPCompile* c);
 
 protected:
+    virtual void GenerateCohorts(CPPCompile* c);
+
     // Computes offset_set - see below.
     void BuildOffsetSet(CPPCompile* c);
 
@@ -214,7 +216,7 @@ public:
         BuildInitType();
     }
 
-    bool IsCompound() const override { return true; }
+    bool UsesCompoundVectors() const override { return true; }
 
 private:
     void BuildInitType() { inits_type = std::string("CPP_CustomInits<") + CPPType() + ">"; }
@@ -236,7 +238,7 @@ public:
             inits_type = std::string("CPP_BasicConsts<") + CPP_type + ", " + c_type + ", " + tag + "Val>";
     }
 
-    bool IsCompound() const override { return false; }
+    bool UsesCompoundVectors() const override { return false; }
 
     void BuildCohortElement(CPPCompile* c, std::string init_type, std::vector<std::string>& ivs) override;
 };
@@ -254,7 +256,12 @@ public:
             inits_type = std::string("CPP_IndexedInits<") + CPPType() + ">";
     }
 
-    bool IsCompound() const override { return true; }
+    // This isn't true (anymore) because we separately build up the compound
+    // vectors needed for the initialization.
+    bool UsesCompoundVectors() const override { return false; }
+
+    void GenerateInitializers(CPPCompile* c) override;
+    void GenerateCohorts(CPPCompile* c) override;
 
     void BuildCohortElement(CPPCompile* c, std::string init_type, std::vector<std::string>& ivs) override;
 };

--- a/src/script_opt/CPP/RuntimeOps.cc
+++ b/src/script_opt/CPP/RuntimeOps.cc
@@ -194,11 +194,7 @@ void remove_element__CPP(TableValPtr aggr, ListValPtr indices) {
     check_iterators__CPP(iterators_invalidated);
 }
 
-// A helper function that takes a parallel vectors of attribute tags
-// and values and returns a collective AttributesPtr corresponding to
-// those instantiated attributes.  For attributes that don't have
-// associated expressions, the corresponding value should be nil.
-static AttributesPtr build_attrs__CPP(vector<int> attr_tags, vector<ValPtr> attr_vals) {
+AttributesPtr build_attrs__CPP(IntVec attr_tags, vector<ValPtr> attr_vals) {
     vector<AttrPtr> attrs;
     int nattrs = attr_tags.size();
     for ( auto i = 0; i < nattrs; ++i ) {
@@ -243,7 +239,7 @@ TableValPtr table_constructor__CPP(vector<ValPtr> indices, vector<ValPtr> vals, 
     return aggr;
 }
 
-void assign_attrs__CPP(IDPtr id, std::vector<int> attr_tags, std::vector<ValPtr> attr_vals) {
+void assign_attrs__CPP(IDPtr id, IntVec attr_tags, ValVec attr_vals) {
     id->SetAttrs(build_attrs__CPP(std::move(attr_tags), std::move(attr_vals)));
 }
 

--- a/src/script_opt/CPP/RuntimeOps.cc
+++ b/src/script_opt/CPP/RuntimeOps.cc
@@ -91,7 +91,7 @@ ValPtr when_index_slice__CPP(VectorVal* vec, const ListVal* lv) {
     return v;
 }
 
-ValPtr when_invoke__CPP(Func* f, std::vector<ValPtr> args, Frame* frame, void* caller_addr) {
+ValPtr when_invoke__CPP(Func* f, ValVec args, Frame* frame, void* caller_addr) {
     auto trigger = frame->GetTrigger();
 
     if ( trigger ) {

--- a/src/script_opt/CPP/RuntimeOps.h
+++ b/src/script_opt/CPP/RuntimeOps.h
@@ -18,7 +18,16 @@ namespace detail {
 
 class CPPRuntime {
 public:
-    static auto RawOptField(const RecordValPtr& rv, int field) { return rv->RawOptField(field); }
+    static auto& RawField(const RecordValPtr& rv, int field) { return rv->RawField(field); }
+    static auto& RawField(RecordVal* rv, int field) { return rv->RawField(field); }
+    static auto& RawOptField(const RecordValPtr& rv, int field) { return rv->RawOptField(field); }
+    static auto& RawOptField(RecordVal* rv, int field) { return rv->RawOptField(field); }
+
+    static const auto& GetCreationInits(const RecordType* rt) { return rt->CreationInits(); }
+
+    static RecordVal* BuildRecordVal(RecordTypePtr t, std::vector<std::optional<ZVal>> init_vals) {
+        return new RecordVal(std::move(t), std::move(init_vals));
+    }
 };
 
 // Returns the concatenation of the given strings.

--- a/src/script_opt/CPP/RuntimeVec.cc
+++ b/src/script_opt/CPP/RuntimeVec.cc
@@ -109,7 +109,7 @@ VEC_OP1(comp, ~, )
     }
 
 // Analogous to VEC_OP1, instantiates a function for a given binary operation,
-// with customimzable kernels for "int" and "double" operations.
+// with customizable kernels for "int" and "double" operations.
 // This version is for operations whose result type is the same as the
 // operand type.
 #define VEC_OP2(name, op, int_kernel, double_kernel, zero_check, is_bool)                                              \

--- a/src/script_opt/CPP/Stmts.cc
+++ b/src/script_opt/CPP/Stmts.cc
@@ -305,15 +305,22 @@ void CPPCompile::GenValueSwitchStmt(const Expr* e, const case_list* cases) {
 
 void CPPCompile::GenWhenStmt(const WhenStmt* w) {
     auto wi = w->Info();
-    auto wl = wi->Lambda();
 
-    if ( ! wl )
-        reporter->FatalError("cannot compile deprecated \"when\" statement");
+    vector<string> local_aggrs;
 
+    for ( auto& l : wi->WhenExprLocals() )
+        if ( IsAggr(l->GetType()) )
+            local_aggrs.push_back(IDNameStr(l.get()));
+
+    auto when_lambda = GenExpr(wi->Lambda(), GEN_NATIVE);
+    GenWhenStmt(wi.get(), when_lambda, w->GetLocationInfo(), std::move(local_aggrs));
+}
+
+void CPPCompile::GenWhenStmt(const WhenInfo* wi, const std::string& when_lambda, const Location* loc,
+                             vector<string> local_aggrs) {
     auto is_return = wi->IsReturn() ? "true" : "false";
     auto timeout = wi->TimeoutExpr();
     auto timeout_val = timeout ? GenExpr(timeout, GEN_NATIVE) : "-1.0";
-    auto loc = w->GetLocationInfo();
 
     Emit("{ // begin a new scope for internal variables");
 
@@ -331,17 +338,18 @@ void CPPCompile::GenWhenStmt(const WhenStmt* w) {
     NL();
 
     Emit("std::vector<ValPtr> CPP__local_aggrs;");
-    for ( auto& l : wi->WhenExprLocals() )
-        if ( IsAggr(l->GetType()) )
-            Emit("CPP__local_aggrs.emplace_back(%s);", IDNameStr(l.get()));
+    for ( auto& la : local_aggrs )
+        Emit("CPP__local_aggrs.emplace_back(%s);", la);
 
-    Emit("CPP__wi->Instantiate(%s);", GenExpr(wi->Lambda(), GEN_NATIVE));
+    Emit("CPP__wi->Instantiate(%s);", when_lambda);
 
     // We need a new frame for the trigger to unambiguously associate
     // with, in case we're called multiple times with our existing frame.
     Emit("auto new_frame = make_intrusive<Frame>(0, nullptr, nullptr);");
     Emit("auto curr_t = f__CPP->GetTrigger();");
     Emit("auto curr_assoc = f__CPP->GetTriggerAssoc();");
+    if ( ! ret_type || ret_type->Tag() == TYPE_VOID )
+        Emit("// Note, the following works even if curr_t is nil.");
     Emit("new_frame->SetTrigger({NewRef{}, curr_t});");
     Emit("new_frame->SetTriggerAssoc(curr_assoc);");
 

--- a/src/script_opt/CPP/Stmts.cc
+++ b/src/script_opt/CPP/Stmts.cc
@@ -352,7 +352,7 @@ void CPPCompile::GenWhenStmt(const WhenStmt* w) {
 
     if ( ret_type && ret_type->Tag() != TYPE_VOID ) {
         // Note, ret_type can be active but we *still* don't have
-        // a return type, due to the faked-up "any" return type
+        // a return value, due to the faked-up "any" return type
         // associated with "when" lambdas, so check for that case.
         Emit("if ( curr_t )");
         StartBlock();

--- a/src/script_opt/CPP/Util.cc
+++ b/src/script_opt/CPP/Util.cc
@@ -17,6 +17,16 @@ string Fmt(double d) {
     if ( d == 0.0 && signbit(d) )
         return "-0.0";
 
+    if ( isinf(d) ) {
+        string infty = "std::numeric_limits<double>::infinity()";
+        if ( d < 0.0 )
+            infty = "-" + infty;
+        return infty;
+    }
+
+    if ( isnan(d) )
+        return "std::numeric_limits<double>::quiet_NaN()";
+
     // Unfortunately, to_string(double) is hardwired to use %f with
     // default of 6 digits precision.
     char buf[8192];

--- a/src/script_opt/CPP/Vars.cc
+++ b/src/script_opt/CPP/Vars.cc
@@ -111,10 +111,30 @@ string CPPCompile::LocalName(const ID* l) const {
     auto n = l->Name();
     auto without_module = strstr(n, "::");
 
-    if ( without_module )
-        return Canonicalize(without_module + 2);
-    else
-        return Canonicalize(n);
+    while ( without_module ) {
+        n = without_module + 2;
+        without_module = strstr(n, "::");
+    }
+
+    return Canonicalize(n);
+}
+
+string CPPCompile::CaptureName(const ID* l) const {
+    // We want to strip both the module and any inlining appendage.
+    auto n = l->Name();
+    auto without_module = strstr(n, "::");
+
+    while ( without_module ) {
+        n = without_module + 2;
+        without_module = strstr(n, "::");
+    }
+
+    auto appendage = strchr(n, '.');
+
+    if ( appendage )
+        return string(n, appendage - n) + "_";
+
+    return string(n) + "_";
 }
 
 string CPPCompile::Canonicalize(const char* name) const {
@@ -127,7 +147,7 @@ string CPPCompile::Canonicalize(const char* name) const {
         if ( c == '<' || c == '>' )
             continue;
 
-        if ( c == ':' || c == '-' )
+        if ( c == ':' || c == '-' || c == '.' )
             c = '_';
 
         cname += c;

--- a/src/script_opt/Expr.cc
+++ b/src/script_opt/Expr.cc
@@ -475,7 +475,8 @@ ExprPtr UnaryExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     auto op_val = op->FoldVal();
     if ( op_val ) {
         auto fold = Fold(op_val.get());
-        return TransformMe(make_intrusive<ConstExpr>(fold), c, red_stmt);
+        if ( fold->GetType()->Tag() != TYPE_OPAQUE )
+            return TransformMe(make_intrusive<ConstExpr>(fold), c, red_stmt);
     }
 
     if ( c->Optimizing() )
@@ -523,7 +524,8 @@ ExprPtr BinaryExpr::Reduce(Reducer* c, StmtPtr& red_stmt) {
     auto op2_fold_val = op2->FoldVal();
     if ( op1_fold_val && op2_fold_val ) {
         auto fold = Fold(op1_fold_val.get(), op2_fold_val.get());
-        return TransformMe(make_intrusive<ConstExpr>(fold), c, red_stmt);
+        if ( fold->GetType()->Tag() != TYPE_OPAQUE )
+            return TransformMe(make_intrusive<ConstExpr>(fold), c, red_stmt);
     }
 
     if ( c->Optimizing() )

--- a/src/script_opt/Expr.cc
+++ b/src/script_opt/Expr.cc
@@ -115,6 +115,9 @@ bool Expr::IsReducedConditional(Reducer* c) const {
                 return NonReduced(this);
 
             if ( op1->Tag() == EXPR_LIST ) {
+                if ( ! op1->IsReduced(c) )
+                    return NonReduced(this);
+
                 auto l1 = op1->AsListExpr();
                 auto& l1_e = l1->Exprs();
 

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -401,7 +401,6 @@ static void use_CPP() {
             ++num_used;
 
             auto b = s->second.body;
-            b->SetHash(hash);
 
             // We may have already updated the body if
             // we're using code compiled for standalone.
@@ -532,6 +531,9 @@ static void analyze_scripts_for_ZAM() {
 }
 
 void clear_script_analysis() {
+    if ( analysis_options.gen_CPP )
+        return;
+
     IDOptInfo::ClearGlobalInitExprs();
 
     // We need to explicitly clear out the optimization information

--- a/testing/btest/scripts/policy/frameworks/cluster/cluster_started_restart_manager.zeek
+++ b/testing/btest/scripts/policy/frameworks/cluster/cluster_started_restart_manager.zeek
@@ -1,4 +1,5 @@
 # @TEST-DOC: Verify cluster_started() is not rebroadcasted if the manager restarts.
+# @TEST-REQUIRES: test "${ZEEK_USE_CPP}" != "1"
 # @TEST-PORT: SUPERVISOR_PORT
 # @TEST-PORT: MANAGER_PORT
 # @TEST-PORT: PROXY_PORT

--- a/testing/btest/scripts/policy/frameworks/cluster/cluster_started_restart_worker.zeek
+++ b/testing/btest/scripts/policy/frameworks/cluster/cluster_started_restart_worker.zeek
@@ -1,4 +1,5 @@
 # @TEST-DOC: Verify cluster_started() is not rebroadcasted if a worker restarts.
+# @TEST-REQUIRES: test "${ZEEK_USE_CPP}" != "1"
 # @TEST-PORT: SUPERVISOR_PORT
 # @TEST-PORT: MANAGER_PORT
 # @TEST-PORT: PROXY_PORT


### PR DESCRIPTION
I've been using `-O gen-C++` script optimization on some large script collections, which revealed that some facets of how the generated code performs its (massive) initializations could take a huge amount of time to compile. This PR addresses two instances of the problem, both regarding large `std::vector` initializers. Compilation is much slower if the individual initializers are non-trivial C++ objects as opposed to very simple types (`int`s and `struct`s, in particular), so the changes switch to using the latter.

Running on the diverse set of scripts also exposed a number of previously-untickled bugs, which the PR also fixes. Finally, it includes some low-level changes for tidy-ness and enabling more flexible use of some compile-time and run-time components. 