### PR TITLE
spicy/protocol-analyzer: Move Done() after EndOfData()

### DIFF
--- a/src/spicy/protocol-analyzer.cc
+++ b/src/spicy/protocol-analyzer.cc
@@ -131,8 +131,6 @@ void TCP_Analyzer::Init() {
 }
 
 void TCP_Analyzer::Done() {
-    ProtocolAnalyzer::Done();
-
     EndOfData(true);
     EndOfData(false);
 

--- a/src/spicy/protocol-analyzer.cc
+++ b/src/spicy/protocol-analyzer.cc
@@ -131,11 +131,15 @@ void TCP_Analyzer::Init() {
 }
 
 void TCP_Analyzer::Done() {
-    analyzer::tcp::TCP_ApplicationAnalyzer::Done();
     ProtocolAnalyzer::Done();
 
     EndOfData(true);
     EndOfData(false);
+
+    // ProtocolAnalyzer::Done() or EndOfData() may instantiate
+    // new child analyzers which isn't valid after a call to
+    // Analyzer::Done() anymore. So delay calling it.
+    analyzer::tcp::TCP_ApplicationAnalyzer::Done();
 }
 
 void TCP_Analyzer::DeliverStream(int len, const u_char* data, bool is_orig) {


### PR DESCRIPTION
We've got crash reports involving Spicy analyzers that appear to be caused by `ProtocolAnalyzer::Done()` or `EndOfData()` instantiating new child analyzers *after* `analyzer::tcp::TCP_ApplicationAnalyzer::Done();` was called, resulting in the following code being executed:

https://github.com/zeek/zeek/blob/ac5cbcc43e7527a22513ec7ce5685b2bdeefbb98/src/analyzer/Analyzer.cc#L117-L122

The call to `->Done()` on `new_children` in turn may reference the `TCP_SessionAdapter`, e.g. through `AnalyzerViolation()`, resulting in access to already freed memory.

This feels like a stop gap. We've done something similar for the HTTP analyzer in the past, but I wonder if there's a better idea? 6ef9423f3cff13e6c73f97eb6a3a27d6f64cc320