### PR TITLE
ScriptOpt: Ensure global statements have non-null scope

### DIFF
--- a/src/script_opt/ProfileFunc.cc
+++ b/src/script_opt/ProfileFunc.cc
@@ -80,6 +80,8 @@ ProfileFunc::ProfileFunc(const Expr* e, bool _abs_rec_fields) {
 void ProfileFunc::Profile(const FuncType* ft, const StmtPtr& body) {
     num_params = ft->Params()->NumFields();
 
+    assert(profiled_scope != nullptr);
+
     auto& ov = profiled_scope->OrderedVars();
     for ( int i = 0; i < num_params; ++i )
         params.insert(ov[i].get());

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -66,12 +66,14 @@ void analyze_global_stmts(Stmt* stmts) {
     auto id = install_ID("<global-stmts>", GLOBAL_MODULE_NAME, true, false);
     auto empty_args_t = make_intrusive<RecordType>(nullptr);
     auto func_t = make_intrusive<FuncType>(empty_args_t, nullptr, FUNC_FLAVOR_FUNCTION);
+    func_t->SetName("<global-stmts>");
     id->SetType(func_t);
 
     auto sc = current_scope();
     std::vector<IDPtr> empty_inits;
     global_stmts = make_intrusive<ScriptFunc>(id);
     global_stmts->AddBody(stmts->ThisPtr(), empty_inits, sc->Length());
+    global_stmts->SetScope(sc);
 
     global_stmts_ind = funcs.size();
     funcs.emplace_back(global_stmts, sc, stmts->ThisPtr(), 0);


### PR DESCRIPTION
The ProfileFunc() logic assumed that GetScope() returned a non-nullptr. This holds except for the synthetic global statements function.

Fix the latter and add an assert, also add a name to the type so it's easier to recognize in a debugger what's going on, otherwise the name is "".

This was found by UBSAN due to it seeing the ->OrderedVars() call on a nullptr. Elsewhere, num_params == 0 shielded from that access and so didn't lead to crashes.