### PR TITLE
logging: Replace threading::Value** with std::vector

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,15 @@ Breaking Changes
   new ``OpaqueVal::DoSerializeData`` and ``OpaqueVal::DoUnserializeData``
   methods.
 
+* Certain internal methods on the broker and logging classes have been changed to
+  accept std::vector<threading::Value> parameters instead of threading::Value**
+  to leverage automatic memory management, reduce the number of allocations
+  and use move semantics to express ownership.
+
+  The DoWrite() and HookLogWrite() methods which can be provided by plugins
+  are not affected by this change, so we keep backwards compatibility with
+  existing log writers.
+
 New Functionality
 -----------------
 

--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -223,18 +223,16 @@ public:
                           const broker::endpoint_info& peer = NoPeer);
 
     /**
-     * Send a log entry to any interested peers.  The topic name used is
-     * implicitly "bro/log/<stream-name>".
+     * Send a log entry to any interested peers.
+     *
      * @param stream the stream to which the log entry belongs.
      * @param writer the writer to use for outputting this log entry.
      * @param path the log path to output the log entry to.
-     * @param num_vals the number of fields to log.
-     * @param vals the log values to log, of size num_vals.
-     * See the Broker::SendFlags record type.
+     * @param rec the log record.
      * @return true if the message is sent successfully.
      */
-    bool PublishLogWrite(EnumVal* stream, EnumVal* writer, std::string path, int num_vals,
-                         const threading::Value* const* vals);
+    bool PublishLogWrite(EnumVal* stream, EnumVal* writer, const std::string& path,
+                         const logging::detail::LogRecord& rec);
 
     /**
      * Automatically send an event to any interested peers whenever it is

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -1158,9 +1158,10 @@ bool Manager::WriteToFilters(const Manager::Stream* stream, zeek::RecordValPtr c
         if ( zeek::plugin_mgr->HavePluginForHook(zeek::plugin::HOOK_LOG_WRITE) ) {
             // The current HookLogWrite API takes a threading::Value**.
             // Fabricate the pointer array on the fly. Mutation is allowed.
-            std::vector<threading::Value*> vals(rec.size());
-            for ( size_t i = 0; i < rec.size(); i++ )
-                vals[i] = &rec[i];
+            std::vector<threading::Value*> vals;
+            vals.reserve(rec.size());
+            for ( auto& v : rec )
+                vals.emplace_back(&v);
 
             bool res =
                 zeek::plugin_mgr->HookLogWrite(filter->writer->GetType()->AsEnumType()->Lookup(

--- a/src/logging/Manager.h
+++ b/src/logging/Manager.h
@@ -268,9 +268,10 @@ public:
                                   const threading::Field* const* fields);
 
     /**
-     * Writes out log entries that have already passed through all
-     * filters (and have raised any events). This is meant called for logs
-     * received already processed from remote.
+     * Writes out log entries received from remote nodes.
+     *
+     * The given record has passed through all policy filters and raised events
+     * on the sending node. It's only meant to be written out.
      *
      * @param stream The enum value corresponding to the log stream.
      *
@@ -278,13 +279,11 @@ public:
      *
      * @param path The path of the target log stream to write to.
      *
-     * @param num_fields The number of log values to write.
-     *
-     * @param vals An array of log values to write, of size num_fields.
-     * The method takes ownership of the array.
+     * @param rec Representation of the log record to write.
+
+     * @return Returns true if the record was processed successfully.
      */
-    bool WriteFromRemote(EnumVal* stream, EnumVal* writer, const std::string& path, int num_fields,
-                         threading::Value** vals);
+    bool WriteFromRemote(EnumVal* id, EnumVal* writer, const std::string& path, detail::LogRecord&& rec);
 
     /**
      * Announces all instantiated writers to a given Broker peer.
@@ -365,9 +364,6 @@ protected:
     bool FinishedRotation(WriterFrontend* writer, const char* new_name, const char* old_name, double open, double close,
                           bool success, bool terminating);
 
-    // Deletes the values as passed into Write().
-    void DeleteVals(int num_fields, threading::Value** vals);
-
 private:
     struct Filter;
     struct Stream;
@@ -376,9 +372,9 @@ private:
     bool TraverseRecord(Stream* stream, Filter* filter, RecordType* rt, TableVal* include, TableVal* exclude,
                         const std::string& path, const std::list<int>& indices);
 
-    threading::Value** RecordToFilterVals(const Stream* stream, Filter* filter, RecordVal* columns);
+    detail::LogRecord RecordToLogRecord(const Stream* stream, Filter* filter, RecordVal* columns);
+    threading::Value ValToLogVal(std::optional<ZVal>& val, Type* ty);
 
-    threading::Value* ValToLogVal(std::optional<ZVal>& val, Type* ty);
     Stream* FindStream(EnumVal* id);
     void RemoveDisabledWriters(Stream* stream);
     void InstallRotationTimer(WriterInfo* winfo);

--- a/src/logging/WriterBackend.cc
+++ b/src/logging/WriterBackend.cc
@@ -219,15 +219,18 @@ bool WriterBackend::Write(int arg_num_fields, zeek::Span<detail::LogRecord> reco
         //
         // We keep the raw pointer for this API, as threading::Value
         // itself manages strings, sets and vectors using raw pointers,
-        // so this seems more consistent than mixing.
-        std::vector<Value*> valps(num_fields);
+        // so this is more consistent than mixing.
+        std::vector<Value*> valps;
+        valps.reserve(num_fields);
 
         for ( size_t j = 0; j < records.size(); j++ ) {
             auto& write_vals = records[j];
             for ( int f = 0; f < num_fields; f++ )
-                valps[f] = &write_vals[f];
+                valps.emplace_back(&write_vals[f]);
 
             success = DoWrite(num_fields, fields, &valps[0]);
+
+            valps.clear();
 
             if ( ! success )
                 break;

--- a/src/logging/WriterBackend.h
+++ b/src/logging/WriterBackend.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "zeek/Span.h"
 #include "zeek/logging/Component.h"
 #include "zeek/threading/MsgThread.h"
 
@@ -12,6 +13,12 @@ class data;
 }
 
 namespace zeek::logging {
+
+namespace detail {
+
+using LogRecord = std::vector<threading::Value>;
+
+}
 
 class WriterFrontend;
 
@@ -137,21 +144,16 @@ public:
     bool Init(int num_fields, const threading::Field* const* fields);
 
     /**
-     * Writes one log entry.
+     * Write a batch of log records.
      *
      * @param num_fields: The number of log fields for this stream. The
      * value must match what was passed to Init().
      *
-     * @param An array of size \a num_fields with the log values. Their
-     * types must match with the field passed to Init(). The method
-     * takes ownership of \a vals..
-     *
-     * Returns false if an error occurred, in which case the writer must
-     * not be used any further.
+     * @param records Span of LogRecord instances to write out.
      *
      * @return False if an error occurred.
      */
-    bool Write(int num_fields, int num_writes, threading::Value*** vals);
+    bool Write(int arg_num_fields, zeek::Span<detail::LogRecord> records);
 
     /**
      * Sets the buffering status for the writer, assuming the writer

--- a/src/logging/WriterFrontend.cc
+++ b/src/logging/WriterFrontend.cc
@@ -132,7 +132,6 @@ WriterFrontend::~WriterFrontend() {
 
 void WriterFrontend::Stop() {
     if ( disabled ) {
-        CleanupWriteBuffer();
         return;
     }
 
@@ -198,10 +197,8 @@ void WriterFrontend::Write(detail::LogRecord&& arg_vals) {
 }
 
 void WriterFrontend::FlushWriteBuffer() {
-    if ( disabled ) {
-        CleanupWriteBuffer();
+    if ( disabled )
         return;
-    }
 
     if ( write_buffer.Empty() )
         // Nothing to do.
@@ -247,7 +244,5 @@ void WriterFrontend::Rotate(const char* rotated_path, double open, double close,
         // Still signal log manager that we're done.
         log_mgr->FinishedRotation(this, nullptr, nullptr, 0, 0, false, terminating);
 }
-
-void WriterFrontend::CleanupWriteBuffer() { write_buffer.Clear(); }
 
 } // namespace zeek::logging

--- a/src/logging/WriterFrontend.h
+++ b/src/logging/WriterFrontend.h
@@ -8,6 +8,71 @@ namespace zeek::logging {
 
 class Manager;
 
+
+namespace detail {
+
+/**
+ * Implements a buffer accumulating log records in \a WriterFrontend instance
+ * before passing them to \a WriterBackend instances.
+ *
+ * \see WriterFrontend::Write
+ */
+class WriteBuffer {
+public:
+    /**
+     * Constructor.
+     */
+    explicit WriteBuffer(size_t buffer_size) : buffer_size(buffer_size) {}
+
+    /**
+     * Push a record to the buffer.
+     *
+     * @param record The records vals.
+     */
+    void WriteRecord(LogRecord&& record) { records.emplace_back(std::move(record)); }
+
+    /**
+     * Moves the records out of the buffer and resets it.
+     *
+     * @return The currently buffered log records.
+     */
+    std::vector<LogRecord> TakeRecords() && {
+        auto tmp = std::move(records);
+
+        // Re-initialize the buffer.
+        records.clear();
+        records.reserve(buffer_size);
+
+        return tmp;
+    }
+
+    /**
+     * @return The size of the buffer.
+     */
+    size_t Size() const { return records.size(); }
+
+    /**
+     * @return True if buffer is empty.
+     */
+    size_t Empty() const { return records.empty(); }
+
+    /**
+     * @return True if size equals or exceeds configured buffer size.
+     */
+    bool Full() const { return records.size() >= buffer_size; }
+
+    /**
+     * Clear the records buffer.
+     */
+    void Clear() { records.clear(); }
+
+private:
+    size_t buffer_size;
+    std::vector<LogRecord> records;
+};
+
+} // namespace detail
+
 /**
  * Bridge class between the logging::Manager and backend writer threads. The
  * Manager instantiates one \a WriterFrontend for each open logging filter.
@@ -84,13 +149,14 @@ public:
      * FlushWriteBuffer(). The backend writer triggers this with a
      * message at every heartbeat.
      *
-     * See WriterBackend::Writer() for arguments (except that this method
-     * takes only a single record, not an array). The method takes
-     * ownership of \a vals.
+     * If the frontend has remote logging enabled, the record is also
+     * published to interested peers.
      *
+     * @param rec Representation of the log record. Callee takes ownership.
+
      * This method must only be called from the main thread.
      */
-    void Write(int num_fields, threading::Value** vals);
+    void Write(detail::LogRecord&& rec);
 
     /**
      * Sets the buffering state.
@@ -185,8 +251,6 @@ public:
 protected:
     friend class Manager;
 
-    void DeleteVals(int num_fields, threading::Value** vals);
-
     EnumVal* stream;
     EnumVal* writer;
 
@@ -204,8 +268,7 @@ protected:
 
     // Buffer for bulk writes.
     static const int WRITER_BUFFER_SIZE = 1000;
-    int write_buffer_pos;             // Position of next write in buffer.
-    threading::Value*** write_buffer; // Buffer of size WRITER_BUFFER_SIZE.
+    detail::WriteBuffer write_buffer; // Buffer of size WRITER_BUFFER_SIZE.
 
 private:
     void CleanupWriteBuffer();

--- a/src/logging/WriterFrontend.h
+++ b/src/logging/WriterFrontend.h
@@ -61,11 +61,6 @@ public:
      */
     bool Full() const { return records.size() >= buffer_size; }
 
-    /**
-     * Clear the records buffer.
-     */
-    void Clear() { records.clear(); }
-
 private:
     size_t buffer_size;
     std::vector<LogRecord> records;
@@ -269,9 +264,6 @@ protected:
     // Buffer for bulk writes.
     static const int WRITER_BUFFER_SIZE = 1000;
     detail::WriteBuffer write_buffer; // Buffer of size WRITER_BUFFER_SIZE.
-
-private:
-    void CleanupWriteBuffer();
 };
 
 } // namespace zeek::logging

--- a/src/threading/SerialTypes.h
+++ b/src/threading/SerialTypes.h
@@ -104,9 +104,9 @@ private:
  * those Vals supported).
  */
 struct Value {
-    TypeTag type;    //! The type of the value.
-    TypeTag subtype; //! Inner type for sets and vectors.
-    bool present;    //! False for optional record fields that are not set.
+    TypeTag type;         //! The type of the value.
+    TypeTag subtype;      //! Inner type for sets and vectors.
+    bool present = false; //! False for optional record fields that are not set.
 
     struct set_t {
         zeek_int_t size;
@@ -186,6 +186,16 @@ struct Value {
         : type(arg_type), subtype(arg_subtype), present(arg_present) {}
 
     /**
+     * Copy constructor.
+     */
+    Value(const Value& other);
+
+    /**
+     * Move constructor.
+     */
+    Value(Value&& other) noexcept;
+
+    /**
      * Destructor.
      */
     ~Value();
@@ -241,7 +251,6 @@ struct Value {
 
 private:
     friend class IPAddr;
-    Value(const Value& other) = delete;
 
     // For values read by the input framework, this can represent the line number
     // containing this value. Used by the Ascii reader primarily.


### PR DESCRIPTION
While looking at the logging API/code: When converting from `RecordVal` to the `threading::Value**` construct, there are individual `new threading::Value(...)` calls for every field. Instead, it's also possible to allocate the needed `threading::Value`s as a single array in one go, reducing pressure on the malloc implementation. While at it, also switching to `std::vector` for automatic memory management.

This is a RFC PR to a) run the benchmarker and b) get a feeling if others would be okay changing what I think are mostly internal APIs on WriterFrontend and WriterBackend. I added backwards compat, but these are "slow implementations" doing copies that maybe we shouldn't even provide.

For a 500k syn packet pcap (10kpps), with `-C -D -b base/protocols/conn` using glibc's malloc, processing is roughly 17% faster:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `taskset -c 1 /opt/zeek-dev-prod-orig/bin/zeek --no-unused-warnings -D -C -b -r /media/awelzel/T7/pcaps/awelzel/500k-syns-slow.pcap base/protocols/conn Log::default_writer=Log::WRITER_NONE` | 16.604 ± 0.073 | 16.559 | 16.688 | 1.21 ± 0.01 |
| `taskset -c 1 /opt/zeek-dev-prod/bin/zeek --no-unused-warnings -D -C -b -r /media/awelzel/T7/pcaps/awelzel/500k-syns-slow.pcap base/protocols/conn Log::default_writer=Log::WRITER_NONE` | 13.768 ± 0.109 | 13.685 | 13.892 | 1.00 |


Using jemalloc, with this branch it's maybe 1%-2% faster, but by far not as impressive:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `taskset -c 1 /opt/zeek-dev-prod-orig/bin/zeek --no-unused-warnings -D -C -b -r /media/awelzel/T7/pcaps/awelzel/500k-syns-slow.pcap base/protocols/conn Log::default_writer=Log::WRITER_NONE` | 10.203 ± 0.026 | 10.184 | 10.232 | 1.02 ± 0.01 |
| `taskset -c 1 /opt/zeek-dev-prod/bin/zeek --no-unused-warnings -D -C -b -r /media/awelzel/T7/pcaps/awelzel/500k-syns-slow.pcap base/protocols/conn Log::default_writer=Log::WRITER_NONE` | 10.050 ± 0.102 | 9.983 | 10.168 | 1.00 |

---

PCAPs (not so exciting except for 500k-syns-slow).

![Screenshot from 2024-08-21 14-23-16](https://github.com/user-attachments/assets/b42280f5-1d03-4bdf-b59c-04ebae4da85b)

Logging micro-benchmarks show improvement (table-complex-key most left is likely noise, shouldn't be impacted by this changeset).
![Screenshot from 2024-08-21 14-24-15](https://github.com/user-attachments/assets/181e369b-fb75-4d1a-af6d-09e1a4afa76e)
