### PR TITLE
RunState: Drop broker_mgr->Active() usage

### DIFF
--- a/src/RunState.cc
+++ b/src/RunState.cc
@@ -31,7 +31,6 @@ extern "C" {
 #include "zeek/Reporter.h"
 #include "zeek/Scope.h"
 #include "zeek/Timer.h"
-#include "zeek/broker/Manager.h"
 #include "zeek/iosource/Manager.h"
 #include "zeek/iosource/PktDumper.h"
 #include "zeek/iosource/PktSrc.h"
@@ -275,8 +274,6 @@ void run_loop() {
         }
 #endif
         current_iosrc = nullptr;
-        auto communication_enabled = broker_mgr->Active();
-
         if ( ! ready.empty() ) {
             for ( const auto& src : ready ) {
                 auto* iosrc = src.src;
@@ -289,8 +286,7 @@ void run_loop() {
                     iosrc->Process();
             }
         }
-        else if ( (have_pending_timers || communication_enabled || BifConst::exit_only_after_terminate) &&
-                  ! pseudo_realtime ) {
+        else if ( (have_pending_timers || BifConst::exit_only_after_terminate) && pseudo_realtime == 0.0 ) {
             // Take advantage of the lull to get up to
             // date on timers and events.  Because we only
             // have timers as sources, going to sleep here
@@ -330,7 +326,7 @@ void run_loop() {
 
         // Terminate if we're running pseudo_realtime and
         // the interface has been closed.
-        if ( pseudo_realtime && communication_enabled ) {
+        if ( pseudo_realtime != 0.0 ) {
             iosource::PktSrc* ps = iosource_mgr->GetPktSrc();
             if ( ps && ! ps->IsOpen() )
                 iosource_mgr->Terminate();

--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -109,7 +109,7 @@ public:
     /**
      * Returns true if any Broker communication is currently active.
      */
-    bool Active();
+    [[deprecated("Remove with v8.1 - unused")]] bool Active();
 
     /**
      * Advances time.  Broker data store expiration is driven by this


### PR DESCRIPTION
...and deprecate it. The communication_enabled flag doesn't really make a difference in how the IO loop works.