### PR TITLE
Bump clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 #
 repos:
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v17.0.3'
+  rev: 'v18.1.8'
   hooks:
   - id: clang-format
     types_or:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
   rev: v0.6.13
   hooks:
   - id: cmake-format
-    exclude: '^auxil/.*$'
 
 - repo: https://github.com/crate-ci/typos
   rev: v1.16.21

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -77,14 +77,14 @@ public:
          *
          * @param name The resulting name from the lookup.
          */
-        virtual void Resolved(const std::string& name){};
+        virtual void Resolved(const std::string& name) {};
 
         /**
          * Called when a name lookup finishes.
          *
          * @param addrs A table of the resulting addresses from the lookup.
          */
-        virtual void Resolved(TableValPtr addrs){};
+        virtual void Resolved(TableValPtr addrs) {};
 
         /**
          * Generic callback method for all request types.

--- a/src/IPAddr.h
+++ b/src/IPAddr.h
@@ -130,7 +130,7 @@ public:
     /**
      * Copy constructor.
      */
-    IPAddr(const IPAddr& other) : in6(other.in6){};
+    IPAddr(const IPAddr& other) : in6(other.in6) {};
 
     /**
      * Destructor.

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -104,7 +104,7 @@ public:
     [[noreturn]] void Internal(const char* msg) const;
     void InternalWarning(const char* msg) const;
 
-    virtual void Describe(ODesc* d) const {/* FIXME: Add code */};
+    virtual void Describe(ODesc* d) const { /* FIXME: Add code */ };
 
     void AddLocation(ODesc* d) const;
 

--- a/src/Type.h
+++ b/src/Type.h
@@ -794,7 +794,7 @@ class OpaqueType final : public Type {
 public:
     explicit OpaqueType(const std::string& name);
     TypePtr ShallowClone() override { return make_intrusive<OpaqueType>(name); }
-    ~OpaqueType() override{};
+    ~OpaqueType() override {};
 
     const std::string& Name() const { return name; }
 

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -527,7 +527,7 @@ bool Contents_RPC::CheckResync(int& len, const u_char*& data, bool orig) {
                 NeedResync();
                 return false;
         } // end switch
-    }     // end while (len>0)
+    } // end while (len>0)
 
     return false;
 }
@@ -623,7 +623,7 @@ void Contents_RPC::DeliverStream(int len, const u_char* data, bool orig) {
                 // yet.
             } break;
         } // end switch
-    }     // end while
+    } // end while
 }
 
 RPC_Analyzer::RPC_Analyzer(const char* name, Connection* conn, detail::RPC_Interpreter* arg_interp)

--- a/src/file_analysis/analyzer/x509/X509Common.h
+++ b/src/file_analysis/analyzer/x509/X509Common.h
@@ -27,7 +27,7 @@ namespace detail {
 
 class X509Common : public file_analysis::Analyzer {
 public:
-    ~X509Common() override{};
+    ~X509Common() override {};
 
     /**
      * Retrieve an X509 extension value from an OpenSSL BIO to which it was

--- a/src/fuzzers/generic-analyzer-fuzzer.cc
+++ b/src/fuzzers/generic-analyzer-fuzzer.cc
@@ -33,7 +33,7 @@ class Fuzzer {
 public:
     Fuzzer(TransportProto proto, const zeek::Tag& analyzer_tag) : proto{proto}, analyzer_tag{analyzer_tag} {}
 
-    virtual ~Fuzzer(){};
+    virtual ~Fuzzer() {};
 
     zeek::Connection* AddConnection() {
         static constexpr double network_time_start = 1439471031;

--- a/src/logging/writers/none/None.h
+++ b/src/logging/writers/none/None.h
@@ -11,7 +11,7 @@ namespace zeek::logging::writer::detail {
 class None : public WriterBackend {
 public:
     explicit None(WriterFrontend* frontend) : WriterBackend(frontend) {}
-    ~None() override{};
+    ~None() override {};
 
     static WriterBackend* Instantiate(WriterFrontend* frontend) { return new None(frontend); }
 

--- a/src/packet_analysis/Dispatcher.h
+++ b/src/packet_analysis/Dispatcher.h
@@ -19,7 +19,7 @@ namespace detail {
  */
 class Dispatcher {
 public:
-    Dispatcher() : table(std::vector<AnalyzerPtr>(1, nullptr)){};
+    Dispatcher() : table(std::vector<AnalyzerPtr>(1, nullptr)) {};
     ~Dispatcher();
 
     /**

--- a/src/script_opt/CPP/RuntimeInitSupport.h
+++ b/src/script_opt/CPP/RuntimeInitSupport.h
@@ -19,7 +19,7 @@ namespace detail {
 // with recursive types.
 class CPPTableType : public TableType {
 public:
-    CPPTableType() : TableType(nullptr, nullptr){};
+    CPPTableType() : TableType(nullptr, nullptr) {};
 
     void SetIndexAndYield(TypeListPtr ind, TypePtr yield) {
         indices = std::move(ind);

--- a/src/util.cc
+++ b/src/util.cc
@@ -1645,36 +1645,34 @@ FILE* open_file(const string& path, const string& mode) {
     return rval;
 }
 
-TEST_CASE("util path ops"){
+TEST_CASE("util path ops") {
 #ifdef _MSC_VER
 // TODO: adapt these tests to Windows paths
 #else
-    SUBCASE("SafeDirname"){SafeDirname d("/this/is/a/path", false);
-CHECK(d.result == "/this/is/a");
+    SUBCASE("SafeDirname") {
+        SafeDirname d("/this/is/a/path", false);
+        CHECK(d.result == "/this/is/a");
 
-SafeDirname d2("invalid", false);
-CHECK(d2.result == ".");
+        SafeDirname d2("invalid", false);
+        CHECK(d2.result == ".");
 
-SafeDirname d3("./filename", false);
-CHECK(d2.result == ".");
-}
+        SafeDirname d3("./filename", false);
+        CHECK(d2.result == ".");
+    }
 
-SUBCASE("SafeBasename") {
-    SafeBasename b("/this/is/a/path", false);
-    CHECK(b.result == "path");
-    CHECK(! b.error);
+    SUBCASE("SafeBasename") {
+        SafeBasename b("/this/is/a/path", false);
+        CHECK(b.result == "path");
+        CHECK(! b.error);
 
-    SafeBasename b2("justafile", false);
-    CHECK(b2.result == "justafile");
-    CHECK(! b2.error);
-}
+        SafeBasename b2("justafile", false);
+        CHECK(b2.result == "justafile");
+        CHECK(! b2.error);
+    }
 #endif
 }
 
-SafeDirname::SafeDirname(const char* path, bool error_aborts)
-    : SafePathOp() {
-    DoFunc(path ? path : "", error_aborts);
-}
+SafeDirname::SafeDirname(const char* path, bool error_aborts) : SafePathOp() { DoFunc(path ? path : "", error_aborts); }
 
 SafeDirname::SafeDirname(const string& path, bool error_aborts) : SafePathOp() { DoFunc(path, error_aborts); }
 
@@ -2303,8 +2301,7 @@ static void strerror_r_helper(char* result, char* buf, size_t buflen) {
         buf[buflen - 1] = 0;
 }
 
-static void strerror_r_helper(int result, char* buf, size_t buflen) { /* XSI flavor of strerror_r, no-op. */
-}
+static void strerror_r_helper(int result, char* buf, size_t buflen) { /* XSI flavor of strerror_r, no-op. */ }
 
 void zeek_strerror_r(int zeek_errno, char* buf, size_t buflen) {
 #ifdef _MSC_VER


### PR DESCRIPTION
This patch contains a bump of the configured clang-format version from
17.0.3 to 18.1.8 and automatically generated C++ source updates. The
main difference we are seeing from this is fixes for previously
incomplete reformats.