### PR TITLE
Pre-commit - remove spicy-format for the moment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,10 +32,3 @@ repos:
   hooks:
     - id: typos
       exclude: '^(.typos.toml|src/SmithWaterman.cc|testing/.*|auxil/.*|scripts/base/frameworks/files/magic/.*|CHANGES)$'
-
-- repo: https://github.com/bbannier/spicy-format
-  rev: v0.15.0
-  hooks:
-    - id: spicy-format
-      # TODO: Reformat existing large analyzers just before 8.0.
-      exclude: '(^testing/.*)|(protocol/ldap/.*)|(protocol/quic/.*)|(protocol/websocket/.*)'


### PR DESCRIPTION
This currently errors during compilation, because pre-commit does not pass --locked during compilation, without a way to enable it.

See https://github.com/pre-commit/pre-commit/issues/3162 for details.