### PR TITLE
Spicy SSL: reformat with new version of spicy format, bump spicy-format to 0.16.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       exclude: '^(.typos.toml|src/SmithWaterman.cc|testing/.*|auxil/.*|scripts/base/frameworks/files/magic/.*|CHANGES)$'
 
 - repo: https://github.com/bbannier/spicy-format
-  rev: v0.16.1
+  rev: v0.16.2
   hooks:
     - id: spicy-format
       # TODO: Reformat existing large analyzers just before 8.0.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       exclude: '^(.typos.toml|src/SmithWaterman.cc|testing/.*|auxil/.*|scripts/base/frameworks/files/magic/.*|CHANGES)$'
 
 - repo: https://github.com/bbannier/spicy-format
-  rev: v0.15.0
+  rev: v0.16.1
   hooks:
     - id: spicy-format
       # TODO: Reformat existing large analyzers just before 8.0.

--- a/src/analyzer/protocol/ssl/spicy/SSL.spicy
+++ b/src/analyzer/protocol/ssl/spicy/SSL.spicy
@@ -701,7 +701,7 @@ type SSL2Record = unit(lengthone: uint8, inout msg: Message, inout sh: Share) {
     var length: uint16;
 
     on lengthtwo {
-        self.length = (cast<uint16>(lengthone) & 0x7F)<<8 | self.lengthtwo;
+        self.length = (cast<uint16>(lengthone) & 0x7F) << 8 | self.lengthtwo;
     }
     message_type: uint8;
 
@@ -712,7 +712,7 @@ type SSL2Record = unit(lengthone: uint8, inout msg: Message, inout sh: Share) {
         SSL2ProtocolMessages::ssl_server_verify -> : skip bytes &size=self.length;
         SSL2ProtocolMessages::ssl_request_certificate -> : skip bytes &size=self.length;
         SSL2ProtocolMessages::ssl_client_certificate -> : skip bytes &size=self.length;
-    } if(get_encrypted(sh) == False) ;
+    } if(get_encrypted(sh) == False);
     : skip bytes &size=self.length if(get_encrypted(sh) == True);
 
     on %done {
@@ -842,7 +842,7 @@ function determine_encryption_on(pr: PlaintextRecord, content_type: uint8, hands
         return False;
 
     if (content_type != 23) # application_data
-    return False;
+        return False;
 
     ## in theory, we should check for TLS13 or draft-TLS13 instead of doing the reverse.
     ## But - people use weird version numbers. And all of those weird version numbers are


### PR DESCRIPTION
Reformats SSL.spicy with spicy-format and bumps the version so that everything is in sync.