### PR TITLE
Update Dockerfile to avoid LegacyKeyValueFormat warning

### DIFF
--- a/docker/final.Dockerfile
+++ b/docker/final.Dockerfile
@@ -35,5 +35,5 @@ RUN apt-get -q update \
 
 # Copy over Zeek installation from build
 COPY --from=zeek-build /usr/local/zeek /usr/local/zeek
-ENV PATH "/usr/local/zeek/bin:${PATH}"
-ENV PYTHONPATH "/usr/local/zeek/lib/zeek/python:${PYTHONPATH}"
+ENV PATH="/usr/local/zeek/bin:${PATH}"
+ENV PYTHONPATH="/usr/local/zeek/lib/zeek/python:${PYTHONPATH}"


### PR DESCRIPTION
This is just a nit-picky change to reduce unnecessary warnings.

The warnings in question, which arise when building a Zeek Docker container:
```
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 38)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 39)
```

The explanation for them: https://docs.docker.com/reference/build-checks/legacy-key-value-format/

Change tested by checking the ENVs afterwards:
```
 % docker image inspect zeek-arm64:latest | jq ".[0].Config.Env"
[
  "PATH=/usr/local/zeek/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
  "PYTHONPATH=/usr/local/zeek/lib/zeek/python:"
]
```