### PR TITLE
zeek-setup: Support enabling debug streams through env variable

### DIFF
--- a/src/DebugLogger.h
+++ b/src/DebugLogger.h
@@ -85,6 +85,9 @@ public:
 
     bool IsEnabled(DebugStream stream) const { return streams[int(stream)].enabled; }
 
+    // Are any streams enabled?
+    bool HasEnabledStreams() const { return ! enabled_streams.empty(); }
+
     void SetVerbose(bool arg_verbose) { verbose = arg_verbose; }
     bool IsVerbose() const { return verbose; }
 

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -170,7 +170,10 @@ void usage(const char* prog, int code) {
                                           "not set, will use first IPv4 address from /etc/resolv.conf");
     fprintf(stderr,
             "    $ZEEK_DEBUG_LOG_STDERR          | Use stderr for debug logs generated via "
-            "the -B flag");
+            "the -B flag\n");
+    fprintf(stderr,
+            "    $ZEEK_DEBUG_LOG_STREAMS         | Enable debugging output for selected "
+            "streams (see the -B flag)");
 
     fprintf(stderr, "\n");
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -556,9 +556,13 @@ SetupResult setup(int argc, char** argv, Options* zopts) {
         reporter->FatalError("-u incompatible with --no-unused-warnings");
 
 #ifdef DEBUG
-    if ( options.debug_log_streams ) {
+    if ( options.debug_log_streams )
         debug_logger.EnableStreams(options.debug_log_streams->data());
 
+    if ( const auto* streams = getenv("ZEEK_DEBUG_LOG_STREAMS") )
+        debug_logger.EnableStreams(streams);
+
+    if ( debug_logger.HasEnabledStreams() ) {
         if ( getenv("ZEEK_DEBUG_LOG_STDERR") )
             debug_logger.OpenDebugLog(nullptr);
         else


### PR DESCRIPTION
For debugging btests, it can be convenient to enable debug streams by setting an environment variable rather than editing zeek invocations and adding -B selectively.

Sample use case:

    $ export ZEEK_DEBUG_LOG_STREAMS=all
    $ btest -d core/failing-test.zeek
    $ less .tmp/core/failing-test/debug.log

Zeek's -B option and ZEEK_DEBUG_LOG_STREAMS are additive.