### PR TITLE
Install `procps` in OpenSuse Leap images

### DIFF
--- a/ci/opensuse-leap-15.5/Dockerfile
+++ b/ci/opensuse-leap-15.5/Dockerfile
@@ -21,6 +21,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/openSUSE:Leap:15.5
     libpcap-devel \
     make \
     openssh \
+    procps \
     python311 \
     python311-devel \
     python311-pip \

--- a/ci/opensuse-leap-15.6/Dockerfile
+++ b/ci/opensuse-leap-15.6/Dockerfile
@@ -21,6 +21,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/openSUSE:Leap:15.6
     libpcap-devel \
     make \
     openssh \
+    procps \
     python312 \
     python312-devel \
     python312-pip \


### PR DESCRIPTION
The tests `core.sigterm-regular` and `core.sigterm-stdin` rely on `ps` to be present which is not the case anymore on OpenSuse Leap; install it explicitly there.