### PR TITLE
Fix input error test nondeterminism

### DIFF
--- a/testing/btest/Baseline/scripts.base.frameworks.input.invalid-lines-duplicate/.stderrwithoutfirstline
+++ b/testing/btest/Baseline/scripts.base.frameworks.input.invalid-lines-duplicate/.stderrwithoutfirstline
@@ -3,5 +3,4 @@ warning: ..<...>/Input::READER_ASCII: ../input.log, line 3: Not enough fields in
 warning: ..<...>/Input::READER_ASCII: ../input.log, line 9: Suppressed 5 warning(s)
 warning: ..<...>/Input::READER_ASCII: ../input.log, line 10: Not enough fields in line 'hello' of ../input.log. Found 0 fields, want positions 1 and -1
 warning: ..<...>/Input::READER_ASCII: ../input.log, line 16: Suppressed 6 warning(s)
-received termination signal
 >>>

--- a/testing/btest/scripts/base/frameworks/input/invalid-lines-duplicate.zeek
+++ b/testing/btest/scripts/base/frameworks/input/invalid-lines-duplicate.zeek
@@ -1,6 +1,6 @@
 # @TEST-EXEC: btest-bg-run zeek zeek -b %INPUT
 # @TEST-EXEC: btest-bg-wait 10
-# @TEST-EXEC: sed 1d .stderr > .stderrwithoutfirstline
+# @TEST-EXEC: sed -e 1d -e '/received termination/d' .stderr > .stderrwithoutfirstline
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff .stderrwithoutfirstline
 
 redef exit_only_after_terminate = T;
@@ -46,5 +46,5 @@ event zeek_init() {
 
 
 event Input::end_of_data(name: string, source:string) {
-	terminate();
+    terminate();
 }


### PR DESCRIPTION
Test introduced in #3949 caused nondeterminism (spotted by @awelzel [here](https://cirrus-ci.com/task/5479888096854016?logs=test#L2021))

It seems like other similar tests get by because they have more "stuff" before they call `terminate()` most likely. But, to be safe, just removing the "received termination signal" line seems like the best approach.

also fixed tabs vs. spaces :)