### PR TITLE
Fix flaky `missing-file-initially` test

### DIFF
--- a/testing/scripts/wait-for-file
+++ b/testing/scripts/wait-for-file
@@ -7,17 +7,21 @@ if [[ $# -ne 2 ]]; then
     exit 1
 fi
 
+SLEEP_INTERVAL=0.1
+SLEEP_INTERVAL_MS=100
+
 wait_file=$1
 max_wait=$2
-wait_count=0
+# Avoid floating point arithmetic by using milliseconds
+wait_countdown=$((${max_wait}000 / ${SLEEP_INTERVAL_MS}))
 
 while [[ ! -e $wait_file ]]; do
-    let "wait_count += 1"
+    let "wait_countdown -= 1"
 
-    if [[ $wait_count -ge $max_wait ]]; then
+    if [[ $wait_countdown -le 0 ]]; then
         echo >&2 "error: file '$wait_file' does not exist after $max_wait seconds"
         exit 1
     fi
 
-    sleep 1
+    sleep $SLEEP_INTERVAL
 done


### PR DESCRIPTION
@awelzel (again) found a flaky test from #3949 - result in centosstream9 [here](https://cirrus-ci.com/task/5259252405633024?logs=test#L2029)

The test got flaky probably from #3949 on centosstream9 CI. You can replicate that behavior by increasing the sleep time when waiting for the file such that the test will attempt to read the missing file again. Since the one second wait for file is glacially slow for this, speeding it up should mean that the file gets created sooner and so the test won't try to open the file again. But, it's always still technically possible, since the test will wait for 10 seconds and the heartbeat seems to be 1 second. At least if that happens, it's probably a bug or massive slowdown of some kind.