### PR TITLE
"-O gen-C++" fix for naming "when" captures

### DIFF
--- a/src/script_opt/CPP/Vars.cc
+++ b/src/script_opt/CPP/Vars.cc
@@ -133,15 +133,13 @@ string CPPCompile::LocalName(const ID* l) const { return Canonicalize(trim_name(
 
 string CPPCompile::CaptureName(const ID* c) const {
     // We want to strip both the module and any inlining appendage.
-    auto n = Canonicalize(trim_name(c).c_str());
+    auto tn = trim_name(c);
 
-    auto appendage = n.find(".");
-    if ( appendage != string::npos ) {
-        n.erase(n.begin() + appendage, n.end());
-        n.push_back('_');
-    }
+    auto appendage = tn.find(".");
+    if ( appendage != string::npos )
+        tn.erase(tn.begin() + appendage, tn.end());
 
-    return n;
+    return Canonicalize(tn.c_str());
 }
 
 string CPPCompile::Canonicalize(const char* name) const {

--- a/src/script_opt/CPP/maint/find-test-files.sh
+++ b/src/script_opt/CPP/maint/find-test-files.sh
@@ -1,10 +1,9 @@
 #! /bin/sh
 
 find ../testing/btest -type f |
-    grep -E -v 'Baseline|\.tmp|__load__' |
-    grep -E '\.(zeek|test)$' |
-    sort |
+    xargs grep -E -l '@TEST' |
     xargs grep -E -l '^[ 	]*(event|print)' |
     xargs grep -E -c 'REQUIRES.*CPP.*((!=.*1)|(==.*0))' |
     grep ':0$' |
-    sed 's,:0,,'
+    sed 's,:0,,' |
+    sort

--- a/testing/btest/Baseline.cpp/core.max-analyzer-violations/weird.log
+++ b/testing/btest/Baseline.cpp/core.max-analyzer-violations/weird.log
@@ -7,7 +7,7 @@
 #open XXXX-XX-XX-XX-XX-XX
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	name	addl	notice	peer	source
 #types	time	string	addr	port	addr	port	string	string	bool	string	string
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	127.0.0.1	58246	127.0.0.1	110	pop3_server_command_unknown	-	F	zeek	POP3
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	127.0.0.1	58246	127.0.0.1	110	pop3_server_command_unknown	+	F	zeek	POP3
 XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	127.0.0.1	58246	127.0.0.1	110	line_terminated_with_single_CR	-	F	zeek	CONTENTLINE
 XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	127.0.0.1	58246	127.0.0.1	110	too_many_analyzer_violations	-	F	zeek	POP3
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/btest/Baseline.cpp/language.sizeof/output
+++ b/testing/btest/Baseline.cpp/language.sizeof/output
@@ -7,11 +7,13 @@ Expr: 18446744073709551612
 Signed Expr: 4
 Double -1.23: 1.230000
 Enum ENUM3: 2
+Enum in record: 2 2
 File 21.000000
 Function add_interface: 2
 Integer -10: 10
 Interval -5.0 secs: 5.000000
 Port 80/tcp: 65616
+Port in record: 65616 65616
 Record [i=10, j=<uninitialized>, k=<uninitialized>]: 3
 Set: 3
 String 'Hello': 5


### PR DESCRIPTION
This PR fixes a non-deterministic problem that can arise in the code generated for `-O gen-C++`. The issue is that when inlining script function calls (which comes earlier in the compilation process), variables have _`.n`_ appended to their names to prevent name collisions. Previously, the `-O gen-C++` compilation had logic to remove these appendages when converting script-level variable names to C++-level names. However, the logic was flawed in that by the time it tested for the appendage, it had already been transformed to no longer use a `.`. The fix is to remove the appendage prior to executing that other logic. (The bug was non-deterministic because the result of the name transformation is stored in a map, and often the map would have the correct value due to order-of-compiling lambdas, but sometimes an incorrect value would wind up in it.)

When testing this change, I also updated one of the maintenance scripts, and updated two of the Baselines to reflect recent BTest changes. I kept those bundled with this change for convenience, but if in the future it's helpful to split those out into their own PRs, let me know.