### PR TITLE
Enshrine `.evt` raising event order in a test

### DIFF
--- a/testing/btest/Baseline/spicy.hook-priority/output
+++ b/testing/btest/Baseline/spicy.hook-priority/output
@@ -2,4 +2,6 @@
 Spicy: highest prio
 Spicy: default prio
 Spicy: lowest prio
+Zeek: highest prio, [x=default]
 Zeek: default prio, [x=default]
+Zeek: lowest prio, [x=default]

--- a/testing/btest/spicy/hook-priority.zeek
+++ b/testing/btest/spicy/hook-priority.zeek
@@ -12,9 +12,19 @@ event zeek_init()
 	Analyzer::register_for_port(Analyzer::ANALYZER_FOO, 80/tcp);
 	}
 
+event foo_last(x: foo::X)
+	{
+	print "Zeek: lowest prio", x;
+	}
+
 event foo(x: foo::X)
 	{
 	print "Zeek: default prio", x;
+	}
+
+event foo_first(x: foo::X)
+	{
+	print "Zeek: highest prio", x;
 	}
 
 # @TEST-START-FILE foo.spicy
@@ -54,8 +64,8 @@ protocol analyzer Foo over TCP:
 # by examining the data though which above Spicy hooks mutate; we expect to see
 # data from the default priority handler since we should run right after it.
 on foo::X -> event foo(self);
+on foo::X -> event foo_first(self) &priority=-500;
+on foo::X -> event foo_last(self) &priority=-1500;
 
 export foo::X;
-
-# TODO(bbannier): test that EVT hook priority can correctly be overriden.
 # @TEST-END-FILE


### PR DESCRIPTION
It seems like, given two event triggers in a .evt file, that the order they are parsed is the order the events will be raised via `raise_event` later. This isn't groundbreaking, but this behavior isn't anywhere in a test nor is it documented (from what I can tell). At the very least, some user might notice this behavior and rely on it, which I don't think is unreasonable (that user is me). So, this modifies the existing test that raises two of the same event and makes it also test the order, both with an assertion and by removing the `sort` call.

For what it's worth, I'd also like to document this behavior, but it's fine if it's not. I looked into the spicy plugin history for insights about this, but didn't find any before hitting another import from another repo, which goes before the GH import of Spicy, but I tried :)

And, for good measure: is this a safe assumption? Digging through the code I see nothing that would make the second event fire before the first