### PR TITLE
Fix CI jobs failing to run due to unsupported use of `pip install`

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -24,12 +24,12 @@ jobs:
       # event, so we only need to authenticate in that case. Use
       # unauthenticated access otherwise so this action can e.g., also run from
       # clones.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: github.event_name == 'schedule'
         with:
           submodules: "recursive"
           token: ${{ secrets.ZEEK_BOT_TOKEN }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: github.event_name != 'schedule'
         with:
           submodules: "recursive"
@@ -131,7 +131,7 @@ jobs:
         # Only send notifications for scheduled runs. Runs from pull requests
         # show failures in the GitHub UI.
         if: failure() && github.event_name == 'schedule'
-        uses: dawidd6/action-send-mail@v3.7.0
+        uses: dawidd6/action-send-mail@v3.12.0
         with:
           server_address: ${{secrets.SMTP_HOST}}
           server_port: ${{secrets.SMTP_PORT}}

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -71,7 +71,7 @@ jobs:
           # `python2` so this is a simple workaround until we drop Python 2
           # support and explicitly use `python3` for all invocations.
           sudo ln -sf /usr/bin/python3 /usr/local/bin/python
-          sudo pip3 install -r doc/requirements.txt
+          sudo pip3 install --break-system-packages -r doc/requirements.txt
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-    - uses: pre-commit/action@v3.0.0
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4


### PR DESCRIPTION
The GH action image `ubuntu-latest` recently switched to a version which does not support running `pip install` without `--break-system-packages` anymore. This PR fixes affected workflows.
