### PR TITLE
Fix invalid Sphinx directive in docstring

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -2910,7 +2910,7 @@ export {
 	## enabled log streams.
 	##
 	## In earlier Zeek releases this was governed by :zeek:see:`Threading::heartbeat_interval`.
-	## For Broker, see also :zeek::see:`Broker::log_batch_interval`.
+	## For Broker, see also :zeek:see:`Broker::log_batch_interval`.
 	##
 	## .. :zeek:see:`Log::flush`
 	## .. :zeek:see:`Log::set_buf`


### PR DESCRIPTION
Use of `:zeek::see:..` instead of `:zeek:see:..` caused a Sphinx build failure which prevented automatic regeneration of docs.