### PR TITLE
Fix installation of Python packages in generate docs CI job again

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     if: github.repository == 'zeek/zeek'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       # We only perform a push if the action was triggered via a schedule
@@ -71,7 +71,7 @@ jobs:
           # `python2` so this is a simple workaround until we drop Python 2
           # support and explicitly use `python3` for all invocations.
           sudo ln -sf /usr/bin/python3 /usr/local/bin/python
-          sudo pip3 install --break-system-packages -r doc/requirements.txt
+          sudo pip3 install -r doc/requirements.txt
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2


### PR DESCRIPTION
This pins the generate-docs GH workflow to run on a fixed version of
ubuntu so we get defined semantics of `pip install` wrt system packages.
We were previously using the `ubuntu-latest` image and GH has been
switching this from ubuntu-22.04 to 24.04 and back again, also see
actions/runner-images#10636.