### PR TITLE
Skip modbus protocol testing with Spicy SSL enabled

### DIFF
--- a/testing/btest/core/analyzer-confirmation-violation-info.zeek
+++ b/testing/btest/core/analyzer-confirmation-violation-info.zeek
@@ -1,5 +1,5 @@
 # @TEST-DOC: The SSL analyzer picks up on the traffic in pppoe-over-qing, but then raises analyzer_violation_info
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h
+# @TEST-REQUIRES: ! have-spicy-ssl
 # @TEST-EXEC: zeek -r $TRACES/pppoe-over-qinq.pcap %INPUT
 # @TEST-EXEC: btest-diff .stdout
 

--- a/testing/btest/coverage/bare-load-baseline.test
+++ b/testing/btest/coverage/bare-load-baseline.test
@@ -9,7 +9,7 @@
 # below does. Don't ask. :-)
 
 # @TEST-REQUIRES: $SCRIPTS/have-spicy  # This test logs loaded scripts, so disable it if Spicy and it associated plugin is unavailable.
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h # Enabling Spicy SSL changes the loaded scripts, skip in this case
+# @TEST-REQUIRES: ! have-spicy-ssl  # Enabling Spicy SSL changes the loaded scripts, skip in this case
 # @TEST-EXEC: zeek -b misc/loaded-scripts
 # @TEST-EXEC: test -e loaded_scripts.log
 # @TEST-EXEC: cat loaded_scripts.log | grep -E -v '#' | awk 'NR>0{print $1}' | sed -e ':a' -e '$!N' -e 's/^\(.*\).*\n\1.*/\1/' -e 'ta' >prefix

--- a/testing/btest/coverage/default-load-baseline.test
+++ b/testing/btest/coverage/default-load-baseline.test
@@ -8,7 +8,7 @@
 # below does. Don't ask. :-)
 
 # @TEST-REQUIRES: ${SCRIPTS}/have-spicy
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h # Enabling Spicy SSL changes the loaded scripts, skip in this case
+# @TEST-REQUIRES: ! have-spicy-ssl  # Enabling Spicy SSL changes the loaded scripts, skip in this case
 # @TEST-EXEC: zeek misc/loaded-scripts
 # @TEST-EXEC: test -e loaded_scripts.log
 # @TEST-EXEC: cat loaded_scripts.log | grep -E -v '#' | sed 's/ //g' | sed -e ':a' -e '$!N' -e 's/^\(.*\).*\n\1.*/\1/' -e 'ta' >prefix

--- a/testing/btest/plugins/hooks.zeek
+++ b/testing/btest/plugins/hooks.zeek
@@ -1,6 +1,6 @@
 # @TEST-REQUIRES: test "${ZEEK_ZAM}" != "1"
 # @TEST-REQUIRES: ${SCRIPTS}/have-spicy  # This test logs loaded scripts, so disable it if Spicy and the associated plugin are unavailable.
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h # Enabling Spicy SSL changes baselines and thus changes raised events. Skip in this case.
+# @TEST-REQUIRES: ! have-spicy-ssl  # Enabling Spicy SSL changes baselines and thus changes raised events. Skip in this case.
 # @TEST-EXEC: ${DIST}/auxil/zeek-aux/plugin-support/init-plugin -u . Demo Hooks
 # @TEST-EXEC: cp -r %DIR/hooks-plugin/* .
 # @TEST-EXEC: ./configure --zeek-dist=${DIST} && make

--- a/testing/btest/scripts/base/protocols/modbus/modbus_and_non_modbus_on_port_502.test
+++ b/testing/btest/scripts/base/protocols/modbus/modbus_and_non_modbus_on_port_502.test
@@ -1,3 +1,4 @@
+# @TEST-REQUIRES: ! have-spicy-ssl  # Spicy analyzer causes conn.log baseline difference
 # @TEST-EXEC: zeek -r $TRACES/modbus/modbus-and-non-modbus-p502.pcap
 # @TEST-EXEC: btest-diff conn.log
 # @TEST-EXEC: btest-diff modbus.log

--- a/testing/btest/scripts/base/protocols/ssl/certificate_request.zeek
+++ b/testing/btest/scripts/base/protocols/ssl/certificate_request.zeek
@@ -1,7 +1,7 @@
 # This tests the certificate_request message parsing
 
 # Does not work in spicy version, due to missing DTLS support
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h
+# @TEST-REQUIRES: ! have-spicy-ssl
 
 # @TEST-EXEC: zeek -b -r $TRACES/tls/client-certificate.pcap %INPUT > out
 # @TEST-EXEC: zeek -C -b -r $TRACES/tls/certificate-request-failed.pcap %INPUT >> out

--- a/testing/btest/scripts/base/protocols/ssl/dtls-13.test
+++ b/testing/btest/scripts/base/protocols/ssl/dtls-13.test
@@ -1,6 +1,6 @@
 # This tests a normal SSL connection and the log it outputs.
 
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h # DTLS not supported in Spicy SSL
+# @TEST-REQUIRES: ! have-spicy-ssl  # DTLS not supported in Spicy SSL
 # @TEST-EXEC: zeek -C -r $TRACES/tls/dtls13-wolfssl.pcap %INPUT
 # @TEST-EXEC: cp ssl.log ssl-all.log
 # @TEST-EXEC: echo "start CID test"

--- a/testing/btest/scripts/base/protocols/ssl/dtls-stun-dpd.test
+++ b/testing/btest/scripts/base/protocols/ssl/dtls-stun-dpd.test
@@ -1,4 +1,4 @@
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h # DTLS is not supported in Spicy SSL yet
+# @TEST-REQUIRES: ! have-spicy-ssl  # DTLS is not supported in Spicy SSL yet
 # @TEST-EXEC: zeek -b -r $TRACES/tls/webrtc-stun.pcap %INPUT
 # @TEST-EXEC: btest-diff ssl.log
 # @TEST-EXEC: touch dpd.log

--- a/testing/btest/scripts/base/protocols/ssl/dtls.test
+++ b/testing/btest/scripts/base/protocols/ssl/dtls.test
@@ -1,6 +1,6 @@
 # This tests a normal SSL connection and the log it outputs.
 
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h # DTLS is not supported in Spicy SSL yet
+# @TEST-REQUIRES: ! have-spicy-ssl  # DTLS is not supported in Spicy SSL yet
 # @TEST-EXEC: zeek -b -r $TRACES/tls/dtls1_0.pcap %INPUT
 # @TEST-EXEC: btest-diff ssl.log
 # @TEST-EXEC: btest-diff x509.log

--- a/testing/btest/scripts/base/protocols/ssl/keyexchange.test
+++ b/testing/btest/scripts/base/protocols/ssl/keyexchange.test
@@ -1,5 +1,5 @@
 # Does not work in spicy version, due to missing DTLS support
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h
+# @TEST-REQUIRES: ! have-spicy-ssl
 
 # @TEST-EXEC: zeek -b -r $TRACES/tls/dhe.pcap %INPUT
 # @TEST-EXEC: cat ssl.log > ssl-all.log

--- a/testing/btest/scripts/policy/protocols/ssl/decryption.zeek
+++ b/testing/btest/scripts/policy/protocols/ssl/decryption.zeek
@@ -1,5 +1,5 @@
 # @TEST-REQUIRES: grep -q "#define OPENSSL_HAVE_KDF_H" $BUILD/zeek-config.h
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h # Decryption is not supported in Spicy SSL
+# @TEST-REQUIRES: ! have-spicy-ssl  # Decryption is not supported in Spicy SSL
 
 # @TEST-EXEC: zeek -B dpd -C -r $TRACES/tls/tls12-decryption.pcap %INPUT
 # @TEST-EXEC: btest-diff http.log

--- a/testing/btest/scripts/policy/protocols/ssl/ssl-log-ext.zeek
+++ b/testing/btest/scripts/policy/protocols/ssl/ssl-log-ext.zeek
@@ -1,5 +1,5 @@
 # Does not work in spicy version, due to missing DTLS support
-# @TEST-REQUIRES: ! grep -q "#define ENABLE_SPICY_SSL" $BUILD/zeek-config.h
+# @TEST-REQUIRES: ! have-spicy-ssl
 
 # @TEST-EXEC: zeek -b -r $TRACES/tls/dhe.pcap %INPUT
 # @TEST-EXEC: cat ssl.log > ssl-all.log

--- a/testing/scripts/have-spicy-ssl
+++ b/testing/scripts/have-spicy-ssl
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if grep -q "#define ENABLE_SPICY_SSL" "${BUILD}/zeek-config.h"; then
+    exit 0
+fi
+
+exit 1


### PR DESCRIPTION
@0xxon , think for the time we can skip the test?

This also introduces a helper similarly what we do for other features (af-packet, spicy, javascript, ...)