### PR TITLE
Fix Clang 19 deprecation failure

### DIFF
--- a/src/DFA.cc
+++ b/src/DFA.cc
@@ -265,9 +265,9 @@ DFA_State_Cache::~DFA_State_Cache() {
 DFA_State* DFA_State_Cache::Lookup(const NFA_state_list& nfas, DigestStr* digest) {
     // We assume that state ID's don't exceed 10 digits, plus
     // we allow one more character for the delimiter.
-    auto id_tag_buf = std::make_unique<u_char[]>(nfas.length() * 11 + 1);
+    auto id_tag_buf = std::make_unique<char[]>(nfas.length() * 11 + 1);
     auto id_tag = id_tag_buf.get();
-    u_char* p = id_tag;
+    char* p = id_tag;
 
     for ( int i = 0; i < nfas.length(); ++i ) {
         NFA_State* n = nfas[i];
@@ -287,7 +287,7 @@ DFA_State* DFA_State_Cache::Lookup(const NFA_state_list& nfas, DigestStr* digest
     // HashKey because the data is copied into the key.
     hash128_t hash;
     KeyedHash::Hash128(id_tag, p - id_tag, &hash);
-    *digest = DigestStr(reinterpret_cast<const unsigned char*>(hash), 16);
+    *digest = DigestStr(reinterpret_cast<const char*>(hash), 16);
 
     auto entry = states.find(*digest);
     if ( entry == states.end() ) {

--- a/src/DFA.cc
+++ b/src/DFA.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/DFA.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/Desc.h"
 #include "zeek/EquivClass.h"
 #include "zeek/Hash.h"

--- a/src/DFA.h
+++ b/src/DFA.h
@@ -18,7 +18,7 @@ class DFA_Machine;
 
 // Transitions to the uncomputed state indicate that we haven't yet
 // computed the state to go to.
-#define DFA_UNCOMPUTED_STATE -2
+#define DFA_UNCOMPUTED_STATE (-2)
 #define DFA_UNCOMPUTED_STATE_PTR ((DFA_State*)DFA_UNCOMPUTED_STATE)
 
 class DFA_State : public Obj {

--- a/src/DFA.h
+++ b/src/DFA.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <sys/types.h> // for u_char
+#include <sys/types.h>
 #include <cassert>
 #include <map>
 #include <string>
@@ -67,7 +67,7 @@ protected:
     DFA_State* mark;
 };
 
-using DigestStr = std::basic_string<u_char>;
+using DigestStr = std::string;
 
 struct DFA_State_Cache_Stats {
     // Sum of all NFA states

--- a/src/analyzer/protocol/ssl/SSL.cc
+++ b/src/analyzer/protocol/ssl/SSL.cc
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "zeek/Reporter.h"
-#include "zeek/analyzer/Manager.h"
 #include "zeek/analyzer/protocol/ssl/events.bif.h"
 #include "zeek/analyzer/protocol/ssl/ssl_pac.h"
 #include "zeek/analyzer/protocol/ssl/tls-handshake_pac.h"
@@ -276,7 +275,7 @@ bool SSL_Analyzer::TryDecryptApplicationData(int len, const u_char* data, bool i
 
         // FIXME: should we change types here?
         const u_char* encrypted = data;
-        size_t encrypted_len = len;
+        int encrypted_len = len;
 
         if ( is_orig )
             c_seq++;

--- a/src/analyzer/protocol/ssl/SSL.cc
+++ b/src/analyzer/protocol/ssl/SSL.cc
@@ -3,6 +3,7 @@
 #include <arpa/inet.h>
 #include <openssl/evp.h>
 #include <openssl/opensslv.h>
+#include <vector>
 
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/Manager.h"
@@ -22,6 +23,8 @@
 
 namespace zeek::analyzer::ssl {
 
+using byte_buffer = std::vector<u_char>;
+
 template<typename T>
 static inline T MSB(const T a) {
     return ((a >> 8) & 0xff);
@@ -32,12 +35,13 @@ static inline T LSB(const T a) {
     return (a & 0xff);
 }
 
-static std::basic_string<unsigned char> fmt_seq(uint32_t num) {
-    std::basic_string<unsigned char> out(4, '\0');
+static byte_buffer fmt_seq(uint32_t num) {
+    byte_buffer out(4, '\0');
     out.reserve(13);
     uint32_t netnum = htonl(num);
-    out.append(reinterpret_cast<u_char*>(&netnum), 4);
-    out.append(5, '\0');
+    uint8_t* p = reinterpret_cast<uint8_t*>(&netnum);
+    out.insert(out.end(), p, p + 4);
+    out.insert(out.end(), 5, '\0');
     return out;
 }
 
@@ -271,7 +275,7 @@ bool SSL_Analyzer::TryDecryptApplicationData(int len, const u_char* data, bool i
         const u_char* s_iv = keys.data() + 68;
 
         // FIXME: should we change types here?
-        u_char* encrypted = (u_char*)data;
+        const u_char* encrypted = data;
         size_t encrypted_len = len;
 
         if ( is_orig )
@@ -280,14 +284,15 @@ bool SSL_Analyzer::TryDecryptApplicationData(int len, const u_char* data, bool i
             s_seq++;
 
         // AEAD nonce, length 12
-        std::basic_string<unsigned char> s_aead_nonce;
+        byte_buffer s_aead_nonce;
+        s_aead_nonce.reserve(12);
         if ( is_orig )
-            s_aead_nonce.assign(c_iv, 4);
+            s_aead_nonce.insert(s_aead_nonce.end(), c_iv, c_iv + 4);
         else
-            s_aead_nonce.assign(s_iv, 4);
+            s_aead_nonce.insert(s_aead_nonce.end(), s_iv, s_iv + 4);
 
         // this should be the explicit counter
-        s_aead_nonce.append(encrypted, 8);
+        s_aead_nonce.insert(s_aead_nonce.end(), encrypted, encrypted + 8);
         assert(s_aead_nonce.size() == 12);
 
         EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
@@ -310,28 +315,28 @@ bool SSL_Analyzer::TryDecryptApplicationData(int len, const u_char* data, bool i
         else
             EVP_DecryptInit(ctx, EVP_aes_256_gcm(), s_wk, s_aead_nonce.data());
 
-        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, encrypted + encrypted_len);
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, const_cast<u_char*>(encrypted + encrypted_len));
 
         // AEAD tag
-        std::basic_string<unsigned char> s_aead_tag;
+        byte_buffer s_aead_tag;
         if ( is_orig )
             s_aead_tag = fmt_seq(c_seq);
         else
             s_aead_tag = fmt_seq(s_seq);
 
+        assert(s_aead_tag.size() == 13);
         s_aead_tag[8] = content_type;
         s_aead_tag[9] = MSB(raw_tls_version);
         s_aead_tag[10] = LSB(raw_tls_version);
         s_aead_tag[11] = MSB(encrypted_len);
         s_aead_tag[12] = LSB(encrypted_len);
-        assert(s_aead_tag.size() == 13);
 
         auto decrypted = std::vector<u_char>(encrypted_len +
                                              16); // see OpenSSL manpage - 16 is the block size for the supported cipher
         int decrypted_len = 0;
 
         EVP_DecryptUpdate(ctx, NULL, &decrypted_len, s_aead_tag.data(), s_aead_tag.size());
-        EVP_DecryptUpdate(ctx, decrypted.data(), &decrypted_len, (const u_char*)encrypted, encrypted_len);
+        EVP_DecryptUpdate(ctx, decrypted.data(), &decrypted_len, encrypted, encrypted_len);
         assert(static_cast<decltype(decrypted.size())>(decrypted_len) <= decrypted.size());
         decrypted.resize(decrypted_len);
 


### PR DESCRIPTION
This is a draft PR to get some CI runs, this kind of scares me with unintended consequences so having a list would be nice ;) .

Fixes #3994

Clang 19 with libc++ started failing to compile because the default implementation of `std::char_traits` was removed, making uses of `std::char_traits<unsigned char>` invalid (by consequence, also `std::basic_string<unsigned char>`). This was more of used for convenience before, but it should be roughly the same behavior with `char`.

Note that I initially wanted to just replace `u_char` with `char`, but that's probably bad because openssl expects `unsigned char` (and *lots* of other stuff) :/ That's pretty reasonable, though.

See relevant LLVM commits:

https://github.com/llvm/llvm-project/commit/aeecef08c385b1e4955155dd649a2d3724463849

https://github.com/llvm/llvm-project/commit/08a0faf4cd32bce6c51027ea9b5ec351747995b4