### PR TITLE
CI: Add Ubuntu Clang task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -368,7 +368,7 @@ macos_sonoma_task:
 freebsd14_task:
   freebsd_instance:
     # FreeBSD 14 EOL: Nov 30 2028
-    image_family: freebsd-14-0
+    image_family: freebsd-14-1
     << : *FREEBSD_RESOURCES_TEMPLATE
 
   prepare_script: ./ci/freebsd/prepare.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -268,6 +268,18 @@ ubuntu24_task:
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
 
+# Same as above, but using Clang and libc++
+ubuntu24_clang_libcpp_task:
+  container:
+    # Ubuntu 24.04 EOL: Jun 2029
+    dockerfile: ci/ubuntu-24.04/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  env:
+    CC: clang-18
+    CXX: clang++-18
+    CXXFLAGS: -stdlib=libc++
+
 ubuntu22_task:
   container:
     # Ubuntu 22.04 EOL: June 2027

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -36,6 +36,8 @@ RUN apt-get update && apt-get -y install \
     unzip \
     wget \
     zlib1g-dev \
+    libc++-dev \
+    libc++abi-dev \
   && apt autoclean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
~This will be a draft because I couldn't get the cirrus CLI working on the config file here so it may take a try or two 🙊~

This feels more like a band-aid solution - it still requires very manual intervention to get the next builds, but at least this way we don't rely on whatever Clang/libc++ happens to ship with FreeBSD for the only libc++ testing. It seems like sanitizer builds don't use libc++ (they use clang), but I'd rather a dedicated Linux/Clang/libc++ task at least.

Related #3997 - if the new images were there, that issue would have been caught long before it was a real issue. This is intended to fail until that's merged