### PR TITLE
Switch CPPCompile::Canonicalize() to use std::string instead of char* pointer

### DIFF
--- a/src/script_opt/CPP/DeclFunc.cc
+++ b/src/script_opt/CPP/DeclFunc.cc
@@ -10,7 +10,7 @@ void CPPCompile::DeclareFunc(const FuncInfo& func) {
     if ( ! IsCompilable(func) )
         return;
 
-    auto fname = Canonicalize(BodyName(func).c_str()) + "_zf";
+    auto fname = Canonicalize(BodyName(func)) + "_zf";
     auto pf = func.Profile();
     auto f = func.Func();
     const auto& body = func.Body();
@@ -25,7 +25,7 @@ void CPPCompile::DeclareFunc(const FuncInfo& func) {
 void CPPCompile::DeclareLambda(const LambdaExpr* l, const ProfileFunc* pf) {
     ASSERT(is_CPP_compilable(pf));
 
-    auto lname = Canonicalize(l->Name().c_str()) + "_lb";
+    auto lname = Canonicalize(l->Name()) + "_lb";
     auto body = l->Ingredients()->Body();
     auto l_id = l->Ingredients()->GetID();
     auto& ids = l->OuterIDs();

--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -646,7 +646,7 @@ string CPPCompile::GenLambdaExpr(const Expr* e) {
 
 string CPPCompile::GenLambdaExpr(const Expr* e, string capture_args) {
     auto l = static_cast<const LambdaExpr*>(e);
-    auto name = Canonicalize(l->Name().c_str()) + "_lb_cl";
+    auto name = Canonicalize(l->Name()) + "_lb_cl";
     auto cl_args = string("\"") + name + "\"" + std::move(capture_args);
     auto body = string("make_intrusive<") + name + ">(" + cl_args + ")";
     auto func = string("make_intrusive<CPPLambdaFunc>(\"") + l->Name() + "\", cast_intrusive<FuncType>(" +

--- a/src/script_opt/CPP/GenFunc.cc
+++ b/src/script_opt/CPP/GenFunc.cc
@@ -10,7 +10,7 @@ void CPPCompile::CompileFunc(const FuncInfo& func) {
     if ( ! IsCompilable(func) )
         return;
 
-    auto fname = Canonicalize(BodyName(func).c_str()) + "_zf";
+    auto fname = Canonicalize(BodyName(func)) + "_zf";
     auto pf = func.Profile();
     auto f = func.Func();
     const auto& body = func.Body();
@@ -19,7 +19,7 @@ void CPPCompile::CompileFunc(const FuncInfo& func) {
 }
 
 void CPPCompile::CompileLambda(const LambdaExpr* l, const ProfileFunc* pf) {
-    auto lname = Canonicalize(l->Name().c_str()) + "_lb";
+    auto lname = Canonicalize(l->Name()) + "_lb";
     auto body = l->Ingredients()->Body();
     auto l_id = l->Ingredients()->GetID();
     auto& ids = l->OuterIDs();

--- a/src/script_opt/CPP/Inits.cc
+++ b/src/script_opt/CPP/Inits.cc
@@ -259,7 +259,7 @@ void CPPCompile::GenStandaloneActivation() {
 
         auto f = func.Func();
         auto fname = BodyName(func);
-        auto bname = Canonicalize(fname.c_str()) + "_zf";
+        auto bname = Canonicalize(fname) + "_zf";
 
         if ( compiled_funcs.count(bname) == 0 )
             // We didn't wind up compiling it.

--- a/src/script_opt/CPP/Vars.cc
+++ b/src/script_opt/CPP/Vars.cc
@@ -129,7 +129,7 @@ static string trim_name(const ID* id) {
     return ns;
 }
 
-string CPPCompile::LocalName(const ID* l) const { return Canonicalize(trim_name(l).c_str()); }
+string CPPCompile::LocalName(const ID* l) const { return Canonicalize(trim_name(l)); }
 
 string CPPCompile::CaptureName(const ID* c) const {
     // We want to strip both the module and any inlining appendage.
@@ -139,15 +139,13 @@ string CPPCompile::CaptureName(const ID* c) const {
     if ( appendage != string::npos )
         tn.erase(tn.begin() + appendage, tn.end());
 
-    return Canonicalize(tn.c_str());
+    return Canonicalize(tn);
 }
 
-string CPPCompile::Canonicalize(const char* name) const {
+string CPPCompile::Canonicalize(const std::string& name) const {
     string cname;
 
-    for ( int i = 0; name[i]; ++i ) {
-        auto c = name[i];
-
+    for ( auto c : name ) {
         // Strip <>'s - these get introduced for lambdas.
         if ( c == '<' || c == '>' )
             continue;

--- a/src/script_opt/CPP/Vars.h
+++ b/src/script_opt/CPP/Vars.h
@@ -47,7 +47,7 @@ std::string CaptureName(const IDPtr& l) const { return CaptureName(l.get()); }
 
 // Returns a canonicalized name, with various non-alphanumeric characters
 // stripped or transformed, and guaranteed not to conflict with C++ keywords.
-std::string Canonicalize(const char* name) const;
+std::string Canonicalize(const std::string& name) const;
 
 // Returns the name of the global corresponding to an expression (which must
 // be a EXPR_NAME).


### PR DESCRIPTION
This simple PR is just addressing some cleanup that I noted earlier but postponed for the next time I would be running the full `-O gen-C++` test suite. It simplifies an interface that originally was in terms of `const char*` but really should be in terms of `const std::string&`.