### PR TITLE
Fix for ZAM memory leak when looping over vectors of records

### DIFF
--- a/src/script_opt/ZAM/OPs/iterations.op
+++ b/src/script_opt/ZAM/OPs/iterations.op
@@ -77,7 +77,10 @@ op-types U X I I
 eval	NextVectorIterCore($2, $3)
 	$$ = $2.iter;
 	if ( Z_IS_MANAGED )
+		{
+		ZVal::DeleteManagedType($1);
 		$1 = BuildVal(vv[$2.iter]->ToVal(Z_TYPE), Z_TYPE);
+		}
 	else
 		$1 = *vv[$2.iter];
 	$2.IterFinished();
@@ -87,7 +90,10 @@ internal-op Next-Vector-Blank-Iter-Val-Var
 class Vsb
 eval	NextVectorIterCore($1, $2)
 	if ( Z_IS_MANAGED )
+		{
+		ZVal::DeleteManagedType($$);
 		$$ = BuildVal(vv[$1.iter]->ToVal(Z_TYPE), Z_TYPE);
+		}
 	else
 		$$ = *vv[$1.iter];
 	$1.IterFinished();


### PR DESCRIPTION
For some forms of `for` statements looping over vectors of records (or other "managed" types), ZAM code would leak memory when assigning to the loop variable.