### PR TITLE
Fix for ZAM memory leak when coercing values to "any"

### DIFF
--- a/src/script_opt/ZAM/OPs/coercions.op
+++ b/src/script_opt/ZAM/OPs/coercions.op
@@ -128,7 +128,9 @@ eval	if ( $1->Size() > 0 )
 unary-expr-op To-Any-Coerce
 op-type X
 set-type $1
-eval	AssignTarget($$, ZVal($1.ToVal(Z_TYPE), ZAM::any_base_type))
+eval	auto orig_lhs = $$; /* hold in case $$ = $1 */
+	$$ = ZVal($1.ToVal(Z_TYPE), ZAM::any_base_type);
+	ZVal::DeleteManagedType(orig_lhs);
 
 unary-expr-op From-Any-Coerce
 no-const


### PR DESCRIPTION
Along with https://github.com/zeek/zeek/pull/4013, this leak turned up in some testing of a bunch of content against a big PCAP. The leak occurs when the value being coerced to `any` is _not_ a "managed" (reference-counted) type. In that case, any previous value in the target frame slot would be simply overwritten, whereas if it was managed, it instead needed to be `Unref`'d.