### PR TITLE
Fix for access to uninitialized memory in ZAM's "cat" built-in

### DIFF
--- a/src/script_opt/ZAM/BuiltInSupport.cc
+++ b/src/script_opt/ZAM/BuiltInSupport.cc
@@ -72,7 +72,7 @@ void FixedCatArg::RenderInto(const ZVal& z, char*& res) {
             n = modp_dtoa2(d, res, 6);
             res += n;
 
-            if ( util::approx_equal(d, nearbyint(d), 1e-9) && std::isfinite(d) && ! strchr(tmp, 'e') ) {
+            if ( util::approx_equal(d, nearbyint(d), 1e-9) && std::isfinite(d) ) {
                 // disambiguate from integer
                 *(res++) = '.';
                 *(res++) = '0';

--- a/src/script_opt/ZAM/BuiltInSupport.h
+++ b/src/script_opt/ZAM/BuiltInSupport.h
@@ -42,7 +42,6 @@ public:
 
 protected:
     TypePtr t;
-    char tmp[256];
 };
 
 class StringCatArg : public CatArg {


### PR DESCRIPTION
This one is a bit embarrassing 😏. When implementing ZAM's built-in `cat()` functionality, for the code that differentiates `double` values that are very close to integers I copied [this line](https://github.com/zeek/zeek/blob/e4dbba20a4c7ff827ba481cec97e33d96b31f1df/src/Desc.cc#L146) of functionality from `src/Desc.cc`. It refers to a local `tmp` which _didn't exist_ in the ZAM function where I put the snippet ... BUT _did_ exist as a vestigial member variable, so the darn code compiled. My recent big ASAN run caught this; here, we just get rid of the associated test, as darned if I can figure out when it would actually matter. (If there _is_ such a case, it should be documented in `src/Desc.cc`!)