### PR TITLE
Fix nullptr deref in Spicy accept/decline input

### DIFF
--- a/src/spicy/manager.cc
+++ b/src/spicy/manager.cc
@@ -593,25 +593,25 @@ static ::TransportProto transport_protocol(const hilti::rt::Port port) {
 }
 
 static void hook_accept_input() {
-    auto cookie = static_cast<rt::Cookie*>(hilti::rt::context::cookie());
-    assert(cookie);
-
-    if ( auto x = cookie->protocol ) {
-        auto tag = spicy_mgr->tagForProtocolAnalyzer(x->analyzer->GetAnalyzerTag());
-        SPICY_DEBUG(hilti::rt::fmt("confirming protocol %s", tag.AsString()));
-        return x->analyzer->AnalyzerConfirmation(tag);
+    if ( auto cookie = static_cast<rt::Cookie*>(hilti::rt::context::cookie()) ) {
+        if ( auto x = cookie->protocol ) {
+            auto tag = spicy_mgr->tagForProtocolAnalyzer(x->analyzer->GetAnalyzerTag());
+            SPICY_DEBUG(hilti::rt::fmt("confirming protocol %s", tag.AsString()));
+            return x->analyzer->AnalyzerConfirmation(tag);
+        }
     }
 }
 
 static void hook_decline_input(const std::string& reason) {
-    auto cookie = static_cast<rt::Cookie*>(hilti::rt::context::cookie());
-    assert(cookie);
-
-    if ( auto x = cookie->protocol ) {
-        auto tag = spicy_mgr->tagForProtocolAnalyzer(x->analyzer->GetAnalyzerTag());
-        SPICY_DEBUG(hilti::rt::fmt("rejecting protocol %s: %s", tag.AsString(), reason));
-        return x->analyzer->AnalyzerViolation(reason.c_str(), nullptr, 0, tag);
+    if ( auto cookie = static_cast<rt::Cookie*>(hilti::rt::context::cookie()) ) {
+        if ( auto x = cookie->protocol ) {
+            auto tag = spicy_mgr->tagForProtocolAnalyzer(x->analyzer->GetAnalyzerTag());
+            SPICY_DEBUG(hilti::rt::fmt("rejecting protocol %s: %s", tag.AsString(), reason));
+            return x->analyzer->AnalyzerViolation(reason.c_str(), nullptr, 0, tag);
+        }
     }
+    else
+        SPICY_DEBUG(hilti::rt::fmt("attempting to reject protocol without cookie: %s", reason));
 }
 
 void Manager::InitPostScript() {


### PR DESCRIPTION
Seems like this is a continuation of #4006

I was getting assertions in `hook_decline_input` running the Redis analyzer [on all ports](https://github.com/evantypanski/spicy-redis/tree/topic/etyp/all-ports) on [4SICS-GeekLounge-151022.pcap](https://share.netresec.com/s/gw6Y2QzJHqDD5pr/download/4SICS-GeekLounge-151022.pcap)

is there any better debug output that could be used? I don't think the accept input one has any usable info :/