### PR TITLE
communityid: Do not include ports for non TCP, UDP, ICMP

### DIFF
--- a/src/communityid.bif
+++ b/src/communityid.bif
@@ -23,6 +23,7 @@ function community_id_v1%(cid: conn_id, seed: count &default=0, do_base64: bool 
     uint8_t hash_padbyte = 0;
     uint16_t hash_src_port = 0;
     uint16_t hash_dst_port = 0;
+    bool has_ports = true;
 
     const auto& orig_addr = cid_rec->GetFieldAs<zeek::AddrVal>(0);
     const auto& orig_port = cid_rec->GetFieldAs<zeek::PortVal>(1);
@@ -57,6 +58,15 @@ function community_id_v1%(cid: conn_id, seed: count &default=0, do_base64: bool 
             }
 
             hash_proto = static_cast<uint8_t>(cid_proto);
+            has_ports = false;
+
+            // The following isn't right if the conn_id entry comes
+            // from Zeek's core, because there's no native SCTP support.
+            // Assuming someone used 80/unknown for an SCTP conn_id record,
+            // it still somehow works right.
+            if ( hash_proto == IPPROTO_SCTP )
+                has_ports = true;
+
             break;
         }
         default:
@@ -107,8 +117,11 @@ function community_id_v1%(cid: conn_id, seed: count &default=0, do_base64: bool 
     dlen += digest_update(ctx, hash_dst_addr, is_ipv4 ? 4 : 16);
     dlen += digest_update(ctx, &hash_proto, 1);
     dlen += digest_update(ctx, &hash_padbyte, 1);
-    dlen += digest_update(ctx, &hash_src_port, 2);
-    dlen += digest_update(ctx, &hash_dst_port, 2);
+
+    if ( has_ports ) {
+        dlen += digest_update(ctx, &hash_src_port, 2);
+        dlen += digest_update(ctx, &hash_dst_port, 2);
+    }
 
     u_char digest[ZEEK_SHA_DIGEST_LENGTH];
     zeek::detail::hash_final(ctx, digest);

--- a/testing/btest/Baseline/bifs.community_id.v1/out
+++ b/testing/btest/Baseline/bifs.community_id.v1/out
@@ -9,5 +9,5 @@ PASS: expected '1:9pr4ZGTICiuZoIh90RRYE2RyXpU=', got '1:9pr4ZGTICiuZoIh90RRYE2Ry
 PASS: expected '1:IO27GQzPuCtNnwFvjWALMHu5tJE=', got '1:IO27GQzPuCtNnwFvjWALMHu5tJE=' ([orig_h=fe80:1:203:405:607:809:a0b:c0d, orig_p=128/icmp, resp_h=fe80:1011:1213:1415:1617:1819:1a1b:1c1d, resp_p=129/icmp, proto=1], seed=1)
 PASS: expected '', got '' ([orig_h=1.2.3.4, orig_p=0/unknown, resp_h=5.6.7.8, resp_p=0/unknown, proto=65535], seed=0)
 PASS: expected '', got '' ([orig_h=fe80:1:203:405:607:809:a0b:c0d, orig_p=0/unknown, resp_h=fe80:1011:1213:1415:1617:1819:1a1b:1c1d, resp_p=0/unknown, proto=65535], seed=1)
-PASS: expected '1:yXTIO8p5F2ZhuXBcNBN8CsgCUTE=', got '1:yXTIO8p5F2ZhuXBcNBN8CsgCUTE=' ([orig_h=1.2.3.4, orig_p=0/unknown, resp_h=5.6.7.8, resp_p=0/unknown, proto=10], seed=0)
-PASS: expected '1:OrvlNyNZWyubXHIUHR/w18b5im8=', got '1:OrvlNyNZWyubXHIUHR/w18b5im8=' ([orig_h=fe80:1:203:405:607:809:a0b:c0d, orig_p=0/unknown, resp_h=fe80:1011:1213:1415:1617:1819:1a1b:1c1d, resp_p=0/unknown, proto=10], seed=1)
+PASS: expected '1:7bYuQ7nyGBIQn7uDcQ5WraAnhWI=', got '1:7bYuQ7nyGBIQn7uDcQ5WraAnhWI=' ([orig_h=1.2.3.4, orig_p=0/unknown, resp_h=5.6.7.8, resp_p=0/unknown, proto=10], seed=0)
+PASS: expected '1:rcMO2BlHXpMNFXyyWqSDUQCBRBc=', got '1:rcMO2BlHXpMNFXyyWqSDUQCBRBc=' ([orig_h=fe80:1:203:405:607:809:a0b:c0d, orig_p=0/unknown, resp_h=fe80:1011:1213:1415:1617:1819:1a1b:1c1d, resp_p=0/unknown, proto=10], seed=1)

--- a/testing/btest/bifs/community_id/v1.zeek
+++ b/testing/btest/bifs/community_id/v1.zeek
@@ -29,7 +29,7 @@ event zeek_init()
 	         $resp_h=[fe80:1011:1213:1415:1617:1819:1A1B:1C1D], $resp_p=0/unknown], 1, "");
 
 	# Test with some unknown-but-valid proto values.
-	test_it([$orig_h=1.2.3.4, $orig_p=0/unknown, $resp_h=5.6.7.8, $resp_p=0/unknown, $proto=10], 0, "1:yXTIO8p5F2ZhuXBcNBN8CsgCUTE=");
+	test_it([$orig_h=1.2.3.4, $orig_p=0/unknown, $resp_h=5.6.7.8, $resp_p=0/unknown, $proto=10], 0, "1:7bYuQ7nyGBIQn7uDcQ5WraAnhWI=");
 	test_it([$orig_h=[fe80:0001:0203:0405:0607:0809:0A0B:0C0D], $orig_p=0/unknown,
-	         $resp_h=[fe80:1011:1213:1415:1617:1819:1A1B:1C1D], $resp_p=0/unknown, $proto=10], 1, "1:OrvlNyNZWyubXHIUHR/w18b5im8=");
+	         $resp_h=[fe80:1011:1213:1415:1617:1819:1A1B:1C1D], $resp_p=0/unknown, $proto=10], 1, "1:rcMO2BlHXpMNFXyyWqSDUQCBRBc=");
 	}


### PR DESCRIPTION
Checked against the result of pycommunityid. The SCTP case isn't quite right, because Zeek's core will not have extracted any ports for SCTP.
