### PR TITLE
Minor include cleanups

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -71,6 +71,7 @@ IncludeBlocks: Regroup
 # 4: any header that starts with "zeek/"
 # 5: everything else, which should catch any of the auto-generated code from the
 #    build directory as well
+# 6: third party doctest header
 #
 # Sections 0-1 and 2-3 get grouped together in their respective blocks
 IncludeCategories:
@@ -86,6 +87,8 @@ IncludeCategories:
   - Regex: '^<[[:print:]]+>'
     Priority: 2
     SortPriority: 3
+  - Regex: '^"zeek/3rdparty/doctest.h'
+    Priority: 6
   - Regex: '^"zeek/'
     Priority: 4
   - Regex: '.*'

--- a/src/DNS_Mapping.cc
+++ b/src/DNS_Mapping.cc
@@ -2,9 +2,10 @@
 
 #include <ares_nameser.h>
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/DNS_Mgr.h"
 #include "zeek/Reporter.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 namespace zeek::detail {
 

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -32,7 +32,6 @@ using ztd::out_ptr::out_ptr;
 #include <ares_dns.h>
 #include <ares_nameser.h>
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/DNS_Mapping.h"
 #include "zeek/Event.h"
 #include "zeek/Expr.h"
@@ -46,6 +45,8 @@ using ztd::out_ptr::out_ptr;
 #include "zeek/ZeekString.h"
 #include "zeek/iosource/Manager.h"
 #include "zeek/telemetry/Manager.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 // Number of seconds we'll wait for a reply.
 constexpr int DNS_TIMEOUT = 5;

--- a/src/Dict.cc
+++ b/src/Dict.cc
@@ -2,8 +2,9 @@
 
 #include "zeek/Dict.h"
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/Hash.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 namespace zeek {
 

--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -8,7 +8,6 @@
 #include <highwayhash/instruction_sets.h>
 #include <highwayhash/sip_hash.h>
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/DebugLogger.h"
 #include "zeek/Desc.h"
 #include "zeek/Reporter.h"
@@ -17,6 +16,8 @@
 #include "zeek/digest.h"
 
 #include "const.bif.netvar_h"
+
+#include "zeek/3rdparty/doctest.h"
 
 namespace zeek::detail {
 

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -7,12 +7,13 @@
 #include <cstdlib>
 #include <utility>
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/CCL.h"
 #include "zeek/DFA.h"
 #include "zeek/EquivClass.h"
 #include "zeek/Reporter.h"
 #include "zeek/ZeekString.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 zeek::detail::CCL* zeek::detail::curr_ccl = nullptr;
 zeek::detail::Specific_RE_Matcher* zeek::detail::rem = nullptr;

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -9,7 +9,6 @@
 #include <syslog.h>
 #include <unistd.h>
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/Conn.h"
 #include "zeek/Desc.h"
 #include "zeek/Event.h"
@@ -23,6 +22,8 @@
 #include "zeek/input.h"
 #include "zeek/plugin/Manager.h"
 #include "zeek/plugin/Plugin.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 #ifdef SYSLOG_INT
 extern "C" {

--- a/src/RuleMatcher.cc
+++ b/src/RuleMatcher.cc
@@ -1,8 +1,6 @@
 
 #include "zeek/RuleMatcher.h"
 
-#include "zeek/zeek-config.h"
-
 #include <algorithm>
 #include <functional>
 
@@ -24,6 +22,7 @@
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/Analyzer.h"
 #include "zeek/module_util.h"
+#include "zeek/plugin/Manager.h"
 
 using namespace std;
 

--- a/src/RuleMatcher.h
+++ b/src/RuleMatcher.h
@@ -13,7 +13,6 @@
 #include "zeek/Rule.h"
 #include "zeek/ScannedFile.h"
 #include "zeek/ZeekString.h"
-#include "zeek/plugin/Manager.h"
 
 // #define MATCHER_PRINT_STATS
 

--- a/src/ZeekString.cc
+++ b/src/ZeekString.cc
@@ -9,11 +9,12 @@
 #include <iostream>
 #include <sstream> // Needed for unit testing
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/ID.h"
 #include "zeek/Reporter.h"
 #include "zeek/Val.h"
 #include "zeek/util.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 #ifdef DEBUG
 #define DEBUG_STR(msg) DBG_LOG(zeek::DBG_STRING, msg)

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -5,11 +5,12 @@
 #include <binpac.h>
 #include <algorithm>
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/Event.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/Manager.h"
 #include "zeek/analyzer/protocol/pia/PIA.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 namespace zeek::analyzer {
 

--- a/src/analyzer/protocol/smtp/BDAT.cc
+++ b/src/analyzer/protocol/smtp/BDAT.cc
@@ -1,10 +1,11 @@
 #include "zeek/analyzer/protocol/smtp/BDAT.h"
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/Conn.h"
 #include "zeek/DebugLogger.h"
 #include "zeek/analyzer/protocol/mime/MIME.h"
 #include "zeek/util.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 namespace zeek::analyzer::smtp::detail {
 

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -2,7 +2,6 @@
 
 #include <broker/error.hh>
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/Desc.h"
 #include "zeek/File.h"
 #include "zeek/Func.h"
@@ -12,6 +11,8 @@
 #include "zeek/Scope.h"
 #include "zeek/broker/data.bif.h"
 #include "zeek/module_util.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 using namespace std;
 

--- a/src/file_analysis/FileReassembler.cc
+++ b/src/file_analysis/FileReassembler.cc
@@ -2,8 +2,9 @@
 
 #include "zeek/file_analysis/FileReassembler.h"
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/file_analysis/File.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 namespace zeek::file_analysis {
 

--- a/src/iosource/Manager.cc
+++ b/src/iosource/Manager.cc
@@ -14,13 +14,11 @@
 
 #include "zeek/NetVar.h"
 #include "zeek/RunState.h"
-#include "zeek/broker/Manager.h"
 #include "zeek/iosource/Component.h"
 #include "zeek/iosource/IOSource.h"
 #include "zeek/iosource/PktDumper.h"
 #include "zeek/iosource/PktSrc.h"
 #include "zeek/plugin/Manager.h"
-#include "zeek/util.h"
 
 #define DEFAULT_PREFIX "pcap"
 

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -19,7 +19,6 @@
 #include "zeek/Timer.h"
 #include "zeek/Type.h"
 #include "zeek/broker/Manager.h"
-#include "zeek/input.h"
 #include "zeek/logging/WriterBackend.h"
 #include "zeek/logging/WriterFrontend.h"
 #include "zeek/logging/logging.bif.h"
@@ -2027,13 +2026,11 @@ bool Manager::FinishedRotation(WriterFrontend* writer, const char* new_name, con
     --rotations_pending;
 
     if ( ! success ) {
-        DBG_LOG(DBG_LOGGING, "Non-successful rotating writer '%s', file '%s' at %.6f,", writer->Name(), filename,
-                run_state::network_time);
+        DBG_LOG(DBG_LOGGING, "Non-successful rotating writer '%s', new_name '%s'", writer->Name(), new_name);
         return true;
     }
 
-    DBG_LOG(DBG_LOGGING, "Finished rotating %s at %.6f, new name %s", writer->Name(), run_state::network_time,
-            new_name);
+    DBG_LOG(DBG_LOGGING, "Finished rotating %s, new name %s", writer->Name(), new_name);
 
     WriterInfo* winfo = FindWriter(writer);
     if ( ! winfo )

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -15,13 +15,14 @@
 #include <string>
 #include <vector>
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/Func.h"
 #include "zeek/RunState.h"
 #include "zeek/logging/Manager.h"
 #include "zeek/logging/writers/ascii/ascii.bif.h"
 #include "zeek/threading/SerialTypes.h"
 #include "zeek/util.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 using namespace std;
 using zeek::threading::Field;

--- a/src/net_util.cc
+++ b/src/net_util.cc
@@ -10,10 +10,11 @@
 #include <sys/types.h>
 #include <memory>
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/IP.h"
 #include "zeek/IPAddr.h"
 #include "zeek/Reporter.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 const char* transport_proto_string(TransportProto proto) {
     switch ( proto ) {

--- a/src/telemetry/Manager.cc
+++ b/src/telemetry/Manager.cc
@@ -6,6 +6,7 @@
 
 // CivetServer is from the civetweb submodule in prometheus-cpp
 #include <CivetServer.h>
+#include <fnmatch.h>
 #include <prometheus/collectable.h>
 #include <prometheus/exposer.h>
 #include <prometheus/registry.h>
@@ -20,7 +21,6 @@
 #include "zeek/IPAddr.h"
 #include "zeek/RunState.h"
 #include "zeek/ZeekString.h"
-#include "zeek/broker/Manager.h"
 #include "zeek/iosource/Manager.h"
 #include "zeek/telemetry/ProcessStats.h"
 #include "zeek/telemetry/Timer.h"

--- a/src/telemetry/Manager.cc
+++ b/src/telemetry/Manager.cc
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <thread>
 
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/Func.h"
 #include "zeek/ID.h"
 #include "zeek/IPAddr.h"
@@ -25,6 +24,8 @@
 #include "zeek/telemetry/ProcessStats.h"
 #include "zeek/telemetry/Timer.h"
 #include "zeek/threading/formatters/detail/json.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 namespace zeek::telemetry {
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -46,7 +46,6 @@
 #include <vector>
 
 #include "zeek/3rdparty/ConvertUTF.h"
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/Desc.h"
 #include "zeek/Hash.h"
 #include "zeek/NetVar.h"
@@ -59,6 +58,8 @@
 #include "zeek/input.h"
 #include "zeek/iosource/Manager.h"
 #include "zeek/iosource/PktSrc.h"
+
+#include "zeek/3rdparty/doctest.h"
 
 using namespace std;
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -20,9 +20,6 @@
 #include "zeek/3rdparty/sqlite3.h"
 #endif
 
-#define DOCTEST_CONFIG_IMPLEMENT
-
-#include "zeek/3rdparty/doctest.h"
 #include "zeek/Anon.h"
 #include "zeek/DFA.h"
 #include "zeek/DNS_Mgr.h"
@@ -76,6 +73,9 @@
 extern "C" {
 #include "zeek/3rdparty/setsignal.h"
 };
+
+#define DOCTEST_CONFIG_IMPLEMENT
+#include "zeek/3rdparty/doctest.h"
 
 zeek::detail::ScriptCoverageManager zeek::detail::script_coverage_mgr;
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -14,14 +14,15 @@
 #include <cstdlib>
 #include <cstring>
 #include <list>
+#include <memory>
 #include <optional>
+#include <set>
+#include <string>
 
 #ifdef USE_SQLITE
 #include "zeek/3rdparty/sqlite3.h"
 #endif
 
-#include "zeek/Anon.h"
-#include "zeek/DFA.h"
 #include "zeek/DNS_Mgr.h"
 #include "zeek/Debug.h"
 #include "zeek/Desc.h"
@@ -42,8 +43,6 @@
 #include "zeek/Scope.h"
 #include "zeek/ScriptCoverageManager.h"
 #include "zeek/Stats.h"
-#include "zeek/Stmt.h"
-#include "zeek/Tag.h"
 #include "zeek/Timer.h"
 #include "zeek/Traverse.h"
 #include "zeek/Trigger.h"
@@ -54,7 +53,6 @@
 #include "zeek/file_analysis/Manager.h"
 #include "zeek/input.h"
 #include "zeek/input/Manager.h"
-#include "zeek/input/readers/raw/Raw.h"
 #include "zeek/iosource/Manager.h"
 #include "zeek/logging/Manager.h"
 #include "zeek/module_util.h"
@@ -191,8 +189,8 @@ extern "C" char version[];
 extern "C" const char zeek_build_info[];
 
 const char* zeek::detail::command_line_policy = nullptr;
-vector<string> zeek::detail::params;
-set<string> requested_plugins;
+std::vector<std::string> zeek::detail::params;
+std::set<std::string> requested_plugins;
 const char* proc_status_file = nullptr;
 
 zeek::OpaqueTypePtr md5_type;
@@ -283,8 +281,8 @@ static bool show_plugins(int level) {
         printf("\nInactive dynamic plugins:\n");
 
         for ( plugin::Manager::inactive_plugin_list::const_iterator i = inactives.begin(); i != inactives.end(); i++ ) {
-            string name = (*i).first;
-            string path = (*i).second;
+            std::string name = (*i).first;
+            std::string path = (*i).second;
             printf("  %s (%s)\n", name.c_str(), path.c_str());
         }
     }
@@ -748,7 +746,7 @@ SetupResult setup(int argc, char** argv, Options* zopts) {
         auto ipbb = make_intrusive<BuiltinFunc>(init_bifs, ipbid->Name(), false);
 
         if ( options.event_trace_file )
-            etm = make_unique<EventTraceMgr>(*options.event_trace_file);
+            etm = std::make_unique<EventTraceMgr>(*options.event_trace_file);
 
         // Parsing involves reading input files, including any input
         // interactively provided by the user at the console. Temporarily
@@ -784,7 +782,7 @@ SetupResult setup(int argc, char** argv, Options* zopts) {
         // Assign the script_args for command line processing in Zeek scripts.
         if ( ! options.script_args.empty() ) {
             auto script_args_val = id::find_val<VectorVal>("zeek_script_args");
-            for ( const string& script_arg : options.script_args ) {
+            for ( const auto& script_arg : options.script_args ) {
                 script_args_val->Assign(script_args_val->Size(), make_intrusive<StringVal>(script_arg));
             }
         }


### PR DESCRIPTION
Mostly motivated the input.h one in logging being curious, but also superfluous broker/Manager.h includes. And moving the doctest.h header at the bottom seemed also nice.

Comments welcome :-)