### PR TITLE
RFC: plugin: Add InitPreExecution()

### DIFF
--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -484,6 +484,14 @@ void Manager::InitPostScript() {
         (*i)->InitPostScript();
 }
 
+void Manager::InitPreExecution() {
+    assert(init);
+
+    for ( plugin_list::iterator i = Manager::ActivePluginsInternal()->begin();
+          i != Manager::ActivePluginsInternal()->end(); i++ )
+        (*i)->InitPreExecution();
+}
+
 void Manager::FinishPlugins() {
     assert(init);
 

--- a/src/plugin/Manager.h
+++ b/src/plugin/Manager.h
@@ -123,6 +123,13 @@ public:
     void InitPostScript();
 
     /**
+     * Fourth-stage initialization of the manager. This is called just before
+     * enqueuing zeek_init(), after script analysis and optimization completed.
+     * It forwards to the corresponding Plugin methods.
+     */
+    void InitPreExecution();
+
+    /**
      * Finalizes all plugins at termination time. This forwards to the
      * corresponding Plugin \a Done() methods.
      */

--- a/src/plugin/Plugin.cc
+++ b/src/plugin/Plugin.cc
@@ -249,6 +249,8 @@ void Plugin::InitPreScript() {}
 
 void Plugin::InitPostScript() {}
 
+void Plugin::InitPreExecution() {}
+
 Plugin::bif_item_list Plugin::BifItems() const { return bif_items; }
 
 void Plugin::Done() {

--- a/src/plugin/Plugin.h
+++ b/src/plugin/Plugin.h
@@ -749,6 +749,14 @@ protected:
     virtual void InitPostScript();
 
     /**
+     * Third-stage initialization of the plugin called just before enqueueing
+     * zeek_init(), after script analysis and optimization completed.
+     * This can be overridden by derived classes; they must however call the
+     * parent's implementation.
+     */
+    virtual void InitPreExecution();
+
+    /**
      * Finalizer method that derived classes can override for performing
      * custom tasks at shutdown.  This can be overridden by derived
      * classes; they must however call the parent's implementation.

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -26,7 +26,6 @@ AnalyOpt analysis_options;
 std::unordered_set<const Func*> non_recursive_funcs;
 
 void (*CPP_init_hook)() = nullptr;
-void (*CPP_activation_hook)() = nullptr;
 
 // Tracks all of the loaded functions (including event handlers and hooks).
 static std::vector<FuncInfo> funcs;

--- a/src/script_opt/ScriptOpt.h
+++ b/src/script_opt/ScriptOpt.h
@@ -271,8 +271,4 @@ extern bool IsZAM_BuiltInCond(const CallExpr* c);
 // to a non-empty value.
 extern void (*CPP_init_hook)();
 
-// Used for "standalone" C++-compiled scripts to complete their activation;
-// called after parsing and BiF initialization, but before zeek_init.
-extern void (*CPP_activation_hook)();
-
 } // namespace zeek::detail

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -992,8 +992,8 @@ SetupResult setup(int argc, char** argv, Options* zopts) {
         // we don't have any other source for it.
         run_state::detail::update_network_time(util::current_time());
 
-    if ( CPP_activation_hook )
-        (*CPP_activation_hook)();
+    // Plugin pre-execution hook.
+    plugin_mgr->InitPreExecution();
 
     if ( zeek_init )
         event_mgr.Enqueue(zeek_init, Args{});


### PR DESCRIPTION
Currently, plugins do not have a way to further inspect or even mutate script functions after ZAM optimization ran. One use-case here is zeek-perf-support [1]. This plugin wraps Stmt instances of functions, events and hooks hooks with a small assembly stub to support JIT map files [2] and for integration with perf tools.

This change introduces a new InitPreExecution() hook that runs after ZAM optimization completed, just before the zeek_init() event is enqueued.

Additionally, remove the existing CPP_activation_hook. It doesn't seem to be used. If it becomes necessary in the future, the new InitPreExecution() hook can be leveraged instead.

[1] https://github.com/zeek/zeek-perf-support
[2] https://github.com/torvalds/linux/blob/master/tools/perf/Documentation/jit-interface.txt