### PR TITLE
CI: Use test.sh script for running ZAM tests, but disable parts of it

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -426,12 +426,12 @@ asan_sanitizer_zam_task:
     << : *RESOURCES_TEMPLATE
 
   << : *CI_TEMPLATE
-  test_script:
-    # Run just the btests with zam as alternative.
-    - cd testing/btest && ../../auxil/btest/btest -a zam -A -d -j ${ZEEK_CI_BTEST_JOBS}
   env:
     ZEEK_CI_CONFIGURE_FLAGS: *ASAN_SANITIZER_CONFIG
     ASAN_OPTIONS: detect_leaks=1:detect_odr_violation=0
+    ZEEK_CI_SKIP_UNIT_TESTS: 1
+    ZEEK_CI_SKIP_EXTERNAL_BTESTS: 1
+    ZEEK_CI_BTEST_EXTRA_ARGS: -a zam
   << : *ZAM_SKIP_TASK_ON_PR
 
 ubsan_sanitizer_task:
@@ -457,15 +457,15 @@ ubsan_sanitizer_zam_task:
     << : *RESOURCES_TEMPLATE
 
   << : *CI_TEMPLATE
-  test_script:
-    # Run just the btests with zam as alternative.
-    - cd testing/btest && ../../auxil/btest/btest -a zam -A -d -j ${ZEEK_CI_BTEST_JOBS}
   env:
     CC: clang-18
     CXX: clang++-18
     ZEEK_CI_CONFIGURE_FLAGS: *UBSAN_SANITIZER_CONFIG
     ZEEK_TAILORED_UB_CHECKS: 1
     UBSAN_OPTIONS: print_stacktrace=1
+    ZEEK_CI_SKIP_UNIT_TESTS: 1
+    ZEEK_CI_SKIP_EXTERNAL_BTESTS: 1
+    ZEEK_CI_BTEST_EXTRA_ARGS: -a zam
   << : *ZAM_SKIP_TASK_ON_PR
 
 tsan_sanitizer_task:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -40,6 +40,11 @@ function banner {
 }
 
 function run_unit_tests {
+    if [[ ${ZEEK_CI_SKIP_UNIT_TESTS} -eq 1 ]]; then
+        printf "Skipping unit tests as requested by task configureation\n\n"
+        return 0
+    fi
+
     banner "Running unit tests"
 
     pushd build
@@ -60,7 +65,7 @@ function run_btests {
     pushd testing/btest
 
     ZEEK_PROFILER_FILE=$(pwd)/.tmp/script-coverage/XXXXXX \
-        ${BTEST} -z ${ZEEK_CI_BTEST_RETRIES} -d -A -x btest-results.xml -j ${ZEEK_CI_BTEST_JOBS} || result=1
+        ${BTEST} -z ${ZEEK_CI_BTEST_RETRIES} -d -A -x btest-results.xml -j ${ZEEK_CI_BTEST_JOBS} ${ZEEK_CI_BTEST_EXTRA_ARGS} || result=1
     make coverage
     prep_artifacts
     popd
@@ -68,11 +73,16 @@ function run_btests {
 }
 
 function run_external_btests {
+    if [[ ${ZEEK_CI_SKIP_EXTERNAL_BTESTS} -eq 1 ]]; then
+        printf "Skipping external tests as requested by task configuration\n\n"
+        return 0
+    fi
+
     local zeek_testing_pid=""
     local zeek_testing_pid_private=""
     pushd testing/external/zeek-testing
     ZEEK_PROFILER_FILE=$(pwd)/.tmp/script-coverage/XXXXXX \
-        ${BTEST} -d -A -x btest-results.xml -j ${ZEEK_CI_BTEST_JOBS} >btest.out 2>&1 &
+        ${BTEST} -d -A -x btest-results.xml -j ${ZEEK_CI_BTEST_JOBS} ${ZEEK_CI_BTEST_EXTRA_ARGS} >btest.out 2>&1 &
     zeek_testing_pid=$!
     popd
 


### PR DESCRIPTION
This ensures that the normal test setup is run, which enables greedy mode on Cirrus allowing us to over-provision the testing. This should help speed up the ZAM builds a bit.

This cuts the time for the ZAM ASAN builds roughly in half.