### PR TITLE
Fix documentation for `have_spicy` [skip CI]

### DIFF
--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -5340,7 +5340,7 @@ function has_module_events%(group: string%) : bool
 	%}
 
 ## Returns true if Zeek was built with support for using Spicy analyzers (which
-# is the default).
+## is the default).
 function have_spicy%(%) : bool
 	%{
 #ifdef HAVE_SPICY


### PR DESCRIPTION
The continued line was incorrectly marked up (as a plain comment instead of a Zeekygen comment) which caused only half of the docstring to be rendered by Zeekygen.