### PR TITLE
ZeekArgs: Deprecate val_list_to_args()

### DIFF
--- a/src/ZeekArgs.h
+++ b/src/ZeekArgs.h
@@ -27,6 +27,7 @@ using Args = std::vector<ValPtr>;
  * @return  the converted argument list
  *
  */
+[[deprecated("Remove in v8.1. Convert users to produce zeek::Args directly.")]]
 Args val_list_to_args(const ValPList& vl);
 
 /**


### PR DESCRIPTION
Fly-by deprecation for something that isn't used in-tree anymore.