### PR TITLE
Introducing Zeek Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Follow us on Twitter at [@zeekurity](https://twitter.com/zeekurity).
 
 [![Slack](https://img.shields.io/badge/slack-@zeek-brightgreen.svg?logo=slack)](https://zeek.org/slack)
 [![Discourse](https://img.shields.io/discourse/status?server=https%3A%2F%2Fcommunity.zeek.org)](https://community.zeek.org)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Zeek%20Guru-006BFF)](https://gurubase.io/g/zeek)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Zeek%20Guru-4EC428)](https://gurubase.io/g/zeek)
 
 </h4>
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Follow us on Twitter at [@zeekurity](https://twitter.com/zeekurity).
 
 [![Slack](https://img.shields.io/badge/slack-@zeek-brightgreen.svg?logo=slack)](https://zeek.org/slack)
 [![Discourse](https://img.shields.io/discourse/status?server=https%3A%2F%2Fcommunity.zeek.org)](https://community.zeek.org)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Zeek%20Guru-006BFF)](https://gurubase.io/g/zeek)
 
 </h4>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Zeek Guru](https://gurubase.io/g/zeek) to Gurubase. Zeek Guru uses the data from this repo and data from the [docs](https://docs.zeek.org/en/master/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Zeek Guru", which highlights that Zeek now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Zeek Guru in Gurubase, just let me know that's totally fine.
