### PR TITLE
Disable core.expr-execption btest under ZAM to fix CI builds

### DIFF
--- a/testing/btest/Baseline/core.expr-exception/reporter.log
+++ b/testing/btest/Baseline/core.expr-exception/reporter.log
@@ -7,13 +7,13 @@
 #open XXXX-XX-XX-XX-XX-XX
 #fields	ts	level	message	location
 #types	time	enum	string	string
-XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 10
-XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 10
-XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 10
-XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 10
-XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 10
-XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 10
-XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 10
-XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 10
-XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 10
+XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 16
+XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 16
+XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 16
+XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 16
+XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 16
+XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 16
+XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 16
+XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 16
+XXXXXXXXXX.XXXXXX	Reporter::ERROR	field value missing (c$ftp)	<...>/expr-exception.zeek, line 16
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/btest/core/expr-exception.zeek
+++ b/testing/btest/core/expr-exception.zeek
@@ -1,6 +1,12 @@
 # Expressions in an event handler that raise interpreter exceptions
 # shouldn't abort Zeek entirely, but just return from the function body.
 #
+# Skip this test when using ZAM. It generates a memory leak on CI under ASAN,
+# which causes a build failure.
+#
+# This should be removed when #4052 has been addressed.
+# @TEST-REQUIRES: test "${ZEEK_ZAM}" != "1"
+
 # @TEST-EXEC: zeek -b -r $TRACES/wikipedia.trace base/protocols/ftp base/protocols/http base/frameworks/reporter %INPUT >output
 # @TEST-EXEC: TEST_DIFF_CANONIFIER="$SCRIPTS/diff-remove-abspath | $SCRIPTS/diff-remove-timestamps" btest-diff reporter.log
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Relates to #4052.

For the time being I think we should disable the test for ZAM, so that `fullci` and nightly runs end up green.