### PR TITLE
Fix -O dump-final-ZAM to work in conjunction with -O no-ZAM-opt

### DIFF
--- a/src/script_opt/ZAM/Driver.cc
+++ b/src/script_opt/ZAM/Driver.cc
@@ -404,16 +404,19 @@ void ZAMCompiler::Dump() {
         }
     }
     else if ( analysis_options.dump_final_ZAM ) {
-        ASSERT(remapped_frame);
-
         printf("\nFrame for %s:\n", func->GetName().c_str());
 
-        for ( auto i = 0U; i < shared_frame_denizens.size(); ++i ) {
-            printf("frame[%d] =", i);
-            for ( auto& id : shared_frame_denizens[i].ids )
-                printf(" %s", id->Name());
-            printf("\n");
+        if ( remapped_frame ) {
+            for ( auto i = 0U; i < shared_frame_denizens.size(); ++i ) {
+                printf("frame[%d] =", i);
+                for ( auto& id : shared_frame_denizens[i].ids )
+                    printf(" %s", id->Name());
+                printf("\n");
+            }
         }
+        else
+            for ( const auto& elem : frame_layout1 )
+                printf("frame[%d] = %s\n", elem.second, elem.first->Name());
     }
 
     if ( ! insts2.empty() )


### PR DESCRIPTION
The original implementation of `-O dump-final-ZAM` mis-assumed that the regular full ZAM optimization had been done, which includes doubling up where local variables live in the `ZVal` frame used for execution. That failed when also specifying `-O no-ZAM-opt` to skip final ZAM optimization. This PR remedies the issue.