### PR TITLE
Add location information to ZAM run-time errors about vector length mismatches

### DIFF
--- a/src/script_opt/ZAM/ZBody.cc
+++ b/src/script_opt/ZAM/ZBody.cc
@@ -622,7 +622,8 @@ static void vec_exec(ZOp op, TypePtr t, VectorVal*& v1, const VectorVal* v2, con
     auto n = vec2.size();
 
     if ( vec3.size() != n ) {
-        ZAM_run_time_error(util::fmt("vector operands are of different sizes (%d vs. %d)", int(n), int(vec3.size())));
+        ZAM_run_time_error(z.loc,
+                           util::fmt("vector operands are of different sizes (%d vs. %d)", int(n), int(vec3.size())));
         return;
     }
 


### PR DESCRIPTION
As noted in https://github.com/zeek/zeek/pull/4022, that commit added a fix for a ZAM ASAN issue that introduced a not-great error message. At the time I thought that making the message coherent would take non-trivial work, but it turns out it was in fact trivial. This PR provides that fix; I did it as a `--fixup` but if that's not something done across merges, let me know and I'll do it standalone.