### PR TITLE
Remove obsolete Broker compatibility layer

### DIFF
--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -1,8 +1,9 @@
 #include "zeek/broker/Manager.h"
 
-#include <broker/broker.hh>
 #include <broker/config.hh>
 #include <broker/configuration.hh>
+#include <broker/endpoint.hh>
+#include <broker/variant.hh>
 #include <broker/zeek.hh>
 #include <unistd.h>
 #include <cstdio>
@@ -32,34 +33,14 @@
 #include "zeek/telemetry/Manager.h"
 #include "zeek/util.h"
 
-#ifdef BROKER_HAS_VARIANT
-#include <broker/variant.hh>
-#endif
-
 using namespace std;
 
 namespace {
-
-broker::data&& convert_if_broker_variant(broker::data&& arg) { return std::move(arg); }
-
-broker::data& convert_if_broker_variant(broker::data& arg) { return arg; }
-
-broker::data&& convert_if_broker_variant_or_move(broker::data& arg) { return std::move(arg); }
-
-broker::vector& broker_vector_from(broker::data& arg) { return broker::get<broker::vector>(arg); }
-
-#ifdef BROKER_HAS_VARIANT
-
-broker::data convert_if_broker_variant(const broker::variant& arg) { return arg.to_data(); }
-
-broker::data convert_if_broker_variant_or_move(const broker::variant& arg) { return arg.to_data(); }
 
 broker::vector broker_vector_from(const broker::variant& arg) {
     auto tmp = arg.to_data();
     return std::move(broker::get<broker::vector>(tmp));
 }
-
-#endif
 
 // Converts a string_view into a string to make sure that we can safely call `.c_str()` on the result.
 template<class View>
@@ -213,23 +194,13 @@ struct scoped_reporter_location {
 #ifdef DEBUG
 namespace {
 
-std::string RenderMessage(const broker::data& d) { return util::json_escape_utf8(broker::to_string(d)); }
-
-#ifdef BROKER_HAS_VARIANT
-
 std::string RenderMessage(const broker::variant& d) { return util::json_escape_utf8(broker::to_string(d)); }
 
 std::string RenderMessage(const broker::variant_list& d) { return util::json_escape_utf8(broker::to_string(d)); }
 
-#endif
-
 std::string RenderMessage(const broker::store::response& x) {
     return util::fmt("%s [id %" PRIu64 "]", (x.answer ? broker::to_string(*x.answer).c_str() : "<no answer>"), x.id);
 }
-
-std::string RenderMessage(const broker::vector* xs) { return broker::to_string(*xs); }
-
-std::string RenderMessage(const broker::vector& xs) { return broker::to_string(xs); }
 
 std::string RenderMessage(const broker::status& s) { return broker::to_string(s.code()); }
 
@@ -240,13 +211,12 @@ std::string RenderMessage(const broker::error& e) {
         return util::fmt("%s (null)", broker::to_string(e.code()).c_str());
 }
 
-template<class DataOrVariant>
-std::string RenderMessage(const std::string& topic, const DataOrVariant& x) {
+std::string RenderMessage(const std::string& topic, const broker::variant& x) {
     return util::fmt("%s -> %s", RenderMessage(x).c_str(), topic.c_str());
 }
 
-template<class DataOrVariant>
-std::string RenderEvent(const std::string& topic, const std::string& name, const DataOrVariant& args) {
+template<class VariantOrList>
+std::string RenderEvent(const std::string& topic, const std::string& name, const VariantOrList& args) {
     return util::fmt("%s(%s) -> %s", name.c_str(), RenderMessage(args).c_str(), topic.c_str());
 }
 
@@ -569,8 +539,8 @@ bool Manager::PublishEvent(string topic, std::string name, broker::vector args, 
     if ( peer_count == 0 )
         return true;
 
-    DBG_LOG(DBG_BROKER, "Publishing event: %s", RenderEvent(topic, name, args).c_str());
     broker::zeek::Event ev(std::move(name), std::move(args), broker::to_timestamp(ts));
+    DBG_LOG(DBG_BROKER, "Publishing event: %s", RenderEvent(topic, name, ev.args()).c_str());
     bstate->endpoint.publish(std::move(topic), ev.move_data());
     num_events_outgoing_metric->Inc();
     return true;
@@ -1009,7 +979,7 @@ void Manager::Process() {
         }
 
         if ( broker::is_prefix(topic, broker::topic::store_events_str) ) {
-            ProcessStoreEvent(convert_if_broker_variant(broker::move_data(message)));
+            ProcessStoreEvent(broker::get_data(message).to_data());
             continue;
         }
 
@@ -1245,7 +1215,7 @@ void Manager::ProcessMessage(std::string_view topic, broker::zeek::Event& ev) {
     for ( size_t i = 0; i < args.size(); ++i ) {
         auto got_type = args[i].get_type_name();
         const auto& expected_type = arg_types[i];
-        auto arg = convert_if_broker_variant(args[i]);
+        auto arg = args[i].to_data();
         auto val = detail::data_to_val(arg, expected_type.get());
 
         if ( val )
@@ -1312,7 +1282,7 @@ bool Manager::ProcessMessage(std::string_view, broker::zeek::LogCreate& lc) {
     }
 
     auto writer_info = std::make_unique<logging::WriterBackend::WriterInfo>();
-    if ( ! writer_info->FromBroker(convert_if_broker_variant_or_move(lc.writer_info())) ) {
+    if ( ! writer_info->FromBroker(lc.writer_info().to_data()) ) {
         reporter->Warning("failed to unpack remote log writer info");
         return false;
     }
@@ -1418,7 +1388,7 @@ bool Manager::ProcessMessage(std::string_view, broker::zeek::IdentifierUpdate& i
 
     num_ids_incoming_metric->Inc();
     auto id_name = c_str_safe(iu.id_name());
-    auto id_value = convert_if_broker_variant_or_move(iu.id_value());
+    auto id_value = iu.id_value().to_data();
     const auto& id = zeek::detail::global_scope()->Find(id_name);
 
     if ( ! id ) {

--- a/src/broker/Manager.h
+++ b/src/broker/Manager.h
@@ -2,12 +2,10 @@
 
 #include <broker/backend.hh>
 #include <broker/backend_options.hh>
-#include <broker/data.hh>
 #include <broker/detail/hash.hh>
-#include <broker/endpoint.hh>
 #include <broker/endpoint_info.hh>
-#include <broker/error.hh>
 #include <broker/peer_info.hh>
+#include <broker/store.hh>
 #include <broker/zeek.hh>
 #include <memory>
 #include <stdexcept>
@@ -21,6 +19,14 @@
 #include "zeek/iosource/IOSource.h"
 #include "zeek/logging/Types.h"
 #include "zeek/logging/WriterBackend.h"
+
+namespace broker {
+
+class data;
+class error;
+class endpoint;
+
+} // namespace broker
 
 namespace zeek {
 


### PR DESCRIPTION
Since the transition to broker::variant has been long finalized, there is no more need to be able to go back to a pre-variant version of Broker. Hence, we can drop various utilities that allow Zeek to run with older Broker releases.