### PR TITLE
ZAM optimization now removes hook calls to hooks without any bodies

### DIFF
--- a/src/Expr.h
+++ b/src/Expr.h
@@ -1458,6 +1458,7 @@ protected:
     bool IsFoldableBiF() const;
     bool AllConstArgs() const;
     bool CheckForBuiltin() const;
+    bool IsEmptyHook() const;
     ExprPtr TransformToBuiltin();
 
     ExprPtr func;

--- a/src/script_opt/Stmt.cc
+++ b/src/script_opt/Stmt.cc
@@ -119,7 +119,7 @@ StmtPtr ExprStmt::DoReduce(Reducer* c) {
 
     auto t = e->Tag();
 
-    if ( t == EXPR_NOP )
+    if ( t == EXPR_NOP || t == EXPR_CONST )
         return TransformMe(make_intrusive<NullStmt>(), c);
 
     if ( c->Optimizing() ) {
@@ -138,10 +138,9 @@ StmtPtr ExprStmt::DoReduce(Reducer* c) {
 
     StmtPtr red_e_stmt;
 
-    if ( t == EXPR_CALL )
-        // A bare call.  If we reduce it regularly, if
-        // it has a non-void type it'll generate an
-        // assignment to a temporary.
+    if ( t == EXPR_CALL && ! e->WillTransform(c) )
+        // A bare call.  If we reduce it regularly, if it has a non-void
+        // type it'll generate an assignment to a temporary.
         red_e_stmt = e->ReduceToSingletons(c);
     else {
         e = e->Reduce(c, red_e_stmt);


### PR DESCRIPTION
This PR adds to ZAM script optimization the removal of calls to hooks that don't have any bodies to execute. This has the nice benefit of making it cost-free for developers using script optimization to add in hooks to their scripts even if those hooks might often not be used.
