### PR TITLE
init-bare: Deprecate tcp_reassembler_ports

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -1368,13 +1368,13 @@ const tcp_max_old_segments = 0 &redef;
 ## that still trigger reassembly.
 ##
 ## .. zeek:see:: tcp_reassembler_ports_resp
-const tcp_reassembler_ports_orig: set[port] = {} &redef;
+const tcp_reassembler_ports_orig: set[port] = {} &redef &deprecated="Remove in v8.1. Non-functional since v4.1";
 
 ## For services without a handler, these sets define responder-side ports
 ## that still trigger reassembly.
 ##
 ## .. zeek:see:: tcp_reassembler_ports_orig
-const tcp_reassembler_ports_resp: set[port] = {} &redef;
+const tcp_reassembler_ports_resp: set[port] = {} &redef &deprecated="Remove in v8.1. Non-functional since v4.1";
 
 ## Defines destination TCP ports for which the contents of the originator stream
 ## should be delivered via :zeek:see:`tcp_contents`.

--- a/src/NetVar.cc
+++ b/src/NetVar.cc
@@ -32,9 +32,6 @@ zeek::RecordType* mime_match;
 
 zeek::RecordType* socks_address;
 
-zeek::TableVal* tcp_reassembler_ports_orig;
-zeek::TableVal* tcp_reassembler_ports_resp;
-
 zeek::TableVal* tcp_content_delivery_ports_orig;
 zeek::TableVal* tcp_content_delivery_ports_resp;
 


### PR DESCRIPTION
...and remove from NetVar, seems left-over.

No NEWS entry because this hasn't been functionally in like forever.