### PR TITLE
Fix ZAM's implementation of `Analyzer::name()` BiF

### DIFF
--- a/src/script_opt/ZAM/Support.cc
+++ b/src/script_opt/ZAM/Support.cc
@@ -33,13 +33,13 @@ size_t broker_mgr_flush_log_buffers() { return zeek::broker_mgr->FlushLogBuffers
 zeek::Connection* session_mgr_find_connection(zeek::Val* cid) { return zeek::session_mgr->FindConnection(cid); }
 
 zeek::StringVal* analyzer_name(zeek::EnumVal* val) {
-    plugin::Component* component = zeek::analyzer_mgr->Lookup(val);
+    plugin::Component* component = zeek::analyzer_mgr->Lookup(val, false);
 
     if ( ! component )
-        component = zeek::packet_mgr->Lookup(val);
+        component = zeek::packet_mgr->Lookup(val, false);
 
     if ( ! component )
-        component = zeek::file_mgr->Lookup(val);
+        component = zeek::file_mgr->Lookup(val, false);
 
     if ( component )
         return new StringVal(component->CanonicalName());

--- a/testing/btest/Baseline.zam/spicy.replaces/conn.log
+++ b/testing/btest/Baseline.zam/spicy.replaces/conn.log
@@ -7,5 +7,5 @@
 #open XXXX-XX-XX-XX-XX-XX
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	proto	service	duration	orig_bytes	resp_bytes	conn_state	local_orig	local_resp	missed_bytes	history	orig_pkts	orig_ip_bytes	resp_pkts	resp_ip_bytes	tunnel_parents	ip_proto
 #types	time	string	addr	port	addr	port	enum	string	interval	count	count	string	bool	bool	count	string	count	count	count	count	set[string]	count
-XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	172.16.238.1	49656	172.16.238.131	80	tcp	spicy_ssh	9.953807	2405	2887	SF	T	T	0	ShAdDaFf	40	4497	30	4455	-	6
+XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	172.16.238.1	49656	172.16.238.131	80	tcp	ssh	9.953807	2405	2887	SF	T	T	0	ShAdDaFf	40	4497	30	4455	-	6
 #close XXXX-XX-XX-XX-XX-XX


### PR DESCRIPTION
ZAM's analyzer lookup implementation deviates from Zeek's in consideration of remappings, which means that running ZAM produced conn.log service names prefixed with "spicy_" whereas regular Zeek doesn't.

I'm mildly uneasy now that there might be other such problems, because I'm pretty sure that for a while we made updates to BiFs without even realizing that there are ZAM counterparts to keep in sync. But scanning `BuiltIn.cc` I'm thinking those should only be a handful, and in a quick scan I didn't find further discrepancies.

@Mohan-Dhawan, @vpax, fyi.