### PR TITLE
Fix warning about Broker::publish call

### DIFF
--- a/scripts/policy/frameworks/cluster/nodes-experimental/manager.zeek
+++ b/scripts/policy/frameworks/cluster/nodes-experimental/manager.zeek
@@ -26,7 +26,7 @@ event node_fully_connected(name: string, id: string, resending: bool)
 		event cluster_started();
 
 		for ( topic in Cluster::broadcast_topics )
-			Broker::publish(topic, Cluster::Experimental::cluster_started);
+			Cluster::publish(topic, Cluster::Experimental::cluster_started);
 		}
 	}
 


### PR DESCRIPTION
This fixes the following warning when running ci/update-zeekygen-docs.sh:

> warning in /home/tim/projects/zeek-master/scripts/policy/frameworks/cluster/nodes-experimental/manager.zeek, line 29: Non-broker cluster backend configured and Broker manager inactive. Did you mean to use Cluster::publish() instead of Broker::publish()?

Strangely, this change doesn't cause any changes in the btest baselines, which I was definitely expecting.