### PR TITLE
zeekygen: Disable Cluster::Experimental module

### DIFF
--- a/scripts/zeekygen/__load__.zeek
+++ b/scripts/zeekygen/__load__.zeek
@@ -32,6 +32,7 @@ event zeek_init() &priority=1000
 	# probably disable all modules, too.
 	disable_module_events("Control");
 	disable_module_events("Cluster::Backend::ZeroMQ");
+	disable_module_events("Cluster::Experimental");
 	disable_module_events("Management::Agent::Runtime");
 	disable_module_events("Management::Controller::Runtime");
 	disable_module_events("Management::Node");


### PR DESCRIPTION
The nodes-experimental/manager.zeek file ends up calling Broker::publish() unconditionally, resulting in a warning. Skip running that code when generating documentation.


Replaces #4120 