### PR TITLE
Push container images for RC candidates to zeek/zeek

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -646,31 +646,7 @@ container_image_manifest_docker_builder:
         '+refs/heads/release/*:refs/remotes/origin/release/*' \
         '+refs/heads/master:refs/remotes/origin/master'
 
-    # Find current versions for lts and feature depending on branches and
-    # tags in the repo. sed for escaping the dot in the version for using
-    # it in the regex below to match against CIRRUS_TAG.
-    lts_ver=$(./ci/find-current-version.sh lts)
-    lts_pat="^v$(echo $lts_ver | sed 's,\.,\\.,g')\.[0-9]+\$"
-    feature_ver=$(./ci/find-current-version.sh feature)
-    feature_pat="^v$(echo $feature_ver | sed 's,\.,\\.,g')\.[0-9]+\$"
-
-    # Construct additional tags for the image. At most this will
-    # be "lts x.0 feature" for an lts branch x.0 that is currently
-    # also the latest feature branch.
-    ADDL_MANIFEST_TAGS=
-    if echo "${CIRRUS_TAG}" | grep -E "${lts_pat}"; then
-        ADDL_MANIFEST_TAGS="${ADDL_MANIFEST_TAGS} lts ${lts_ver}"
-    fi
-
-    if echo "${CIRRUS_TAG}" | grep -E "${feature_pat}"; then
-        ADDL_MANIFEST_TAGS="${ADDL_MANIFEST_TAGS} latest"
-        if [ "${feature_ver}" != "${lts_ver}" ]; then
-          ADDL_MANIFEST_TAGS="${ADDL_MANIFEST_TAGS} ${feature_ver}"
-        fi
-    fi
-
-    # Let downstream know about it.
-    echo "ADDITIONAL_MANIFEST_TAGS=${ADDL_MANIFEST_TAGS}" >> $CIRRUS_ENV
+    ./ci/container-images-addl-tags.sh "${CIRRUS_TAG}" | tee -a $CIRRUS_ENV
 
   # These should've been populated by the previous jobs
   zeek_image_arm64_cache:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -599,7 +599,7 @@ container_image_manifest_docker_builder:
     ( $CIRRUS_CRON == '' ) &&
     ( $CIRRUS_REPO_FULL_NAME == 'zeek/zeek' &&
       ( $CIRRUS_BRANCH == 'master' ||
-        $CIRRUS_TAG =~ 'v[0-9]+\.[0-9]+\.[0-9]+$' ) )
+        $CIRRUS_TAG =~ 'v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$' ) )
   env:
     DOCKER_USERNAME: ENCRYPTED[!505b3dee552a395730a7e79e6aab280ffbe1b84ec62ae7616774dfefe104e34f896d2e20ce3ad701f338987c13c33533!]
     DOCKER_PASSWORD: ENCRYPTED[!6c4b2f6f0e5379ef1091719cc5d2d74c90cfd2665ac786942033d6d924597ffb95dbbc1df45a30cc9ddeec76c07ac620!]
@@ -618,8 +618,12 @@ container_image_manifest_docker_builder:
     # for tags, or zeek/zeek-dev:latest for pushes to master.
     set -x
     if [ -n "${CIRRUS_TAG}" ]; then
-      echo "IMAGE_TAG=$(cat VERSION)" >> $CIRRUS_ENV
       echo "IMAGE_NAME=zeek"  >> $CIRRUS_ENV
+      echo "IMAGE_TAG=$(cat VERSION)" >> $CIRRUS_ENV
+      if [ "${CIRRUS_TAG}" != "v$(cat VERSION)" ]; then
+        echo "CIRRUS_TAG '${CIRRUS_TAG}' and VERSION '$(cat VERSION)' inconsistent!" >&2
+        exit 1
+      fi
     elif [ "${CIRRUS_BRANCH}" = "master" ]; then
       echo "IMAGE_NAME=zeek-dev"  >> $CIRRUS_ENV
       echo "IMAGE_TAG=latest" >> $CIRRUS_ENV

--- a/ci/container-images-addl-tags.sh
+++ b/ci/container-images-addl-tags.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# This script produces output in the form of
+#
+#     $ REMOTE=awelzel ./ci/container-images-addl-tags.sh v7.0.5
+#     ADDITIONAL_MANIFEST_TAGS= lts 7.0 latest
+#
+# This scripts expects visibility to all tags and release branches
+# to work correctly. See the find-current-version.sh for details.
+set -eu
+
+dir="$(cd "$(dirname "$0")" && pwd)"
+
+if [ $# -ne 1 ] || [ -z "${1}" ]; then
+    echo "Usage: $0 <tag>" >&2
+    exit 1
+fi
+
+TAG="${1}"
+
+# Find current versions for lts and feature depending on branches and
+# tags in the repo. sed for escaping the dot in the version for using
+# it in the regex below to match against TAG.
+lts_ver=$(${dir}/find-current-version.sh lts)
+lts_pat="^v$(echo $lts_ver | sed 's,\.,\\.,g')\.[0-9]+\$"
+feature_ver=$(${dir}/find-current-version.sh feature)
+feature_pat="^v$(echo $feature_ver | sed 's,\.,\\.,g')\.[0-9]+\$"
+
+# Construct additional tags for the image. At most this will
+# be "lts x.0 feature" for an lts branch x.0 that is currently
+# also the latest feature branch.
+ADDL_MANIFEST_TAGS=
+if echo "${TAG}" | grep -q -E "${lts_pat}"; then
+    ADDL_MANIFEST_TAGS="${ADDL_MANIFEST_TAGS} lts ${lts_ver}"
+fi
+
+if echo "${TAG}" | grep -q -E "${feature_pat}"; then
+    ADDL_MANIFEST_TAGS="${ADDL_MANIFEST_TAGS} latest"
+    if [ "${feature_ver}" != "${lts_ver}" ]; then
+        ADDL_MANIFEST_TAGS="${ADDL_MANIFEST_TAGS} ${feature_ver}"
+    fi
+fi
+
+echo "ADDITIONAL_MANIFEST_TAGS=${ADDL_MANIFEST_TAGS}"


### PR DESCRIPTION
Primarily tested with the split out `./ci/container-images-addl-tags.sh` script to make sure `-rcX` doesn't produce any additional tags. As commented on #3287, `zeek/zeek` seems more appropriate.

Closes #3287 