### PR TITLE
Document `get_tag` to ensure that `name` exists

### DIFF
--- a/scripts/base/frameworks/analyzer/main.zeek
+++ b/scripts/base/frameworks/analyzer/main.zeek
@@ -100,6 +100,10 @@ export {
 
 	## Translates an analyzer's name to a tag enum value.
 	##
+	## The analyzer is assumed to exist; call
+	## :zeek:see:`Analyzer::has_tag` first to verify that name is a
+	## valid analyzer name.
+	##
 	## name: The analyzer name.
 	##
 	## Returns: The analyzer tag corresponding to the name.


### PR DESCRIPTION
This caused confusion and I don't think it's very intuitive. If called with a name that does not exist, this returns without a value in the script. Changing that seems like it could be more deprecation work - it has [specific handling](https://github.com/zeek/zeek/blob/991bc9644dd9b77f09fff992658f10500dce77e1/src/analyzer/analyzer.bif#L76) that will end up returning a `nullptr`. At least documenting it is better than nothing.