### PR TITLE
Fix incorrect uses of `zeek:see`

### DIFF
--- a/scripts/base/frameworks/logging/main.zeek
+++ b/scripts/base/frameworks/logging/main.zeek
@@ -509,8 +509,8 @@ export {
 	##
 	## Returns: The set of filter names associated with the stream.
 	##
-	## ..zeek:see:: Log::remove_filter Log::add_default_filter
-	##   Log::remove_default_filter Log::get_filter
+	## .. zeek:see:: Log::remove_filter Log::add_default_filter
+	##               Log::remove_default_filter Log::get_filter
 	global get_filter_names: function(id: ID) : set[string];
 
 	## Gets a filter associated with an existing logging stream.
@@ -635,7 +635,7 @@ export {
 	## Type of function to invoke when delaying a log write has completed.
 	##
 	## Functions of this type take the same arguments as :zeek:see:`Log::StreamPolicyHook`
-	## and act as a callback passed to zeek:see:`Log::delay`. They execute
+	## and act as a callback passed to :zeek:see:`Log::delay`. They execute
 	## just before the record is forwarded to the individual log filters.
 	##
 	## Returning ``F`` from a post delay callback discards the log write.
@@ -658,7 +658,7 @@ export {
 	## as parameters.
 	##
 	## Conceptually, the delay is inserted between the execution of the
-	## zeek:see:`Log::log_stream_policy` hook and the policy hooks of filters.
+	## :zeek:see:`Log::log_stream_policy` hook and the policy hooks of filters.
 	##
 	## Calling this function increments a reference count that can subsequently
 	## be decremented using :zeek:see:`Log::delay_finish`.
@@ -701,7 +701,7 @@ export {
 	##
 	## Multiple calls to this function will only ever increase the maximum
 	## delay, the delay cannot be lowered. The default maximum delay for a
-	## stream is zeek:see:`Log::default_max_delay_interval`.
+	## stream is :zeek:see:`Log::default_max_delay_interval`.
 	##
 	## When a stream is removed and re-created via :zeek:see:`Log::create_stream`,
 	## the new stream is re-configured with the previously used maximum delay.

--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -3903,6 +3903,7 @@ export {
 	type DHCP::Addrs: vector of addr;
 
 	## A DHCP message.
+	##
 	## .. zeek:see:: dhcp_message
 	type DHCP::Msg: record {
 		op: count;      ##< Message OP code. 1 = BOOTREQUEST, 2 = BOOTREPLY
@@ -3922,6 +3923,7 @@ export {
 	};
 
 	## DHCP Client Identifier (Option 61)
+	##
 	## .. zeek:see:: dhcp_message
 	type DHCP::ClientID: record {
 		hwtype: count;
@@ -3942,6 +3944,7 @@ export {
 	};
 
 	## DHCP Relay Agent Information Option (Option 82)
+	##
 	## .. zeek:see:: dhcp_message
 	type DHCP::SubOpt: record {
 		code: count;

--- a/scripts/policy/frameworks/management/agent/api.zeek
+++ b/scripts/policy/frameworks/management/agent/api.zeek
@@ -185,7 +185,7 @@ export {
 	## The agent sends this event upon peering as a "check-in", informing
 	## the controller that an agent of the given name is now available to
 	## communicate with. It is a controller-level equivalent of
-	## `:zeek:see:`Broker::peer_added` and triggered by it.
+	## :zeek:see:`Broker::peer_added` and triggered by it.
 	##
 	## instance: an instance name, really the agent's name as per
 	##    :zeek:see:`Management::Agent::get_name`.

--- a/src/analyzer/protocol/ssl/events.bif
+++ b/src/analyzer/protocol/ssl/events.bif
@@ -655,7 +655,7 @@ event ssl_encrypted_data%(c: connection, is_client: bool, record_version: count,
 ## not correct; the client can send more handshake packets before the finished message, e.g.,
 ## when client certificates are used.
 ##
-## Note that :zeek:see::ssl_encrypted_data is also raised for these messages.
+## Note that :zeek:see:`ssl_encrypted_data` is also raised for these messages.
 ##
 ## c: The connection.
 ##

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -881,7 +881,7 @@ function sha256_hash_finish%(handle: opaque of sha256%): string
 ##
 ## Returns: A new, compiled, paraglob with the patterns in *v*
 ##
-## .. zeek:see::paraglob_match paraglob_equals paraglob_add
+## .. zeek:see:: paraglob_match paraglob_equals
 function paraglob_init%(v: any%) : opaque of paraglob
 	%{
 	if ( v->GetType()->Tag() != zeek::TYPE_VECTOR ||
@@ -921,7 +921,7 @@ function paraglob_init%(v: any%) : opaque of paraglob
 ##
 ## Returns: A vector of strings matching the input string.
 ##
-## ## .. zeek:see::paraglob_add paraglob_equals paraglob_init
+## .. zeek:see:: paraglob_equals paraglob_init
 function paraglob_match%(handle: opaque of paraglob, match: string%): string_vec
 	%{
 	return static_cast<ParaglobVal*>(handle)->Get(match);
@@ -935,7 +935,7 @@ function paraglob_match%(handle: opaque of paraglob, match: string%): string_vec
 ##
 ## Returns: True if both paraglobs contain the same patterns, false otherwise.
 ##
-## ## .. zeek:see::paraglob_add paraglob_match paraglob_init
+## .. zeek:see:: paraglob_match paraglob_init
 function paraglob_equals%(p_one: opaque of paraglob, p_two: opaque of paraglob%) : bool
 	%{
 	return zeek::val_mgr->Bool(


### PR DESCRIPTION
This fixes instances where `zeek:see` was used incorrectly so it was not rendered correctly. All these instances have been found by looking for `zeek:see` in the generated HTML where it should not be visible anymore.

I also removed a doc reference to `paraglob_add` which never existed.