### PR TITLE
Support for record extensions when using -O gen-standalone-C++

### DIFF
--- a/src/Type.h
+++ b/src/Type.h
@@ -618,11 +618,16 @@ public:
 
     const detail::AttrPtr& GetAttr(detail::AttrTag a) const { return attrs ? attrs->Find(a) : detail::Attr::nil; }
 
+    const detail::Location* GetLocationInfo() const { return &loc; }
+
     void DescribeReST(ODesc* d, bool roles_only = false) const;
 
     TypePtr type;
     detail::AttributesPtr attrs;
     const char* id = nullptr;
+
+private:
+    detail::Location loc = detail::GetCurrentLocation();
 };
 
 using type_decl_list = PList<TypeDecl>;

--- a/src/script_opt/CPP/InitsInfo.cc
+++ b/src/script_opt/CPP/InitsInfo.cc
@@ -544,7 +544,8 @@ void FuncTypeInfo::AddInitializerVals(std::vector<std::string>& ivs) const {
     ivs.emplace_back(Fmt(static_cast<int>(expressionless_return_okay)));
 }
 
-RecordTypeInfo::RecordTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c, std::move(_t)) {
+RecordTypeInfo::RecordTypeInfo(CPPCompile* _c, TypePtr _t, int _addl_fields)
+    : AbstractTypeInfo(_c, std::move(_t)), addl_fields(_addl_fields) {
     // Note, we leave init_cohort at 0 because the skeleton of this type
     // is built in the first cohort.
     auto r = t->AsRecordType()->Types();
@@ -574,6 +575,7 @@ RecordTypeInfo::RecordTypeInfo(CPPCompile* _c, TypePtr _t) : AbstractTypeInfo(_c
 
 void RecordTypeInfo::AddInitializerVals(std::vector<std::string>& ivs) const {
     ivs.emplace_back(Fmt(c->TrackString(t->GetName())));
+    ivs.emplace_back(Fmt(addl_fields));
 
     auto n = field_names.size();
 

--- a/src/script_opt/CPP/InitsInfo.h
+++ b/src/script_opt/CPP/InitsInfo.h
@@ -644,11 +644,15 @@ private:
 
 class RecordTypeInfo : public AbstractTypeInfo {
 public:
-    RecordTypeInfo(CPPCompile* c, TypePtr _t);
+    RecordTypeInfo(CPPCompile* c, TypePtr _t, int _addl_fields);
 
     void AddInitializerVals(std::vector<std::string>& ivs) const override;
 
 private:
+    // If non-zero, where additional fields begin. Only used for standalone
+    // compilation.
+    int addl_fields;
+
     std::vector<std::string> field_names;
     std::vector<TypePtr> field_types;
     std::vector<int> field_attrs;

--- a/src/script_opt/CPP/RuntimeInits.cc
+++ b/src/script_opt/CPP/RuntimeInits.cc
@@ -383,11 +383,18 @@ TypePtr CPP_TypeInits::BuildRecordType(InitsManager* im, ValElemVec& init_vals, 
     auto r = cast_intrusive<RecordType>(inits_vec[offset]);
     ASSERT(r);
 
-    if ( r->NumFields() == 0 ) {
+    auto addl_fields = init_vals[2];
+
+    if ( addl_fields > 0 || r->NumFields() == 0 ) {
+        // We shouldn't be adding fields if the record doesn't have any
+        // existing fields - that would reflect an initialization botch.
+        if ( addl_fields > 0 && r->NumFields() == 0 )
+            reporter->InternalError("record unexpectedly empty when adding fields");
+
         type_decl_list tl;
 
         auto n = init_vals.size();
-        auto i = 2U;
+        auto i = 3U + addl_fields * 3;
 
         while ( i < n ) {
             auto s = im->Strings(init_vals[i++]);

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -125,13 +125,13 @@ bool should_analyze(const ScriptFuncPtr& f, const StmtPtr& body) {
     return false;
 }
 
-bool obj_matches_opt_files(const Obj* obj) {
+bool filename_matches_opt_files(const char* filename) {
     auto& ofiles = analysis_options.only_files;
 
     if ( ofiles.empty() )
         return false;
 
-    auto fin = util::detail::normalize_path(obj->GetLocationInfo()->filename);
+    auto fin = util::detail::normalize_path(filename);
 
     for ( auto& o : ofiles )
         if ( std::regex_match(fin, o) )
@@ -139,6 +139,8 @@ bool obj_matches_opt_files(const Obj* obj) {
 
     return false;
 }
+
+bool obj_matches_opt_files(const Obj* obj) { return filename_matches_opt_files(obj->GetLocationInfo()->filename); }
 
 static bool optimize_AST(ScriptFuncPtr f, std::shared_ptr<ProfileFunc>& pf, std::shared_ptr<Reducer>& rc,
                          ScopePtr scope, StmtPtr& body) {

--- a/src/script_opt/ScriptOpt.h
+++ b/src/script_opt/ScriptOpt.h
@@ -254,8 +254,9 @@ extern void add_file_analysis_pattern(AnalyOpt& opts, const char* pat);
 // it should be skipped.
 extern bool should_analyze(const ScriptFuncPtr& f, const StmtPtr& body);
 
-// True if the given object's location matches one specified by
+// True if the given filename or object location matches one specified by
 // --optimize-files=...
+extern bool filename_matches_opt_files(const char* filename);
 extern bool obj_matches_opt_files(const Obj* obj);
 inline bool obj_matches_opt_files(const ObjPtr& obj) { return obj_matches_opt_files(obj.get()); }
 


### PR DESCRIPTION
This is the last of PRs related to compiling scripts to standalone C++. It covers an issue that I only found after putting in the earlier PRs: if a script extends a record using `redef record += ...` then the standalone C++ initialization code needs to add those fields explicitly. To enable the compiler to figure out if this is needed, we add a `Location` associated with each record field.