### PR TITLE
Harden the `scripts.base.frameworks.input.missing-file-initially` test

### DIFF
--- a/testing/btest/scripts/base/frameworks/input/missing-file-initially.zeek
+++ b/testing/btest/scripts/base/frameworks/input/missing-file-initially.zeek
@@ -10,6 +10,11 @@
 # @TEST-EXEC: mv does-not-exist.dat does-not-exist-again.dat
 # @TEST-EXEC: echo "3 streaming still works" >> does-not-exist-again.dat
 # @TEST-EXEC: btest-bg-wait 10
+#
+# In case we had unexpected delays in the above, Zeek reports that it
+# suppressed additional log messages about does-not-exist.dat. Remove these:
+# @TEST-EXEC: sed -i -n '/Suppressed [0-9]\+ warning/!p' zeek/.stderr
+#
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-sort btest-diff zeek/.stdout
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-sort btest-diff zeek/.stderr
 


### PR DESCRIPTION
When the test run takes long (on slow/overloaded CI machines, for example) Zeek could log repeated messages about the input file not being available:
```
   warning: ../does-not-exist.dat/Input::READER_ASCII: ../does-not-exist.dat: Could not get stat for ../does-not-exist.dat
  +warning: ../does-not-exist.dat/Input::READER_ASCII: ../does-not-exist.dat: Suppressed 1 warning(s)
  +warning: ../does-not-exist.dat/Input::READER_ASCII: ../does-not-exist.dat: Suppressed 1 warning(s)
  +warning: ../does-not-exist.dat/Input::READER_ASCII: ../does-not-exist.dat: Suppressed 1 warning(s)
   warning: ../does-not-exist.dat/Input::READER_ASCII: Init: cannot open ../does-not-exist.dat
```
This canonicalizes the output by removing such lines.

Resolves #4102.