### PR TITLE
Add SECURITY.md, pointing at the website

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+Zeek's Security Policy is defined on our website at https://zeek.org/security-reporting/
+
+Our Security Release Policy is further clarified at https://github.com/zeek/zeek/wiki/Security-Release-Process


### PR DESCRIPTION
This ensures that the "Security Policy" section under https://github.com/zeek/zeek/security is marked as enabled. We should consider adding the same file to all of the other repos, just for consistency.