### PR TITLE
Fix incomplete includes in Spicy SSL analyer C++ code

### DIFF
--- a/src/analyzer/protocol/ssl/spicy/support.cc
+++ b/src/analyzer/protocol/ssl/spicy/support.cc
@@ -3,7 +3,9 @@
 #include <hilti/rt/libhilti.h>
 #include <cassert>
 
+#include "zeek/Conn.h"
 #include "zeek/Desc.h"
+#include "zeek/analyzer/protocol/tcp/TCP.h"
 #include "zeek/file_analysis/Manager.h"
 #include "zeek/spicy/cookie.h"
 #include "zeek/spicy/runtime-support.h"


### PR DESCRIPTION
This appears to have been broken by
feec451bcee7c459bc9a93e39ae18dc41515ac17.