### PR TITLE
logging: Fix HookLogInit() and HookLogWrite() info usage

### DIFF
--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -1737,7 +1737,7 @@ WriterFrontend* Manager::CreateWriterForFilter(Filter* filter, const std::string
 bool Manager::WriteBatchFromRemote(const detail::LogWriteHeader& header, std::vector<detail::LogRecord>&& records) {
     Stream* stream = FindStream(header.stream_id.get());
     if ( ! stream ) {
-        reporter->Error("Failed to find stream for !");
+        reporter->Error("Failed to find stream %s for remote write", header.stream_name.c_str());
         return false;
     }
 

--- a/testing/btest/plugins/logging-hooks-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/logging-hooks-plugin/src/Plugin.cc
@@ -49,6 +49,8 @@ void Plugin::HookLogInit(const std::string& writer, const std::string& instantia
 
     fprintf(stderr, "%.6f %-15s %s %d/%d %s\n", zeek::run_state::network_time, "| HookLogInit", info.path, local,
             remote, d.Description());
+
+    info_addr_init = &info;
 }
 
 bool Plugin::HookLogWrite(const std::string& writer, const std::string& filter,
@@ -62,5 +64,17 @@ bool Plugin::HookLogWrite(const std::string& writer, const std::string& filter,
     else if ( round == 3 )
         vals[1]->present = false;
 
+    if ( ! info_addr_write )
+        info_addr_write = &info;
+    else if ( info_addr_write != &info )
+        fprintf(stderr, "FAIL: subsequent info addr %p differs from %p\n", &info, info_addr_write);
+
     return true;
+}
+
+void Plugin::Done() {
+    if ( ! info_addr_init || ! info_addr_write || info_addr_init != info_addr_write ) {
+        fprintf(stderr, "FAIL: info_addr_init=%p info_addr_write=%p\n", info_addr_init, info_addr_write);
+        exit(1);
+    }
 }

--- a/testing/btest/plugins/logging-hooks-plugin/src/Plugin.h
+++ b/testing/btest/plugins/logging-hooks-plugin/src/Plugin.h
@@ -17,8 +17,13 @@ protected:
     // Overridden from plugin::Plugin.
     zeek::plugin::Configuration Configure() override;
 
+    // Overridden from plugin::Plugin.
+    void Done() override;
+
 private:
     int round;
+    const zeek::logging::WriterBackend::WriterInfo* info_addr_init = nullptr;
+    const zeek::logging::WriterBackend::WriterInfo* info_addr_write = nullptr;
 };
 
 extern Plugin plugin;


### PR DESCRIPTION
There's two instances of WriterBackend::WriterInfo for a given
writer. One in Manager::WriterInfo that's accessible via
stream.writers and a copy within WriterFrontend.

Commit 78999d1 switched to use the
address of the frontend's info instance for HookLogWrite() invocations,
breaking users using the address for identification purposes.

---

This PR contains two more commits as cleanup. I'm happy do ditch them if that's easier for 7.1 maintenance (though wouldn't mind if they make it in).

Thanks @pbcullen for the report.