### PR TITLE
Fixes for -O gen-standalone-C++ generation of lambdas

### DIFF
--- a/src/script_opt/CPP/DeclFunc.cc
+++ b/src/script_opt/CPP/DeclFunc.cc
@@ -30,8 +30,13 @@ void CPPCompile::DeclareLambda(const LambdaExpr* l, const ProfileFunc* pf) {
     auto l_id = l->Ingredients()->GetID();
     auto& ids = l->OuterIDs();
 
-    for ( auto id : ids )
-        lambda_names[id] = CaptureName(id);
+    for ( auto lid : ids ) {
+        if ( lambda_names.count(lid) > 0 ) {
+            ASSERT(lambda_names[lid] == CaptureName(lid));
+        }
+        else
+            lambda_names[lid] = CaptureName(lid);
+    }
 
     CreateFunction(l_id->GetType<FuncType>(), pf, lname, body, 0, l, FUNC_FLAVOR_FUNCTION);
 }

--- a/src/script_opt/CPP/Driver.cc
+++ b/src/script_opt/CPP/Driver.cc
@@ -79,6 +79,10 @@ void CPPCompile::Compile(bool report_uncompilable) {
             }
         }
 
+        for ( auto& l : pfs->Lambdas() )
+            if ( obj_matches_opt_files(l) )
+                accessed_lambdas.insert(l);
+
         for ( auto& ea : pfs->ExprAttrs() )
             if ( obj_matches_opt_files(ea.first) ) {
                 auto& attr = ea.first;

--- a/src/script_opt/CPP/RuntimeInitSupport.cc
+++ b/src/script_opt/CPP/RuntimeInitSupport.cc
@@ -177,7 +177,11 @@ FuncValPtr lookup_func__CPP(string name, int num_bodies, vector<p_hash_type> has
 
     for ( auto h : hashes ) {
         auto cs = compiled_scripts.find(h);
-        ASSERT(cs != compiled_scripts.end());
+
+        if ( cs == compiled_scripts.end() ) {
+            cs = compiled_standalone_scripts.find(h);
+            ASSERT(cs != compiled_standalone_scripts.end());
+        }
 
         const auto& f = cs->second;
         bodies.emplace_back(f.body);

--- a/src/script_opt/CPP/maint/README
+++ b/src/script_opt/CPP/maint/README
@@ -21,15 +21,14 @@ The maintenance workflow:
 
 	rm CPP-gen.cc
 	ninja
-	src/zeek -b -O gen-standalone-C++ \
-		--optimize-files=base/protocols/conn \
-		--optimize-files=base/utils/files \
-		--optimize-files=base/utils/addr \
-		base/protocols/conn >my-test.zeek
+	src/zeek -O gen-standalone-C++ \
+		--optimize-files=policy \
+		policy/misc/loaded-scripts.zeek >my-test.zeek
+	rm -f loaded_scripts.log
 	ninja
-	src/zeek -b -r some.pcap my-test.zeek
-	# Confirm that it generates conn.log
-	rm CPP-gen.cc
+	src/zeek my-test.zeek
+	# Confirm that it generates loaded_scripts.log
+	rm CPP-gen.cc loaded_scripts.log
 	ninja
 
     Do this first because if it can't, you'll be making changes to the


### PR DESCRIPTION
As noted in the final discussion of https://github.com/zeek/zeek/pull/4165, I found one more problem (so far!) in generating standalone C++ for scripts, which is making sure that the compiler produces definitions for all of the lambdas needed by the standalone code. This PR addresses that, along with a sanity check for processing lambda captures, and updated maintenance instructions for checking for correct operation of standalone compilation.