### PR TITLE
Improve Frame performance

### DIFF
--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -77,7 +77,7 @@ DebuggerState::DebuggerState() {
     BreakFromSignal(false);
 
     // ### Don't choose this arbitrary size! Extend Frame.
-    dbg_locals = new Frame(1024, /* func = */ nullptr, /* fn_args = */ nullptr);
+    dbg_locals = detail::MakeFrame(1024, /* func = */ nullptr, /* fn_args = */ nullptr).release();
 }
 
 DebuggerState::~DebuggerState() { Unref(dbg_locals); }

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -44,6 +44,12 @@ inline void Unref(Frame* f);
 
 class Frame {
 public:
+    ~Frame() {
+        // Unref() all elements.
+        for ( int i = 0; i < size; i++ )
+            frame[i] = nullptr;
+    }
+
     /**
      * Returns the size of the frame.
      *

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -308,7 +308,7 @@ ScriptFunc::~ScriptFunc() {
                 ZVal::DeleteManagedType(cvec[i]);
     }
 
-    delete captures_frame;
+    Unref(captures_frame);
     delete captures_offset_mapping;
 }
 

--- a/src/Trigger.h
+++ b/src/Trigger.h
@@ -166,6 +166,8 @@ private:
     ValCache cache;
 };
 
+using TriggerPtr = IntrusivePtr<Trigger>;
+
 class Manager final : public iosource::IOSource {
 public:
     Manager();

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -1066,11 +1066,11 @@ SetupResult setup(int argc, char** argv, Options* zopts) {
     if ( stmts ) {
         auto [body, scope] = get_global_stmts();
         StmtFlowType flow;
-        Frame f(scope->Length(), nullptr, nullptr);
-        g_frame_stack.push_back(&f);
+        auto f = detail::MakeFrame(scope->Length(), nullptr, nullptr);
+        g_frame_stack.push_back(f.get());
 
         try {
-            body->Exec(&f, flow);
+            body->Exec(f.get(), flow);
         } catch ( InterpreterException& ) {
             reporter->FatalError("failed to execute script statements at top-level scope");
         }


### PR DESCRIPTION
Looking for thoughts if this change is too intricate, but I think it'd be worth it. After looking at #4175, I realized the following changes should improve performance around Frame creation:

    1) Don't have Frame inherit from Obj. Microbenchmarking indicates that
       the Obj constructor and destructor take significant additional time
       and provide no value.
    
    2) Allocate a Frame object and its containing elements using a single new[]
       and use placement new to construct the Frame within that memory chunk.
       The Frame's elements are right after the Frame object in the
       allocated memory.

XXX: There's memory leaks, likely overestimating improvements :-(