### PR TITLE
Ignore mDNS broadcasts.

### DIFF
--- a/scripts/policy/protocols/dns/detect-external-names.zeek
+++ b/scripts/policy/protocols/dns/detect-external-names.zeek
@@ -15,17 +15,18 @@ export {
 		## **must** be set appropriately for this detection.
 		External_Name,
 		};
+
+	## Default is to ignore mDNS broadcasts.
+	option skip_resp_host_port_pairs: set[addr, port] = { [[224.0.0.251, [ff02::fb]], 5353/udp] };
 }
 
 event dns_A_reply(c: connection, msg: dns_msg, ans: dns_answer, a: addr) &priority=-3
 	{
-	local multicast: set[addr] = { 224.0.0.251, [ff02::fb] };
 
 	if ( |Site::local_zones| == 0 )
 		return;
 
-	# Ignore mdns.
-	if ( c$id$resp_h in multicast && c$id$resp_p == 5353/udp )
+	if ( [c$id$resp_h, c$id$resp_p] in skip_resp_host_port_pairs )
 		return;
 
 	# Check for responses from remote hosts that point at local hosts

--- a/scripts/policy/protocols/dns/detect-external-names.zeek
+++ b/scripts/policy/protocols/dns/detect-external-names.zeek
@@ -19,7 +19,13 @@ export {
 
 event dns_A_reply(c: connection, msg: dns_msg, ans: dns_answer, a: addr) &priority=-3
 	{
+	local multicast: set[addr] = { 224.0.0.251, [ff02::fb] };
+
 	if ( |Site::local_zones| == 0 )
+		return;
+
+	# Ignore mdns.
+	if ( c$id$resp_h in multicast && c$id$resp_p == 5353/udp )
 		return;
 
 	# Check for responses from remote hosts that point at local hosts


### PR DESCRIPTION
Ignore mDNS broadcasts from local devices. I'm pretty sure this is not what the original script authors wanted to detect, and it's not really "external", but also isn't likely to be in names a local DNS server is authoritative for. 