### PR TITLE
Fix options parsing segfault

### DIFF
--- a/src/Options.cc
+++ b/src/Options.cc
@@ -424,10 +424,16 @@ Options parse_cmdline(int argc, char** argv) {
     opterr = 0;
 
     // getopt may permute the array, so need yet another array
-    auto zargs = std::make_unique<char*[]>(zeek_args.size());
+    //
+    // Make sure this array is one greater than zeek_args and ends in nullptr, otherwise
+    // getopt may go beyond the end of the array
+    auto zargs = std::make_unique<char*[]>(zeek_args.size() + 1);
 
     for ( size_t i = 0; i < zeek_args.size(); ++i )
         zargs[i] = zeek_args[i].data();
+
+    // Make sure getopt doesn't go past the end
+    zargs[zeek_args.size()] = nullptr;
 
     while ( (op = getopt_long(zeek_args.size(), zargs.get(), opts, long_opts, &long_optsind)) != EOF )
         switch ( op ) {


### PR DESCRIPTION
A command like this would segfault (particular number of arguments and last option expects an argument but is not given one):

```
zeek -b test.zeek --debug
```

The issue was that `getopt_long` was using a null element to determine what the end of the options array is. If it saw a non-null element after `--debug` it would say it's the argument for optarg, even if it's beyond `zeek_args.size()`. Instead, just make sure the array is null-terminated.

EDIT: This is probably dependent on the `libc` implementation, by the way, since it doesn't seem like that's intended from documentation :)