### PR TITLE
Add is_valid_subnet BiF

### DIFF
--- a/src/script_opt/FuncInfo.cc
+++ b/src/script_opt/FuncInfo.cc
@@ -340,6 +340,7 @@ static std::unordered_map<std::string, unsigned int> func_attrs = {
     {"is_v6_addr", ATTR_FOLDABLE},
     {"is_v6_subnet", ATTR_FOLDABLE},
     {"is_valid_ip", ATTR_FOLDABLE},
+    {"is_valid_subnet", ATTR_FOLDABLE},
     {"join_string_set", ATTR_FOLDABLE},
     {"join_string_vec", ATTR_FOLDABLE},
     {"levenshtein_distance", ATTR_FOLDABLE},

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -2829,6 +2829,19 @@ function is_valid_ip%(ip: string%): bool
 	return zeek::val_mgr->Bool(rval);
 	%}
 
+## Checks if a string is a valid IPv4 or IPv6 subnet.
+##
+## cidr: the string to check for valid subnet formatting.
+##
+## Returns: T if the string is a valid IPv4 or IPv6 subnet format.
+function is_valid_subnet%(cidr: string%): bool
+	%{
+	char* s = cidr->AsString()->Render();
+	auto rval = zeek::IPPrefix::IsValid(s);
+	delete [] s;
+	return zeek::val_mgr->Bool(rval);
+	%}
+
 ## Converts a :zeek:type:`string` to a :zeek:type:`subnet`.
 ##
 ## sn: The subnet to convert.

--- a/testing/btest/opt/ZAM-bif-tracking.zeek
+++ b/testing/btest/opt/ZAM-bif-tracking.zeek
@@ -373,6 +373,7 @@ global known_BiFs = set(
 	"is_v6_addr",
 	"is_v6_subnet",
 	"is_valid_ip",
+	"is_valid_subnet",
 	"join_string_set",
 	"join_string_vec",
 	"levenshtein_distance",


### PR DESCRIPTION
I came across the need to have an `is_valid_subnet` function so I went ahead and added it, but had some questions about what folks would like to see w.r.t. btests. It seems to make sense to add the btests for this to `./testing/btest/scripts/base/utils/addrs.test` or create a similar file named `subnets.test`. I also noticed that there were regexes for ipv4/6 addrs as part of the btest for `is_valid_subnet`. Should I create similar regexes for subnets? Should I also add those to a similar `base/utils/subnets.zeek` file?

I also added the function in places that seemed germane to ZAM, but I'm not sure what I'm doing there exactly so any feedback/recs there would be appreciated as well.