### PR TITLE
Pack some classes for better memory usages

### DIFF
--- a/src/Conn.h
+++ b/src/Conn.h
@@ -59,8 +59,8 @@ struct ConnTuple {
     IPAddr dst_addr;
     uint32_t src_port = 0;
     uint32_t dst_port = 0;
-    bool is_one_way = false; // if true, don't canonicalize order
     uint16_t proto = UNKNOWN_IP_PROTO;
+    bool is_one_way = false; // if true, don't canonicalize order
 };
 
 static inline int addr_port_canon_lt(const IPAddr& addr1, uint32_t p1, const IPAddr& addr2, uint32_t p2) {

--- a/src/EventRegistry.h
+++ b/src/EventRegistry.h
@@ -164,8 +164,8 @@ private:
     void UpdateFuncBodies();
 
     EventGroupKind kind;
-    std::string name;
     bool enabled = true;
+    std::string name;
     std::unordered_set<detail::ScriptFuncPtr> funcs;
 };
 

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -747,6 +747,12 @@ private:
     zeek::Tag tag;
     ID id;
 
+    bool skip;
+    bool finished;
+    bool removing;
+    bool timers_canceled;
+    TimerPList timers;
+
     Connection* conn;
     Analyzer* parent;
     const zeek::detail::Rule* signature;
@@ -761,12 +767,6 @@ private:
 
     bool protocol_confirmed;
     bool analyzer_confirmed;
-
-    TimerPList timers;
-    bool timers_canceled;
-    bool skip;
-    bool finished;
-    bool removing;
 
     uint64_t analyzer_violations = 0;
 

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.h
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.h
@@ -105,10 +105,10 @@ private:
     bool did_EOF;
     bool skip_deliveries;
 
-    uint64_t seq_to_skip;
-
-    bool in_delivery;
     analyzer::tcp::TCP_Flags flags;
+    bool in_delivery;
+
+    uint64_t seq_to_skip;
 
     FilePtr record_contents_file; // file on which to reassemble contents
 

--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -161,16 +161,6 @@ public:
     uint32_t eth_type;
 
     /**
-     * Layer 2 source address.
-     */
-    const u_char* l2_src = nullptr;
-
-    /**
-     * Layer 2 destination address.
-     */
-    const u_char* l2_dst = nullptr;
-
-    /**
      * (Outermost) VLAN tag if any, else 0.
      */
     uint32_t vlan = 0;
@@ -207,6 +197,24 @@ public:
      * by the hardware/kernel before being received by zeek.
      */
     bool l4_checksummed = false;
+
+    /**
+     * Layer 2 source address.
+     */
+    const u_char* l2_src = nullptr;
+
+    /**
+     * Layer 2 destination address.
+     */
+    const u_char* l2_dst = nullptr;
+
+    /**
+     * This flag indicates whether a packet has been processed. This can
+     * mean different things depending on the traffic, but generally it
+     * means that a packet has been logged in some way. We default to
+     * false, and this can be set to true for any number of reasons.
+     */
+    bool processed = false;
 
     /**
      * Indicates whether this packet should be recorded.
@@ -265,14 +273,6 @@ public:
     int gre_link_type = DLT_RAW;
 
     /**
-     * This flag indicates whether a packet has been processed. This can
-     * mean different things depending on the traffic, but generally it
-     * means that a packet has been logged in some way. We default to
-     * false, and this can be set to true for any number of reasons.
-     */
-    bool processed = false;
-
-    /**
      * The session related to this packet, if one exists.
      */
     session::Session* session = nullptr;
@@ -283,7 +283,7 @@ private:
 
     // True if we need to delete associated packet memory upon
     // destruction.
-    bool copy;
+    bool copy = false;
 };
 
 } // namespace zeek

--- a/src/threading/SerialTypes.h
+++ b/src/threading/SerialTypes.h
@@ -126,9 +126,8 @@ struct Field {
  * those Vals supported).
  */
 struct Value {
-    TypeTag type;         //! The type of the value.
-    TypeTag subtype;      //! Inner type for sets and vectors.
-    bool present = false; //! False for optional record fields that are not set.
+    TypeTag type;    //! The type of the value.
+    TypeTag subtype; //! Inner type for sets and vectors.
 
     struct set_t {
         zeek_int_t size;
@@ -182,6 +181,8 @@ struct Value {
 
         _val() { memset(this, 0, sizeof(_val)); }
     } val;
+
+    bool present = false; //! False for optional record fields that are not set.
 
     /**
      * Constructor.


### PR DESCRIPTION
Opening this as a draft PR to get benchmark numbers

- Analyzer: Reduce from 208 bytes to 192 bytes, remove one cache line
- EventGroup: Reduce from 104 bytes to 96 bytes
- Packet: Reduce from 188 bytes to 192 bytes, remove one cache line
- threading::Value: Reduce from 48 bytes to 40 bytes
- ConnTuple: push hole to the end of struct
- TCP_Reassembler: Reduce from 240 bytes to 232 bytes