### PR TITLE
Add note to Traces/README about possible malware in pe/pe.trace

### DIFF
--- a/testing/btest/Traces/README
+++ b/testing/btest/Traces/README
@@ -39,3 +39,7 @@ Trace Index/Sources:
 - http/docker-http-upgrade.pcap
   Provided by blightzero on #4068
   https://github.com/zeek/zeek/issues/4068
+- pe/pe.trace
+  VirusTotal reports that this file contains malware. The PE analyzer was originally added
+  to decode info for malware, so this is expected. See
+  https://zeekorg.slack.com/archives/CSZBXF6TH/p1738261449655049

--- a/testing/btest/Traces/README
+++ b/testing/btest/Traces/README
@@ -6,8 +6,9 @@ depend on them for tests.
 
 Trace Index/Sources:
 
-- modbus/modbus-eit.trace: Sourced from https://www.netresec.com/?page=PCAP4SICS, credit to https://cs3sthlm.se/. The packets in this trace were pulled from the 4SICS-GeekLounge-151021.pcap file.
-
+- modbus/modbus-eit.trace:
+  Sourced from https://www.netresec.com/?page=PCAP4SICS, credit to https://cs3sthlm.se/.
+  The packets in this trace were pulled from the 4SICS-GeekLounge-151021.pcap file.
 - [ldap/simpleauth.pcap](https://github.com/arkime/arkime/blob/main/tests/pcap/ldap-simpleauth.pcap)
 - ldap/simpleauth-diff-port.pcap: made with
   `tcprewrite -r 3268:32681 -i simpleauth.pcap -o simpleauth-diff-port.pcap`


### PR DESCRIPTION
Slack user Zach Robinette reported that VirusTotal threw a warning about the pe/pe.trace pcap we have in our btest traces library. This PR adds a note to Traces/README that we're aware of it and that it's expected.