### PR TITLE
Remove unused SupervisedNode::InitCluster declaration

### DIFF
--- a/src/supervisor/Supervisor.h
+++ b/src/supervisor/Supervisor.h
@@ -368,17 +368,6 @@ struct SupervisorStemHandle {
  */
 struct SupervisedNode {
     /**
-     * Initialize the Supervised node within the Zeek Cluster Framework.
-     * This function populates the "Cluster::nodes" script-layer variable
-     * that otherwise is expected to be populated by a
-     * "cluster-layout.zeek" script in other context (e.g. ZeekCtl
-     * generates that cluster layout).
-     * @return  true if the supervised node is using the Cluster Framework
-     * else false.
-     */
-    bool InitCluster() const;
-
-    /**
      * Initialize the Supervised node.
      * @param options  the Zeek options to extend/modify as appropriate
      * for the node's configuration.


### PR DESCRIPTION
The move of the cluster table initialization to the script layer removed the implementation, but overlooked this declaration. See: 737b1a20138e3720b5b5e33eef69377e35ff46db