### PR TITLE
Preserve Original Casing in DNS Queries & HTTP Headers to Prevent Data Obfuscation

### DIFF
--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -185,11 +185,6 @@ bool DNS_Interpreter::ParseQuestion(detail::DNS_MsgInfo* msg, const u_char*& dat
     if ( dns_event && ! msg->skip_event ) {
         String* original_name = new String(name, name_end - name, true);
 
-        // Downcase the Name to normalize it
-        for ( u_char* np = name; np < name_end; ++np )
-            if ( isupper(*np) )
-                *np = tolower(*np);
-
         String* question_name = new String(name, name_end - name, true);
 
         SendReplyOrRejectEvent(msg, dns_event, data, len, question_name, original_name);
@@ -336,14 +331,6 @@ u_char* DNS_Interpreter::ExtractName(const u_char*& data, int& len, u_char* name
         --name;
         name[0] = 0;
     }
-
-    // Convert labels to lower case for consistency.
-    if ( downcase )
-        for ( u_char* np = name_start; np < name; ++np )
-            if ( isupper(*np) )
-                *np = tolower(*np);
-
-    return name;
 }
 
 bool DNS_Interpreter::ExtractLabel(const u_char*& data, int& len, u_char*& name, int& name_len,

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -1564,8 +1564,9 @@ void HTTP_Analyzer::HTTP_Header(bool is_orig, analyzer::mime::MIME_Header* h) {
         auto upper_hn = analyzer::mime::to_string_val(h->get_name());
         upper_hn->ToUpper();
 
-        EnqueueConnEvent(http_header, ConnVal(), val_mgr->Bool(is_orig), analyzer::mime::to_string_val(h->get_name()),
-                         std::move(upper_hn), analyzer::mime::to_string_val(h->get_value()));
+        EnqueueConnEvent(http_header, ConnVal(), val_mgr->Bool(is_orig), 
+            analyzer::mime::to_string_val(h->get_name()),
+            analyzer::mime::to_string_val(h->get_value()));
     }
 }
 


### PR DESCRIPTION
Originally in Zeek, hostnames in DNS queries were converted to lowercase, reflecting DNS's case-insensitivity. HTTP headers underwent a process that transformed them into uppercase.

While these conventions align with protocol specifications, adversaries can exploit them. 
Example: If Base64-encoded data is exfiltrated through DNS queries, altering the case could obscure the encoded content. 

Methods like these would circumvent detection rules designed to identify Base64 data. This commit emphasizes the importance of observing actual data rather than relying solely on interpreted formats.