### PR TITLE
Downgrade internal errors to reporter warnings in file/directory BiFs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,10 @@ Changed Functionality
 
   Furthermore, the script now supports and logs IPv6 results.
 
+- The mkdir(), rmdir(), unlink(), and rename() functions now trigger reporter
+  warnings instead of builtin errors when hitting trouble. This allows Zeek to
+  continue gracefully in case of such problems, particularly during zeek_init().
+
 Removed Functionality
 ---------------------
 

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -4494,8 +4494,7 @@ function mkdir%(f: string%): bool
 		     && S_ISDIR(filestat.st_mode) )
 			return zeek::val_mgr->True();
 
-		zeek::emit_builtin_error(zeek::util::fmt("cannot create directory '%s': %s", filename,
-		                                         strerror(error)));
+		zeek::reporter->Warning("cannot create directory '%s': %s", filename, strerror(error));
 		return zeek::val_mgr->False();
 		}
 	else
@@ -4519,8 +4518,7 @@ function rmdir%(d: string%): bool
 
 	if ( rmdir(dirname) < 0 )
 		{
-		zeek::emit_builtin_error(zeek::util::fmt("cannot remove directory '%s': %s", dirname,
-		                                         strerror(errno)));
+		zeek::reporter->Warning("cannot remove directory '%s': %s", dirname, strerror(errno));
 		return zeek::val_mgr->False();
 		}
 	else
@@ -4543,8 +4541,7 @@ function unlink%(f: string%): bool
 
 	if ( unlink(filename) < 0 )
 		{
-		zeek::emit_builtin_error(zeek::util::fmt("cannot unlink file '%s': %s", filename,
-		                                         strerror(errno)));
+		zeek::reporter->Warning("cannot unlink file '%s': %s", filename, strerror(errno));
 		return zeek::val_mgr->False();
 		}
 	else
@@ -4569,8 +4566,7 @@ function rename%(src_f: string, dst_f: string%): bool
 
 	if ( rename(src_filename, dst_filename) < 0 )
 		{
-		zeek::emit_builtin_error(zeek::util::fmt("cannot rename file '%s' to '%s': %s", src_filename,
-		                                         dst_filename, strerror(errno)));
+		zeek::reporter->Warning("cannot rename file '%s' to '%s': %s", src_filename, dst_filename, strerror(errno));
 		return zeek::val_mgr->False();
 		}
 	else

--- a/testing/btest/Baseline/bifs.directory_operations/out
+++ b/testing/btest/Baseline/bifs.directory_operations/out
@@ -9,3 +9,4 @@ F
 F
 F
 F
+Shutting down.

--- a/testing/btest/bifs/directory_operations.zeek
+++ b/testing/btest/bifs/directory_operations.zeek
@@ -4,7 +4,7 @@
 
 event zeek_init()
 	{
-	# Test succesful operations...
+	# Test successful operations...
 	print mkdir("testdir");
 	print mkdir("testdir");
 	local a = open("testdir/testfile");
@@ -14,11 +14,17 @@ event zeek_init()
 	print unlink("testdir2/testfile2");
 	print rmdir("testdir2");
 
-
+	# ... and failing ones.
 	print unlink("nonexisting");
 	print rename("a", "b");
 	print rmdir("nonexisting");
 	a = open("testfile");
 	close(a);
 	print mkdir("testfile");
+	}
+
+event zeek_done()
+	{
+	# Only reached when above failures don't cause Zeek to exit.
+	print "Shutting down.";
 	}


### PR DESCRIPTION
This allows Zeek execution to continue gracefully in the presence of such errors, particularly at zeek_init() time. Includes a tweak to expand the `bifs.directory_operations` test to check continuation after errors.

Resolves #3595.