### PR TITLE
Fix crash related to Broker stores

### DIFF
--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -1724,6 +1724,12 @@ detail::StoreHandleVal* Manager::MakeClone(const string& name, double resync_int
     auto handle = new detail::StoreHandleVal{*result};
     Ref(handle);
 
+    if ( ! handle->proxy.valid() ) {
+        Error("Failed to create clone for data store %s", name.c_str());
+        Unref(handle);
+        return nullptr;
+    }
+
     data_stores.emplace(name, handle);
     if ( ! iosource_mgr->RegisterFd(handle->proxy.mailbox().descriptor(), this) )
         reporter->FatalError("Failed to register broker clone mailbox descriptor with iosource_mgr");


### PR DESCRIPTION
This has been reported in chat and is caused by a race in Broker where the store proxy object can be invalid if the store object is discarded by Broker before the proxy is constructed.