### PR TITLE
Set original/outer packet flags to reflect inner packet results

### DIFF
--- a/src/iosource/Packet.cc
+++ b/src/iosource/Packet.cc
@@ -46,6 +46,7 @@ void Packet::Init(int arg_link_type, pkt_timeval* arg_ts, uint32_t arg_caplen, u
         data = arg_data;
 
     dump_packet = false;
+    dump_size = 0;
 
     time = ts.tv_sec + double(ts.tv_usec) / 1e6;
     eth_type = 0;

--- a/src/packet_analysis/protocol/iptunnel/IPTunnel.h
+++ b/src/packet_analysis/protocol/iptunnel/IPTunnel.h
@@ -37,7 +37,7 @@ public:
      *        the most-recently found depth of encapsulation.
      * @param ec The most-recently found depth of encapsulation.
      */
-    bool ProcessEncapsulatedPacket(double t, const Packet* pkt, const std::shared_ptr<IP_Hdr>& inner,
+    bool ProcessEncapsulatedPacket(double t, Packet* pkt, const std::shared_ptr<IP_Hdr>& inner,
                                    std::shared_ptr<EncapsulationStack> prev, const EncapsulatingConn& ec);
 
     /**
@@ -56,7 +56,7 @@ public:
      *        including the most-recently found depth of encapsulation.
      * @param ec The most-recently found depth of encapsulation.
      */
-    bool ProcessEncapsulatedPacket(double t, const Packet* pkt, uint32_t caplen, uint32_t len, const u_char* data,
+    bool ProcessEncapsulatedPacket(double t, Packet* pkt, uint32_t caplen, uint32_t len, const u_char* data,
                                    int link_type, std::shared_ptr<EncapsulationStack> prev,
                                    const EncapsulatingConn& ec);
 


### PR DESCRIPTION
Zeek's IPTunnel analyzer does not set the 'processed', 'dump_packet' and 'dump_size' flags on the outer packet. As a consequence, when Zeek is run with -c (dump unprocessed packets), the outer packet is dumped even when it is accounted for in tunnel.log. When Zeek is run with -w (essentially dump all packets), the outer packet is not dumped.

Looks like for analyzing a tunnelled packet, the IPTunnel analyzer creates a new packet to handle the inner packet. 
However, the flags set by session analyzers on the inner packet , such as 'processed', 'dump_packet' and 'dump_size', are not properly propagated back to the outer packet.

This commit attempts to address this issue by propagating these flags from the inner packet to the outer packet.
