### PR TITLE
cirrus: Bump FreeBSD 14 task to 14.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -385,7 +385,7 @@ macos_sonoma_task:
 freebsd14_task:
   freebsd_instance:
     # FreeBSD 14 EOL: Nov 30 2028
-    image_family: freebsd-14-1
+    image_family: freebsd-14-2
     << : *FREEBSD_RESOURCES_TEMPLATE
 
   prepare_script: ./ci/freebsd/prepare.sh


### PR DESCRIPTION
CI is currently failing with:

    { "error": { "code": 404, "message": "The resource 'projects/freebsd-org-cloud-dev/global/images/family/freebsd-14-1' was not found" ...