### PR TITLE
CI: Use fewer btest jobs for ZAM tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -424,6 +424,8 @@ asan_sanitizer_zam_task:
     ZEEK_CI_SKIP_UNIT_TESTS: 1
     ZEEK_CI_SKIP_EXTERNAL_BTESTS: 1
     ZEEK_CI_BTEST_EXTRA_ARGS: -a zam
+    # Use a lower number of jobs due to OOM issues with ZAM tasks
+    ZEEK_CI_BTEST_JOBS: 3
   << : *ZAM_SKIP_TASK_ON_PR
 
 ubsan_sanitizer_task:
@@ -458,6 +460,8 @@ ubsan_sanitizer_zam_task:
     ZEEK_CI_SKIP_UNIT_TESTS: 1
     ZEEK_CI_SKIP_EXTERNAL_BTESTS: 1
     ZEEK_CI_BTEST_EXTRA_ARGS: -a zam
+    # Use a lower number of jobs due to OOM issues with ZAM tasks
+    ZEEK_CI_BTEST_JOBS: 3
   << : *ZAM_SKIP_TASK_ON_PR
 
 tsan_sanitizer_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -749,7 +749,7 @@ zeekctl_debian11_task:
   build_script:
     - cd auxil/zeekctl/testing && ./Scripts/build-zeek
   test_script:
-    - cd auxil/zeekctl/testing && ../../btest/btest -A -d -j ${BTEST_JOBS}
+    - cd auxil/zeekctl/testing && ../../btest/btest -A -d -j ${ZEEK_CI_BTEST_JOBS}
   on_failure:
     upload_zeekctl_testing_artifacts:
       path: "auxil/zeekctl/testing/.tmp/**"


### PR DESCRIPTION
This is an attempt to fix the OOM issues we're running into reguarly with the ZAM Asan task and occasionally with the ZAM UBsan task. It's consistently failing during btests, so drop down to a lower number of jobs for these two tasks in comparison to the other Linux-based tasks.