### PR TITLE
util: Fix terminate_processing() called from non-main thread

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -830,7 +830,7 @@ double calc_next_rotate(double current, double interval, double base) {
 
 void terminate_processing() {
     if ( ! run_state::terminating )
-        raise(SIGTERM);
+        kill(getpid(), SIGTERM);
 }
 
 void set_processing_status(const char* status, const char* reason) {


### PR DESCRIPTION
The current raise(SIGTERM) sends a signal to the calling thread. If terminate_processing() is called from a non-main thread and that thread was created at InitPostScript() time when SIGTERM is blocked, or has blocked SIGTERM manually, terminate_processing() has no effect.

Switching to kill(getpid(), SIGTERM) guarantees that a thread that doesn't block the signal (minimally the main thread) will run the handler.