### PR TITLE
Fix return types in docs for double_to_count and double_to_int

### DIFF
--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -2643,18 +2643,6 @@ function int_to_count%(n: int%): count
 	return zeek::val_mgr->Count(n);
 	%}
 
-## Converts a :zeek:type:`double` to a :zeek:type:`count`.
-##
-## d: The :zeek:type:`double` to convert.
-##
-## Returns: The :zeek:type:`double` *d* as unsigned integer, or 0 if *d* < 0.0.
-##          The value returned follows typical rounding rules, as implemented
-##          by rint().
-function double_to_int%(d: double%): int
-	%{
-	return zeek::val_mgr->Int(zeek_int_t(rint(d)));
-	%}
-
 ## Converts a :zeek:type:`double` to a :zeek:type:`int`.
 ##
 ## d: The :zeek:type:`double` to convert.
@@ -2663,6 +2651,18 @@ function double_to_int%(d: double%): int
 ##          follows typical rounding rules, as implemented by rint().
 ##
 ## .. zeek:see:: double_to_time
+function double_to_int%(d: double%): int
+	%{
+	return zeek::val_mgr->Int(zeek_int_t(rint(d)));
+	%}
+
+## Converts a :zeek:type:`double` to a :zeek:type:`count`.
+##
+## d: The :zeek:type:`double` to convert.
+##
+## Returns: The :zeek:type:`double` *d* as unsigned integer, or 0 if *d* < 0.0.
+##          The value returned follows typical rounding rules, as implemented
+##          by rint().
 function double_to_count%(d: double%): count
 	%{
 	if ( d < 0.0 )


### PR DESCRIPTION
The comment blocks for these two methods got reversed somehow.