### PR TITLE
CI: Unconditionally upgrade pip on macOS

### DIFF
--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -9,8 +9,6 @@ brew update
 brew upgrade cmake
 brew install cppzmq openssl@3 swig bison flex ccache libmaxminddb dnsmasq
 
-if [ $(sw_vers -productVersion | cut -d '.' -f 1) -lt 14 ]; then
-    python3 -m pip install --upgrade pip
-fi
-
+# Upgrade pip so we have the --break-system-packages option.
+python3 -m pip install --upgrade pip
 python3 -m pip install --user --break-system-packages websockets


### PR DESCRIPTION
Cirrus must have made a configuration change to their Sonoma image, because the version of pip there doesn't have the `--break-system-packages` argument anymore (https://cirrus-ci.com/task/6422483181502464). We previously were upgrading pip on older versions of macOS for this same reason. This PR removes the condition and always upgrades it now.