### PR TITLE
CI: Change macOS runner to Sequoia

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -377,12 +377,12 @@ alpine_task:
 # Cirrus only supports the following macos runner currently, selecting
 # anything else automatically upgrades to this one.
 #
-#    ghcr.io/cirruslabs/macos-runner:sonoma
+#    ghcr.io/cirruslabs/macos-runner:sequoia
 #
 # See also: https://cirrus-ci.org/guide/macOS/
-macos_sonoma_task:
+macos_sequoia_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-runner:sonoma
+    image: ghcr.io/cirruslabs/macos-runner:sequoia
   prepare_script: ./ci/macos/prepare.sh
   << : *CI_TEMPLATE
   << : *MACOS_ENVIRONMENT

--- a/ci/init-external-repos.sh
+++ b/ci/init-external-repos.sh
@@ -51,9 +51,9 @@ if [[ -n "${CIRRUS_CI}" ]] && [[ "${CIRRUS_REPO_OWNER}" == "zeek" ]] && [[ ! -d 
 
     banner "Trying to clone zeek-testing-private git repo"
     echo "${ZEEK_TESTING_PRIVATE_SSH_KEY}" >cirrus_key.b64
-    if [ "${CIRRUS_TASK_NAME}" == "macos_ventura" -o "${CIRRUS_TASK_NAME}" == "macos_sonoma" ]; then
-        # The base64 command provided with macOS Ventura/Sonoma requires an argument
-        # to pass the input filename
+    if [[ "${CIRRUS_TASK_NAME}" =~ ^macos_ ]]; then
+        # The base64 command provided with macOS requires an argument
+        # to pass the input filename, while -i elsewhere is "ignore garbage".
         base64 -d -i cirrus_key.b64 >cirrus_key
     else
         base64 -d cirrus_key.b64 >cirrus_key


### PR DESCRIPTION
Cirrus is reporting this for macOS builds:

> Only ghcr.io/cirruslabs/macos-runner:sequoia is allowed. Automatically upgraded.

This bumps our builds to Sequoia to resolve it.