### PR TITLE
Quick follow-ups for storage framework merge

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -56,6 +56,7 @@ jobs:
             g++ \
             gcc \
             git \
+            libhiredis-dev \
             libfl-dev \
             libfl2 \
             libkrb5-dev \

--- a/CHANGES
+++ b/CHANGES
@@ -67,121 +67,9 @@
 
 7.2.0-dev.378 | 2025-03-18 11:43:48 -0700
 
-  * Cleanup/update comments across the storage C++ files (Tim Wojtulewicz, Corelight)
+  * Merged new Storage framework (Tim Wojtulewicz, Corelight)
 
-  * Split storage.bif file into events/sync/async, add more comments (Tim Wojtulewicz, Corelight)
-
-  * Update comments in script files, run zeek-format on all of them (Tim Wojtulewicz, Corelight)
-
-  * Allow sync methods to be called from when conditions, add related btest (Tim Wojtulewicz, Corelight)
-
-  * Redis: Handle disconnection correctly via callback (Tim Wojtulewicz, Corelight)
-
-  * Redis: Fix sync erase, add btest for it (Tim Wojtulewicz, Corelight)
-
-  * Remove default argument for callbacks, reorder function arguments (Tim Wojtulewicz, Corelight)
-
-  * Remove file-local expire_running variable (Tim Wojtulewicz, Corelight)
-
-  * Pass network time down to Expire() (Tim Wojtulewicz, Corelight)
-
-  * Add IN_PROGRESS return code, handle for async backends (Tim Wojtulewicz, Corelight)
-
-  * Store sqlite3_stmts directly instead of looking up from a map (Tim Wojtulewicz, Corelight)
-
-  * Reduce code duplication in storage.bif (Tim Wojtulewicz, Corelight)
-
-  * Add OperationResult::MakeVal, use it to reduce some code duplication (Tim Wojtulewicz, Corelight)
-
-  * Rearrange visibility of Backend methods, add DoPoll/DoExpire, add return comments (Tim Wojtulewicz, Corelight)
-
-  * Implement Storage::backend_opened and Storage::backend_lost events (Tim Wojtulewicz, Corelight)
-
-  * SQLite: expand expiration test (Tim Wojtulewicz, Corelight)
-
-  * SQLite: Handle other return values from sqlite3_step (Tim Wojtulewicz, Corelight)
-
-  * Redis: Fix thread-contention issues with Expire(), add more tests (Tim Wojtulewicz, Corelight)
-
-  * Change how redis-server is run during btests, removing redis.conf (Tim Wojtulewicz, Corelight)
-
-  * Completely rework return values from storage operations (Tim Wojtulewicz, Corelight)
-
-  * Update some btests due to timing changes (Tim Wojtulewicz, Corelight)
-
-  * Split sync/async handling into the BIF methods (Tim Wojtulewicz, Corelight)
-
-  * Redis: Rework everything to only use async mode (Tim Wojtulewicz, Corelight)
-
-  * Run expiration on a separate thread (Tim Wojtulewicz, Corelight)
-
-  * Pass network-time-based expiration time to backends instead of an interval (Tim Wojtulewicz, Corelight)
-
-  * Make backend options a record, move actual options to be sub-records (Tim Wojtulewicz, Corelight)
-
-  * Always register backend for expiration, check for open during loop (Tim Wojtulewicz, Corelight)
-
-  * Split sync and async into separate script-land namespaces (Tim Wojtulewicz, Corelight)
-
-  * Remove Backend::SupportsAsync (Tim Wojtulewicz, Corelight)
-
-  * Add btest that uses a Redis backend in a cluster (Tim Wojtulewicz, Corelight)
-
-  * Return generic result for get operations that includes error messages (Tim Wojtulewicz, Corelight)
-
-  * Allow opening and closing backends to be async (Tim Wojtulewicz, Corelight)
-
-  * Redis: Support non-native expiration when reading traces (Tim Wojtulewicz, Corelight)
-
-  * Redis: Add btests for the redis backend (Tim Wojtulewicz, Corelight)
-
-  * Redis: Force storage sync mode when reading pcaps, default to async mode (Tim Wojtulewicz, Corelight)
-
-  * Redis: Add new backend (Tim Wojtulewicz, Corelight)
-
-  * SQLite: Fix some issues with expiration, including in the btest (Tim Wojtulewicz, Corelight)
-
-  * SQLite: Add additional btests, which also cover general storage functionality (Tim Wojtulewicz, Corelight)
-
-    - New erase/overwrite tests
-    - Change existing sqlite-basic test to use async
-    - Test passing bad keys to validate backend type checking
-    - New test for compound keys and values
-
-  * SQLite: Add pragma integrity_check (Tim Wojtulewicz, Corelight)
-
-  * SQLite: Add tuning options to configuration (Tim Wojtulewicz, Corelight)
-
-  * SQLite: Handle automated expiration (Tim Wojtulewicz, Corelight)
-
-  * SQLite: Store/lookup prepared statements instead of recreating (Tim Wojtulewicz, Corelight)
-
-  * Add basic SQLite storage backend (Tim Wojtulewicz, Corelight)
-
-  * Add infrastructure for asynchronous storage operations (Tim Wojtulewicz, Corelight)
-
-  * Add infrastructure for automated expiration of storage entries (Tim Wojtulewicz, Corelight)
-
-    This is used for backends that don't support expiration natively.
-
-  * Change args to Storage::put to be a record (Tim Wojtulewicz, Corelight)
-
-    The number of args being passed to the put() methods was getting to be
-    fairly long, with more on the horizon. Changing to a record means simplifying
-    things a little bit.
-
-  * Pass key/value types for validation when opening backends (Tim Wojtulewicz, Corelight)
-
-  * Lay out initial parts for the Storage framework (Tim Wojtulewicz, Corelight)
-
-    This includes a manager, component manager, BIF and script code, and
-    parts to support new storage backend plugins.
-
-  * DebugLogger: add stream for storage (Tim Wojtulewicz, Corelight)
-
-  * plugin: Add component enum for storage backends (Tim Wojtulewicz, Corelight)
-
-  * Add martinmoene/expected-lite as a submodule (Tim Wojtulewicz, Corelight)
+    See the NEWS for more details about this new feature.
 
 7.2.0-dev.325 | 2025-03-18 09:07:40 +0100
 
@@ -11009,7 +10897,7 @@
 
     Using "in" to query the language const. This also handles the case of not
     having a best guess and continue using the existing behavior.
-    
+
     Given
     keyboard_layout = 1033 (0x0409), "keyboard-English - United States"
     keyboard_layout = 66569 (0x00010409), "keyboard-English - United States (Best Guess)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,10 +354,6 @@ target_include_directories(
     zeek_dynamic_plugin_base SYSTEM
     INTERFACE $<INSTALL_INTERFACE:include/zeek/3rdparty/prometheus-cpp/include>)
 
-target_include_directories(
-    zeek_dynamic_plugin_base SYSTEM
-    INTERFACE $<INSTALL_INTERFACE:include/zeek/3rdparty/expected-lite/include>)
-
 # Convenience function for adding an OBJECT library that feeds directly into the
 # main target(s).
 #

--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,27 @@ New Functionality
 
 - The new ``is_valid_subnet()`` function mirrors ``is_valid_ip()``, for subnets.
 
+- A new Storage framework was merged into the Zeek tree. The intention with this framework
+  is to eventually replace the storage functionality that Broker provides, including
+  direct storage via calls such as ``Cluster::create_store`` and ``Broker::put_unique`` as
+  well as storage-backed tables via the ``&backend`` attribute. This is an initial version
+  for testing, and will be expanded upon in the future. The current state of the framework
+  is as follows:
+
+  - A new API was added for storage backend plugins.
+
+  - Script-level functions for opening and closing backends, and insertion, retrieval, and
+    erasure of elements are available.
+
+  - Backends can support both asynchronous mode (using ``when`` statements) and
+    synchronous mode (blocking until the operation copmletes). BIF methods were added
+    under new ``Storage::Async`` and ``Storage::Sync`` modules for these two modes. The
+    modes can be used interchangeably with the same backend handle.
+
+  - SQLite and Redis backends exist in the Zeek tree by default. We are working on a
+    backend for NATS that will be available as an external plugin, but it is not quite
+    ready yet. Both of the existing backends support usage in a cluster environment.
+
 Changed Functionality
 ---------------------
 

--- a/src/storage/Backend.h
+++ b/src/storage/Backend.h
@@ -76,25 +76,13 @@ public:
      * Completes a callback, releasing the trigger if it was valid or storing the result
      * for later usage if needed.
      */
-    virtual void Complete(OperationResult res) = 0;
+    virtual void Complete(OperationResult res);
+
+    OperationResult Result() const { return result; }
 
 protected:
     zeek::detail::trigger::TriggerPtr trigger;
     const void* assoc = nullptr;
-};
-
-/**
- * A callback that returns an `OperationResult` when it is complete. This is used by most
- * of the storage operations for returning status.
- */
-class OperationResultCallback : public ResultCallback {
-public:
-    OperationResultCallback() = default;
-    OperationResultCallback(detail::trigger::TriggerPtr trigger, const void* assoc);
-    void Complete(OperationResult res) override;
-    OperationResult Result() { return result; }
-
-private:
     OperationResult result;
 };
 
@@ -127,7 +115,7 @@ public:
      * @return A struct describing the result of the operation, containing a code, an
      * optional error string, and a ValPtr for operations that return values.
      */
-    OperationResult Put(OperationResultCallback* cb, ValPtr key, ValPtr value, bool overwrite = true,
+    OperationResult Put(ResultCallback* cb, ValPtr key, ValPtr value, bool overwrite = true,
                         double expiration_time = 0);
 
     /**
@@ -139,7 +127,7 @@ public:
      * @return A struct describing the result of the operation, containing a code, an
      * optional error string, and a ValPtr for operations that return values.
      */
-    OperationResult Get(OperationResultCallback* cb, ValPtr key);
+    OperationResult Get(ResultCallback* cb, ValPtr key);
 
     /**
      * Erases the value for a key from the backend.
@@ -150,7 +138,7 @@ public:
      * @return A struct describing the result of the operation, containing a code, an
      * optional error string, and a ValPtr for operations that return values.
      */
-    OperationResult Erase(OperationResultCallback* cb, ValPtr key);
+    OperationResult Erase(ResultCallback* cb, ValPtr key);
 
     /**
      * Returns whether the backend is opened.
@@ -212,7 +200,7 @@ protected:
      * @return A struct describing the result of the operation, containing a code, an
      * optional error string, and a ValPtr for operations that return values.
      */
-    OperationResult Close(OperationResultCallback* cb);
+    OperationResult Close(ResultCallback* cb);
 
     /**
      * Removes any entries in the backend that have expired. Can be overridden by
@@ -260,26 +248,26 @@ private:
      * Workhorse method for calls to `Manager::CloseBackend()`. See that method for
      * documentation of the arguments. This must be overridden by all backends.
      */
-    virtual OperationResult DoClose(OperationResultCallback* cb) = 0;
+    virtual OperationResult DoClose(ResultCallback* cb) = 0;
 
     /**
      * Workhorse method for calls to `Backend::Put()`. See that method for
      * documentation of the arguments. This must be overridden by all backends.
      */
-    virtual OperationResult DoPut(OperationResultCallback* cb, ValPtr key, ValPtr value, bool overwrite,
+    virtual OperationResult DoPut(ResultCallback* cb, ValPtr key, ValPtr value, bool overwrite,
                                   double expiration_time) = 0;
 
     /**
      * Workhorse method for calls to `Backend::Get()`. See that method for
      * documentation of the arguments. This must be overridden by all backends.
      */
-    virtual OperationResult DoGet(OperationResultCallback* cb, ValPtr key) = 0;
+    virtual OperationResult DoGet(ResultCallback* cb, ValPtr key) = 0;
 
     /**
      * Workhorse method for calls to `Backend::Erase()`. See that method for
      * documentation of the arguments. This must be overridden by all backends.
      */
-    virtual OperationResult DoErase(OperationResultCallback* cb, ValPtr key) = 0;
+    virtual OperationResult DoErase(ResultCallback* cb, ValPtr key) = 0;
 
     /**
      * Optional method for backends to override to provide direct polling. This should be
@@ -337,11 +325,9 @@ public:
                        IntrusivePtr<detail::BackendHandleVal> backend);
     void Complete(OperationResult res) override;
 
-    OperationResult Result() const { return result; }
     IntrusivePtr<detail::BackendHandleVal> Backend() const { return backend; }
 
 private:
-    OperationResult result{};
     IntrusivePtr<detail::BackendHandleVal> backend;
 };
 

--- a/src/storage/Manager.cc
+++ b/src/storage/Manager.cc
@@ -89,7 +89,7 @@ OperationResult Manager::OpenBackend(BackendPtr backend, OpenResultCallback* cb,
     return res;
 }
 
-OperationResult Manager::CloseBackend(BackendPtr backend, OperationResultCallback* cb) {
+OperationResult Manager::CloseBackend(BackendPtr backend, ResultCallback* cb) {
     // Expiration runs on a separate thread and loops over the vector of backends. The mutex
     // here ensures exclusive access. This one happens in a block because we can remove the
     // backend from the vector before actually closing it.

--- a/src/storage/Manager.cc
+++ b/src/storage/Manager.cc
@@ -23,7 +23,7 @@ void detail::ExpirationTimer::Dispatch(double t, bool is_expire) {
     // in the interim.
     if ( ! expire_running.test_and_set() ) {
         DBG_LOG(DBG_STORAGE, "Starting new expiration thread");
-        storage_mgr->expiration_thread = std::jthread([]() { storage_mgr->Expire(); });
+        storage_mgr->expiration_thread = std::jthread([t]() { storage_mgr->Expire(t); });
     }
 
     storage_mgr->StartExpirationTimer();
@@ -107,17 +107,16 @@ OperationResult Manager::CloseBackend(BackendPtr backend, ResultCallback* cb) {
     return res;
 }
 
-void Manager::Expire() {
+void Manager::Expire(double t) {
     // Expiration runs on a separate thread and loops over the vector of backends. The mutex
     // here ensures exclusive access.
     std::unique_lock<std::mutex> lk(backends_mtx);
 
     DBG_LOG(DBG_STORAGE, "Expiration running, have %zu backends to check", backends.size());
 
-    double current_network_time = run_state::network_time;
     for ( auto it = backends.begin(); it != backends.end() && ! run_state::terminating; ++it ) {
         if ( (*it)->IsOpen() )
-            (*it)->Expire(current_network_time);
+            (*it)->Expire(t);
     }
 
     expire_running.clear();

--- a/src/storage/Manager.cc
+++ b/src/storage/Manager.cc
@@ -112,8 +112,6 @@ void Manager::Expire(double t) {
     // here ensures exclusive access.
     std::unique_lock<std::mutex> lk(backends_mtx);
 
-    DBG_LOG(DBG_STORAGE, "Expiration running, have %zu backends to check", backends.size());
-
     for ( auto it = backends.begin(); it != backends.end() && ! run_state::terminating; ++it ) {
         if ( (*it)->IsOpen() )
             (*it)->Expire(t);

--- a/src/storage/Manager.h
+++ b/src/storage/Manager.h
@@ -71,7 +71,7 @@ public:
      * @return A struct describing the result of the operation, containing a code, an
      * optional error string, and a ValPtr for operations that return values.
      */
-    OperationResult CloseBackend(BackendPtr backend, OperationResultCallback* cb);
+    OperationResult CloseBackend(BackendPtr backend, ResultCallback* cb);
 
     /**
      * Runs an expire operation on all open backends. This is called by the expiration

--- a/src/storage/Manager.h
+++ b/src/storage/Manager.h
@@ -77,8 +77,10 @@ public:
      * Runs an expire operation on all open backends. This is called by the expiration
      * timer and shouldn't be called directly otherwise, since it should only happen on a
      * separate thread.
+     *
+     * @param t The network time that the expiration started.
      */
-    void Expire();
+    void Expire(double t);
 
 protected:
     friend class storage::detail::ExpirationTimer;

--- a/src/storage/backend/redis/Redis.h
+++ b/src/storage/backend/redis/Redis.h
@@ -37,9 +37,9 @@ public:
     void OnConnect(int status);
     void OnDisconnect(int status);
 
-    void HandlePutResult(redisReply* reply, OperationResultCallback* callback);
-    void HandleGetResult(redisReply* reply, OperationResultCallback* callback);
-    void HandleEraseResult(redisReply* reply, OperationResultCallback* callback);
+    void HandlePutResult(redisReply* reply, ResultCallback* callback);
+    void HandleGetResult(redisReply* reply, ResultCallback* callback);
+    void HandleEraseResult(redisReply* reply, ResultCallback* callback);
     void HandleGeneric(redisReply* reply);
 
     /**
@@ -51,11 +51,11 @@ public:
 
 private:
     OperationResult DoOpen(OpenResultCallback* cb, RecordValPtr options) override;
-    OperationResult DoClose(OperationResultCallback* cb) override;
-    OperationResult DoPut(OperationResultCallback* cb, ValPtr key, ValPtr value, bool overwrite,
+    OperationResult DoClose(ResultCallback* cb) override;
+    OperationResult DoPut(ResultCallback* cb, ValPtr key, ValPtr value, bool overwrite,
                           double expiration_time) override;
-    OperationResult DoGet(OperationResultCallback* cb, ValPtr key) override;
-    OperationResult DoErase(OperationResultCallback* cb, ValPtr key) override;
+    OperationResult DoGet(ResultCallback* cb, ValPtr key) override;
+    OperationResult DoErase(ResultCallback* cb, ValPtr key) override;
     void DoExpire(double current_network_time) override;
     void DoPoll() override;
 
@@ -69,7 +69,7 @@ private:
     std::deque<redisReply*> reply_queue;
 
     OpenResultCallback* open_cb;
-    OperationResultCallback* close_cb;
+    ResultCallback* close_cb;
     std::mutex expire_mutex;
 
     std::string server_addr;

--- a/src/storage/backend/redis/Redis.h
+++ b/src/storage/backend/redis/Redis.h
@@ -59,7 +59,7 @@ private:
     void DoExpire(double current_network_time) override;
     void DoPoll() override;
 
-    OperationResult ParseGetReply(redisReply* reply) const;
+    OperationResult ParseReplyError(std::string_view op_str, std::string_view reply_err_str) const;
 
     redisAsyncContext* async_ctx = nullptr;
 

--- a/src/storage/backend/sqlite/SQLite.cc
+++ b/src/storage/backend/sqlite/SQLite.cc
@@ -237,12 +237,18 @@ OperationResult SQLite::DoErase(ResultCallback* cb, ValPtr key) {
 void SQLite::DoExpire(double current_network_time) {
     auto stmt = expire_stmt.get();
 
-    if ( auto res = CheckError(sqlite3_bind_double(stmt, 1, current_network_time)); res.code != ReturnCode::SUCCESS ) {
-        sqlite3_reset(stmt);
-        // TODO: do something with the error here?
+    int status = sqlite3_bind_double(stmt, 1, current_network_time);
+    if ( status != SQLITE_OK ) {
+        // TODO: do something with the error?
+    }
+    else {
+        status = sqlite3_step(stmt);
+        if ( status != SQLITE_ROW ) {
+            // TODO: should this return an error somehow? Reporter warning?
+        }
     }
 
-    Step(stmt, false);
+    sqlite3_reset(stmt);
 }
 
 // returns true in case of error

--- a/src/storage/backend/sqlite/SQLite.cc
+++ b/src/storage/backend/sqlite/SQLite.cc
@@ -115,7 +115,7 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
 /**
  * Finalizes the backend when it's being closed.
  */
-OperationResult SQLite::DoClose(OperationResultCallback* cb) {
+OperationResult SQLite::DoClose(ResultCallback* cb) {
     OperationResult op_res{ReturnCode::SUCCESS};
 
     if ( db ) {
@@ -146,8 +146,7 @@ OperationResult SQLite::DoClose(OperationResultCallback* cb) {
 /**
  * The workhorse method for Put(). This must be implemented by plugins.
  */
-OperationResult SQLite::DoPut(OperationResultCallback* cb, ValPtr key, ValPtr value, bool overwrite,
-                              double expiration_time) {
+OperationResult SQLite::DoPut(ResultCallback* cb, ValPtr key, ValPtr value, bool overwrite, double expiration_time) {
     if ( ! db )
         return {ReturnCode::NOT_CONNECTED};
 
@@ -193,7 +192,7 @@ OperationResult SQLite::DoPut(OperationResultCallback* cb, ValPtr key, ValPtr va
 /**
  * The workhorse method for Get(). This must be implemented for plugins.
  */
-OperationResult SQLite::DoGet(OperationResultCallback* cb, ValPtr key) {
+OperationResult SQLite::DoGet(ResultCallback* cb, ValPtr key) {
     if ( ! db )
         return {ReturnCode::NOT_CONNECTED};
 
@@ -213,7 +212,7 @@ OperationResult SQLite::DoGet(OperationResultCallback* cb, ValPtr key) {
 /**
  * The workhorse method for Erase(). This must be implemented for plugins.
  */
-OperationResult SQLite::DoErase(OperationResultCallback* cb, ValPtr key) {
+OperationResult SQLite::DoErase(ResultCallback* cb, ValPtr key) {
     if ( ! db )
         return {ReturnCode::NOT_CONNECTED};
 

--- a/src/storage/backend/sqlite/SQLite.cc
+++ b/src/storage/backend/sqlite/SQLite.cc
@@ -291,6 +291,8 @@ OperationResult SQLite::Step(sqlite3_stmt* stmt, bool parse_value) {
     else if ( step_status == SQLITE_BUSY )
         // TODO: this could retry a number of times instead of just failing
         ret = {ReturnCode::TIMEOUT};
+    else if ( step_status == SQLITE_CONSTRAINT )
+        ret = {ReturnCode::KEY_EXISTS};
     else
         ret = {ReturnCode::OPERATION_FAILED};
 

--- a/src/storage/backend/sqlite/SQLite.h
+++ b/src/storage/backend/sqlite/SQLite.h
@@ -24,11 +24,11 @@ public:
 
 private:
     OperationResult DoOpen(OpenResultCallback* cb, RecordValPtr options) override;
-    OperationResult DoClose(OperationResultCallback* cb) override;
-    OperationResult DoPut(OperationResultCallback* cb, ValPtr key, ValPtr value, bool overwrite,
+    OperationResult DoClose(ResultCallback* cb) override;
+    OperationResult DoPut(ResultCallback* cb, ValPtr key, ValPtr value, bool overwrite,
                           double expiration_time) override;
-    OperationResult DoGet(OperationResultCallback* cb, ValPtr key) override;
-    OperationResult DoErase(OperationResultCallback* cb, ValPtr key) override;
+    OperationResult DoGet(ResultCallback* cb, ValPtr key) override;
+    OperationResult DoErase(ResultCallback* cb, ValPtr key) override;
     void DoExpire(double current_network_time) override;
 
     /**

--- a/src/storage/storage-async.bif
+++ b/src/storage/storage-async.bif
@@ -107,7 +107,7 @@ function Storage::Async::__close_backend%(backend: opaque of Storage::BackendHan
 	if ( ! trigger )
 		return nullptr;
 
-	auto cb = new OperationResultCallback(trigger, frame->GetTriggerAssoc());
+	auto cb = new ResultCallback(trigger, frame->GetTriggerAssoc());
 	auto b = cast_handle(backend);
 	if ( ! b ) {
 		cb->Complete(b.error());
@@ -128,7 +128,7 @@ function Storage::Async::__put%(backend: opaque of Storage::BackendHandle, key: 
 	if ( ! trigger )
 		return nullptr;
 
-	auto cb = new OperationResultCallback(trigger, frame->GetTriggerAssoc());
+	auto cb = new ResultCallback(trigger, frame->GetTriggerAssoc());
 	auto b = cast_handle(backend);
 	if ( ! b ) {
 		cb->Complete(b.error());
@@ -153,7 +153,7 @@ function Storage::Async::__get%(backend: opaque of Storage::BackendHandle, key: 
 	if ( ! trigger )
 		return nullptr;
 
-	auto cb = new OperationResultCallback(trigger, frame->GetTriggerAssoc());
+	auto cb = new ResultCallback(trigger, frame->GetTriggerAssoc());
 	auto b = cast_handle(backend);
 	if ( ! b ) {
 		cb->Complete(b.error());
@@ -174,7 +174,7 @@ function Storage::Async::__erase%(backend: opaque of Storage::BackendHandle, key
 	if ( ! trigger )
 		return nullptr;
 
-	auto cb = new OperationResultCallback(trigger, frame->GetTriggerAssoc());
+	auto cb = new ResultCallback(trigger, frame->GetTriggerAssoc());
 	auto b = cast_handle(backend);
 	if ( ! b ) {
 		cb->Complete(b.error());

--- a/src/storage/storage-sync.bif
+++ b/src/storage/storage-sync.bif
@@ -68,7 +68,7 @@ function Storage::Sync::__close_backend%(backend: opaque of Storage::BackendHand
 	if ( ! b )
 		op_result = b.error();
 	else {
-		auto cb = new OperationResultCallback();
+		auto cb = new ResultCallback();
 		op_result = storage_mgr->CloseBackend((*b)->backend, cb);
 
 		// If the backend only supports async, block until it's ready and then pull the result out of
@@ -96,7 +96,7 @@ function Storage::Sync::__put%(backend: opaque of Storage::BackendHandle, key: a
 		if ( expire_time > 0.0 )
 			expire_time += run_state::network_time;
 
-		auto cb = new OperationResultCallback();
+		auto cb = new ResultCallback();
 		auto key_v = IntrusivePtr<Val>{NewRef{}, key};
 		auto val_v = IntrusivePtr<Val>{NewRef{}, value};
 		op_result = (*b)->backend->Put(cb, key_v, val_v, overwrite, expire_time);
@@ -122,7 +122,7 @@ function Storage::Sync::__get%(backend: opaque of Storage::BackendHandle, key: a
 	if ( ! b )
 		op_result = b.error();
 	else {
-		auto cb = new OperationResultCallback();
+		auto cb = new ResultCallback();
 		auto key_v = IntrusivePtr<Val>{NewRef{}, key};
 		op_result = (*b)->backend->Get(cb, key_v);
 
@@ -147,7 +147,7 @@ function Storage::Sync::__erase%(backend: opaque of Storage::BackendHandle, key:
 	if ( ! b )
 		op_result = b.error();
 	else {
-		auto cb = new OperationResultCallback();
+		auto cb = new ResultCallback();
 		auto key_v = IntrusivePtr<Val>{NewRef{}, key};
 		op_result = (*b)->backend->Erase(cb, key_v);
 

--- a/testing/btest/Baseline/scripts.base.frameworks.storage.overwriting/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.storage.overwriting/out
@@ -3,3 +3,9 @@ open result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=<opaque of
 put result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=<uninitialized>]
 get result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=value7890]
 get result same as inserted, T
+put result, [code=Storage::KEY_EXISTS, error_str=<uninitialized>, value=<uninitialized>]
+get result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=value7890]
+get result same as originally inserted, T
+put result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=<uninitialized>]
+get result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=value2345]
+get result same as overwritten, T

--- a/testing/btest/Baseline/scripts.base.frameworks.storage.redis-sync/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.storage.redis-sync/out
@@ -3,8 +3,11 @@ open_result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=<opaque of
 put result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=<uninitialized>]
 get result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=value1234]
 get result same as inserted, T
-overwrite put result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=<uninitialized>]
-get result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=value5678]
-get result same as inserted, T
+put result, [code=Storage::KEY_EXISTS, error_str=<uninitialized>, value=<uninitialized>]
+get result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=value1234]
+get result same as originally inserted, T
+put result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=<uninitialized>]
+get result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=value2345]
+get result same as overwritten, T
 Storage::backend_opened, Storage::REDIS, [redis=[server_host=127.0.0.1, server_port=xxxx/tcp, server_unix_socket=<uninitialized>, key_prefix=testing]]
 Storage::backend_lost, Storage::REDIS, [redis=[server_host=127.0.0.1, server_port=xxxx/tcp, server_unix_socket=<uninitialized>, key_prefix=testing]], Client disconnected

--- a/testing/btest/plugins/storage-plugin/src/StorageDummy.cc
+++ b/testing/btest/plugins/storage-plugin/src/StorageDummy.cc
@@ -34,7 +34,7 @@ OperationResult StorageDummy::DoOpen(OpenResultCallback* cb, RecordValPtr option
 /**
  * Finalizes the backend when it's being closed.
  */
-OperationResult StorageDummy::DoClose(OperationResultCallback* cb) {
+OperationResult StorageDummy::DoClose(ResultCallback* cb) {
     open = false;
     return {ReturnCode::SUCCESS};
 }
@@ -42,7 +42,7 @@ OperationResult StorageDummy::DoClose(OperationResultCallback* cb) {
 /**
  * The workhorse method for Put(). This must be implemented by plugins.
  */
-OperationResult StorageDummy::DoPut(OperationResultCallback* cb, ValPtr key, ValPtr value, bool overwrite,
+OperationResult StorageDummy::DoPut(ResultCallback* cb, ValPtr key, ValPtr value, bool overwrite,
                                     double expiration_time) {
     auto json_key = key->ToJSON()->ToStdString();
     auto json_value = value->ToJSON()->ToStdString();
@@ -53,7 +53,7 @@ OperationResult StorageDummy::DoPut(OperationResultCallback* cb, ValPtr key, Val
 /**
  * The workhorse method for Get(). This must be implemented for plugins.
  */
-OperationResult StorageDummy::DoGet(OperationResultCallback* cb, ValPtr key) {
+OperationResult StorageDummy::DoGet(ResultCallback* cb, ValPtr key) {
     auto json_key = key->ToJSON();
     auto it = data.find(json_key->ToStdString());
     if ( it == data.end() )
@@ -71,7 +71,7 @@ OperationResult StorageDummy::DoGet(OperationResultCallback* cb, ValPtr key) {
 /**
  * The workhorse method for Erase(). This must be implemented for plugins.
  */
-OperationResult StorageDummy::DoErase(OperationResultCallback* cb, ValPtr key) {
+OperationResult StorageDummy::DoErase(ResultCallback* cb, ValPtr key) {
     auto json_key = key->ToJSON();
     auto it = data.find(json_key->ToStdString());
     if ( it == data.end() )

--- a/testing/btest/plugins/storage-plugin/src/StorageDummy.h
+++ b/testing/btest/plugins/storage-plugin/src/StorageDummy.h
@@ -26,7 +26,7 @@ public:
     /**
      * Finalizes the backend when it's being closed.
      */
-    zeek::storage::OperationResult DoClose(zeek::storage::OperationResultCallback* cb = nullptr) override;
+    zeek::storage::OperationResult DoClose(zeek::storage::ResultCallback* cb = nullptr) override;
 
     /**
      * Returns whether the backend is opened.
@@ -36,19 +36,18 @@ public:
     /**
      * The workhorse method for Put().
      */
-    zeek::storage::OperationResult DoPut(zeek::storage::OperationResultCallback* cb, zeek::ValPtr key,
-                                         zeek::ValPtr value, bool overwrite = true,
-                                         double expiration_time = 0) override;
+    zeek::storage::OperationResult DoPut(zeek::storage::ResultCallback* cb, zeek::ValPtr key, zeek::ValPtr value,
+                                         bool overwrite = true, double expiration_time = 0) override;
 
     /**
      * The workhorse method for Get().
      */
-    zeek::storage::OperationResult DoGet(zeek::storage::OperationResultCallback* cb, zeek::ValPtr key) override;
+    zeek::storage::OperationResult DoGet(zeek::storage::ResultCallback* cb, zeek::ValPtr key) override;
 
     /**
      * The workhorse method for Erase().
      */
-    zeek::storage::OperationResult DoErase(zeek::storage::OperationResultCallback* cb, zeek::ValPtr key) override;
+    zeek::storage::OperationResult DoErase(zeek::storage::ResultCallback* cb, zeek::ValPtr key) override;
 
 private:
     std::map<std::string, std::string> data;

--- a/testing/btest/plugins/storage.zeek
+++ b/testing/btest/plugins/storage.zeek
@@ -10,9 +10,6 @@
 
 @load base/frameworks/storage/sync
 
-# Create a typename here that can be passed down into get().
-type str: string;
-
 type StorageDummyOpts : record {
 	open_fail: bool;
 };
@@ -30,7 +27,7 @@ event zeek_init() {
 
 	# Test basic operation. The second get() should return an error
 	# as the key should have been erased.
-	local open_res = Storage::Sync::open_backend(Storage::STORAGEDUMMY, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::STORAGEDUMMY, opts, string, string);
 	print "open result", open_res;
 	local b = open_res$value;
 	local put_res = Storage::Sync::put(b, [$key=key, $value=value, $overwrite=F]);
@@ -56,7 +53,7 @@ event zeek_init() {
 
 	# Test failing to open the handle and test closing an invalid handle.
 	opts$dummy$open_fail = T;
-	open_res = Storage::Sync::open_backend(Storage::STORAGEDUMMY, opts, str, str);
+	open_res = Storage::Sync::open_backend(Storage::STORAGEDUMMY, opts, string, string);
 	print "open result 2", open_res;
 	local close_res = Storage::Sync::close_backend(open_res$value);
 	print "close result of closed handle", close_res;

--- a/testing/btest/scripts/base/frameworks/file-analysis/bifs/enable-disable.zeek
+++ b/testing/btest/scripts/base/frameworks/file-analysis/bifs/enable-disable.zeek
@@ -26,5 +26,5 @@ event zeek_init()
 event pe_dos_header(f: fa_file, h: PE::DOSHeader)
 	{
 	print "got pe_dos_header event";
-	exit(0);
+	terminate();
 	}

--- a/testing/btest/scripts/base/frameworks/storage/erase.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/erase.zeek
@@ -7,9 +7,6 @@
 @load base/frameworks/storage/sync
 @load policy/frameworks/storage/backend/sqlite
 
-# Create a typename here that can be passed down into get().
-type str: string;
-
 event zeek_init()
 	{
 	# Create a database file in the .tmp directory with a 'testing' table
@@ -20,7 +17,7 @@ event zeek_init()
 
 	# Test inserting/retrieving a key/value pair that we know won't be in
 	# the backend yet.
-	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, string, string);
 	print "open result", open_res;
 	local b = open_res$value;
 

--- a/testing/btest/scripts/base/frameworks/storage/expiration.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/expiration.zeek
@@ -9,9 +9,6 @@
 redef Storage::expire_interval = 2 secs;
 redef exit_only_after_terminate = T;
 
-# Create a typename here that can be passed down into get().
-type str: string;
-
 global b: opaque of Storage::BackendHandle;
 global key1: string = "key1234";
 global value1: string = "value1234";
@@ -36,7 +33,7 @@ event setup_test()
 	local opts : Storage::BackendOptions;
 	opts$sqlite = [$database_path = "storage-test.sqlite", $table_name = "testing"];
 
-	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, string, string);
 	print "open result", open_res;
 
 	b = open_res$value;

--- a/testing/btest/scripts/base/frameworks/storage/overwriting.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/overwriting.zeek
@@ -7,9 +7,6 @@
 @load base/frameworks/storage/sync
 @load policy/frameworks/storage/backend/sqlite
 
-# Create a typename here that can be passed down into get().
-type str: string;
-
 event zeek_init() {
 	local opts : Storage::BackendOptions;
 	opts$sqlite = [$database_path = "storage-test.sqlite", $table_name = "testing"];
@@ -17,7 +14,7 @@ event zeek_init() {
 	local key = "key1234";
 	local value = "value7890";
 
-	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, string, string);
 	print "open result", open_res;
 	local b = open_res$value;
 

--- a/testing/btest/scripts/base/frameworks/storage/overwriting.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/overwriting.zeek
@@ -7,24 +7,50 @@
 @load base/frameworks/storage/sync
 @load policy/frameworks/storage/backend/sqlite
 
+# Create a typename here that can be passed down into get().
+type str: string;
+
 event zeek_init() {
 	local opts : Storage::BackendOptions;
-	opts$sqlite = [$database_path = "storage-test.sqlite", $table_name = "testing"];
+	opts$sqlite = [$database_path = "testing.sqlite", $table_name = "testing"];
 
-	local key = "key1234";
+	local key = "key1111";
 	local value = "value7890";
+	local value2 = "value2345";
 
-	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, string, string);
-	print "open result", open_res;
-	local b = open_res$value;
+	local res = Storage::Sync::open_backend(Storage::SQLITE, opts, str, str);
+	print "open result", res;
+	local b = res$value;
 
-	local res = Storage::Sync::put(b, [$key=key, $value=value]);
+	# Put a first value. This should return Storage::SUCCESS.
+	res = Storage::Sync::put(b, [$key=key, $value=value]);
 	print "put result", res;
 
-	local res2 = Storage::Sync::get(b, key);
-	print "get result", res2;
-	if ( res2$code == Storage::SUCCESS && res2?$value )
-		print "get result same as inserted", value == (res2$value as string);
+	# Get the first value, validate that it's what we inserted.
+	res = Storage::Sync::get(b, key);
+	print "get result", res;
+	if ( res$code == Storage::SUCCESS && res?$value )
+		print "get result same as inserted", value == (res$value as string);
+
+	# This will return a Storage::KEY_EXISTS since we don't want overwriting.
+	res = Storage::Sync::put(b, [$key=key, $value=value2, $overwrite=F]);
+	print "put result", res;
+
+	# Verify that the overwrite didn't actually happen.
+	res = Storage::Sync::get(b, key);
+	print "get result", res;
+	if ( res$code == Storage::SUCCESS && res?$value )
+		print "get result same as originally inserted", value == (res$value as string);
+
+	# This will return a Storage::SUCESSS since we're asking for an overwrite.
+	res = Storage::Sync::put(b, [$key=key, $value=value2, $overwrite=T]);
+	print "put result", res;
+
+	# Verify that the overwrite happened.
+	res = Storage::Sync::get(b, key);
+	print "get result", res;
+	if ( res$code == Storage::SUCCESS && res?$value )
+		print "get result same as overwritten", value2 == (res$value as string);
 
 	Storage::Sync::close_backend(b);
 }

--- a/testing/btest/scripts/base/frameworks/storage/redis-async-reading-pcap.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis-async-reading-pcap.zeek
@@ -13,9 +13,6 @@
 @load base/frameworks/storage/async
 @load policy/frameworks/storage/backend/redis
 
-# Create a typename here that can be passed down into open_backend()
-type str: string;
-
 event zeek_init()
 	{
 	local opts: Storage::BackendOptions;
@@ -25,7 +22,7 @@ event zeek_init()
 	local key = "key1234";
 	local value = "value5678";
 
-	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, string, string);
 	print "open result", open_res;
 	local b = open_res$value;
 

--- a/testing/btest/scripts/base/frameworks/storage/redis-async.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis-async.zeek
@@ -15,9 +15,6 @@
 
 redef exit_only_after_terminate = T;
 
-# Create a typename here that can be passed down into open_backend()
-type str: string;
-
 event zeek_init()
 	{
 	local opts: Storage::BackendOptions;
@@ -28,7 +25,7 @@ event zeek_init()
 	local value = "value5678";
 
 	when [opts, key, value] ( local open_res = Storage::Async::open_backend(
-	    Storage::REDIS, opts, str, str) )
+	    Storage::REDIS, opts, string, string) )
 		{
 		print "open result", open_res;
 		local b = open_res$value;

--- a/testing/btest/scripts/base/frameworks/storage/redis-cluster.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis-cluster.zeek
@@ -33,7 +33,6 @@ global redis_data_written: event() &is_used;
 @if ( Cluster::local_node_type() == Cluster::WORKER )
 
 global backend: opaque of Storage::BackendHandle;
-type str: string;
 
 event zeek_init()
 	{
@@ -41,7 +40,7 @@ event zeek_init()
 	opts$redis = [ $server_host="127.0.0.1", $server_port=to_port(getenv(
 	    "REDIS_PORT")), $key_prefix="testing" ];
 
-	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, string, string);
 	backend = open_res$value;
 	}
 

--- a/testing/btest/scripts/base/frameworks/storage/redis-disconnect.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis-disconnect.zeek
@@ -14,9 +14,6 @@
 
 redef exit_only_after_terminate = T;
 
-# Create a typename here that can be passed down into open_backend()
-type str: string;
-
 event Storage::backend_opened(tag: string, config: any) {
 	print "Storage::backend_opened", tag, config;
 }
@@ -35,7 +32,7 @@ event zeek_init()
 	local key = "key1234";
 	local value = "value1234";
 
-	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, string, string);
 	print "open_result", open_res;
 
 	# Kill the redis server so the backend will disconnect and fire the backend_lost event.

--- a/testing/btest/scripts/base/frameworks/storage/redis-erase.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis-erase.zeek
@@ -12,9 +12,6 @@
 @load base/frameworks/storage/sync
 @load policy/frameworks/storage/backend/redis
 
-# Create a typename here that can be passed down into open_backend()
-type str: string;
-
 event zeek_init()
 	{
 	local opts: Storage::BackendOptions;
@@ -24,7 +21,7 @@ event zeek_init()
 	local key = "key1234";
 	local value = "value1234";
 
-	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, string, string);
 	print "open_result", open_res;
 
 	local b = open_res$value;

--- a/testing/btest/scripts/base/frameworks/storage/redis-expiration.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis-expiration.zeek
@@ -15,9 +15,6 @@
 redef Storage::expire_interval = 2secs;
 redef exit_only_after_terminate = T;
 
-# Create a typename here that can be passed down into open_backend()
-type str: string;
-
 global b: opaque of Storage::BackendHandle;
 global key1: string = "key1234";
 global value1: string = "value1234";
@@ -43,7 +40,7 @@ event setup_test()
 	opts$redis = [ $server_host="127.0.0.1", $server_port=to_port(getenv(
 	    "REDIS_PORT")), $key_prefix="testing" ];
 
-	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, string, string);
 	print "open result", open_res;
 
 	b = open_res$value;

--- a/testing/btest/scripts/base/frameworks/storage/redis-native-expiration.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis-native-expiration.zeek
@@ -15,9 +15,6 @@
 redef Storage::expire_interval = 2secs;
 redef exit_only_after_terminate = T;
 
-# Create a typename here that can be passed down into open_backend()
-type str: string;
-
 global b: opaque of Storage::BackendHandle;
 global key1: string = "key1234";
 global value1: string = "value1234";
@@ -43,7 +40,7 @@ event setup_test()
 	opts$redis = [ $server_host="127.0.0.1", $server_port=to_port(getenv(
 	    "REDIS_PORT")), $key_prefix="testing" ];
 
-	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, string, string);
 	print "open result", open_res;
 
 	b = open_res$value;

--- a/testing/btest/scripts/base/frameworks/storage/redis-sync.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis-sync.zeek
@@ -12,9 +12,6 @@
 @load base/frameworks/storage/sync
 @load policy/frameworks/storage/backend/redis
 
-# Create a typename here that can be passed down into open_backend()
-type str: string;
-
 event Storage::backend_opened(tag: string, config: any) {
 	print "Storage::backend_opened", tag, config;
 }
@@ -33,7 +30,7 @@ event zeek_init()
 	local key = "key1234";
 	local value = "value1234";
 
-	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, string, string);
 	print "open_result", open_res;
 
 	local b = open_res$value;

--- a/testing/btest/scripts/base/frameworks/storage/redis-sync.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis-sync.zeek
@@ -29,28 +29,42 @@ event zeek_init()
 
 	local key = "key1234";
 	local value = "value1234";
+	local value2 = "value2345";
 
-	local open_res = Storage::Sync::open_backend(Storage::REDIS, opts, string, string);
-	print "open_result", open_res;
+	local res = Storage::Sync::open_backend(Storage::REDIS, opts, string, string);
+	print "open_result", res;
 
-	local b = open_res$value;
+	local b = res$value;
 
-	local res = Storage::Sync::put(b, [ $key=key, $value=value ]);
+	# Put a first value. This should return Storage::SUCCESS.
+	res = Storage::Sync::put(b, [$key=key, $value=value]);
 	print "put result", res;
 
-	local res2 = Storage::Sync::get(b, key);
-	print "get result", res2;
-	if ( res2$code == Storage::SUCCESS && res2?$value )
-		print "get result same as inserted", value == ( res2$value as string );
+	# Get the first value, validate that it's what we inserted.
+	res = Storage::Sync::get(b, key);
+	print "get result", res;
+	if ( res$code == Storage::SUCCESS && res?$value )
+		print "get result same as inserted", value == (res$value as string);
 
-	local value2 = "value5678";
-	res = Storage::Sync::put(b, [ $key=key, $value=value2, $overwrite=T ]);
-	print "overwrite put result", res;
+	# This will return a Storage::KEY_EXISTS since we don't want overwriting.
+	res = Storage::Sync::put(b, [$key=key, $value=value2, $overwrite=F]);
+	print "put result", res;
 
-	res2 = Storage::Sync::get(b, key);
-	print "get result", res2;
-	if ( res2$code == Storage::SUCCESS && res2?$value )
-		print "get result same as inserted", value2 == ( res2$value as string );
+	# Verify that the overwrite didn't actually happen.
+	res = Storage::Sync::get(b, key);
+	print "get result", res;
+	if ( res$code == Storage::SUCCESS && res?$value )
+		print "get result same as originally inserted", value == (res$value as string);
+
+	# This will return a Storage::SUCESSS since we're asking for an overwrite.
+	res = Storage::Sync::put(b, [$key=key, $value=value2, $overwrite=T]);
+	print "put result", res;
+
+	# Verify that the overwrite happened.
+	res = Storage::Sync::get(b, key);
+	print "get result", res;
+	if ( res$code == Storage::SUCCESS && res?$value )
+		print "get result same as overwritten", value2 == (res$value as string);
 
 	Storage::Sync::close_backend(b);
 	}

--- a/testing/btest/scripts/base/frameworks/storage/sqlite-basic-reading-pcap.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite-basic-reading-pcap.zeek
@@ -9,9 +9,6 @@
 
 redef exit_only_after_terminate = T;
 
-# Create a typename here that can be passed down into get().
-type str: string;
-
 event zeek_init()
 	{
 	# Create a database file in the .tmp directory with a 'testing' table
@@ -23,7 +20,7 @@ event zeek_init()
 
 	# Test inserting/retrieving a key/value pair that we know won't be in
 	# the backend yet.
-	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, string, string);
 	print "open result", open_res;
 
 	local b = open_res$value;

--- a/testing/btest/scripts/base/frameworks/storage/sqlite-basic-sync-in-when.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite-basic-sync-in-when.zeek
@@ -8,9 +8,6 @@
 
 redef exit_only_after_terminate = T;
 
-# Create a typename here that can be passed down into get().
-type str: string;
-
 event Storage::backend_opened(tag: string, config: any) {
 	print "Storage::backend_opened", tag, config;
 }
@@ -27,7 +24,7 @@ event zeek_init()
 	# Test inserting/retrieving a key/value pair that we know won't be in
 	# the backend yet.
 	when [opts, key, value] ( local open_res = Storage::Sync::open_backend(
-	    Storage::SQLITE, opts, str, str) )
+	    Storage::SQLITE, opts, string, string) )
 		{
 		print "open result", open_res;
 		local b = open_res$value;

--- a/testing/btest/scripts/base/frameworks/storage/sqlite-basic.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite-basic.zeek
@@ -8,9 +8,6 @@
 
 redef exit_only_after_terminate = T;
 
-# Create a typename here that can be passed down into get().
-type str: string;
-
 event Storage::backend_opened(tag: string, config: any) {
 	print "Storage::backend_opened", tag, config;
 }
@@ -27,7 +24,7 @@ event zeek_init()
 	# Test inserting/retrieving a key/value pair that we know won't be in
 	# the backend yet.
 	when [opts, key, value] ( local open_res = Storage::Async::open_backend(
-	    Storage::SQLITE, opts, str, str) )
+	    Storage::SQLITE, opts, string, string) )
 		{
 		print "open result", open_res;
 		local b = open_res$value;

--- a/testing/btest/scripts/base/frameworks/storage/sqlite-error-handling.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite-error-handling.zeek
@@ -7,9 +7,6 @@
 @load base/frameworks/reporter
 @load policy/frameworks/storage/backend/sqlite
 
-# Create a typename here that can be passed down into open_backend.
-type str: string;
-
 event zeek_init() {
 	# Test opening a database with an invalid path
 	local opts : Storage::BackendOptions;
@@ -17,12 +14,12 @@ event zeek_init() {
 	               $table_name = "testing"];
 
 	# This should report an error in .stderr and reporter.log
-	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, str, str);
+	local open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, string, string);
 	print "Open result", open_res;
 
 	# Open a valid database file
 	opts$sqlite$database_path = "test.sqlite";
-	open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, str, str);
+	open_res = Storage::Sync::open_backend(Storage::SQLITE, opts, string, string);
 	print "Open result 2", open_res;
 
 	local b = open_res$value;


### PR DESCRIPTION
These are few quick follow-up items from the storage framework merge yesterday:

- Add `libhiredis-dev` to the set of packages installed for the generate-docs workflow. Otherwise, the Redis docs don't get included because the backend doesn't get built.
- Remove installing `expected-lite` for plugins, which was breaking OBS.
- Fix some minor Coverity findings in the SQLite backend.
- Merge the `OperationResultCallback` code into `ResultCallback`, and remove the former. `OpenResultCallback` was just a super-set of `OperationResultCallback` and so `OperationResultCallback` doesn't need to exist.
- Add NEWS entry and removed giant block of commits from CHANGES
- Fix a couple of data races with non-native expiration reported by tsan
- Removed unnecessary type aliases in the btests, which I never took care of after https://github.com/zeek/zeek/pull/4194 got merged.
- Fixed SQLite `put` operations when overwriting is disabled so it returns the right status code.