### PR TITLE
Topic/awelzel/4177 4178 custom event metadata

### DIFF
--- a/src/Event.cc
+++ b/src/Event.cc
@@ -52,7 +52,14 @@ void Event::Dispatch(bool no_remote) {
         reporter->BeginErrorHandler();
 
     try {
-        handler->Call(&args, no_remote, ts);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        // Call with ts = 0.0 so that CurrentEventTime() is used for
+        // events that need to be auto published.
+        //
+        // Replace in v8.1 with handler->Call(&args).
+        handler->Call(&args, no_remote, 0.0);
+#pragma GCC diagnostic pop
     }
 
     catch ( InterpreterException& e ) {

--- a/src/EventHandler.cc
+++ b/src/EventHandler.cc
@@ -78,6 +78,13 @@ void EventHandler::Call(Args* vl, bool no_remote, double ts) {
             if ( valid_args ) {
                 auto ev_args = std::move(xs).Build();
 
+                // If ts is provided as 0.0, use the current event time
+                // or else use network_time.
+                if ( ts == 0.0 )
+                    ts = zeek::event_mgr.CurrentEventTime();
+                if ( ts == 0.0 )
+                    ts = zeek::run_state::network_time;
+
                 for ( auto it = auto_publish.begin();; ) {
                     const auto& topic = *it;
                     ++it;
@@ -96,6 +103,13 @@ void EventHandler::Call(Args* vl, bool no_remote, double ts) {
     if ( local )
         // No try/catch here; we pass exceptions upstream.
         local->Invoke(vl);
+}
+
+void EventHandler::Call(Args* vl) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    Call(vl, true, 0.0);
+#pragma GCC diagnostic pop
 }
 
 void EventHandler::NewEvent(Args* vl) {

--- a/src/EventHandler.h
+++ b/src/EventHandler.h
@@ -47,7 +47,14 @@ public:
         auto_publish.erase(topic);
     }
 
+    [[deprecated(
+        "Remove in v8.1, the no_remote and ts parameters are AutoPublish() specific and won't have an effect "
+        "in the future.")]]
     void Call(zeek::Args* vl, bool no_remote = false, double ts = run_state::network_time);
+
+    // Call the function associated with this handler. This for now just
+    // invokes Call with no_remote=false and ts=0.0.
+    void Call(zeek::Args* vl);
 
     // Returns true if there is at least one local or remote handler.
     explicit operator bool() const;


### PR DESCRIPTION
Draft to run the benchmarker on it.

---

What this does:

* Store generic event metadata as a std::vector rather than the network timestamp explicitly
* Don't extract network timestamp if it isn't needed.
* Deprecate EventHandler::Call() to remove no_remote and ts as these are auto-publish specific.