### PR TITLE
Remove "experimental" from the QUIC history field's comment string

### DIFF
--- a/scripts/base/protocols/quic/main.zeek
+++ b/scripts/base/protocols/quic/main.zeek
@@ -43,7 +43,7 @@ export {
 		## packet if available.
 		client_protocol: string &log &optional;
 
-		## Experimental QUIC history.
+		## QUIC history.
 		##
 		## Letters have the following meaning with client-sent
 		## letters being capitalized:


### PR DESCRIPTION
We're unlikely to fundamentally change (or remove) this field at this point, and some users wondered whether we might do so, given the labeling.