### PR TITLE
Event/EventMgr cleanup

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,11 @@ Zeek 7.2.0
 Breaking Changes
 ----------------
 
+- The ``is_remote_event()``, ``current_analyzer()`` and ``current_event_time()``
+  builtin functions do not return the previous event's values anymore when event
+  draining has completed. The same applies to the corresponding C++ accessors on
+  the ``EventMgr`` class. The functions now return false, 0 or the zero time instead.
+
 New Functionality
 -----------------
 

--- a/src/Event.cc
+++ b/src/Event.cc
@@ -2,16 +2,13 @@
 
 #include "zeek/Event.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/Desc.h"
-#include "zeek/Func.h"
-#include "zeek/NetVar.h"
 #include "zeek/Trigger.h"
 #include "zeek/Val.h"
 #include "zeek/iosource/Manager.h"
-#include "zeek/iosource/PktSrc.h"
 #include "zeek/plugin/Manager.h"
+
+#include "event.bif.netvar_h"
 
 zeek::EventMgr zeek::event_mgr;
 

--- a/src/Event.cc
+++ b/src/Event.cc
@@ -69,7 +69,6 @@ EventMgr::EventMgr() {
     current_src = util::detail::SOURCE_LOCAL;
     current_aid = 0;
     current_ts = 0;
-    src_val = nullptr;
     draining = false;
 }
 
@@ -79,8 +78,6 @@ EventMgr::~EventMgr() {
         Unref(head);
         head = n;
     }
-
-    Unref(src_val);
 }
 
 void EventMgr::Enqueue(const EventHandlerPtr& h, Args vl, util::detail::SourceID src, analyzer::ID aid, Obj* obj,

--- a/src/Event.cc
+++ b/src/Event.cc
@@ -49,7 +49,11 @@ void Event::Dispatch(bool no_remote) {
         reporter->BeginErrorHandler();
 
     try {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        // Replace in v8.1 with handler->Call(&args).
         handler->Call(&args, no_remote, ts);
+#pragma GCC diagnostic pop
     }
 
     catch ( InterpreterException& e ) {

--- a/src/Event.h
+++ b/src/Event.h
@@ -123,7 +123,6 @@ protected:
     util::detail::SourceID current_src;
     analyzer::ID current_aid;
     double current_ts;
-    RecordVal* src_val;
     bool draining;
 };
 

--- a/src/Event.h
+++ b/src/Event.h
@@ -34,7 +34,7 @@ public:
 
     void Describe(ODesc* d) const override;
 
-protected:
+private:
     friend class EventMgr;
 
     // This method is protected to make sure that everybody goes through
@@ -116,7 +116,7 @@ public:
     uint64_t num_events_queued = 0;
     uint64_t num_events_dispatched = 0;
 
-protected:
+private:
     void QueueEvent(Event* event);
 
     Event* current = nullptr;

--- a/src/Event.h
+++ b/src/Event.h
@@ -52,7 +52,6 @@ protected:
 
 class EventMgr final : public Obj, public iosource::IOSource {
 public:
-    EventMgr();
     ~EventMgr() override;
 
     /**
@@ -84,21 +83,23 @@ public:
     void Dispatch(Event* event, bool no_remote = false);
 
     void Drain();
-    bool IsDraining() const { return draining; }
+    bool IsDraining() const { return current != nullptr; }
 
     bool HasEvents() const { return head != nullptr; }
 
-    // Returns the source ID of last raised event.
-    util::detail::SourceID CurrentSource() const { return current_src; }
+    // Returns the source ID of the current event.
+    util::detail::SourceID CurrentSource() const { return current ? current->Source() : util::detail::SOURCE_LOCAL; }
 
-    // Returns the ID of the analyzer which raised the last event, or 0 if
+    // Returns the ID of the analyzer which raised the current event, or 0 if
     // non-analyzer event.
-    analyzer::ID CurrentAnalyzer() const { return current_aid; }
+    analyzer::ID CurrentAnalyzer() const { return current ? current->Analyzer() : 0; }
 
-    // Returns the timestamp of the last raised event. The timestamp reflects the network time
+    // Returns the timestamp of the current event. The timestamp reflects the network time
     // the event was intended to be executed. For scheduled events, this is the time the event
     // was scheduled to. For any other event, this is the time when the event was created.
-    double CurrentEventTime() const { return current_ts; }
+    //
+    // If no event is being processed, returns 0.0.
+    double CurrentEventTime() const { return current ? current->Time() : 0.0; }
 
     int Size() const { return num_events_queued - num_events_dispatched; }
 
@@ -118,12 +119,9 @@ public:
 protected:
     void QueueEvent(Event* event);
 
-    Event* head;
-    Event* tail;
-    util::detail::SourceID current_src;
-    analyzer::ID current_aid;
-    double current_ts;
-    bool draining;
+    Event* current = nullptr;
+    Event* head = nullptr;
+    Event* tail = nullptr;
 };
 
 extern EventMgr event_mgr;

--- a/src/Event.h
+++ b/src/Event.h
@@ -5,12 +5,10 @@
 #include <tuple>
 #include <type_traits>
 
-#include "zeek/Flare.h"
-#include "zeek/IntrusivePtr.h"
 #include "zeek/ZeekArgs.h"
-#include "zeek/ZeekList.h"
 #include "zeek/analyzer/Analyzer.h"
 #include "zeek/iosource/IOSource.h"
+#include "zeek/util.h"
 
 namespace zeek {
 

--- a/src/EventHandler.cc
+++ b/src/EventHandler.cc
@@ -6,7 +6,6 @@
 #include "zeek/Event.h"
 #include "zeek/Func.h"
 #include "zeek/ID.h"
-#include "zeek/NetVar.h"
 #include "zeek/Scope.h"
 #include "zeek/Var.h"
 #include "zeek/broker/Data.h"

--- a/src/EventHandler.h
+++ b/src/EventHandler.h
@@ -4,13 +4,11 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
 #include <unordered_set>
 
 #include "zeek/Type.h"
 #include "zeek/ZeekArgs.h"
-#include "zeek/ZeekList.h"
 
 namespace zeek {
 

--- a/src/EventHandler.h
+++ b/src/EventHandler.h
@@ -45,7 +45,18 @@ public:
         auto_publish.erase(topic);
     }
 
+    [[deprecated(
+        "Remove in v8.1. The no_remote and ts parameters are AutoPublish() specific and won't have an effect "
+        "in the future. Use Call(args)")]]
     void Call(zeek::Args* vl, bool no_remote = false, double ts = run_state::network_time);
+
+    // Call the function associated with this handler.
+    void Call(zeek::Args* vl) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        Call(vl, false, run_state::network_time);
+#pragma GCC diagnostic pop
+    }
 
     // Returns true if there is at least one local or remote handler.
     explicit operator bool() const;

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -4973,9 +4973,9 @@ function uninstall_dst_net_filter%(snet: subnet%) : bool
 	return zeek::val_mgr->Bool(packet_mgr->GetPacketFilter()->RemoveDst(snet));
 	%}
 
-## Checks whether the last raised event came from a remote peer.
+## Checks whether the current event came from a remote peer.
 ##
-## Returns: True if the last raised event came from a remote peer.
+## Returns: True if the current event came from a remote peer.
 function is_remote_event%(%) : bool
 	%{
 	return zeek::val_mgr->Bool(zeek::event_mgr.CurrentSource() != zeek::util::detail::SOURCE_LOCAL);


### PR DESCRIPTION
This is a prep for #4177, but it's subtle enough I'm opening this separately.

Instead of copying event information onto the EventMgr, this PR proposes to store a pointer to the event instead. This changes semantics of some of the bifs if invoked outside of event draining, but I doubt this really matters.

@rsmmr - would you mind looking?