### PR TITLE
Add "U" to QUIC history docstrings and expand version string docs

### DIFF
--- a/scripts/base/protocols/quic/consts.zeek
+++ b/scripts/base/protocols/quic/consts.zeek
@@ -1,6 +1,9 @@
 module QUIC;
 
 export {
+	## A mapping from QUIC's raw version numbers to readable strings.
+	## Unexpected versions become "unknown-<hex>", with a hexadecimal
+	## rendering of the version number.
 	const version_strings: table[count] of string = {
 		[0x00000001] = "1",
 		[0x6b3343cf] = "quicv2",

--- a/scripts/base/protocols/quic/main.zeek
+++ b/scripts/base/protocols/quic/main.zeek
@@ -1,4 +1,4 @@
-##! Initial idea for a quic.log.
+##! Implements base functionality for QUIC analysis. Generates quic.log.
 
 @load base/frameworks/notice/weird
 @load base/protocols/conn/removal-hooks
@@ -19,7 +19,8 @@ export {
 		id:          conn_id &log;
 
 		## QUIC version as found in the first INITIAL packet from
-		## the client.
+		## the client. This will often be "1" or "quicv2", but see
+		## the :zeek:see:`QUIC::version_strings` table for details.
 		version:     string  &log;
 
 		## First Destination Connection ID used by client. This is
@@ -57,6 +58,7 @@ export {
 		## R       RETRY packet
 		## C       CONNECTION_CLOSE packet
 		## S       SSL Client/Server Hello
+		## U       Unfamiliar QUIC version
 		## ======  ====================================================
 		history: string &log &default="";
 


### PR DESCRIPTION
Looks like we overlooked documenting "U" in zeek/zeek#3526 — does that look right to you @awelzel?