### PR TITLE
btest/brokerstore-attr-persistence-clone: Add BTEST_BG_RUN_SLEEP=1

### DIFF
--- a/testing/btest/broker/store/brokerstore-attr-persistence-clone.zeek
+++ b/testing/btest/broker/store/brokerstore-attr-persistence-clone.zeek
@@ -1,8 +1,12 @@
 # @TEST-PORT: BROKER_PORT
 
 # @TEST-EXEC: zeek -b %DIR/sort-stuff.zeek common.zeek one.zeek > output1
-# @TEST-EXEC: btest-bg-run master "cp ../*.sqlite . && zeek -b %DIR/sort-stuff.zeek ../common.zeek ../two.zeek >../output2"
-# @TEST-EXEC: btest-bg-run clone "zeek -b %DIR/sort-stuff.zeek ../common.zeek ../three.zeek >../output3"
+#
+# This test becomes flaky when not sleeping for a second after starting the
+# test. Due to that, we set BTEST_BG_RUN_SLEEP=1 explicitly. See #4312 and
+# #4295 for background.
+# @TEST-EXEC: BTEST_BG_RUN_SLEEP=1 btest-bg-run master "cp ../*.sqlite . && zeek -b %DIR/sort-stuff.zeek ../common.zeek ../two.zeek >../output2"
+# @TEST-EXEC: BTEST_BG_RUN_SLEEP=1 btest-bg-run clone "zeek -b %DIR/sort-stuff.zeek ../common.zeek ../three.zeek >../output3"
 # @TEST-EXEC: btest-bg-wait 20
 
 # @TEST-EXEC: btest-diff output1


### PR DESCRIPTION
This test has become flaky after #4295. It hasn't been failing regularly enough locally to make it approachable. Annotate with BTEST_BG_RUN_SLEEP=1 to revert to pre #4295 behavior, hopefully fixing the flakiness as a side-effect.

Closes #4312

---

Anyone any gripes with calling this a "fix"?