### PR TITLE
Pile of Coverity fixes

### DIFF
--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -160,7 +160,7 @@ int TraceState::LogTrace(const char* fmt, ...) {
 
     if ( ! loc.filename ) {
         static constexpr const char str[] = "<no filename>";
-        loc.filename = util::copy_string(str, std::size(str) - 1);
+        loc.filename = str;
         loc.last_line = 0;
     }
 
@@ -679,7 +679,7 @@ string get_context_description(const Stmt* stmt, const Frame* frame) {
         loc = *stmt->GetLocationInfo();
     else {
         static constexpr const char str[] = "<no filename>";
-        loc.filename = util::copy_string(str, std::size(str) - 1);
+        loc.filename = str;
         loc.last_line = 0;
     }
 

--- a/src/DebugLogger.cc
+++ b/src/DebugLogger.cc
@@ -122,7 +122,7 @@ void DebugLogger::EnableStreams(const char* s) {
         for ( i = 0; i < NUM_DBGS; ++i ) {
             if ( ltok == streams[i].prefix ) {
                 streams[i].enabled = true;
-                enabled_streams.insert(ltok);
+                enabled_streams.insert(std::move(ltok));
                 goto next;
             }
         }

--- a/src/EventRegistry.cc
+++ b/src/EventRegistry.cc
@@ -38,7 +38,7 @@ void EventRegistry::Register(EventHandlerPtr handler, bool is_from_script) {
     handlers[name] = std::unique_ptr<EventHandler>(handler.Ptr());
 
     if ( ! is_from_script )
-        not_only_from_script.insert(name);
+        not_only_from_script.insert(std::move(name));
 }
 
 EventHandler* EventRegistry::Lookup(std::string_view name) {

--- a/src/EventTrace.cc
+++ b/src/EventTrace.cc
@@ -831,7 +831,7 @@ void ValTraceMgr::AssessChange(const ValTrace* vt, const ValTrace* prev_vt) {
         if ( previous_deltas.count(full_delta) > 0 )
             continue;
 
-        previous_deltas.insert(full_delta);
+        previous_deltas.insert(std::move(full_delta));
 
         ValUsed(vp);
         curr_ev->AddDelta(vp, rhs, needs_lhs, is_first_def);

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -288,7 +288,7 @@ ScriptFunc::ScriptFunc(std::string _name, FuncTypePtr ft, std::vector<StmtPtr> b
         Body b;
         b.stmts = std::move(bs[i]);
         b.priority = priorities[i];
-        bodies.push_back(b);
+        bodies.push_back(std::move(b));
     }
 
     std::stable_sort(bodies.begin(), bodies.end());
@@ -564,7 +564,7 @@ void ScriptFunc::AddBody(StmtPtr new_body, const std::vector<IDPtr>& new_inits, 
     current_body = new_body;
     current_priority = b.priority = priority;
 
-    bodies.push_back(b);
+    bodies.push_back(std::move(b));
     std::stable_sort(bodies.begin(), bodies.end());
 }
 
@@ -898,7 +898,7 @@ FunctionIngredients::FunctionIngredients(ScopePtr _scope, StmtPtr _body, const s
     auto flavor = id->GetType<zeek::FuncType>()->Flavor();
     if ( flavor == FUNC_FLAVOR_EVENT || flavor == FUNC_FLAVOR_HOOK ) {
         auto module_group = event_registry->RegisterGroup(EventGroupKind::Module, module_name);
-        groups.insert(module_group);
+        groups.insert(std::move(module_group));
     }
 }
 
@@ -912,7 +912,7 @@ zeek::RecordValPtr make_backtrace_element(std::string_view name, const VectorVal
 
     auto elem = make_intrusive<RecordVal>(elem_type);
     elem->Assign(function_name_idx, name.data());
-    elem->Assign(function_args_idx, std::move(args));
+    elem->Assign(function_args_idx, args);
 
     if ( loc ) {
         elem->Assign(file_location_idx, loc->filename);

--- a/src/TunnelEncapsulation.h
+++ b/src/TunnelEncapsulation.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <vector>
 
 #include "zeek/ID.h"
@@ -28,7 +26,7 @@ public:
     /**
      * Default tunnel connection constructor.
      */
-    EncapsulatingConn() : src_port(0), dst_port(0), proto(TRANSPORT_UNKNOWN), type(BifEnum::Tunnel::NONE), uid() {}
+    EncapsulatingConn() = default;
 
     /**
      * Construct an IP tunnel "connection" with its own UID.
@@ -42,13 +40,7 @@ public:
      */
     EncapsulatingConn(const IPAddr& s, const IPAddr& d, BifEnum::Tunnel::Type t = BifEnum::Tunnel::IP,
                       uint16_t ip_proto = UNKNOWN_IP_PROTO)
-        : src_addr(s),
-          dst_addr(d),
-          src_port(0),
-          dst_port(0),
-          ip_proto(ip_proto),
-          type(t),
-          uid(UID(detail::bits_per_uid)) {
+        : src_addr(s), dst_addr(d), ip_proto(ip_proto), type(t), uid(UID(detail::bits_per_uid)) {
         switch ( ip_proto ) {
             case IPPROTO_ICMP: proto = TRANSPORT_ICMP; break;
             case IPPROTO_UDP: proto = TRANSPORT_UDP; break;
@@ -141,11 +133,11 @@ public:
 protected:
     IPAddr src_addr;
     IPAddr dst_addr;
-    uint16_t src_port;
-    uint16_t dst_port;
-    TransportProto proto;
-    uint16_t ip_proto;
-    BifEnum::Tunnel::Type type;
+    uint16_t src_port = 0;
+    uint16_t dst_port = 0;
+    TransportProto proto = TRANSPORT_UNKNOWN;
+    uint16_t ip_proto = UNKNOWN_IP_PROTO;
+    BifEnum::Tunnel::Type type = BifEnum::Tunnel::NONE;
     UID uid;
 };
 

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1607,7 +1607,7 @@ void EnumType::CheckAndAddName(const string& module_name, const char* name, zeek
 void EnumType::AddNameInternal(const string& module_name, const char* name, zeek_int_t val, bool is_export) {
     string fullname = detail::make_full_var_name(module_name.c_str(), name);
     names[fullname] = val;
-    rev_names[val] = fullname;
+    rev_names[val] = std::move(fullname);
 }
 
 void EnumType::AddNameInternal(const string& full_name, zeek_int_t val) {

--- a/src/ZeekString.cc
+++ b/src/ZeekString.cc
@@ -85,6 +85,18 @@ const String& String::operator=(const String& bs) {
     return *this;
 }
 
+String& String::operator=(String&& other) noexcept {
+    b = other.b;
+    n = other.n;
+    final_NUL = other.final_NUL;
+    use_free_to_delete = other.use_free_to_delete;
+
+    other.b = nullptr;
+    other.Reset();
+
+    return *this;
+}
+
 bool String::operator==(const String& bs) const { return Bstr_eq(this, &bs); }
 
 bool String::operator<(const String& bs) const { return Bstr_cmp(this, &bs) < 0; }
@@ -493,6 +505,10 @@ TEST_CASE("construction") {
     zeek::String s10{true, text5, 6};
     s10.SetUseFreeToDelete(1);
     CHECK_EQ(s10.Bytes(), text5);
+
+    // Test the move constructor.
+    zeek::String s11{std::move(s5)};
+    CHECK_EQ(s11.Len(), 6);
 }
 
 TEST_CASE("set/assignment/comparison") {
@@ -534,6 +550,9 @@ TEST_CASE("set/assignment/comparison") {
     zeek::String s5{};
     CHECK_LT(s5, s);
     CHECK_FALSE(s < s5);
+
+    zeek::String s6 = std::move(s3);
+    CHECK_EQ(s6, "def");
 }
 
 TEST_CASE("searching/modification") {

--- a/src/ZeekString.cc
+++ b/src/ZeekString.cc
@@ -468,6 +468,8 @@ TEST_CASE("construction") {
     zeek::String s5{std::string("abcdef")};
     CHECK_EQ(s5.Len(), 6);
 
+    // Test the copy constructor.
+    // coverity[copy_instead_of_move]
     zeek::String s6{s5};
     CHECK_EQ(s6.Len(), 6);
 

--- a/src/ZeekString.h
+++ b/src/ZeekString.h
@@ -54,6 +54,7 @@ public:
     ~String() { Reset(); }
 
     const String& operator=(const String& bs);
+    String& operator=(String&& bs) noexcept;
     bool operator==(const String& bs) const;
     bool operator<(const String& bs) const;
     bool operator==(std::string_view s) const;

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -998,7 +998,7 @@ vector<string> IRC_Analyzer::SplitWords(const string& input, char split) {
     // Add line end if needed.
     if ( start < input.size() ) {
         word = input.substr(start, input.size() - start);
-        words.push_back(word);
+        words.push_back(std::move(word));
     }
 
     return words;

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -815,7 +815,7 @@ std::vector<std::string> POP3_Analyzer::TokenizeLine(const std::string& input, c
             tokens.push_back(token);
 
         token = input.substr(splitPos + 1, input.size() - splitPos);
-        tokens.push_back(token);
+        tokens.push_back(std::move(token));
     }
 
     return tokens;

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -24,7 +24,7 @@ static const char* pop3_cmd_word[] = {
 #include "POP3_cmd.def"
 };
 
-#define POP3_CMD_WORD(code) ((code >= 0) ? pop3_cmd_word[code] : "(UNKNOWN)")
+#define POP3_CMD_WORD(code) (((code) >= 0) ? pop3_cmd_word[code] : "(UNKNOWN)")
 
 POP3_Analyzer::POP3_Analyzer(Connection* conn) : analyzer::tcp::TCP_ApplicationAnalyzer("POP3", conn) {
     masterState = detail::POP3_START;
@@ -78,7 +78,7 @@ void POP3_Analyzer::DeliverStream(int len, const u_char* data, bool orig) {
 }
 
 static std::string trim_whitespace(const char* in) {
-    int n = strlen(in);
+    size_t n = strlen(in);
     char* out = new char[n + 1];
     char* out_p = out;
 
@@ -673,6 +673,7 @@ void POP3_Analyzer::ProcessReply(int length, const char* line) {
                         masterState = detail::POP3_UPDATE;
 
                     break;
+                default: util::unreachable();
             }
 
             POP3Event(pop3_reply, false, cmd, message);
@@ -727,6 +728,7 @@ void POP3_Analyzer::ProcessReply(int length, const char* line) {
                          masterState == detail::POP3_START )
                         masterState = detail::POP3_FINISHED;
                     break;
+                default: util::unreachable();
             }
 
             POP3Event(pop3_reply, false, cmd, message);
@@ -809,7 +811,7 @@ std::vector<std::string> POP3_Analyzer::TokenizeLine(const std::string& input, c
         return tokens;
     }
 
-    if ( (splitPos = input.find(split, 0)) < input.size() ) {
+    if ( splitPos = input.find(split, 0); splitPos < input.size() ) {
         token = input.substr(start, splitPos);
         if ( token.size() > 0 && token[0] != split )
             tokens.push_back(token);
@@ -821,7 +823,7 @@ std::vector<std::string> POP3_Analyzer::TokenizeLine(const std::string& input, c
     return tokens;
 }
 
-void POP3_Analyzer::POP3Event(EventHandlerPtr event, bool is_orig, const char* arg1, const char* arg2) {
+void POP3_Analyzer::POP3Event(const EventHandlerPtr& event, bool is_orig, const char* arg1, const char* arg2) {
     if ( ! event )
         return;
 

--- a/src/analyzer/protocol/pop3/POP3.h
+++ b/src/analyzer/protocol/pop3/POP3.h
@@ -102,7 +102,7 @@ protected:
     std::vector<std::string> TokenizeLine(const std::string& input, char split);
     int ParseCmd(std::string cmd);
     void AuthSuccessful();
-    void POP3Event(EventHandlerPtr event, bool is_orig, const char* arg1 = nullptr, const char* arg2 = nullptr);
+    void POP3Event(const EventHandlerPtr& event, bool is_orig, const char* arg1 = nullptr, const char* arg2 = nullptr);
 
     analyzer::mime::MIME_Mail* mail;
     std::list<std::string> cmds;

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -655,7 +655,7 @@ bool Manager::PublishEvent(string topic, std::string name, broker::vector args, 
     if ( peer_count == 0 )
         return true;
 
-    broker::zeek::Event ev(std::move(name), std::move(args), broker::to_timestamp(ts));
+    broker::zeek::Event ev(name, args, broker::to_timestamp(ts));
     DBG_LOG(DBG_BROKER, "Publishing event: %s", RenderEvent(topic, name, ev.args()).c_str());
     bstate->endpoint.publish(std::move(topic), ev.move_data());
     num_events_outgoing_metric->Inc();

--- a/src/cluster/BifSupport.cc
+++ b/src/cluster/BifSupport.cc
@@ -95,7 +95,7 @@ zeek::ValPtr publish_event(const zeek::ValPtr& topic, zeek::ArgsSpan args) {
         return zeek::val_mgr->False();
     }
 
-    const auto topic_str = topic->AsStringVal()->ToStdString();
+    auto topic_str = topic->AsStringVal()->ToStdString();
 
     auto timestamp = zeek::event_mgr.CurrentEventTime();
 
@@ -126,7 +126,7 @@ zeek::ValPtr publish_event(const zeek::ValPtr& topic, zeek::ArgsSpan args) {
                 return zeek::val_mgr->False();
             }
 
-            return zeek::val_mgr->Bool(zeek::broker_mgr->PublishEvent(topic_str, args[0]->AsRecordVal()));
+            return zeek::val_mgr->Bool(zeek::broker_mgr->PublishEvent(std::move(topic_str), args[0]->AsRecordVal()));
         }
         else {
             zeek::emit_builtin_error(zeek::util::fmt("Publish of unknown record type '%s'",

--- a/src/cluster/websocket/WebSocket-IXWebSocket.cc
+++ b/src/cluster/websocket/WebSocket-IXWebSocket.cc
@@ -124,8 +124,9 @@ std::unique_ptr<WebSocketServer> StartServer(std::unique_ptr<WebSocketEventDispa
 
         // These callbacks run in per client threads. The actual processing happens
         // on the main thread via a single WebSocketDemux instance.
-        ix::OnMessageCallback message_callback = [dispatcher, id, remotePort, remoteIp,
-                                                  ixws](const ix::WebSocketMessagePtr& msg) mutable {
+        ix::OnMessageCallback message_callback = [dispatcher, id = std::move(id), remotePort,
+                                                  remoteIp = std::move(remoteIp),
+                                                  ixws = std::move(ixws)](const ix::WebSocketMessagePtr& msg) mutable {
             if ( msg->type == ix::WebSocketMessageType::Open ) {
                 dispatcher->QueueForProcessing(
                     WebSocketOpen{id, msg->openInfo.uri, msg->openInfo.protocol, std::move(ixws)});

--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -287,7 +287,7 @@ bool Manager::ActivateDynamicPluginInternal(const std::string& name, bool ok_if_
 
     if ( util::is_file(init) ) {
         DBG_LOG(DBG_PLUGINS, "  Loading %s", init.c_str());
-        scripts_to_load.push_back(init);
+        scripts_to_load.push_back(std::move(init));
     }
 
     // Load {bif,scripts}/__load__.zeek automatically.
@@ -295,14 +295,14 @@ bool Manager::ActivateDynamicPluginInternal(const std::string& name, bool ok_if_
 
     if ( util::is_file(init) ) {
         DBG_LOG(DBG_PLUGINS, "  Loading %s", init.c_str());
-        scripts_to_load.push_back(init);
+        scripts_to_load.push_back(std::move(init));
     }
 
     init = dir + "scripts/__load__.zeek";
 
     if ( util::is_file(init) ) {
         DBG_LOG(DBG_PLUGINS, "  Loading %s", init.c_str());
-        scripts_to_load.push_back(init);
+        scripts_to_load.push_back(std::move(init));
     }
 
     // Mark this plugin as activated by clearing the path.
@@ -426,7 +426,7 @@ void Manager::ExtendZeekPathForPlugins() {
                 continue;
 
             DBG_LOG(DBG_PLUGINS, "  Adding %s to ZEEKPATH", script_dir.c_str());
-            path_additions.push_back(script_dir);
+            path_additions.push_back(std::move(script_dir));
         } catch ( const std::regex_error& e ) {
             // This really shouldn't ever happen, but we do need to catch the exception.
             // Report a fatal error because something is wrong if this occurs.

--- a/src/probabilistic/CardinalityCounter.cc
+++ b/src/probabilistic/CardinalityCounter.cc
@@ -134,6 +134,10 @@ void CardinalityCounter::AddElement(uint64_t hash) {
  **/
 double CardinalityCounter::Size() const {
     double answer = 0;
+
+    if ( m == 0 )
+        return -1.0;
+
     for ( unsigned int i = 0; i < m; i++ )
         answer += pow(2, -((int)buckets[i]));
 

--- a/src/probabilistic/CardinalityCounter.h
+++ b/src/probabilistic/CardinalityCounter.h
@@ -75,7 +75,8 @@ public:
      * Get the current estimated number of elements in the data
      * structure
      *
-     * @return Estimated number of elements
+     * @return Estimated number of elements. Returns -1.0 if there are
+     * zero buckets.
      **/
     double Size() const;
 

--- a/src/script_opt/CPP/DeclFunc.cc
+++ b/src/script_opt/CPP/DeclFunc.cc
@@ -128,7 +128,7 @@ void CPPCompile::DeclareSubclass(const FuncTypePtr& ft, const ProfileFunc* pf, c
 
     if ( lambda_ids ) {
         for ( auto& id : *lambda_ids ) {
-            auto name = lambda_names[id];
+            const auto& name = lambda_names[id];
             auto tn = FullTypeName(id->GetType());
             addl_args = addl_args + ", " + tn + " _" + name;
 
@@ -202,7 +202,7 @@ void CPPCompile::BuildLambda(const FuncTypePtr& ft, const ProfileFunc* pf, const
                              const LambdaExpr* l, const IDPList* lambda_ids) {
     // Declare the member variables for holding the captures.
     for ( auto& id : *lambda_ids ) {
-        auto name = lambda_names[id];
+        const auto& name = lambda_names[id];
         auto tn = FullTypeName(id->GetType());
         Emit("%s %s;", tn, name);
     }

--- a/src/script_opt/CPP/DeclFunc.cc
+++ b/src/script_opt/CPP/DeclFunc.cc
@@ -130,9 +130,16 @@ void CPPCompile::DeclareSubclass(const FuncTypePtr& ft, const ProfileFunc* pf, c
         for ( auto& id : *lambda_ids ) {
             const auto& name = lambda_names[id];
             auto tn = FullTypeName(id->GetType());
-            addl_args = addl_args + ", " + tn + " _" + name;
+            addl_args += ", ";
+            addl_args += tn;
+            addl_args += " _";
+            addl_args += name;
 
-            inits = inits + ", " + name + "(std::move(_" + name + "))";
+            inits += ", ";
+            inits += name;
+            inits += "(std::move(_";
+            inits += name;
+            inits += "))";
         }
     }
 

--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -1053,13 +1053,13 @@ string CPPCompile::GenDirectAssign(const ExprPtr& lhs, const string& rhs_native,
     if ( n->IsBlank() )
         return rhs_native;
 
-    auto name = IDNameStr(n);
+    const auto& name = IDNameStr(n);
 
     string gen;
 
     if ( n->IsGlobal() ) {
         const auto& t = n->GetType();
-        auto gn = globals[n->Name()];
+        const auto& gn = globals[n->Name()];
 
         if ( t->Tag() == TYPE_FUNC && t->AsFuncType()->Flavor() == FUNC_FLAVOR_EVENT ) {
             gen = string("set_event__CPP(") + gn + ", " + rhs_val_ptr + ", " + gn + "_ev)";

--- a/src/script_opt/CPP/Stmts.cc
+++ b/src/script_opt/CPP/Stmts.cc
@@ -320,7 +320,7 @@ void CPPCompile::GenWhenStmt(const WhenInfo* wi, const std::string& when_lambda,
                              vector<string> local_aggrs) {
     auto is_return = wi->IsReturn() ? "true" : "false";
     auto timeout = wi->TimeoutExpr();
-    auto timeout_val = timeout ? GenExpr(timeout, GEN_NATIVE) : "-1.0";
+    const auto& timeout_val = timeout ? GenExpr(timeout, GEN_NATIVE) : "-1.0";
 
     Emit("{ // begin a new scope for internal variables");
 

--- a/src/script_opt/CPP/Vars.cc
+++ b/src/script_opt/CPP/Vars.cc
@@ -35,7 +35,7 @@ void CPPCompile::CreateGlobal(const ID* g) {
 
         auto gi = GenerateGlobalInit(g);
         global_id_info->AddInstance(gi);
-        global_gis[g] = gi;
+        global_gis[g] = std::move(gi);
     }
 
     if ( is_bif )

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -519,7 +519,7 @@ static void analyze_scripts_for_ZAM(std::shared_ptr<ProfileFuncs> pfs) {
             if ( g->GetType()->Tag() != TYPE_FUNC )
                 continue;
 
-            auto v = g->GetVal();
+            const auto& v = g->GetVal();
             if ( v )
                 func_used_indirectly.insert(v->AsFunc());
         }

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -471,7 +471,7 @@ static void generate_CPP(std::shared_ptr<ProfileFuncs> pfs) {
     const bool standalone = analysis_options.gen_standalone_CPP;
     const bool report = analysis_options.report_uncompilable;
 
-    CPPCompile cpp(funcs, pfs, gen_name, standalone, report);
+    CPPCompile cpp(funcs, std::move(pfs), gen_name, standalone, report);
 }
 
 static void analyze_scripts_for_ZAM(std::shared_ptr<ProfileFuncs> pfs) {
@@ -655,7 +655,7 @@ void analyze_scripts(bool no_unused_warnings) {
             reporter->FatalError("-O ZAM and -O gen-C++ conflict");
 
         auto pfs = std::make_shared<ProfileFuncs>(funcs, is_CPP_compilable, true, false);
-        generate_CPP(pfs);
+        generate_CPP(std::move(pfs));
         exit(0);
     }
 

--- a/src/script_opt/ZAM/AM-Opt.cc
+++ b/src/script_opt/ZAM/AM-Opt.cc
@@ -722,7 +722,7 @@ void ZAMCompiler::ReMapVar(const ID* id, int slot, zeek_uint_t inst) {
 
         FrameSharingInfo info;
         info.is_managed = is_managed;
-        shared_frame_denizens.push_back(info);
+        shared_frame_denizens.push_back(std::move(info));
 
         if ( is_managed )
             managed_slotsI.push_back(apt_slot);

--- a/src/script_opt/ZAM/Driver.cc
+++ b/src/script_opt/ZAM/Driver.cc
@@ -329,7 +329,7 @@ void ZAMCompiler::CreateSharedFrameDenizens() {
         // execution.
         info.is_managed = false;
 
-        shared_frame_denizens_final.push_back(info);
+        shared_frame_denizens_final.push_back(std::move(info));
     }
 }
 

--- a/src/script_opt/ZAM/Stmt.cc
+++ b/src/script_opt/ZAM/Stmt.cc
@@ -941,8 +941,8 @@ const ZAMStmt ZAMCompiler::CompileReturn(const ReturnStmt* r) {
 const ZAMStmt ZAMCompiler::CompileCatchReturn(const CatchReturnStmt* cr) {
     retvars.push_back(cr->RetVar());
 
-    auto hold_func = ZAM::curr_func;
-    auto hold_loc = ZAM::curr_loc;
+    const auto& hold_func = ZAM::curr_func;
+    const auto& hold_loc = ZAM::curr_loc;
 
     ZAM::curr_func = cr->Func()->GetName();
 

--- a/src/script_opt/ZAM/Stmt.cc
+++ b/src/script_opt/ZAM/Stmt.cc
@@ -542,24 +542,24 @@ const ZAMStmt ZAMCompiler::GenSwitch(const SwitchStmt* sw, int slot, InternalTyp
     switch ( it ) {
         case TYPE_INTERNAL_INT:
             tbl = int_casesI.size();
-            int_casesI.push_back(new_int_cases);
+            int_casesI.push_back(std::move(new_int_cases));
             break;
 
         case TYPE_INTERNAL_UNSIGNED:
             tbl = uint_casesI.size();
-            uint_casesI.push_back(new_uint_cases);
+            uint_casesI.push_back(std::move(new_uint_cases));
             break;
 
         case TYPE_INTERNAL_DOUBLE:
             tbl = double_casesI.size();
-            double_casesI.push_back(new_double_cases);
+            double_casesI.push_back(std::move(new_double_cases));
             break;
 
         case TYPE_INTERNAL_STRING:
         case TYPE_INTERNAL_ADDR:
         case TYPE_INTERNAL_SUBNET:
             tbl = str_casesI.size();
-            str_casesI.push_back(new_str_cases);
+            str_casesI.push_back(std::move(new_str_cases));
             break;
 
         default: reporter->InternalError("bad switch type");

--- a/src/telemetry/Opaques.h
+++ b/src/telemetry/Opaques.h
@@ -31,7 +31,7 @@ class TelemetryValImpl : public TelemetryVal {
 public:
     using HandleType = std::shared_ptr<Handle>;
 
-    explicit TelemetryValImpl(HandleType hdl) : TelemetryVal(hdl), hdl(hdl) {}
+    explicit TelemetryValImpl(HandleType hdl) : TelemetryVal(hdl), hdl(std::move(hdl)) {}
 
     HandleType GetHandle() const noexcept { return hdl; }
 

--- a/src/util.h
+++ b/src/util.h
@@ -599,11 +599,11 @@ template<typename T>
 std::vector<T> split(T s, const T& delim) {
     // If there's no delimiter, return a copy of the existing string.
     if ( delim.empty() )
-        return {T(s)};
+        return {std::move(s)};
 
     // If the delimiter won't fit in the string, just return a copy as well.
     if ( s.size() < delim.size() )
-        return {T(s)};
+        return {std::move(s)};
 
     std::vector<T> l;
 

--- a/src/util.h
+++ b/src/util.h
@@ -661,5 +661,20 @@ inline std::vector<std::wstring_view> split(const wchar_t* s, const wchar_t* del
     return split(std::wstring_view(s), std::wstring_view(delim));
 }
 
+/**
+ * Implementation of std::unreachable. Once C++23 is supported this can be replaced with
+ * an alias. This implementation is taken from cppreference.
+ */
+[[noreturn]] inline void unreachable() {
+    // Uses compiler specific extensions if possible.  Even if no extension is used,
+    // undefined behavior is still raised by an empty function body and the noreturn
+    // attribute.
+#if defined(_MSC_VER) && ! defined(__clang__) // MSVC
+    __assume(false);
+#else // GCC, Clang
+    __builtin_unreachable();
+#endif
+}
+
 } // namespace util
 } // namespace zeek


### PR DESCRIPTION
A Friday-afternoon spree of Coverity fixing:

- Lots of `std::move` additions, a couple of removals where they weren't doing anything, and one where Coverity actually flagged a use of an object after it was moved.
- A couple of potential memory leaks in the debug code. That code probably isn't used much, but Coverity flagged them anyways.
- A few minor fixes in the POP3 analyzer that clangd/flycheck in emacs were complaining about.
- Added an assert to avoid a divide-by-zero in `CardinalityCounter`
- Avoided some copies by using const-auto references. These were reported by Coverity.
- Avoided additional temporary strings with some concatenation in script_opt
- Disabled executing up any of the telemetry listener code if the ZEEKCTL_CHECK_CONFIG environment variable is set. Previously we still would create the callback object and just not start up the listener, but this lead to leaking the callback object. There's no reason to allocate it though if we're not going to use it.