### PR TITLE
Revert addition of std::unreachable

### DIFF
--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -673,7 +673,7 @@ void POP3_Analyzer::ProcessReply(int length, const char* line) {
                         masterState = detail::POP3_UPDATE;
 
                     break;
-                default: util::unreachable();
+                default: break;
             }
 
             POP3Event(pop3_reply, false, cmd, message);
@@ -728,7 +728,7 @@ void POP3_Analyzer::ProcessReply(int length, const char* line) {
                          masterState == detail::POP3_START )
                         masterState = detail::POP3_FINISHED;
                     break;
-                default: util::unreachable();
+                default: break;
             }
 
             POP3Event(pop3_reply, false, cmd, message);

--- a/src/util.h
+++ b/src/util.h
@@ -661,20 +661,5 @@ inline std::vector<std::wstring_view> split(const wchar_t* s, const wchar_t* del
     return split(std::wstring_view(s), std::wstring_view(delim));
 }
 
-/**
- * Implementation of std::unreachable. Once C++23 is supported this can be replaced with
- * an alias. This implementation is taken from cppreference.
- */
-[[noreturn]] inline void unreachable() {
-    // Uses compiler specific extensions if possible.  Even if no extension is used,
-    // undefined behavior is still raised by an empty function body and the noreturn
-    // attribute.
-#if defined(_MSC_VER) && ! defined(__clang__) // MSVC
-    __assume(false);
-#else // GCC, Clang
-    __builtin_unreachable();
-#endif
-}
-
 } // namespace util
 } // namespace zeek


### PR DESCRIPTION
After further testing with the fuzzer corpus, std::unreachable isn't necessary here. It's fine to just let the default case break to fix the Coverity warning.