### PR TITLE
Switch libkrb5 check to exclude only Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1060,7 +1060,7 @@ if (LIBMMDB_FOUND)
 endif ()
 
 set(USE_KRB5 false)
-if (${CMAKE_SYSTEM_NAME} MATCHES Linux)
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     find_package(LibKrb5)
     if (LIBKRB5_FOUND)
         set(USE_KRB5 true)

--- a/ci/freebsd/prepare.sh
+++ b/ci/freebsd/prepare.sh
@@ -6,7 +6,7 @@ set -e
 set -x
 
 env ASSUME_ALWAYS_YES=YES pkg bootstrap
-pkg install -y bash cppzmq git cmake swig bison python3 base64 flex ccache jq dnsmasq
+pkg install -y bash cppzmq git cmake swig bison python3 base64 flex ccache jq dnsmasq krb5
 pkg upgrade -y curl
 pyver=$(python3 -c 'import sys; print(f"py{sys.version_info[0]}{sys.version_info[1]}")')
 pkg install -y $pyver-sqlite3


### PR DESCRIPTION
https://github.com/zeek/zeek/pull/131 disabled krb5 on everything except Linux back in 2018. We must have fixed whatever was wrong with it on FreeBSD because it builds and tests fine on that platform now. This PR switches the check to disable it on Darwin since that platform is still failing for the same reasons listed in that old PR. I opened https://github.com/zeek/zeek/issues/4360 to capture what's wrong with enabling Darwin too.

Thanks to Slack user Carlos Lopez for pointing on out that CMake was failing to find it on FreeBSD 14.