### PR TITLE
Clear sessions when session manager is done

### DIFF
--- a/src/RunState.cc
+++ b/src/RunState.cc
@@ -385,7 +385,7 @@ void finish_run(int drain_events) {
         event_mgr.Drain();
 
         if ( session_mgr )
-            session_mgr->Done();
+            session_mgr->Clear();
     }
 
 #ifdef DEBUG

--- a/src/RunState.cc
+++ b/src/RunState.cc
@@ -106,7 +106,7 @@ RETSIGTYPE watchdog(int /* signo */) {
             }
 
             get_final_stats();
-            finish_run(0);
+            util::detail::set_processing_status("TERMINATING", "watchdog");
 
             reporter->FatalErrorWithCore("**watchdog timer expired, t = %d.%06d, start = %d.%06d, dispatched = %d",
                                          int_ct, frac_ct, int_pst, frac_pst, current_dispatched);
@@ -340,9 +340,7 @@ void run_loop() {
         }
     }
 
-    // Get the final statistics now, and not when finish_run() is
-    // called, since that might happen quite a bit in the future
-    // due to expiring pending timers, and we don't want to ding
+    // Get the final statistics now, as we don't want to ding
     // for any packets dropped beyond this point.
     get_final_stats();
 }
@@ -373,29 +371,6 @@ void get_final_stats() {
                        s.received, ps->Path().c_str(), s.dropped, dropped_pct, not_processed, unprocessed_pct,
                        filtered.c_str());
     }
-}
-
-void finish_run(int drain_events) {
-    util::detail::set_processing_status("TERMINATING", "finish_run");
-
-    if ( drain_events ) {
-        if ( session_mgr )
-            session_mgr->Drain();
-
-        event_mgr.Drain();
-
-        if ( session_mgr )
-            session_mgr->Clear();
-    }
-
-#ifdef DEBUG
-    extern int reassem_seen_bytes, reassem_copied_bytes;
-    // DEBUG_MSG("Reassembly (TCP and IP/Frag): %d bytes seen, %d bytes copied\n",
-    // 	reassem_seen_bytes, reassem_copied_bytes);
-
-    extern int num_packets_held, num_packets_cleaned;
-    // DEBUG_MSG("packets clean up: %d/%d\n", num_packets_cleaned, num_packets_held);
-#endif
 }
 
 void delete_run() {

--- a/src/RunState.h
+++ b/src/RunState.h
@@ -26,7 +26,6 @@ extern void init_run(const std::optional<std::string>& interfaces, const std::op
                      const std::optional<std::string>& pcap_output_file, bool do_watchdog);
 extern void run_loop();
 extern void get_final_stats();
-extern void finish_run(int drain_events);
 extern void delete_run(); // Reclaim all memory, etc.
 extern void update_network_time(double new_network_time);
 extern void dispatch_packet(zeek::Packet* pkt, zeek::iosource::PktSrc* pkt_src);

--- a/src/fuzzers/fuzzer-setup.h
+++ b/src/fuzzers/fuzzer-setup.h
@@ -88,7 +88,7 @@ void fuzzer_cleanup_one_input() {
     zeek::event_mgr.Drain();
     zeek::session_mgr->Drain();
     zeek::event_mgr.Drain();
-    zeek::session_mgr->Clear();
+    zeek::session_mgr->Done();
     run_state::terminating = false;
 }
 

--- a/src/fuzzers/fuzzer-setup.h
+++ b/src/fuzzers/fuzzer-setup.h
@@ -88,7 +88,7 @@ void fuzzer_cleanup_one_input() {
     zeek::event_mgr.Drain();
     zeek::session_mgr->Drain();
     zeek::event_mgr.Drain();
-    zeek::session_mgr->Done();
+    zeek::session_mgr->Clear();
     run_state::terminating = false;
 }
 

--- a/src/session/Manager.cc
+++ b/src/session/Manager.cc
@@ -82,9 +82,10 @@ Manager::Manager() {
     });
 }
 
-Manager::~Manager() { delete stats; }
-
-void Manager::Done() { Clear(); }
+Manager::~Manager() {
+    Clear();
+    delete stats;
+}
 
 Connection* Manager::FindConnection(Val* v) {
     zeek::detail::ConnKey conn_key(v);

--- a/src/session/Manager.cc
+++ b/src/session/Manager.cc
@@ -82,12 +82,9 @@ Manager::Manager() {
     });
 }
 
-Manager::~Manager() {
-    Clear();
-    delete stats;
-}
+Manager::~Manager() { delete stats; }
 
-void Manager::Done() {}
+void Manager::Done() { Clear(); }
 
 Connection* Manager::FindConnection(Val* v) {
     zeek::detail::ConnKey conn_key(v);

--- a/src/session/Manager.h
+++ b/src/session/Manager.h
@@ -59,7 +59,8 @@ public:
     Manager();
     ~Manager();
 
-    void Done(); // call to drain events before destructing
+    [[deprecated("Remove in v8.1 - no functionality. Use Drain() and Clear().")]]
+    void Done() {};
 
     // Looks up the connection referred to by the given Val,
     // which should be a conn_id record.  Returns nil if there's

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -322,7 +322,9 @@ static void done_with_network() {
     event_mgr.Drain();
     event_mgr.Drain();
 
-    run_state::detail::finish_run(1);
+    session_mgr->Drain();
+    event_mgr.Drain();
+    session_mgr->Clear();
 
 #ifdef USE_PERFTOOLS_DEBUG
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -391,7 +391,6 @@ static void terminate_zeek() {
 
     event_mgr.Drain();
 
-    session_mgr->Clear();
     plugin_mgr->FinishPlugins();
 
     finish_script_execution();


### PR DESCRIPTION
When manually shutting down Zeek from a plugin in a step by step fashion, I got confused because the session manager keeps sessions in its map beyond the point where the session manager is considered done. I haven't found a reason to keep sessions after this point. Am I missing something?

If not, this change hopefully simplifies the shutdown control flow a tiny bit.