### PR TITLE
Suppress warnings from compilation of external ixwebsocket dependency

### DIFF
--- a/src/cluster/websocket/auxil/CMakeLists.txt
+++ b/src/cluster/websocket/auxil/CMakeLists.txt
@@ -5,3 +5,7 @@ set(USE_TLS ON)
 set(USE_OPEN_SSL ON)
 
 add_subdirectory(IXWebSocket)
+
+# We are not interested in any warnings from `IXWebSocket`'s compilation
+# itself, suppress them.
+target_compile_options(ixwebsocket PRIVATE "-w")


### PR DESCRIPTION
Clang warns about declared but unused parameters somewhere in the guts of IXWebSocket (internal code, not its headers). We are not interested in this or similar warnings since we do not control this code, so suppress all warnings for this target.