### PR TITLE
Fix TSAN reports in ZeroMQ backend's DoTerminate()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -80,6 +80,12 @@ New Functionality
   Note that the new ``Cluster::listen_websocket()`` API will only become stable
   with Zeek 8.0.
 
+  Two new events, ``Cluster::websocket_client_added()`` and ``Cluster::websocket_client_lost()``,
+  have been added for WebSocket clients connecting and disconnecting. Note that
+  currently, even after ``Cluster::websocket_client_lost()`` ran, events sent from
+  that client may still be in transit and later executed, even on the node running
+  the WebSocket server.
+
 Changed Functionality
 ---------------------
 

--- a/src/cluster/Backend.cc
+++ b/src/cluster/Backend.cc
@@ -213,11 +213,6 @@ void ThreadedBackend::QueueForProcessing(QueueMessage&& qmessages) {
         onloop->QueueForProcessing(std::move(qmessages));
 }
 
-void ThreadedBackend::Process() {
-    if ( onloop )
-        onloop->Process();
-}
-
 void ThreadedBackend::Process(QueueMessage&& msg) {
     // sonarlint wants to use std::visit. not sure...
     if ( auto* emsg = std::get_if<EventMessage>(&msg) ) {

--- a/src/cluster/Backend.cc
+++ b/src/cluster/Backend.cc
@@ -203,6 +203,7 @@ bool ThreadedBackend::DoInit() {
 
 void ThreadedBackend::DoTerminate() {
     if ( onloop ) {
+        onloop->Process();
         onloop->Close();
         onloop = nullptr;
     }

--- a/src/cluster/Backend.h
+++ b/src/cluster/Backend.h
@@ -571,12 +571,6 @@ protected:
     void QueueForProcessing(QueueMessage&& messages);
 
     /**
-     * Delegate to onloop->Process() to trigger processing
-     * of outstanding queued messages explicitly, if any.
-     */
-    void Process();
-
-    /**
      * The default DoInit() implementation of ThreadedBackend
      * registers itself as a counting IO source to keep the IO
      * loop alive after initialization.

--- a/src/cluster/Backend.h
+++ b/src/cluster/Backend.h
@@ -564,7 +564,8 @@ protected:
     /**
      * To be used by implementations to enqueue messages for processing on the IO loop.
      *
-     * It's safe to call this method from any thread.
+     * It's safe to call this method from any thread before ThreadedBackend's
+     * DoTerminate() implementation is invoked.
      *
      * @param messages Messages to be enqueued.
      */
@@ -582,6 +583,17 @@ protected:
      */
     bool DoInit() override;
 
+    /**
+     * Common DoTerminate() functionality for threaded backends.
+     *
+     * The default DoTerminate() implementation of ThreadedBackend
+     * runs OnLoop's Process() once to drain any pending messages, then
+     * closes and unsets it.
+     *
+     * Classes deriving from ThreadedBackend need to ensure that all threads
+     * calling QeueuForProcessing() have terminated before invoking the
+     * ThreadedBackend's DoTerminate() implementation.
+     */
     void DoTerminate() override;
 
 private:

--- a/src/cluster/backend/zeromq/ZeroMQ.cc
+++ b/src/cluster/backend/zeromq/ZeroMQ.cc
@@ -116,8 +116,6 @@ void ZeroMQBackend::DoInitPostScript() {
 }
 
 void ZeroMQBackend::DoTerminate() {
-    ThreadedBackend::DoTerminate();
-
     // If self_thread is running, notify it to shutdown via the inproc
     // socket, then wait for it to terminate.
     if ( self_thread.joinable() && ! self_thread_shutdown_requested ) {
@@ -152,6 +150,8 @@ void ZeroMQBackend::DoTerminate() {
         proxy_thread.reset();
     }
 
+    // ThreadedBackend::DoTerminate() cleans up the onloop instance.
+    ThreadedBackend::DoTerminate();
     ZEROMQ_DEBUG("Terminated");
 }
 

--- a/testing/btest/cluster/websocket/bad-subscriptions.zeek
+++ b/testing/btest/cluster/websocket/bad-subscriptions.zeek
@@ -29,8 +29,6 @@
 @load ./zeromq-test-bootstrap
 redef exit_only_after_terminate = T;
 
-global event_count = 0;
-
 global ping: event(msg: string, c: count) &is_used;
 global pong: event(msg: string, c: count) &is_used;
 

--- a/testing/btest/cluster/websocket/no-subscriptions.zeek
+++ b/testing/btest/cluster/websocket/no-subscriptions.zeek
@@ -30,9 +30,6 @@
 @load ./zeromq-test-bootstrap
 redef exit_only_after_terminate = T;
 
-global expected_ping_count = 100;
-global ping_count = 0;
-
 event zeek_init()
 	{
 	Cluster::subscribe("/test/pings");


### PR DESCRIPTION
@timwoj reported seeing TSAN issues with current master: https://cirrus-ci.com/task/4914494461181952?logs=test#L2350

The cause was ZeroMQ's internal thread calling `QueueForProcessing()` and accessing `onloop` while the main thread would unset it. The main change in this PR is to call `ThreadedBackend::DoTerminate()` after ensuring the ZeroMQ internal thread has stopped.