### PR TITLE
`#include` Cleanup Part 1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ We would like to thank ... for their contributions to this release.
 Breaking Changes
 ----------------
 
+- The code base underwent a big cleanup of #include usage, across almost all of the
+  files. We tested builds of all of the existing third-party packages and only noticed one
+  or two failures, but there is a possibility for breakage related to this cleanup.
+
 New Functionality
 -----------------
 

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -8,7 +8,9 @@
 #include <map>
 #include <vector>
 
+#include "zeek/Dict.h"
 #include "zeek/Func.h"
+#include "zeek/Hash.h"
 #include "zeek/IPAddr.h"
 #include "zeek/RE.h"
 #include "zeek/Reporter.h"

--- a/src/DNS_Mapping.cc
+++ b/src/DNS_Mapping.cc
@@ -3,6 +3,7 @@
 #include "zeek/DNS_Mapping.h"
 
 #include <ares_nameser.h>
+#include <cinttypes>
 
 #include "zeek/DNS_Mgr.h"
 #include "zeek/Reporter.h"

--- a/src/DebugLogger.h
+++ b/src/DebugLogger.h
@@ -9,7 +9,7 @@
 
 #include "zeek/zeek-config.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <set>
 #include <string>
 

--- a/src/Dict.h
+++ b/src/Dict.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cinttypes>
 #include <cmath>
 #include <cstdint>
 #include <fstream>

--- a/src/EquivClass.h
+++ b/src/EquivClass.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace zeek::detail {
 

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -524,6 +524,8 @@ void ScriptFunc::CreateCaptures(std::unique_ptr<std::vector<ZVal>> cvec) {
     }
 }
 
+void ScriptFunc::SetCapturesVec(std::unique_ptr<std::vector<ZVal>> cv) { captures_vec = std::move(cv); }
+
 void ScriptFunc::SetCaptures(Frame* f) {
     const auto& captures = type->GetCaptures();
     ASSERT(captures);

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -30,6 +30,7 @@
 #include "zeek/RunState.h"
 #include "zeek/Scope.h"
 #include "zeek/ScriptProfile.h"
+#include "zeek/Stats.h"
 #include "zeek/Stmt.h"
 #include "zeek/Traverse.h"
 #include "zeek/Var.h"

--- a/src/Func.h
+++ b/src/Func.h
@@ -11,9 +11,16 @@
 
 #include "zeek/Obj.h"
 #include "zeek/Scope.h"
-#include "zeek/Stmt.h"
+#include "zeek/StmtBase.h"
+#include "zeek/StmtEnums.h"
 #include "zeek/TraverseTypes.h"
-#include "zeek/Type.h" /* for function_flavor */
+#include "zeek/Type.h" /* for FunctionFlavor */
+
+// This is needed in order to chain-include ZVal.h, which is what's
+// actually needed by Func.h. If you don't include Val.h along with
+// ZVal.h, Windows fails to build because of the forward declarations
+// in ZVal.h.
+#include "zeek/Val.h"
 #include "zeek/ZeekArgs.h"
 #include "zeek/ZeekList.h"
 
@@ -223,7 +230,7 @@ public:
      *
      * @param cv The value used for captures_vec.
      */
-    void SetCapturesVec(std::unique_ptr<std::vector<ZVal>> cv) { captures_vec = std::move(cv); }
+    void SetCapturesVec(std::unique_ptr<std::vector<ZVal>> cv);
 
     // Same definition as in Frame.h.
     using OffsetMap = std::unordered_map<std::string, int>;

--- a/src/Hash.cc
+++ b/src/Hash.cc
@@ -2,11 +2,10 @@
 
 #include "zeek/Hash.h"
 
-#include "zeek/zeek-config.h"
-
 #include <highwayhash/highwayhash_target.h>
 #include <highwayhash/instruction_sets.h>
 #include <highwayhash/sip_hash.h>
+#include <cinttypes>
 
 #include "zeek/DebugLogger.h"
 #include "zeek/Desc.h"

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -6,6 +6,7 @@
 
 #include "zeek/Attr.h"
 #include "zeek/Desc.h"
+#include "zeek/Dict.h"
 #include "zeek/EventRegistry.h"
 #include "zeek/Expr.h"
 #include "zeek/File.h"

--- a/src/IntrusivePtr.h
+++ b/src/IntrusivePtr.h
@@ -6,7 +6,7 @@
 #include <type_traits>
 #include <utility>
 
-#include "Obj.h"
+#include "zeek/Obj.h"
 
 namespace zeek {
 

--- a/src/List.h
+++ b/src/List.h
@@ -21,11 +21,10 @@
 //	Entries must be either a pointer to the data or nonzero data with
 //	sizeof(data) <= sizeof(void*).
 
-#include <stdarg.h>
 #include <cassert>
+#include <cstdarg>
 #include <initializer_list>
 #include <iterator>
-#include <utility>
 
 #include "zeek/util.h"
 

--- a/src/NetVar.h
+++ b/src/NetVar.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "zeek/EventRegistry.h"
-#include "zeek/Stats.h"
 #include "zeek/Val.h"
 
 namespace zeek::detail {

--- a/src/OpaqueVal.h
+++ b/src/OpaqueVal.h
@@ -15,9 +15,6 @@
 #include "zeek/RandTest.h"
 #include "zeek/Val.h"
 #include "zeek/digest.h"
-#include "zeek/telemetry/Counter.h"
-#include "zeek/telemetry/Gauge.h"
-#include "zeek/telemetry/Histogram.h"
 
 namespace broker {
 class data;

--- a/src/Reassem.cc
+++ b/src/Reassem.cc
@@ -5,6 +5,7 @@
 #include "zeek/zeek-config.h"
 
 #include <algorithm>
+#include <cinttypes>
 #include <limits>
 
 #include "zeek/Desc.h"

--- a/src/Reporter.h
+++ b/src/Reporter.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <stdarg.h>
+#include <cstdarg>
 #include <list>
 #include <map>
 #include <string>

--- a/src/ScriptCoverageManager.cc
+++ b/src/ScriptCoverageManager.cc
@@ -4,6 +4,7 @@
 
 #include <sys/stat.h>
 #include <algorithm>
+#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 #include <fstream>

--- a/src/SerializationFormat.cc
+++ b/src/SerializationFormat.cc
@@ -3,6 +3,7 @@
 #include "zeek/SerializationFormat.h"
 
 #include <cctype>
+#include <cinttypes>
 
 #include "zeek/DebugLogger.h"
 #include "zeek/IPAddr.h"

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -8,6 +8,7 @@
 
 #include "zeek/Conn.h"
 #include "zeek/DNS_Mgr.h"
+#include "zeek/Dict.h"
 #include "zeek/Event.h"
 #include "zeek/File.h"
 #include "zeek/Func.h"

--- a/src/Tag.cc
+++ b/src/Tag.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/Tag.h"
 
+#include <cinttypes>
+
 #include "zeek/Val.h"
 
 namespace zeek {

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -4,6 +4,7 @@
 
 #include "zeek/zeek-config.h"
 
+#include <cinttypes>
 #include <list>
 #include <map>
 #include <string>

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -2,11 +2,8 @@
 
 #include "zeek/analyzer/protocol/http/HTTP.h"
 
-#include "zeek/zeek-config.h"
-
 #include <algorithm>
 #include <cctype>
-#include <cmath>
 #include <cstdlib>
 #include <string>
 
@@ -346,9 +343,9 @@ void HTTP_Entity::SubmitHeader(analyzer::mime::MIME_Header* h) {
     else if ( analyzer::mime::istrequal(h->get_name(), "content-range") &&
               http_message->MyHTTP_Analyzer()->HTTP_ReplyCode() == 206 ) {
         data_chunk_t vt = h->get_value_token();
-        string byte_unit(vt.data, vt.length);
+        std::string byte_unit(vt.data, vt.length);
         vt = h->get_value_after_token();
-        string byte_range(vt.data, vt.length);
+        std::string byte_range(vt.data, vt.length);
         byte_range.erase(remove(byte_range.begin(), byte_range.end(), ' '), byte_range.end());
 
         if ( byte_unit != "bytes" ) {
@@ -357,22 +354,22 @@ void HTTP_Entity::SubmitHeader(analyzer::mime::MIME_Header* h) {
         }
 
         size_t p = byte_range.find('/');
-        if ( p == string::npos ) {
+        if ( p == std::string::npos ) {
             http_message->Weird("HTTP_content_range_cannot_parse");
             return;
         }
 
-        string byte_range_resp_spec = byte_range.substr(0, p);
-        string instance_length_str = byte_range.substr(p + 1);
+        std::string byte_range_resp_spec = byte_range.substr(0, p);
+        std::string instance_length_str = byte_range.substr(p + 1);
 
         p = byte_range_resp_spec.find('-');
-        if ( p == string::npos ) {
+        if ( p == std::string::npos ) {
             http_message->Weird("HTTP_content_range_cannot_parse");
             return;
         }
 
-        string first_byte_pos = byte_range_resp_spec.substr(0, p);
-        string last_byte_pos = byte_range_resp_spec.substr(p + 1);
+        std::string first_byte_pos = byte_range_resp_spec.substr(0, p);
+        std::string last_byte_pos = byte_range_resp_spec.substr(p + 1);
 
         if ( DEBUG_http )
             DEBUG_MSG("Parsed Content-Range: %s %s-%s/%s\n", byte_unit.c_str(), first_byte_pos.c_str(),

--- a/src/analyzer/protocol/http/HTTP.h
+++ b/src/analyzer/protocol/http/HTTP.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <queue>
+#include <string>
+
 #include "zeek/IPAddr.h"
 #include "zeek/analyzer/protocol/http/events.bif.h"
 #include "zeek/analyzer/protocol/mime/MIME.h"
@@ -9,7 +12,6 @@
 #include "zeek/analyzer/protocol/tcp/ContentLine.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 #include "zeek/analyzer/protocol/zip/ZIP.h"
-#include "zeek/binpac_zeek.h"
 
 namespace zeek::analyzer::http {
 
@@ -43,7 +45,7 @@ public:
     int64_t BodyLength() const { return body_length; }
     int64_t HeaderLength() const { return header_length; }
     void SkipBody() { deliver_body = 0; }
-    const string& FileID() const { return precomputed_file_id; }
+    const std::string& FileID() const { return precomputed_file_id; }
 
 protected:
     class UncompressedOutput;

--- a/src/analyzer/protocol/smb/smb1-com-nt-create-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-nt-create-andx.pac
@@ -1,3 +1,7 @@
+%extern{
+#include "zeek/Dict.h"
+%}
+
 refine connection SMB_Conn += {
 	function proc_smb1_nt_create_andx_request(header: SMB_Header, val: SMB1_nt_create_andx_request): bool
 		%{

--- a/src/analyzer/protocol/smb/smb2-com-create.pac
+++ b/src/analyzer/protocol/smb/smb2-com-create.pac
@@ -1,3 +1,7 @@
+%extern{
+#include "zeek/Dict.h"
+%}
+
 refine connection SMB_Conn += {
 
 	function proc_smb2_create_request(h: SMB2_Header, val: SMB2_create_request): bool

--- a/src/analyzer/protocol/tcp/TCP_Flags.h
+++ b/src/analyzer/protocol/tcp/TCP_Flags.h
@@ -2,15 +2,9 @@
 
 #pragma once
 
-// This needs to remain the first include in this file, or some defines aren't
-// set correctly when netinet/tcp.h is included and the CentOS 7 build breaks.
-// clang-format off
-#include "zeek/net_util.h"
-
 #include <netinet/tcp.h>
 #include <sys/types.h>
 #include <string>
-// clang-format on
 
 namespace zeek::analyzer::tcp {
 

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -7,6 +7,7 @@
 #include "zeek/File.h"
 #include "zeek/Reporter.h"
 #include "zeek/RuleMatcher.h"
+#include "zeek/Stats.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/Analyzer.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"

--- a/src/broker/Data.cc
+++ b/src/broker/Data.cc
@@ -5,6 +5,7 @@
 #include <broker/error.hh>
 
 #include "zeek/Desc.h"
+#include "zeek/Dict.h"
 #include "zeek/File.h"
 #include "zeek/Func.h"
 #include "zeek/ID.h"

--- a/src/cluster/Backend.h
+++ b/src/cluster/Backend.h
@@ -10,21 +10,15 @@
 #include <variant>
 
 #include "zeek/EventHandler.h"
-#include "zeek/IntrusivePtr.h"
 #include "zeek/Span.h"
 #include "zeek/Tag.h"
+#include "zeek/Val.h"
+#include "zeek/ZeekArgs.h"
+#include "zeek/cluster/BifSupport.h"
 #include "zeek/cluster/Serializer.h"
 #include "zeek/logging/Types.h"
 
 namespace zeek {
-
-class FuncVal;
-
-using FuncValPtr = IntrusivePtr<FuncVal>;
-
-class Val;
-using ValPtr = IntrusivePtr<Val>;
-using ArgsSpan = Span<const ValPtr>;
 
 namespace detail {
 template<class Proc, class Work>

--- a/src/digest.h
+++ b/src/digest.h
@@ -7,9 +7,10 @@
 #pragma once
 
 #include <sys/types.h> // for u_char
-#include <zeek/util.h>
 #include <cstdint>
 #include <cstdio>
+
+#include "zeek/util.h"
 
 // Required buffer size for an MD5 digest.
 #define ZEEK_MD5_DIGEST_LENGTH 16

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -7,6 +7,7 @@
 
 #include "zeek/CompHash.h"
 #include "zeek/Desc.h"
+#include "zeek/Dict.h"
 #include "zeek/Event.h"
 #include "zeek/EventHandler.h"
 #include "zeek/Expr.h"

--- a/src/iosource/Component.cc
+++ b/src/iosource/Component.cc
@@ -4,6 +4,7 @@
 
 #include "zeek/Desc.h"
 #include "zeek/Reporter.h"
+#include "zeek/Type.h"
 
 namespace zeek::iosource {
 

--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -10,7 +10,7 @@
 #include <pcap-int.h>
 #endif
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "zeek/Event.h"
 #include "zeek/iosource/BPF_Program.h"

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "zeek/Desc.h"
+#include "zeek/Dict.h"
 #include "zeek/Event.h"
 #include "zeek/EventHandler.h"
 #include "zeek/File.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include "zeek/RunState.h"
+#include "zeek/Stats.h"
 #include "zeek/iosource/Manager.h"
 #include "zeek/supervisor/Supervisor.h"
 #include "zeek/zeek-setup.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,6 +3,7 @@
 #include "zeek/zeek-config.h"
 
 #include <unistd.h>
+#include <cinttypes>
 
 #include "zeek/RunState.h"
 #include "zeek/Stats.h"

--- a/src/mmdb.bif
+++ b/src/mmdb.bif
@@ -1,5 +1,5 @@
 %%{
-#include <zeek/MMDB.h>
+#include "zeek/MMDB.h"
 %%}
 
 ## Initializes MMDB for later use of lookup_location.

--- a/src/net_util.h
+++ b/src/net_util.h
@@ -5,18 +5,9 @@
 #include "zeek/zeek-config.h"
 
 #include <cstdint>
-
-// Define first.
-enum TransportProto : uint8_t {
-    TRANSPORT_UNKNOWN,
-    TRANSPORT_TCP,
-    TRANSPORT_UDP,
-    TRANSPORT_ICMP,
-};
-
-extern const char* transport_proto_string(TransportProto proto);
-
-enum IPFamily { IPv4, IPv6 };
+#include <memory>
+#include <string>
+#include <utility>
 
 // Force these files to stay in this order. Normally, clang-format
 // wants to move sys/types.h to the end of this block, but that
@@ -35,8 +26,6 @@ enum IPFamily { IPv4, IPv6 };
 #include <netinet/ip_icmp.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
-
-#include "zeek/util.h"
 
 #ifdef HAVE_NETINET_IP6_H
 #include <netinet/ip6.h>
@@ -125,6 +114,18 @@ struct ip6_rthdr {
 #if ! defined(TCPOPT_TIMESTAMP) && defined(TCPOPT_TSTAMP)
 #define TCPOPT_TIMESTAMP TCPOPT_TSTAMP
 #endif
+
+// Define first.
+enum TransportProto : uint8_t {
+    TRANSPORT_UNKNOWN,
+    TRANSPORT_TCP,
+    TRANSPORT_UDP,
+    TRANSPORT_ICMP,
+};
+
+extern const char* transport_proto_string(TransportProto proto);
+
+enum IPFamily { IPv4, IPv6 };
 
 namespace zeek {
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -83,6 +83,7 @@
 
 %{
 #include <cassert>
+#include <cinttypes>
 #include <cstdlib>
 #include <cstring>
 #include <set>

--- a/src/plugin/Component.cc
+++ b/src/plugin/Component.cc
@@ -4,6 +4,8 @@
 
 #include "zeek/Desc.h"
 #include "zeek/Reporter.h"
+#include "zeek/Type.h"
+#include "zeek/Val.h"
 
 namespace zeek::plugin {
 
@@ -15,6 +17,8 @@ Component::Component(component::Type arg_type, const std::string& arg_name, Tag:
     canon_name = util::canonify_name(name);
     canon_name_val = make_intrusive<StringVal>(canon_name);
 }
+
+Component::~Component() {}
 
 void Component::Describe(ODesc* d) const {
     d->Add("    ");
@@ -95,4 +99,7 @@ void Component::SetEnabled(bool arg_enabled) {
             break;
     }
 }
+
+StringValPtr Component::CanonicalNameVal() const { return canon_name_val; }
+
 } // namespace zeek::plugin

--- a/src/plugin/Component.h
+++ b/src/plugin/Component.h
@@ -2,17 +2,20 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <string>
 
+#include "zeek/IntrusivePtr.h"
 #include "zeek/Tag.h"
-#include "zeek/Type.h"
-#include "zeek/Val.h"
 
 namespace zeek {
 
 class ODesc;
+class EnumType;
+using EnumTypePtr = IntrusivePtr<EnumType>;
+class EnumVal;
+using EnumValPtr = IntrusivePtr<EnumVal>;
+class StringVal;
+using StringValPtr = IntrusivePtr<StringVal>;
 
 namespace plugin {
 namespace component {
@@ -69,7 +72,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~Component() = default;
+    virtual ~Component();
 
     // Disable.
     Component(const Component& other) = delete;
@@ -99,7 +102,7 @@ public:
      * ID.
      */
     const std::string& CanonicalName() const { return canon_name; }
-    StringValPtr CanonicalNameVal() const { return canon_name_val; }
+    StringValPtr CanonicalNameVal() const;
 
     /**
      * Returns a textual representation of the component. This goes into

--- a/src/probabilistic/BloomFilter.cc
+++ b/src/probabilistic/BloomFilter.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/probabilistic/BloomFilter.h"
 
+#include <cinttypes>
 #include <cmath>
 #include <limits>
 

--- a/src/probabilistic/CardinalityCounter.cc
+++ b/src/probabilistic/CardinalityCounter.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/probabilistic/CardinalityCounter.h"
 
+#include <cinttypes>
 #include <cmath>
 #include <cstdint>
 #include <utility>

--- a/src/re-scan.l
+++ b/src/re-scan.l
@@ -5,11 +5,11 @@
  */
 
 %top{
-// Include stdint.h at the start of the generated file. Typically
+// Include cstdint at the start of the generated file. Typically
 // MSVC will include this header later, after the definitions of
 // the integral type macros. MSVC then complains that about the
-// redefinition of the types. Including stdint.h early avoids this.
-#include <stdint.h>
+// redefinition of the types. Including cstdint early avoids this.
+#include <cstdint>
 }
 
 %{

--- a/src/rule-parse.y
+++ b/src/rule-parse.y
@@ -1,6 +1,6 @@
 %{
 #include "zeek/zeek-config.h"
-#include <stdio.h>
+#include <cstdio>
 #include <netinet/in.h>
 #include <vector>
 

--- a/src/rule-scan.l
+++ b/src/rule-scan.l
@@ -1,9 +1,9 @@
 %top{
-// Include stdint.h at the start of the generated file. Typically
+// Include cstdint at the start of the generated file. Typically
 // MSVC will include this header later, after the definitions of
 // the integral type macros. MSVC then complains that about the
-// redefinition of the types. Including stdint.h early avoids this.
-#include <stdint.h>
+// redefinition of the types. Including cstdint early avoids this.
+#include <cstdint>
 }
 
 %{

--- a/src/scan.l
+++ b/src/scan.l
@@ -1,9 +1,9 @@
 %top{
-// Include stdint.h at the start of the generated file. Typically
+// Include cstdint at the start of the generated file. Typically
 // MSVC will include this header later, after the definitions of
 // the integral type macros. MSVC then complains that about the
-// redefinition of the types. Including stdint.h early avoids this.
-#include <stdint.h>
+// redefinition of the types. Including cstdint early avoids this.
+#include <cstdint>
 }
 
 %{

--- a/src/script_opt/ObjMgr.h
+++ b/src/script_opt/ObjMgr.h
@@ -15,10 +15,10 @@
 
 #pragma once
 
-#include <zeek/Obj.h>
 #include <unordered_map>
 
 #include "zeek/IntrusivePtr.h"
+#include "zeek/Obj.h"
 
 namespace zeek::detail {
 

--- a/src/script_opt/ZAM/IterInfo.h
+++ b/src/script_opt/ZAM/IterInfo.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "zeek/Dict.h"
 #include "zeek/Val.h"
 #include "zeek/ZeekString.h"
 #include "zeek/script_opt/ZAM/ZInstAux.h"

--- a/src/script_opt/ZAM/ZBody.cc
+++ b/src/script_opt/ZAM/ZBody.cc
@@ -4,6 +4,7 @@
 
 #include "zeek/Conn.h"
 #include "zeek/Desc.h"
+#include "zeek/Dict.h"
 #include "zeek/EventHandler.h"
 #include "zeek/File.h"
 #include "zeek/Frame.h"

--- a/src/session/Manager.cc
+++ b/src/session/Manager.cc
@@ -15,6 +15,7 @@
 #include "zeek/Reporter.h"
 #include "zeek/RuleMatcher.h"
 #include "zeek/RunState.h"
+#include "zeek/Stats.h"
 #include "zeek/Timer.h"
 #include "zeek/TunnelEncapsulation.h"
 #include "zeek/packet_analysis/Manager.h"

--- a/src/session/Session.cc
+++ b/src/session/Session.cc
@@ -6,6 +6,7 @@
 #include "zeek/Event.h"
 #include "zeek/IP.h"
 #include "zeek/Reporter.h"
+#include "zeek/Stats.h"
 #include "zeek/Val.h"
 #include "zeek/analyzer/Analyzer.h"
 #include "zeek/session/Manager.h"

--- a/src/spicy/manager.cc
+++ b/src/spicy/manager.cc
@@ -24,10 +24,9 @@
 
 #include <hilti/autogen/config.h>
 
-#include <zeek/analyzer/Manager.h>
-#include <zeek/file_analysis/Manager.h>
-#include <zeek/packet_analysis/Manager.h>
-
+#include "zeek/analyzer/Manager.h"
+#include "zeek/file_analysis/Manager.h"
+#include "zeek/packet_analysis/Manager.h"
 #include "zeek/spicy/file-analyzer.h"
 #include "zeek/spicy/packet-analyzer.h"
 #include "zeek/spicy/protocol-analyzer.h"

--- a/src/storage/Component.h
+++ b/src/storage/Component.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <memory>
+
+#include "zeek/IntrusivePtr.h"
 #include "zeek/plugin/Component.h"
 
 namespace zeek::storage {

--- a/src/storage/Manager.cc
+++ b/src/storage/Manager.cc
@@ -7,6 +7,8 @@
 #include "zeek/RunState.h"
 #include "zeek/storage/ReturnCode.h"
 
+#include "const.bif.netvar_h"
+
 std::atomic_flag expire_running;
 
 namespace zeek::storage {

--- a/src/storage/backend/redis/Redis.cc
+++ b/src/storage/backend/redis/Redis.cc
@@ -3,6 +3,7 @@
 #include "zeek/storage/backend/redis/Redis.h"
 
 #include <algorithm>
+#include <cinttypes>
 
 #include "zeek/DebugLogger.h"
 #include "zeek/Func.h"

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -26,6 +26,7 @@ extern "C" {
 }
 
 #include "zeek/DebugLogger.h"
+#include "zeek/Dict.h"
 #include "zeek/Event.h"
 #include "zeek/EventHandler.h"
 #include "zeek/ID.h"

--- a/src/telemetry/Opaques.cc
+++ b/src/telemetry/Opaques.cc
@@ -2,6 +2,10 @@
 
 #include "Opaques.h"
 
+#include "zeek/telemetry/Counter.h"
+#include "zeek/telemetry/Gauge.h"
+#include "zeek/telemetry/Histogram.h"
+
 using namespace zeek;
 
 TelemetryVal::TelemetryVal(std::shared_ptr<telemetry::Counter>) : OpaqueVal(counter_metric_type) {}
@@ -22,3 +26,33 @@ IMPLEMENT_OPAQUE_VALUE(GaugeMetricVal)
 IMPLEMENT_OPAQUE_VALUE(GaugeMetricFamilyVal)
 IMPLEMENT_OPAQUE_VALUE(HistogramMetricVal)
 IMPLEMENT_OPAQUE_VALUE(HistogramMetricFamilyVal)
+
+template<>
+const char* CounterMetricVal::OpaqueName() const {
+    return telemetry::Counter::OpaqueName;
+}
+
+template<>
+const char* CounterMetricFamilyVal::OpaqueName() const {
+    return telemetry::CounterFamily::OpaqueName;
+}
+
+template<>
+const char* GaugeMetricVal::OpaqueName() const {
+    return telemetry::Gauge::OpaqueName;
+}
+
+template<>
+const char* GaugeMetricFamilyVal::OpaqueName() const {
+    return telemetry::GaugeFamily::OpaqueName;
+}
+
+template<>
+const char* HistogramMetricVal::OpaqueName() const {
+    return telemetry::Histogram::OpaqueName;
+}
+
+template<>
+const char* HistogramMetricFamilyVal::OpaqueName() const {
+    return telemetry::HistogramFamily::OpaqueName;
+}

--- a/src/telemetry/Opaques.h
+++ b/src/telemetry/Opaques.h
@@ -10,6 +10,17 @@
 
 namespace zeek {
 
+namespace telemetry {
+
+class Counter;
+class CounterFamily;
+class Gauge;
+class GaugeFamily;
+class Histogram;
+class HistogramFamily;
+
+} // namespace telemetry
+
 /**
  * Base class for metric handles. Handle types are not serializable.
  */
@@ -43,7 +54,7 @@ public:
 protected:
     ValPtr DoClone(CloneState*) override { return make_intrusive<TelemetryValImpl>(hdl); }
 
-    const char* OpaqueName() const override { return Handle::OpaqueName; }
+    const char* OpaqueName() const override;
 
 private:
     HandleType hdl;

--- a/src/telemetry/ProcessStats.cc
+++ b/src/telemetry/ProcessStats.cc
@@ -9,10 +9,10 @@
 #include <libproc.h>
 #include <mach/mach.h>
 #include <mach/task.h>
-#include <math.h>
-#include <stdlib.h>
 #include <sys/resource.h>
 #include <unistd.h>
+#include <cmath>
+#include <cstdlib>
 
 namespace zeek::telemetry::detail {
 

--- a/src/threading/BasicThread.cc
+++ b/src/threading/BasicThread.cc
@@ -5,6 +5,7 @@
 #include "zeek/zeek-config.h"
 
 #include <pthread.h>
+#include <cinttypes>
 #include <csignal>
 
 #include "zeek/threading/Manager.h"

--- a/src/util.h
+++ b/src/util.h
@@ -63,8 +63,6 @@
 extern HeapLeakChecker* heap_checker;
 #endif
 
-#include <stdint.h>
-
 extern "C" {
 #include "zeek/3rdparty/modp_numtoa.h"
 }

--- a/src/util.h
+++ b/src/util.h
@@ -16,7 +16,6 @@
 
 #include <libgen.h>
 #include <unistd.h>
-#include <cinttypes>
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -43,6 +43,7 @@
 #include "zeek/Scope.h"
 #include "zeek/ScriptCoverageManager.h"
 #include "zeek/Stats.h"
+#include "zeek/Stmt.h"
 #include "zeek/Timer.h"
 #include "zeek/Traverse.h"
 #include "zeek/Trigger.h"

--- a/src/zeekygen/Configuration.cc
+++ b/src/zeekygen/Configuration.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "zeek/Reporter.h"
+#include "zeek/Type.h"
 #include "zeek/zeekygen/utils.h"
 
 using namespace std;

--- a/src/zeekygen/Configuration.h
+++ b/src/zeekygen/Configuration.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <time.h> // for time_t
+#include <ctime> // for time_t
 #include <string>
 #include <vector>
 

--- a/src/zeekygen/IdentifierInfo.h
+++ b/src/zeekygen/IdentifierInfo.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <time.h> // for time_t
+#include <ctime> // for time_t
 #include <list>
 #include <map>
 #include <string>

--- a/src/zeekygen/PackageInfo.h
+++ b/src/zeekygen/PackageInfo.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <time.h> // for time_t
+#include <ctime> // for time_t
 #include <string>
 #include <vector>
 

--- a/src/zeekygen/ScriptInfo.h
+++ b/src/zeekygen/ScriptInfo.h
@@ -4,7 +4,7 @@
 
 #include "zeek/zeek-config.h"
 
-#include <time.h> // for time_t
+#include <ctime> // for time_t
 #include <list>
 #include <map>
 #include <set>

--- a/src/zeekygen/SpicyModuleInfo.h
+++ b/src/zeekygen/SpicyModuleInfo.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <time.h> // for time_t
+#include <ctime> // for time_t
 #include <list>
 #include <string>
 #include <vector>

--- a/src/zeekygen/utils.h
+++ b/src/zeekygen/utils.h
@@ -4,7 +4,7 @@
 
 #include "zeek/zeek-config.h"
 
-#include <time.h> // for time_t
+#include <ctime> // for time_t
 #include <optional>
 #include <string>
 

--- a/testing/btest/plugins/api-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/api-plugin/src/Plugin.cc
@@ -1,11 +1,12 @@
 
 #include "Plugin.h"
 
-#include <zeek/ID.h>
-#include <zeek/Reporter.h>
-#include <zeek/Type.h>
-#include <zeek/Val.h>
 #include <iostream>
+
+#include "zeek/ID.h"
+#include "zeek/Reporter.h"
+#include "zeek/Type.h"
+#include "zeek/Val.h"
 
 namespace btest::plugin::Demo_API {
 Plugin plugin;

--- a/testing/btest/plugins/api-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/api-plugin/src/Plugin.cc
@@ -1,6 +1,7 @@
 
 #include "Plugin.h"
 
+#include <cinttypes>
 #include <iostream>
 
 #include "zeek/ID.h"

--- a/testing/btest/plugins/api-plugin/src/Plugin.h
+++ b/testing/btest/plugins/api-plugin/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_API {
 

--- a/testing/btest/plugins/doctest-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/doctest-plugin/src/Plugin.cc
@@ -1,7 +1,7 @@
 
 #include "Plugin.h"
 
-#include <zeek/3rdparty/doctest.h>
+#include "zeek/3rdparty/doctest.h"
 
 namespace btest::plugin::Demo_Doctest {
 Plugin plugin;

--- a/testing/btest/plugins/doctest-plugin/src/Plugin.h
+++ b/testing/btest/plugins/doctest-plugin/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_Doctest {
 

--- a/testing/btest/plugins/file-plugin/src/Foo.cc
+++ b/testing/btest/plugins/file-plugin/src/Foo.cc
@@ -1,8 +1,9 @@
 #include "Foo.h"
 
-#include <zeek/file_analysis/File.h>
-#include <zeek/file_analysis/Manager.h>
 #include <algorithm>
+
+#include "zeek/file_analysis/File.h"
+#include "zeek/file_analysis/Manager.h"
 
 #include "events.bif.h"
 

--- a/testing/btest/plugins/file-plugin/src/Plugin.h
+++ b/testing/btest/plugins/file-plugin/src/Plugin.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_Foo {
 

--- a/testing/btest/plugins/func-hook-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/func-hook-plugin/src/Plugin.cc
@@ -1,12 +1,12 @@
 
 #include "Plugin.h"
 
-#include <zeek/Conn.h>
-#include <zeek/Desc.h>
-#include <zeek/Event.h>
-#include <zeek/Func.h>
-#include <zeek/Val.h>
-#include <zeek/threading/Formatter.h>
+#include "zeek/Conn.h"
+#include "zeek/Desc.h"
+#include "zeek/Event.h"
+#include "zeek/Func.h"
+#include "zeek/Val.h"
+#include "zeek/threading/Formatter.h"
 
 namespace btest::plugin::Demo_Hooks {
 Plugin plugin;

--- a/testing/btest/plugins/func-hook-plugin/src/Plugin.h
+++ b/testing/btest/plugins/func-hook-plugin/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_Hooks {
 

--- a/testing/btest/plugins/hooks-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/hooks-plugin/src/Plugin.cc
@@ -1,13 +1,14 @@
 #include "Plugin.h"
 
-#include <zeek/Conn.h>
-#include <zeek/Desc.h>
-#include <zeek/Event.h>
-#include <zeek/Func.h>
-#include <zeek/RunState.h>
-#include <zeek/threading/Formatter.h>
 #include <cstring>
 #include <set>
+
+#include "zeek/Conn.h"
+#include "zeek/Desc.h"
+#include "zeek/Event.h"
+#include "zeek/Func.h"
+#include "zeek/RunState.h"
+#include "zeek/threading/Formatter.h"
 
 namespace btest::plugin::Demo_Hooks {
 Plugin plugin;

--- a/testing/btest/plugins/hooks-plugin/src/Plugin.h
+++ b/testing/btest/plugins/hooks-plugin/src/Plugin.h
@@ -1,7 +1,9 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include <string>
+
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_Hooks {
 

--- a/testing/btest/plugins/init-hooks-plugin/src/Plugin.h
+++ b/testing/btest/plugins/init-hooks-plugin/src/Plugin.h
@@ -1,9 +1,10 @@
 #pragma once
-#include <zeek/plugin/Plugin.h>
+
 #include <cstdio>
 
-namespace btest::plugin::Demo_InitHooks {
+#include "zeek/plugin/Plugin.h"
 
+namespace btest::plugin::Demo_InitHooks {
 
 class Plugin : public zeek::plugin::Plugin {
 protected:

--- a/testing/btest/plugins/iosource-plugin/src/Plugin.h
+++ b/testing/btest/plugins/iosource-plugin/src/Plugin.h
@@ -1,11 +1,12 @@
 
 #pragma once
-#include <zeek/Flare.h>
-#include <zeek/plugin/Plugin.h>
 #include <string>
 #include <string_view>
 
+#include "zeek/Flare.h"
+#include "zeek/RunState.h"
 #include "zeek/iosource/Manager.h"
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_Iosource {
 

--- a/testing/btest/plugins/meta-hook-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/meta-hook-plugin/src/Plugin.cc
@@ -1,11 +1,12 @@
 
 #include "Plugin.h"
 
-#include <zeek/Desc.h>
-#include <zeek/Event.h>
-#include <zeek/Func.h>
-#include <zeek/threading/Formatter.h>
 #include <cstdlib>
+
+#include "zeek/Desc.h"
+#include "zeek/Event.h"
+#include "zeek/Func.h"
+#include "zeek/threading/Formatter.h"
 
 namespace btest::plugin::Demo_Meta_Hooks {
 Plugin plugin;

--- a/testing/btest/plugins/meta-hook-plugin/src/Plugin.h
+++ b/testing/btest/plugins/meta-hook-plugin/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_Meta_Hooks {
 

--- a/testing/btest/plugins/pktdumper-plugin/src/Plugin.h
+++ b/testing/btest/plugins/pktdumper-plugin/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_Foo {
 

--- a/testing/btest/plugins/pktsrc-plugin/src/Plugin.h
+++ b/testing/btest/plugins/pktsrc-plugin/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_Foo {
 

--- a/testing/btest/plugins/plugin-load-dependency/1/src/Plugin.h
+++ b/testing/btest/plugins/plugin-load-dependency/1/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Testing_Plugin1 {
 

--- a/testing/btest/plugins/plugin-load-dependency/2/src/Plugin.h
+++ b/testing/btest/plugins/plugin-load-dependency/2/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Testing_Plugin2 {
 

--- a/testing/btest/plugins/plugin-load-dependency/3/src/Plugin.h
+++ b/testing/btest/plugins/plugin-load-dependency/3/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Testing_Plugin3 {
 

--- a/testing/btest/plugins/plugin-load-file-extended/src/Plugin.h
+++ b/testing/btest/plugins/plugin-load-file-extended/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Testing_LoadFileExtended {
 

--- a/testing/btest/plugins/plugin-nopatchversion-plugin/src/Plugin.h
+++ b/testing/btest/plugins/plugin-nopatchversion-plugin/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Testing_NoPatchVersion {
 

--- a/testing/btest/plugins/plugin-withpatchversion-plugin/src/Plugin.h
+++ b/testing/btest/plugins/plugin-withpatchversion-plugin/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Testing_WithPatchVersion {
 

--- a/testing/btest/plugins/protocol-plugin/src/Plugin.h
+++ b/testing/btest/plugins/protocol-plugin/src/Plugin.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_Foo {
 

--- a/testing/btest/plugins/publish-event-hook-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/publish-event-hook-plugin/src/Plugin.cc
@@ -1,10 +1,11 @@
 
 #include "Plugin.h"
 
-#include <zeek/Desc.h>
-#include <zeek/cluster/Backend.h>
 #include <cstdio>
 #include <string>
+
+#include "zeek/Desc.h"
+#include "zeek/cluster/Backend.h"
 
 namespace btest::plugin::Demo_PublishEvent {
 Plugin plugin;

--- a/testing/btest/plugins/publish-event-hook-plugin/src/Plugin.h
+++ b/testing/btest/plugins/publish-event-hook-plugin/src/Plugin.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <zeek/plugin/Plugin.h>
 #include <string>
+
+#include "zeek/plugin/Plugin.h"
 
 namespace btest::plugin::Demo_PublishEvent {
 


### PR DESCRIPTION
This is the first of two PRs to clean up a ton of `#include` usage across the entire codebase. This one is a bunch of one-off fixes to various files and related changes to those fixes. The commits are best-reviewed individually since they're all separate changes.

I'm not entirely sure about https://github.com/zeek/zeek/commit/00a8fcfe07557803b0f89762709a9f59a258cc8b. The primary change is in `plugin/Component.h`, which technically has the possibility of breaking plugin builds.

This is splitting up https://github.com/zeek/zeek/pull/4340.