### PR TITLE
cluster/websocket: Stop and wait for reply thread during Terminate()

### DIFF
--- a/src/cluster/websocket/WebSocket.cc
+++ b/src/cluster/websocket/WebSocket.cc
@@ -249,6 +249,11 @@ void WebSocketEventDispatcher::Terminate() {
     clients.clear();
 
     onloop->Close();
+
+    // Wait for the reply_msg_thread to process any outstanding
+    // WebSocketReply messages before returning.
+    reply_msg_thread->SignalStop();
+    reply_msg_thread->WaitForStop();
 }
 
 void WebSocketEventDispatcher::QueueForProcessing(WebSocketEvent&& event) {

--- a/testing/btest/cluster/websocket/terminate-while-queuing.zeek
+++ b/testing/btest/cluster/websocket/terminate-while-queuing.zeek
@@ -89,7 +89,7 @@ def run(ws_url):
                     tc.send_json(wstest.build_event_v1("/test/pings/", "ping", [f"tc{idx}", i]))
                 except websockets.exceptions.ConnectionClosedOK as e:
                     print("connection closed ok")
-                    assert e.code == 1001  # Remote going away
+                    assert e.code == 1001, f"expected code 1001, got {e.code} - {e}"  # Remote going away
                     i -= 1
                     saw_closed_ok.add(idx)
 


### PR DESCRIPTION
The terminate-while-queueing test added for #4428 failed spuriously indicating that sometimes WebSocket clients receive code 1000 instead of 1001. This happens if the ixwebsocket server is shutdown before the reply thread had a chance to process queued close messages.

Fix by signaling and waiting for the dispatcher's reply thread to terminate before returning from Terminate().