### PR TITLE
Fix compilation error for GCC15 

### DIFF
--- a/src/cluster/websocket/WebSocket.h
+++ b/src/cluster/websocket/WebSocket.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <list>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Include cstdint header to support uint8_t/uint64_t in GCC 15+