### PR TITLE
Downgrade broker clone FatalError to an Error

### DIFF
--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -2092,8 +2092,10 @@ detail::StoreHandleVal* Manager::MakeClone(const string& name, double resync_int
     auto handle = new detail::StoreHandleVal{*result};
     Ref(handle);
 
-    if ( ! handle->proxy.valid() )
-        reporter->FatalError("Failed to create clone for data store %s", name.c_str());
+    if ( ! handle->proxy.valid() ) {
+        reporter->Error("Failed to create clone for data store %s", name.c_str());
+        return nullptr;
+    }
 
     data_stores.emplace(name, handle);
     if ( ! iosource_mgr->RegisterFd(handle->proxy.mailbox().descriptor(), this) )


### PR DESCRIPTION
This PR downgrades the change in https://github.com/zeek/zeek/pull/4226 from a `FatalError` to just an `Error`. @initconf found during testing that having the workers exit was considerably more disruptive than having them just report an error. We can revisit why this error happens later.

This change needs to be pulled into the 7.2 release branch.