### PR TITLE
Prefer libkrb5 from Homebrew over macOS system version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,9 +38,10 @@ Changed Functionality
   published vectors with holes. A reporter error is produced at runtime when
   serialization of vectors with holes is attempted.
 
-- Using libkrb5 for Kerberos support is now allowed on macOS. Due to very old age and
-  brokenness, the system version of the library is unsupported and will fail to
-  configure. Use the version from Homebrew or another newer installation.
+- Kerberos support on macOS has been enabled. Due to incompatibilities, the system
+  provided libkrb5 is ignored, however. Only versions from homebrew are supported and
+  found/picked-up by default. Use --with-krb5 for pointing at a custom librkb5
+  installation.
 
 Removed Functionality
 ---------------------


### PR DESCRIPTION
https://github.com/zeek/zeek/pull/4453 added the ability to search for krb5 on macOS, but by default it's always going to find the system library and fail. This changes it to force the user to pass --with-krb5 on macOS, but allow normal searching on other platforms.