### PR TITLE
Add STLS command to POP3 DPD signature

### DIFF
--- a/scripts/base/protocols/pop3/dpd.sig
+++ b/scripts/base/protocols/pop3/dpd.sig
@@ -8,6 +8,6 @@ signature dpd_pop3_server {
 
 signature dpd_pop3_client {
   ip-proto == tcp
-  payload /(|.*[\r\n])[[:space:]]*([uU][sS][eE][rR][[:space:]]|[aA][pP][oO][pP][[:space:]]|[cC][aA][pP][aA]|[aA][uU][tT][hH])/
+  payload /(|.*[\r\n])[[:space:]]*([uU][sS][eE][rR][[:space:]]|[aA][pP][oO][pP][[:space:]]|[cC][aA][pP][aA]|[aA][uU][tT][hH]|[sS][tT][lL][sS])/
   tcp-state originator
 }

--- a/testing/btest/scripts/base/protocols/pop3/starttls.zeek
+++ b/testing/btest/scripts/base/protocols/pop3/starttls.zeek
@@ -5,15 +5,4 @@
 
 @load base/protocols/conn
 @load base/protocols/ssl
-
-module POP3;
-
-const ports = {
-	110/tcp
-};
-redef likely_server_ports += { ports };
-
-event zeek_init() &priority=5
-	{
-	Analyzer::register_for_ports(Analyzer::ANALYZER_POP3, ports);
-	}
+@load base/protocols/pop3


### PR DESCRIPTION
Looking at POP3 STARTTLS btest, it seemed that POP3 STARTTLS connections can be easily caught by adding `STLS` to the POP3 DPD signature.