### PR TITLE
Generate --event-trace output explicitly rather than in EventTraceMgr destructor

### DIFF
--- a/src/EventTrace.cc
+++ b/src/EventTrace.cc
@@ -958,7 +958,7 @@ EventTraceMgr::EventTraceMgr(const std::string& trace_file) {
         reporter->FatalError("can't open event trace file %s", trace_file.c_str());
 }
 
-EventTraceMgr::~EventTraceMgr() {
+void EventTraceMgr::Generate() {
     if ( events.empty() )
         return;
 

--- a/src/EventTrace.h
+++ b/src/EventTrace.h
@@ -440,7 +440,9 @@ private:
 class EventTraceMgr {
 public:
     EventTraceMgr(const std::string& trace_file);
-    ~EventTraceMgr();
+
+    // Generates the trace upon exit.
+    void Generate();
 
     // Called at the beginning of invoking an event's handlers.
     void StartEvent(const ScriptFunc* ev, const zeek::Args* args);

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -399,6 +399,9 @@ static void terminate_zeek() {
 
     script_coverage_mgr.WriteStats();
 
+    if ( etm )
+        etm->Generate();
+
     delete zeekygen_mgr;
     delete packet_mgr;
     delete analyzer_mgr;


### PR DESCRIPTION
Previously, the `--event-trace` output was generated by the `EventTraceMgr` global object being destructed upon termination of execution, which was done out of simplicity. ASAN revealed that this could lead to issues where it touched data that had been deallocated. This PR changes the generation to occur explicitly, before global objects have been destructed.