### PR TITLE
`#include` Cleanup Part 2

### DIFF
--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/Attr.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/Desc.h"
 #include "zeek/Expr.h"
 #include "zeek/IntrusivePtr.h"

--- a/src/Base64.cc
+++ b/src/Base64.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/Base64.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cmath>
 
 #include "zeek/Conn.h"

--- a/src/Base64.h
+++ b/src/Base64.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <string>
 
 namespace zeek {

--- a/src/CCL.cc
+++ b/src/CCL.cc
@@ -2,11 +2,9 @@
 
 #include "zeek/CCL.h"
 
-#include "zeek/zeek-config.h"
-
 #include <algorithm>
 
-#include "zeek/DFA.h"
+#include "zeek/NFA.h" // for SYM_BOL and SYM_EOL
 #include "zeek/RE.h"
 
 namespace zeek::detail {

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/CompHash.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cstring>
 #include <map>
 #include <vector>

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -2,13 +2,10 @@
 
 #include "zeek/Conn.h"
 
-#include "zeek/zeek-config.h"
-
 #include <binpac.h>
 #include <cctype>
 
 #include "zeek/Desc.h"
-#include "zeek/Event.h"
 #include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/RunState.h"
@@ -17,7 +14,6 @@
 #include "zeek/analyzer/Analyzer.h"
 #include "zeek/analyzer/Manager.h"
 #include "zeek/analyzer/protocol/pia/PIA.h"
-#include "zeek/iosource/IOSource.h"
 #include "zeek/packet_analysis/protocol/ip/SessionAdapter.h"
 #include "zeek/packet_analysis/protocol/tcp/TCP.h"
 #include "zeek/session/Manager.h"

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -4,8 +4,6 @@
 
 #include <sys/types.h>
 #include <string>
-#include <tuple>
-#include <type_traits>
 
 #include "zeek/IPAddr.h"
 #include "zeek/IntrusivePtr.h"

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -38,7 +38,6 @@ using ztd::out_ptr::out_ptr;
 #include "zeek/Hash.h"
 #include "zeek/ID.h"
 #include "zeek/IntrusivePtr.h"
-#include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/RunState.h"
 #include "zeek/Val.h"

--- a/src/DNS_Mgr.h
+++ b/src/DNS_Mgr.h
@@ -5,13 +5,11 @@
 #include <netdb.h>
 #include <list>
 #include <map>
-#include <queue>
 #include <utility>
 #include <variant>
 
 #include "zeek/EventHandler.h"
 #include "zeek/IPAddr.h"
-#include "zeek/List.h"
 #include "zeek/iosource/IOSource.h"
 #include "zeek/util.h"
 

--- a/src/DbgBreakpoint.cc
+++ b/src/DbgBreakpoint.cc
@@ -4,8 +4,6 @@
 
 #include "zeek/DbgBreakpoint.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cassert>
 
 #include "zeek/Debug.h"
@@ -15,7 +13,6 @@
 #include "zeek/ID.h"
 #include "zeek/Reporter.h"
 #include "zeek/Scope.h"
-#include "zeek/Stmt.h"
 #include "zeek/Timer.h"
 #include "zeek/Val.h"
 #include "zeek/module_util.h"

--- a/src/DbgBreakpoint.h
+++ b/src/DbgBreakpoint.h
@@ -4,9 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
-
-#include "zeek/util.h"
 
 namespace zeek::detail {
 

--- a/src/DbgWatch.cc
+++ b/src/DbgWatch.cc
@@ -4,8 +4,6 @@
 
 #include "zeek/DbgWatch.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/Debug.h"
 #include "zeek/Reporter.h"
 

--- a/src/DbgWatch.h
+++ b/src/DbgWatch.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "zeek/util.h"
-
 namespace zeek {
 class Obj;
 }

--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -4,8 +4,6 @@
 
 #include "zeek/Debug.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cctype>
 #include <csignal>
 #include <cstdarg>

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <string>
@@ -11,7 +12,10 @@
 
 #include "zeek/Obj.h"
 #include "zeek/StmtEnums.h"
-#include "zeek/util.h"
+
+#ifdef _MSC_VER
+#include <unistd.h> // Needed to ignore __attribute__((format(printf))) on MSVC
+#endif
 
 namespace zeek {
 

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -5,8 +5,6 @@
 
 #include "zeek/DebugCmds.h"
 
-#include "zeek/zeek-config.h"
-
 #include <regex.h>
 #include <sys/types.h>
 #include <cassert>
@@ -22,7 +20,6 @@
 #include "zeek/PolicyFile.h"
 #include "zeek/Reporter.h"
 #include "zeek/Scope.h"
-#include "zeek/Stmt.h"
 #include "zeek/Val.h"
 #include "zeek/util.h"
 

--- a/src/DebugLogger.h
+++ b/src/DebugLogger.h
@@ -7,13 +7,13 @@
 
 #ifdef DEBUG
 
-#include "zeek/zeek-config.h"
-
 #include <cstdio>
 #include <set>
 #include <string>
 
-#include "zeek/util.h"
+#ifdef _MSC_VER
+#include <unistd.h> // Needed to ignore __attribute__((format(printf))) on MSVC
+#endif
 
 #define DBG_LOG(stream, ...)                                                                                           \
     if ( ::zeek::detail::debug_logger.IsEnabled(stream) )                                                              \

--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -2,14 +2,11 @@
 
 #include "zeek/Desc.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cerrno>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
 
-#include "zeek/3rdparty/ConvertUTF.h"
 #include "zeek/File.h"
 #include "zeek/IPAddr.h"
 #include "zeek/Reporter.h"

--- a/src/Discard.cc
+++ b/src/Discard.cc
@@ -2,14 +2,11 @@
 
 #include "zeek/Discard.h"
 
-#include "zeek/zeek-config.h"
-
 #include <algorithm>
 
 #include "zeek/Func.h"
 #include "zeek/IP.h"
 #include "zeek/Reporter.h" // for InterpreterException
-#include "zeek/RunState.h"
 #include "zeek/Val.h"
 #include "zeek/Var.h"
 #include "zeek/ZeekString.h"

--- a/src/Discard.cc
+++ b/src/Discard.cc
@@ -22,6 +22,8 @@ Discarder::Discarder() {
     discarder_maxlen = static_cast<int>(id::find_val("discarder_maxlen")->AsCount());
 }
 
+Discarder::~Discarder() {}
+
 bool Discarder::IsActive() { return check_ip || check_tcp || check_udp || check_icmp; }
 
 bool Discarder::NextPacket(const std::shared_ptr<IP_Hdr>& ip, int len, int caplen) {

--- a/src/Discard.h
+++ b/src/Discard.h
@@ -19,7 +19,7 @@ namespace detail {
 class Discarder final {
 public:
     Discarder();
-    ~Discarder() = default;
+    ~Discarder();
 
     bool IsActive();
 

--- a/src/EquivClass.cc
+++ b/src/EquivClass.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/EquivClass.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/CCL.h"
 #include "zeek/util.h"
 

--- a/src/EventRegistry.h
+++ b/src/EventRegistry.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <map>
 #include <memory>
 #include <string>

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/Expr.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/DebugLogger.h"
 #include "zeek/Desc.h"
 #include "zeek/Event.h"
@@ -22,7 +20,6 @@
 #include "zeek/Trigger.h"
 #include "zeek/Type.h"
 #include "zeek/broker/Data.h"
-#include "zeek/digest.h"
 #include "zeek/module_util.h"
 #include "zeek/script_opt/Expr.h"
 #include "zeek/script_opt/ScriptOpt.h"

--- a/src/File.cc
+++ b/src/File.cc
@@ -18,18 +18,15 @@
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <algorithm>
 #include <cerrno>
 
 #include "zeek/Attr.h"
 #include "zeek/Desc.h"
 #include "zeek/Event.h"
-#include "zeek/Expr.h"
-#include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/RunState.h"
 #include "zeek/Type.h"
-#include "zeek/Var.h"
+#include "zeek/event.bif.netvar_h"
 
 namespace zeek {
 

--- a/src/Frag.cc
+++ b/src/Frag.cc
@@ -2,9 +2,6 @@
 
 #include "zeek/Frag.h"
 
-#include "zeek/zeek-config.h"
-
-#include "zeek/Hash.h"
 #include "zeek/IP.h"
 #include "zeek/NetVar.h"
 #include "zeek/Reporter.h"

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -13,7 +13,6 @@
 #include "zeek/Obj.h"
 #include "zeek/Type.h"
 #include "zeek/ZeekArgs.h"
-#include "zeek/ZeekList.h" // for typedef val_list
 
 namespace zeek {
 

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -16,6 +16,7 @@
 #include <csignal>
 #include <cstdlib>
 
+// Most of these includes are needed for code included from bif files.
 #include "zeek/Base64.h"
 #include "zeek/Debug.h"
 #include "zeek/Desc.h"

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/ID.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/Attr.h"
 #include "zeek/Desc.h"
 #include "zeek/Dict.h"

--- a/src/IP.cc
+++ b/src/IP.cc
@@ -10,7 +10,6 @@
 #include "zeek/Reporter.h"
 #include "zeek/Type.h"
 #include "zeek/Val.h"
-#include "zeek/Var.h"
 #include "zeek/ZeekString.h"
 
 namespace zeek {

--- a/src/IntSet.cc
+++ b/src/IntSet.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/IntSet.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cstring>
 
 namespace zeek::detail {

--- a/src/MMDB.cc
+++ b/src/MMDB.cc
@@ -6,7 +6,6 @@
 #include <netinet/ip.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
-#include <chrono>
 
 #include "zeek/Func.h"
 #include "zeek/IPAddr.h"

--- a/src/NFA.cc
+++ b/src/NFA.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/NFA.h"
 
-#include "zeek/zeek-config.h"
-
 #include <algorithm>
 
 #include "zeek/Desc.h"

--- a/src/NetVar.cc
+++ b/src/NetVar.cc
@@ -2,8 +2,7 @@
 
 #include "zeek/NetVar.h"
 
-#include "zeek/zeek-config.h"
-
+// EventHandler.h is needed for event.bif.netvar_init later.
 #include "zeek/EventHandler.h"
 #include "zeek/ID.h"
 #include "zeek/Val.h"

--- a/src/NetVar.h
+++ b/src/NetVar.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+// These includes are needed for the inclusion of the bif headers at the end
+// of this file.
 #include "zeek/EventRegistry.h"
 #include "zeek/Val.h"
 

--- a/src/Notifier.cc
+++ b/src/Notifier.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/Notifier.h"
 
-#include <set>
-
 #include "zeek/DebugLogger.h"
 
 zeek::notifier::detail::Registry zeek::notifier::detail::registry;

--- a/src/Obj.cc
+++ b/src/Obj.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/Obj.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cstdlib>
 
 #include "zeek/Desc.h"

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <climits>
 
 namespace zeek {

--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -19,7 +19,6 @@
 
 #include "zeek/CompHash.h"
 #include "zeek/Desc.h"
-#include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/Scope.h"
 #include "zeek/Var.h"

--- a/src/PolicyFile.cc
+++ b/src/PolicyFile.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/PolicyFile.h"
 
-#include "zeek/zeek-config.h"
-
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <cassert>

--- a/src/PriorityQueue.cc
+++ b/src/PriorityQueue.cc
@@ -2,13 +2,9 @@
 
 #include "zeek/PriorityQueue.h"
 
-#include "zeek/zeek-config.h"
-
-#include <cstdio>
 #include <cstdlib>
 
 #include "zeek/Reporter.h"
-#include "zeek/util.h"
 
 namespace zeek::detail {
 

--- a/src/PriorityQueue.h
+++ b/src/PriorityQueue.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <cmath>
 #include <cstdint>
 

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/RE.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cstdlib>
 #include <utility>
 

--- a/src/RandTest.h
+++ b/src/RandTest.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <cstdint>
 
 #define RT_MONTEN                                                                                                      \

--- a/src/Reassem.cc
+++ b/src/Reassem.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/Reassem.h"
 
-#include "zeek/zeek-config.h"
-
 #include <algorithm>
 #include <cinttypes>
 #include <limits>

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -4,8 +4,6 @@
 
 #include "zeek/Reporter.h"
 
-#include "zeek/zeek-config.h"
-
 #include <syslog.h>
 #include <unistd.h>
 
@@ -16,7 +14,6 @@
 #include "zeek/Expr.h"
 #include "zeek/Frame.h"
 #include "zeek/ID.h"
-#include "zeek/NetVar.h"
 #include "zeek/RunState.h"
 #include "zeek/Timer.h"
 #include "zeek/file_analysis/File.h"

--- a/src/Rule.cc
+++ b/src/Rule.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/Rule.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/RuleAction.h"
 #include "zeek/RuleCondition.h"
 #include "zeek/RuleMatcher.h"

--- a/src/RuleAction.cc
+++ b/src/RuleAction.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/RuleAction.h"
 
-#include "zeek/zeek-config.h"
-
 #include <algorithm>
 #include <string>
 
@@ -12,7 +10,6 @@
 #include "zeek/Event.h"
 #include "zeek/Func.h"
 #include "zeek/ID.h"
-#include "zeek/NetVar.h"
 #include "zeek/RuleMatcher.h"
 #include "zeek/Type.h"
 #include "zeek/analyzer/Manager.h"

--- a/src/RuleCondition.cc
+++ b/src/RuleCondition.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/RuleCondition.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/Func.h"
 #include "zeek/ID.h"
 #include "zeek/Reporter.h"

--- a/src/RuleCondition.h
+++ b/src/RuleCondition.h
@@ -5,8 +5,6 @@
 #include <sys/types.h> // for u_char
 #include <cstdint>     // for u_char
 
-#include "zeek/util.h"
-
 namespace zeek::detail {
 
 class RuleEndpointState;

--- a/src/RuleMatcher.h
+++ b/src/RuleMatcher.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <sys/types.h> // for u_char
-#include <climits>
 #include <functional>
 #include <map>
 #include <set>

--- a/src/RunState.h
+++ b/src/RunState.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <optional>
 #include <string>
 

--- a/src/ScannedFile.cc
+++ b/src/ScannedFile.cc
@@ -3,7 +3,6 @@
 #include "zeek/ScannedFile.h"
 
 #include <cerrno>
-#include <climits> // for PATH_MAX
 
 #include "zeek/DebugLogger.h"
 #include "zeek/Reporter.h"

--- a/src/ScannedFile.h
+++ b/src/ScannedFile.h
@@ -2,11 +2,12 @@
 
 #pragma once
 
-#include <zeek/Obj.h>
 #include <list>
 #include <optional>
 #include <string>
 #include <vector>
+
+#include "zeek/Obj.h"
 
 namespace zeek::detail {
 

--- a/src/Scope.cc
+++ b/src/Scope.cc
@@ -2,13 +2,11 @@
 
 #include "zeek/Scope.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/Desc.h"
 #include "zeek/ID.h"
 #include "zeek/IntrusivePtr.h"
 #include "zeek/Reporter.h"
-#include "zeek/Val.h"
+#include "zeek/Type.h"
 #include "zeek/module_util.h"
 
 namespace zeek::detail {

--- a/src/ScriptCoverageManager.h
+++ b/src/ScriptCoverageManager.h
@@ -9,7 +9,6 @@
 
 #include "zeek/ID.h"
 #include "zeek/StmtBase.h"
-#include "zeek/util.h"
 
 namespace zeek::detail {
 

--- a/src/ScriptProfile.cc
+++ b/src/ScriptProfile.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/ScriptProfile.h"
 
+#include <cinttypes>
+
 namespace zeek {
 
 namespace detail {

--- a/src/ScriptProfile.h
+++ b/src/ScriptProfile.h
@@ -7,7 +7,6 @@
 #include <string>
 
 #include "zeek/Func.h"
-#include "zeek/Stmt.h"
 
 namespace zeek {
 

--- a/src/ScriptValidation.cc
+++ b/src/ScriptValidation.cc
@@ -3,8 +3,6 @@
 #include "zeek/ScriptValidation.h"
 
 #include "zeek/Func.h"
-#include "zeek/Reporter.h"
-#include "zeek/Stmt.h"
 #include "zeek/Traverse.h"
 
 namespace zeek::detail {

--- a/src/SerializationFormat.h
+++ b/src/SerializationFormat.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <cstdint>
 #include <string>
 

--- a/src/SmithWaterman.cc
+++ b/src/SmithWaterman.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/SmithWaterman.h"
 
-#include "zeek/zeek-config.h"
-
 #include <algorithm>
 #include <cctype>
 

--- a/src/SmithWaterman.h
+++ b/src/SmithWaterman.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <vector>
 
 #include "zeek/ZeekString.h"

--- a/src/Stats.h
+++ b/src/Stats.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <cstdint>
 #include <memory>
 

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/Stmt.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/CompHash.h"
 #include "zeek/Debug.h"
 #include "zeek/Desc.h"
@@ -13,7 +11,6 @@
 #include "zeek/File.h"
 #include "zeek/Frame.h"
 #include "zeek/IntrusivePtr.h"
-#include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/Scope.h"
 #include "zeek/Traverse.h"

--- a/src/Tag.h
+++ b/src/Tag.h
@@ -2,13 +2,10 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <cstdint>
 #include <string>
 
 #include "zeek/IntrusivePtr.h"
-#include "zeek/util.h"
 
 namespace zeek {
 

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/Timer.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/Desc.h"
 #include "zeek/NetVar.h"
 #include "zeek/RunState.h"

--- a/src/TraverseTypes.h
+++ b/src/TraverseTypes.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 namespace zeek::detail {
 
 class TraversalCallback;

--- a/src/TunnelEncapsulation.h
+++ b/src/TunnelEncapsulation.h
@@ -4,7 +4,6 @@
 
 #include <vector>
 
-#include "zeek/ID.h"
 #include "zeek/IP.h"
 #include "zeek/IPAddr.h"
 #include "zeek/NetVar.h"

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -2,10 +2,7 @@
 
 #include "zeek/Type.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cinttypes>
-#include <list>
 #include <map>
 #include <string>
 #include <unordered_set>

--- a/src/UID.cc
+++ b/src/UID.cc
@@ -7,8 +7,6 @@
 #include "zeek/Reporter.h"
 #include "zeek/util.h"
 
-using namespace std;
-
 namespace zeek {
 
 void UID::Set(zeek_uint_t bits, const uint64_t* v, size_t n) {

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/Var.h"
 
-#include "zeek/zeek-config.h"
-
 #include <memory>
 
 #include "zeek/Desc.h"
@@ -18,7 +16,6 @@
 #include "zeek/Stmt.h"
 #include "zeek/Traverse.h"
 #include "zeek/Val.h"
-#include "zeek/module_util.h"
 #include "zeek/script_opt/IDOptInfo.h"
 #include "zeek/script_opt/ScriptOpt.h"
 #include "zeek/script_opt/StmtOptInfo.h"

--- a/src/WeirdState.cc
+++ b/src/WeirdState.cc
@@ -3,7 +3,6 @@
 #include "zeek/WeirdState.h"
 
 #include "zeek/RunState.h"
-#include "zeek/util.h"
 
 namespace zeek::detail {
 

--- a/src/ZVal.cc
+++ b/src/ZVal.cc
@@ -4,7 +4,6 @@
 #include "zeek/Func.h"
 #include "zeek/OpaqueVal.h"
 #include "zeek/Reporter.h"
-#include "zeek/ZeekString.h"
 
 using namespace zeek;
 

--- a/src/ZVal.h
+++ b/src/ZVal.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
+#include "zeek/IntrusivePtr.h"
 
 namespace zeek {
 
@@ -19,6 +19,7 @@ class RecordVal;
 class StringVal;
 class SubNetVal;
 class TableVal;
+class Type;
 class TypeVal;
 class Val;
 class VectorVal;
@@ -32,6 +33,7 @@ using RecordValPtr = IntrusivePtr<RecordVal>;
 using StringValPtr = IntrusivePtr<StringVal>;
 using SubNetValPtr = IntrusivePtr<SubNetVal>;
 using TableValPtr = IntrusivePtr<TableVal>;
+using TypePtr = IntrusivePtr<Type>;
 using TypeValPtr = IntrusivePtr<TypeVal>;
 using ValPtr = IntrusivePtr<Val>;
 using VectorValPtr = IntrusivePtr<VectorVal>;

--- a/src/ZeekString.cc
+++ b/src/ZeekString.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/ZeekString.h"
 
-#include "zeek/zeek-config.h"
-
 #include <algorithm>
 #include <cctype>
 #include <iostream>

--- a/src/ZeekString.h
+++ b/src/ZeekString.h
@@ -2,11 +2,9 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <sys/types.h>
 #include <iosfwd>
-#include <string>
+#include <string_view>
 #include <vector>
 
 namespace zeek {

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -5,10 +5,10 @@
 #include <binpac.h>
 #include <algorithm>
 
+#include "zeek/Conn.h"
 #include "zeek/Event.h"
-#include "zeek/ZeekString.h"
 #include "zeek/analyzer/Manager.h"
-#include "zeek/analyzer/protocol/pia/PIA.h"
+#include "zeek/packet_analysis/protocol/tcp/TCPSessionAdapter.h"
 
 #include "zeek/3rdparty/doctest.h"
 

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -10,7 +10,6 @@
 
 #include "zeek/EventHandler.h"
 #include "zeek/IntrusivePtr.h"
-#include "zeek/Obj.h"
 #include "zeek/Tag.h"
 #include "zeek/Timer.h"
 

--- a/src/analyzer/Component.h
+++ b/src/analyzer/Component.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/Tag.h"
 #include "zeek/plugin/Component.h"
 #include "zeek/util.h"

--- a/src/analyzer/Manager.cc
+++ b/src/analyzer/Manager.cc
@@ -2,17 +2,12 @@
 
 #include "zeek/analyzer/Manager.h"
 
-#include "zeek/Hash.h"
+#include "zeek/Conn.h"
 #include "zeek/IntrusivePtr.h"
 #include "zeek/RunState.h"
 #include "zeek/Val.h"
-#include "zeek/analyzer/protocol/conn-size/ConnSize.h"
-#include "zeek/analyzer/protocol/pia/PIA.h"
-#include "zeek/analyzer/protocol/tcp/TCP.h"
-#include "zeek/analyzer/protocol/tcp/events.bif.h"
 #include "zeek/packet_analysis/protocol/ip/IPBasedAnalyzer.h"
 #include "zeek/packet_analysis/protocol/ip/SessionAdapter.h"
-#include "zeek/plugin/Manager.h"
 
 namespace zeek::analyzer {
 

--- a/src/analyzer/Manager.h
+++ b/src/analyzer/Manager.h
@@ -24,10 +24,10 @@
 #include <vector>
 
 #include "zeek/IP.h"
+#include "zeek/IPAddr.h"
 #include "zeek/Tag.h"
 #include "zeek/analyzer/Analyzer.h"
 #include "zeek/analyzer/Component.h"
-#include "zeek/analyzer/analyzer.bif.h"
 #include "zeek/net_util.h"
 #include "zeek/plugin/ComponentManager.h"
 

--- a/src/analyzer/protocol/conn-size/ConnSize.cc
+++ b/src/analyzer/protocol/conn-size/ConnSize.cc
@@ -8,7 +8,6 @@
 #include "zeek/Reporter.h"
 #include "zeek/RunState.h"
 #include "zeek/analyzer/protocol/conn-size/events.bif.h"
-#include "zeek/analyzer/protocol/tcp/TCP.h"
 
 namespace zeek::analyzer::conn_size {
 

--- a/src/analyzer/protocol/conn-size/ConnSize.h
+++ b/src/analyzer/protocol/conn-size/ConnSize.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/NetVar.h"
 #include "zeek/analyzer/Analyzer.h"
 
 namespace zeek::analyzer::conn_size {

--- a/src/analyzer/protocol/dce-rpc/DCE_RPC.cc
+++ b/src/analyzer/protocol/dce-rpc/DCE_RPC.cc
@@ -2,11 +2,7 @@
 
 #include "zeek/analyzer/protocol/dce-rpc/DCE_RPC.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cstdlib>
-#include <map>
-#include <string>
 
 using namespace std;
 

--- a/src/analyzer/protocol/dce-rpc/DCE_RPC.h
+++ b/src/analyzer/protocol/dce-rpc/DCE_RPC.h
@@ -2,10 +2,8 @@
 
 #pragma once
 
-#include "zeek/IPAddr.h"
-#include "zeek/NetVar.h"
+#include "zeek/Conn.h"
 #include "zeek/analyzer/protocol/dce-rpc/dce_rpc_pac.h"
-#include "zeek/analyzer/protocol/dce-rpc/events.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 
 namespace zeek::analyzer::dce_rpc {

--- a/src/analyzer/protocol/dhcp/DHCP.cc
+++ b/src/analyzer/protocol/dhcp/DHCP.cc
@@ -2,9 +2,6 @@
 
 #include "zeek/analyzer/protocol/dhcp/DHCP.h"
 
-#include "zeek/analyzer/protocol/dhcp/events.bif.h"
-#include "zeek/analyzer/protocol/dhcp/types.bif.h"
-
 namespace zeek::analyzer::dhcp {
 
 DHCP_Analyzer::DHCP_Analyzer(Connection* conn) : Analyzer("DHCP", conn) { interp = new binpac::DHCP::DHCP_Conn(this); }

--- a/src/analyzer/protocol/dnp3/DNP3.cc
+++ b/src/analyzer/protocol/dnp3/DNP3.cc
@@ -106,7 +106,6 @@
 #include "zeek/analyzer/protocol/dnp3/DNP3.h"
 
 #include "zeek/Reporter.h"
-#include "zeek/analyzer/protocol/dnp3/events.bif.h"
 
 constexpr unsigned int PSEUDO_LENGTH_INDEX = 2;        // index of len field of DNP3 Pseudo Link Layer
 constexpr unsigned int PSEUDO_CONTROL_FIELD_INDEX = 3; // index of ctrl field of DNP3 Pseudo Link Layer

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/analyzer/protocol/dns/DNS.h"
 
-#include "zeek/zeek-config.h"
-
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -792,7 +792,7 @@ bool DNS_Interpreter::ParseRR_EDNS(detail::DNS_MsgInfo* msg, const u_char*& data
 
 void DNS_Interpreter::ExtractOctets(const u_char*& data, int& len, String** p) {
     uint16_t dlen = ExtractShort(data, len);
-    dlen = min(len, static_cast<int>(dlen));
+    dlen = std::min(len, static_cast<int>(dlen));
 
     if ( p )
         *p = new String(data, dlen, false);
@@ -802,8 +802,8 @@ void DNS_Interpreter::ExtractOctets(const u_char*& data, int& len, String** p) {
 }
 
 String* DNS_Interpreter::ExtractStream(const u_char*& data, int& len, int l) {
-    l = max(l, 0);
-    int dlen = min(len, l); // Len in bytes of the algorithm use
+    l = std::max(l, 0);
+    int dlen = std::min(len, l); // Len in bytes of the algorithm use
     auto rval = new String(data, dlen, false);
 
     data += dlen;

--- a/src/analyzer/protocol/dns/DNS.h
+++ b/src/analyzer/protocol/dns/DNS.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "zeek/analyzer/protocol/tcp/TCP.h"
-#include "zeek/binpac_zeek.h"
 
 namespace zeek::analyzer::dns {
 namespace detail {

--- a/src/analyzer/protocol/file/File.cc
+++ b/src/analyzer/protocol/file/File.cc
@@ -8,7 +8,6 @@
 #include "zeek/RuleMatcher.h"
 #include "zeek/analyzer/protocol/file/events.bif.h"
 #include "zeek/file_analysis/Manager.h"
-#include "zeek/util.h"
 
 namespace zeek::analyzer::file {
 

--- a/src/analyzer/protocol/finger/legacy/Finger.cc
+++ b/src/analyzer/protocol/finger/legacy/Finger.cc
@@ -2,12 +2,8 @@
 
 #include "zeek/analyzer/protocol/finger/legacy/Finger.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cctype>
 
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/analyzer/protocol/finger/legacy/events.bif.h"
 #include "zeek/analyzer/protocol/tcp/ContentLine.h"
 

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -2,13 +2,9 @@
 
 #include "zeek/analyzer/protocol/ftp/FTP.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cstdlib>
 
 #include "zeek/Base64.h"
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/RuleMatcher.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/Manager.h"

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -2,13 +2,9 @@
 
 #include "zeek/analyzer/protocol/gnutella/Gnutella.h"
 
-#include "zeek/zeek-config.h"
-
 #include <algorithm>
 #include <cctype>
 
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/analyzer/Manager.h"
 #include "zeek/analyzer/protocol/gnutella/events.bif.h"
 #include "zeek/analyzer/protocol/pia/PIA.h"

--- a/src/analyzer/protocol/gssapi/GSSAPI.cc
+++ b/src/analyzer/protocol/gssapi/GSSAPI.cc
@@ -3,7 +3,6 @@
 #include "zeek/analyzer/protocol/gssapi/GSSAPI.h"
 
 #include "zeek/Reporter.h"
-#include "zeek/analyzer/protocol/gssapi/events.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 namespace zeek::analyzer::gssapi {

--- a/src/analyzer/protocol/gssapi/GSSAPI.h
+++ b/src/analyzer/protocol/gssapi/GSSAPI.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/gssapi/events.bif.h"
 #include "zeek/analyzer/protocol/gssapi/gssapi_pac.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -2,12 +2,8 @@
 
 #include "zeek/analyzer/protocol/ident/Ident.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cctype>
 
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/protocol/ident/events.bif.h"
 

--- a/src/analyzer/protocol/imap/IMAP.h
+++ b/src/analyzer/protocol/imap/IMAP.h
@@ -2,9 +2,6 @@
 
 #pragma once
 
-// for std::transform
-#include <algorithm>
-
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 
 #include "analyzer/protocol/imap/imap_pac.h"

--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -4,11 +4,8 @@
 
 #include "zeek/analyzer/protocol/irc/IRC.h"
 
-#include <iostream>
 #include <unordered_set>
 
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/analyzer/Manager.h"
 #include "zeek/analyzer/protocol/irc/events.bif.h"
 #include "zeek/analyzer/protocol/zip/ZIP.h"

--- a/src/analyzer/protocol/krb/KRB.cc
+++ b/src/analyzer/protocol/krb/KRB.cc
@@ -4,9 +4,6 @@
 
 #include <unistd.h>
 
-#include "zeek/analyzer/protocol/krb/events.bif.h"
-#include "zeek/analyzer/protocol/krb/types.bif.h"
-
 namespace zeek::analyzer::krb {
 
 bool KRB_Analyzer::krb_available = false;

--- a/src/analyzer/protocol/krb/KRB.h
+++ b/src/analyzer/protocol/krb/KRB.h
@@ -2,15 +2,15 @@
 
 #pragma once
 
+// This is needed for USE_KRB5 below.
 #include "zeek/zeek-config.h"
-
-#include <mutex>
 
 #ifdef USE_KRB5
 #include <krb5/krb5.h>
 #endif
 
-#include "analyzer/protocol/krb/krb_pac.h"
+#include "zeek/analyzer/Analyzer.h"
+#include "zeek/analyzer/protocol/krb/krb_pac.h"
 
 namespace zeek::analyzer::krb {
 

--- a/src/analyzer/protocol/krb/KRB_TCP.cc
+++ b/src/analyzer/protocol/krb/KRB_TCP.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/analyzer/protocol/krb/KRB_TCP.h"
 
-#include "zeek/analyzer/protocol/krb/events.bif.h"
-#include "zeek/analyzer/protocol/krb/types.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 namespace zeek::analyzer::krb_tcp {

--- a/src/analyzer/protocol/login/Login.cc
+++ b/src/analyzer/protocol/login/Login.cc
@@ -2,13 +2,9 @@
 
 #include "zeek/analyzer/protocol/login/Login.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cctype>
 #include <cstdlib>
 
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/RE.h"
 #include "zeek/Reporter.h"
 #include "zeek/Var.h"

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -2,12 +2,8 @@
 
 #include "zeek/analyzer/protocol/login/NVT.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cstdlib>
 
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/protocol/login/events.bif.h"

--- a/src/analyzer/protocol/login/Plugin.cc
+++ b/src/analyzer/protocol/login/Plugin.cc
@@ -3,7 +3,6 @@
 #include "zeek/plugin/Plugin.h"
 
 #include "zeek/analyzer/Component.h"
-#include "zeek/analyzer/protocol/login/Login.h"
 #include "zeek/analyzer/protocol/login/RSH.h"
 #include "zeek/analyzer/protocol/login/Rlogin.h"
 #include "zeek/analyzer/protocol/login/Telnet.h"

--- a/src/analyzer/protocol/login/RSH.cc
+++ b/src/analyzer/protocol/login/RSH.cc
@@ -2,10 +2,6 @@
 
 #include "zeek/analyzer/protocol/login/RSH.h"
 
-#include "zeek/zeek-config.h"
-
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/protocol/login/events.bif.h"
 

--- a/src/analyzer/protocol/login/Rlogin.cc
+++ b/src/analyzer/protocol/login/Rlogin.cc
@@ -2,10 +2,6 @@
 
 #include "zeek/analyzer/protocol/login/Rlogin.h"
 
-#include "zeek/zeek-config.h"
-
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/protocol/login/events.bif.h"
 

--- a/src/analyzer/protocol/login/Telnet.cc
+++ b/src/analyzer/protocol/login/Telnet.cc
@@ -2,10 +2,7 @@
 
 #include "zeek/analyzer/protocol/login/Telnet.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/analyzer/protocol/login/NVT.h"
-#include "zeek/analyzer/protocol/login/events.bif.h"
 
 namespace zeek::analyzer::login {
 

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/analyzer/protocol/mime/MIME.h"
 
-#include "zeek/zeek-config.h"
-
 #include <openssl/evp.h>
 
 #include "zeek/Base64.h"

--- a/src/analyzer/protocol/mime/MIME.h
+++ b/src/analyzer/protocol/mime/MIME.h
@@ -4,7 +4,6 @@
 
 #include <cassert>
 #include <cstdio>
-#include <queue>
 #include <vector>
 
 #include "zeek/Reporter.h"

--- a/src/analyzer/protocol/modbus/Modbus.cc
+++ b/src/analyzer/protocol/modbus/Modbus.cc
@@ -2,7 +2,6 @@
 
 #include "zeek/analyzer/protocol/modbus/Modbus.h"
 
-#include "zeek/analyzer/protocol/modbus/events.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 namespace zeek::analyzer::modbus {

--- a/src/analyzer/protocol/mqtt/MQTT.h
+++ b/src/analyzer/protocol/mqtt/MQTT.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "zeek/ID.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 
 namespace binpac {

--- a/src/analyzer/protocol/mysql/MySQL.cc
+++ b/src/analyzer/protocol/mysql/MySQL.cc
@@ -4,7 +4,6 @@
 
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/Manager.h"
-#include "zeek/analyzer/protocol/mysql/events.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 namespace zeek::analyzer::mysql {

--- a/src/analyzer/protocol/mysql/MySQL.h
+++ b/src/analyzer/protocol/mysql/MySQL.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/mysql/events.bif.h"
 #include "zeek/analyzer/protocol/mysql/mysql_pac.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -2,11 +2,7 @@
 
 #include "zeek/analyzer/protocol/ncp/NCP.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cstdlib>
-#include <map>
-#include <string>
 
 #include "zeek/analyzer/protocol/ncp/consts.bif.h"
 #include "zeek/analyzer/protocol/ncp/events.bif.h"

--- a/src/analyzer/protocol/ncp/NCP.h
+++ b/src/analyzer/protocol/ncp/NCP.h
@@ -17,7 +17,6 @@
 //
 //	http://faydoc.tripod.com/structures/21/2149.htm
 
-#include "zeek/NetVar.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 
 #include "analyzer/protocol/ncp/ncp_pac.h"

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -2,12 +2,9 @@
 
 #include "zeek/analyzer/protocol/netbios/NetbiosSSN.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cctype>
 
 #include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/RunState.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/protocol/netbios/events.bif.h"

--- a/src/analyzer/protocol/ntlm/NTLM.cc
+++ b/src/analyzer/protocol/ntlm/NTLM.cc
@@ -3,7 +3,6 @@
 #include "zeek/analyzer/protocol/ntlm/NTLM.h"
 
 #include "zeek/Reporter.h"
-#include "zeek/analyzer/protocol/ntlm/events.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 namespace zeek::analyzer::ntlm {

--- a/src/analyzer/protocol/ntlm/NTLM.h
+++ b/src/analyzer/protocol/ntlm/NTLM.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/ntlm/events.bif.h"
 #include "zeek/analyzer/protocol/ntlm/ntlm_pac.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 

--- a/src/analyzer/protocol/ntp/NTP.cc
+++ b/src/analyzer/protocol/ntp/NTP.cc
@@ -3,7 +3,6 @@
 #include "zeek/analyzer/protocol/ntp/NTP.h"
 
 #include "zeek/Reporter.h"
-#include "zeek/analyzer/protocol/ntp/events.bif.h"
 
 namespace zeek::analyzer::ntp {
 

--- a/src/analyzer/protocol/ntp/NTP.h
+++ b/src/analyzer/protocol/ntp/NTP.h
@@ -2,9 +2,7 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/ntp/events.bif.h"
 #include "zeek/analyzer/protocol/ntp/ntp_pac.h"
-#include "zeek/analyzer/protocol/ntp/types.bif.h"
 
 namespace zeek::analyzer::ntp {
 

--- a/src/analyzer/protocol/radius/RADIUS.cc
+++ b/src/analyzer/protocol/radius/RADIUS.cc
@@ -3,7 +3,6 @@
 #include "zeek/analyzer/protocol/radius/RADIUS.h"
 
 #include "zeek/Reporter.h"
-#include "zeek/analyzer/protocol/radius/events.bif.h"
 
 namespace zeek::analyzer::radius {
 

--- a/src/analyzer/protocol/radius/RADIUS.h
+++ b/src/analyzer/protocol/radius/RADIUS.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/radius/events.bif.h"
 #include "zeek/analyzer/protocol/radius/radius_pac.h"
 
 namespace zeek::analyzer::radius {

--- a/src/analyzer/protocol/rdp/RDP.cc
+++ b/src/analyzer/protocol/rdp/RDP.cc
@@ -5,7 +5,6 @@
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/Manager.h"
 #include "zeek/analyzer/protocol/rdp/events.bif.h"
-#include "zeek/analyzer/protocol/rdp/types.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 namespace zeek::analyzer::rdp {

--- a/src/analyzer/protocol/rdp/RDP.h
+++ b/src/analyzer/protocol/rdp/RDP.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/rdp/events.bif.h"
 #include "zeek/analyzer/protocol/rdp/rdp_pac.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 

--- a/src/analyzer/protocol/rdp/RDPEUDP.cc
+++ b/src/analyzer/protocol/rdp/RDPEUDP.cc
@@ -3,7 +3,6 @@
 #include "zeek/analyzer/protocol/rdp/RDPEUDP.h"
 
 #include "zeek/Reporter.h"
-#include "zeek/analyzer/protocol/rdp/events.bif.h"
 #include "zeek/analyzer/protocol/rdp/rdpeudp_pac.h"
 
 namespace zeek::analyzer::rdpeudp {

--- a/src/analyzer/protocol/rdp/RDPEUDP.h
+++ b/src/analyzer/protocol/rdp/RDPEUDP.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/rdp/events.bif.h"
 #include "zeek/analyzer/protocol/rdp/rdpeudp_pac.h"
 
 namespace zeek::analyzer::rdpeudp {

--- a/src/analyzer/protocol/rfb/RFB.cc
+++ b/src/analyzer/protocol/rfb/RFB.cc
@@ -3,7 +3,6 @@
 #include "zeek/analyzer/protocol/rfb/RFB.h"
 
 #include "zeek/Reporter.h"
-#include "zeek/analyzer/protocol/rfb/events.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 namespace zeek::analyzer::rfb {

--- a/src/analyzer/protocol/rfb/RFB.h
+++ b/src/analyzer/protocol/rfb/RFB.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/rfb/events.bif.h"
 #include "zeek/analyzer/protocol/rfb/rfb_pac.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 

--- a/src/analyzer/protocol/rpc/MOUNT.cc
+++ b/src/analyzer/protocol/rpc/MOUNT.cc
@@ -2,13 +2,8 @@
 
 #include "zeek/analyzer/protocol/rpc/MOUNT.h"
 
-#include "zeek/zeek-config.h"
-
-#include <algorithm>
 #include <vector>
 
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/protocol/rpc/XDR.h"
 #include "zeek/analyzer/protocol/rpc/events.bif.h"

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -2,13 +2,9 @@
 
 #include "zeek/analyzer/protocol/rpc/NFS.h"
 
-#include "zeek/zeek-config.h"
-
 #include <utility>
 #include <vector>
 
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/protocol/rpc/XDR.h"
 #include "zeek/analyzer/protocol/rpc/events.bif.h"

--- a/src/analyzer/protocol/rpc/NFS.h
+++ b/src/analyzer/protocol/rpc/NFS.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/NetVar.h"
 #include "zeek/analyzer/protocol/rpc/RPC.h"
 
 namespace zeek::analyzer::rpc {

--- a/src/analyzer/protocol/rpc/Plugin.cc
+++ b/src/analyzer/protocol/rpc/Plugin.cc
@@ -6,7 +6,6 @@
 #include "zeek/analyzer/protocol/rpc/MOUNT.h"
 #include "zeek/analyzer/protocol/rpc/NFS.h"
 #include "zeek/analyzer/protocol/rpc/Portmap.h"
-#include "zeek/analyzer/protocol/rpc/RPC.h"
 
 namespace zeek::plugin::detail::Zeek_RPC {
 

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -2,10 +2,6 @@
 
 #include "zeek/analyzer/protocol/rpc/Portmap.h"
 
-#include "zeek/zeek-config.h"
-
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/analyzer/protocol/rpc/XDR.h"
 #include "zeek/analyzer/protocol/rpc/events.bif.h"
 

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/analyzer/protocol/rpc/RPC.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cstdlib>
 #include <string>
 

--- a/src/analyzer/protocol/rpc/RPC.h
+++ b/src/analyzer/protocol/rpc/RPC.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/NetVar.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 
 namespace zeek::analyzer::rpc {

--- a/src/analyzer/protocol/rpc/XDR.cc
+++ b/src/analyzer/protocol/rpc/XDR.cc
@@ -2,12 +2,10 @@
 
 #include "zeek/analyzer/protocol/rpc/XDR.h"
 
-#include "zeek/zeek-config.h"
-
+// Needed for ntohl()
+#include <arpa/inet.h>
 #include <algorithm>
 #include <cstring>
-
-#include "zeek/analyzer/protocol/rpc/events.bif.h"
 
 uint32_t zeek::analyzer::rpc::extract_XDR_uint32(const u_char*& buf, int& len) {
     if ( ! buf )

--- a/src/analyzer/protocol/rpc/XDR.h
+++ b/src/analyzer/protocol/rpc/XDR.h
@@ -5,8 +5,6 @@
 #include <netinet/in.h>
 #include <sys/types.h>
 
-#include "zeek/util.h"
-
 namespace zeek::analyzer::rpc {
 
 extern uint32_t extract_XDR_uint32(const u_char*& buf, int& len);

--- a/src/analyzer/protocol/sip/Plugin.cc
+++ b/src/analyzer/protocol/sip/Plugin.cc
@@ -4,7 +4,6 @@
 
 #include "zeek/analyzer/Component.h"
 #include "zeek/analyzer/protocol/sip/SIP.h"
-#include "zeek/analyzer/protocol/sip/SIP_TCP.h"
 
 namespace zeek::plugin::detail::Zeek_SIP {
 

--- a/src/analyzer/protocol/sip/SIP.cc
+++ b/src/analyzer/protocol/sip/SIP.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/analyzer/protocol/sip/SIP.h"
 
-#include "zeek/analyzer/protocol/sip/events.bif.h"
-
 namespace zeek::analyzer::sip {
 
 SIP_Analyzer::SIP_Analyzer(Connection* c) : analyzer::Analyzer("SIP", c) { interp = new binpac::SIP::SIP_Conn(this); }

--- a/src/analyzer/protocol/sip/SIP.h
+++ b/src/analyzer/protocol/sip/SIP.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/sip/events.bif.h"
 #include "zeek/analyzer/protocol/sip/sip_pac.h"
 
 namespace zeek::analyzer::sip {

--- a/src/analyzer/protocol/sip/SIP_TCP.cc
+++ b/src/analyzer/protocol/sip/SIP_TCP.cc
@@ -5,7 +5,6 @@
 
 #include "zeek/analyzer/protocol/sip/SIP_TCP.h"
 
-#include "zeek/analyzer/protocol/sip/events.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 namespace zeek::analyzer::sip_tcp {

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -2,13 +2,9 @@
 
 #include "zeek/analyzer/protocol/smtp/SMTP.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cstdlib>
 #include <limits>
 
-#include "zeek/Event.h"
-#include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/Manager.h"
 #include "zeek/analyzer/protocol/smtp/BDAT.h"

--- a/src/analyzer/protocol/snmp/SNMP.cc
+++ b/src/analyzer/protocol/snmp/SNMP.cc
@@ -2,11 +2,6 @@
 
 #include "zeek/analyzer/protocol/snmp/SNMP.h"
 
-#include "zeek/Func.h"
-#include "zeek/Reporter.h"
-#include "zeek/analyzer/protocol/snmp/events.bif.h"
-#include "zeek/analyzer/protocol/snmp/types.bif.h"
-
 namespace zeek::analyzer::snmp {
 
 SNMP_Analyzer::SNMP_Analyzer(Connection* conn) : Analyzer("SNMP", conn) { interp = new binpac::SNMP::SNMP_Conn(this); }

--- a/src/analyzer/protocol/snmp/SNMP.h
+++ b/src/analyzer/protocol/snmp/SNMP.h
@@ -2,7 +2,8 @@
 
 #pragma once
 
-#include "analyzer/protocol/snmp/snmp_pac.h"
+#include "zeek/analyzer/Analyzer.h"
+#include "zeek/analyzer/protocol/snmp/snmp_pac.h"
 
 namespace zeek::analyzer::snmp {
 

--- a/src/analyzer/protocol/snmp/snmp.pac
+++ b/src/analyzer/protocol/snmp/snmp.pac
@@ -2,7 +2,6 @@
 %include zeek.pac
 
 %extern{
-#include "zeek/Reporter.h"
 #include "zeek/analyzer/protocol/snmp/types.bif.h"
 #include "zeek/analyzer/protocol/snmp/events.bif.h"
 %}

--- a/src/analyzer/protocol/socks/SOCKS.cc
+++ b/src/analyzer/protocol/socks/SOCKS.cc
@@ -2,7 +2,6 @@
 
 #include "zeek/analyzer/protocol/socks/SOCKS.h"
 
-#include "zeek/analyzer/protocol/socks/events.bif.h"
 #include "zeek/analyzer/protocol/socks/socks_pac.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 

--- a/src/analyzer/protocol/ssh/SSH.cc
+++ b/src/analyzer/protocol/ssh/SSH.cc
@@ -4,7 +4,6 @@
 
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/protocol/ssh/events.bif.h"
-#include "zeek/analyzer/protocol/ssh/types.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 namespace zeek::analyzer::ssh {

--- a/src/analyzer/protocol/ssh/SSH.h
+++ b/src/analyzer/protocol/ssh/SSH.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/ssh/events.bif.h"
 #include "zeek/analyzer/protocol/ssh/ssh_pac.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 

--- a/src/analyzer/protocol/ssl/DTLS.cc
+++ b/src/analyzer/protocol/ssl/DTLS.cc
@@ -4,7 +4,6 @@
 
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/protocol/ssl/dtls_pac.h"
-#include "zeek/analyzer/protocol/ssl/events.bif.h"
 #include "zeek/analyzer/protocol/ssl/tls-handshake_pac.h"
 #include "zeek/util.h"
 

--- a/src/analyzer/protocol/ssl/DTLS.h
+++ b/src/analyzer/protocol/ssl/DTLS.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/ssl/events.bif.h"
+#include "zeek/analyzer/Analyzer.h"
 
 namespace binpac {
 namespace DTLS {

--- a/src/analyzer/protocol/ssl/Plugin.cc
+++ b/src/analyzer/protocol/ssl/Plugin.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/plugin/Plugin.h"
 
-#include "zeek/zeek-config.h"
-
 #ifndef ENABLE_SPICY_SSL
 #include "zeek/analyzer/Component.h"
 #include "zeek/analyzer/protocol/ssl/DTLS.h"

--- a/src/analyzer/protocol/ssl/SSL.cc
+++ b/src/analyzer/protocol/ssl/SSL.cc
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "zeek/Reporter.h"
-#include "zeek/analyzer/protocol/ssl/events.bif.h"
 #include "zeek/analyzer/protocol/ssl/ssl_pac.h"
 #include "zeek/analyzer/protocol/ssl/tls-handshake_pac.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"

--- a/src/analyzer/protocol/ssl/SSL.h
+++ b/src/analyzer/protocol/ssl/SSL.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "zeek/analyzer/protocol/pia/PIA.h"
-#include "zeek/analyzer/protocol/ssl/events.bif.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 
 namespace binpac {

--- a/src/analyzer/protocol/ssl/spicy/support.cc
+++ b/src/analyzer/protocol/ssl/spicy/support.cc
@@ -3,7 +3,6 @@
 #include <hilti/rt/libhilti.h>
 #include <cassert>
 
-#include "zeek/Conn.h"
 #include "zeek/Desc.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 #include "zeek/file_analysis/Manager.h"

--- a/src/analyzer/protocol/syslog/legacy/Syslog.h
+++ b/src/analyzer/protocol/syslog/legacy/Syslog.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/tcp/TCP.h"
+#include "zeek/analyzer/Analyzer.h"
 
 #include "analyzer/protocol/syslog/legacy/syslog_pac.h"
 

--- a/src/analyzer/protocol/tcp/ContentLine.cc
+++ b/src/analyzer/protocol/tcp/ContentLine.cc
@@ -4,7 +4,6 @@
 
 #include "zeek/Reporter.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
-#include "zeek/analyzer/protocol/tcp/events.bif.h"
 
 namespace zeek::analyzer::tcp {
 

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -2,19 +2,14 @@
 
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 
-#include <vector>
-
 #include "zeek/DebugLogger.h"
 #include "zeek/Event.h"
 #include "zeek/File.h"
 #include "zeek/IP.h"
-#include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/RunState.h"
-#include "zeek/analyzer/protocol/pia/PIA.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 #include "zeek/analyzer/protocol/tcp/events.bif.h"
-#include "zeek/analyzer/protocol/tcp/types.bif.h"
 #include "zeek/session/Manager.h"
 
 namespace zeek::analyzer::tcp {

--- a/src/analyzer/protocol/tcp/TCP.h
+++ b/src/analyzer/protocol/tcp/TCP.h
@@ -3,10 +3,8 @@
 #pragma once
 
 #include "zeek/Conn.h"
-#include "zeek/IPAddr.h"
 #include "zeek/analyzer/Analyzer.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Endpoint.h"
-#include "zeek/analyzer/protocol/tcp/TCP_Flags.h"
 #include "zeek/packet_analysis/protocol/tcp/TCPSessionAdapter.h"
 
 namespace zeek::analyzer::pia {

--- a/src/analyzer/protocol/tcp/TCP_Endpoint.cc
+++ b/src/analyzer/protocol/tcp/TCP_Endpoint.cc
@@ -4,16 +4,13 @@
 
 #include <cerrno>
 
-#include "zeek/Event.h"
 #include "zeek/File.h"
 #include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
-#include "zeek/RunState.h"
 #include "zeek/Val.h"
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 #include "zeek/analyzer/protocol/tcp/events.bif.h"
-#include "zeek/packet_analysis/Analyzer.h"
 #include "zeek/packet_analysis/protocol/tcp/TCP.h"
 #include "zeek/session/Manager.h"
 

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
-#include <algorithm>
-
 #include "zeek/File.h"
 #include "zeek/Reporter.h"
 #include "zeek/RuleMatcher.h"

--- a/src/analyzer/protocol/zip/Plugin.cc
+++ b/src/analyzer/protocol/zip/Plugin.cc
@@ -3,7 +3,6 @@
 #include "zeek/plugin/Plugin.h"
 
 #include "zeek/analyzer/Component.h"
-#include "zeek/analyzer/protocol/zip/ZIP.h"
 
 namespace zeek::plugin::detail::Zeek_ZIP {
 

--- a/src/analyzer/protocol/zip/ZIP.h
+++ b/src/analyzer/protocol/zip/ZIP.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <zlib.h>
 
 #include "zeek/analyzer/protocol/tcp/TCP.h"

--- a/src/binpac_zeek.h
+++ b/src/binpac_zeek.h
@@ -10,9 +10,6 @@
 #include "zeek/file_analysis/Analyzer.h"
 #include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/util.h"
-
-#include "event.bif.func_h"
 
 namespace binpac {
 

--- a/src/broker/Data.h
+++ b/src/broker/Data.h
@@ -11,7 +11,6 @@
 #include "zeek/OpaqueVal.h"
 #include "zeek/Reporter.h"
 
-#include "broker/config.hh"
 #include "broker/data.hh"
 
 namespace zeek {

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -31,7 +31,6 @@
 #include "zeek/broker/Data.h"
 #include "zeek/broker/Store.h"
 #include "zeek/broker/comm.bif.h"
-#include "zeek/broker/data.bif.h"
 #include "zeek/broker/messaging.bif.h"
 #include "zeek/broker/store.bif.h"
 #include "zeek/cluster/serializer/broker/Serializer.h"

--- a/src/cluster/serializer/binary-serialization-format/Serializer.cc
+++ b/src/cluster/serializer/binary-serialization-format/Serializer.cc
@@ -10,7 +10,6 @@
 #include "zeek/SerializationFormat.h"
 #include "zeek/Type.h"
 #include "zeek/Val.h"
-#include "zeek/cluster/Serializer.h"
 #include "zeek/cluster/serializer/binary-serialization-format/Plugin.h"
 #include "zeek/logging/Types.h"
 #include "zeek/threading/SerialTypes.h"

--- a/src/cluster/websocket/WebSocket.cc
+++ b/src/cluster/websocket/WebSocket.cc
@@ -20,7 +20,6 @@
 #include "zeek/net_util.h"
 #include "zeek/threading/MsgThread.h"
 
-#include "broker/data.bif.h"
 #include "broker/data_envelope.hh"
 #include "broker/error.hh"
 #include "broker/format/json.hh"

--- a/src/file_analysis/AnalyzerSet.cc
+++ b/src/file_analysis/AnalyzerSet.cc
@@ -7,7 +7,6 @@
 #include "zeek/file_analysis/Analyzer.h"
 #include "zeek/file_analysis/File.h"
 #include "zeek/file_analysis/Manager.h"
-#include "zeek/file_analysis/file_analysis.bif.h"
 
 namespace zeek::file_analysis::detail {
 

--- a/src/file_analysis/Component.h
+++ b/src/file_analysis/Component.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/Tag.h"
 #include "zeek/plugin/Component.h"
 

--- a/src/file_analysis/File.cc
+++ b/src/file_analysis/File.cc
@@ -2,21 +2,21 @@
 
 #include "zeek/file_analysis/File.h"
 
-#include <limits>
 #include <utility>
 
+#include "zeek/Conn.h"
 #include "zeek/Event.h"
 #include "zeek/Reporter.h"
 #include "zeek/RuleMatcher.h"
 #include "zeek/Type.h"
 #include "zeek/Val.h"
 #include "zeek/analyzer/Analyzer.h"
-#include "zeek/analyzer/Manager.h"
 #include "zeek/file_analysis/Analyzer.h"
 #include "zeek/file_analysis/FileReassembler.h"
 #include "zeek/file_analysis/FileTimer.h"
 #include "zeek/file_analysis/Manager.h"
 #include "zeek/file_analysis/analyzer/extract/Extract.h"
+#include "zeek/file_analysis/analyzer/extract/events.bif.h"
 
 namespace zeek::file_analysis {
 

--- a/src/file_analysis/File.h
+++ b/src/file_analysis/File.h
@@ -4,12 +4,10 @@
 
 #include <list>
 #include <string>
-#include <utility>
 
 #include "zeek/Tag.h"
 #include "zeek/WeirdState.h"
 #include "zeek/ZeekArgs.h"
-#include "zeek/ZeekList.h" // for ValPList
 #include "zeek/ZeekString.h"
 #include "zeek/file_analysis/AnalyzerSet.h"
 

--- a/src/file_analysis/FileReassembler.h
+++ b/src/file_analysis/FileReassembler.h
@@ -7,7 +7,6 @@
 namespace zeek {
 
 class Connection;
-class File;
 
 namespace file_analysis {
 

--- a/src/file_analysis/Manager.cc
+++ b/src/file_analysis/Manager.cc
@@ -8,11 +8,9 @@
 #include "zeek/Event.h"
 #include "zeek/UID.h"
 #include "zeek/analyzer/Manager.h"
-#include "zeek/digest.h"
 #include "zeek/file_analysis/Analyzer.h"
 #include "zeek/file_analysis/File.h"
 #include "zeek/file_analysis/file_analysis.bif.h"
-#include "zeek/plugin/Manager.h"
 
 using namespace std;
 

--- a/src/file_analysis/analyzer/data_event/DataEvent.h
+++ b/src/file_analysis/analyzer/data_event/DataEvent.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <string>
-
 #include "zeek/EventHandler.h"
 #include "zeek/Val.h"
 #include "zeek/file_analysis/Analyzer.h"

--- a/src/file_analysis/analyzer/entropy/Entropy.cc
+++ b/src/file_analysis/analyzer/entropy/Entropy.cc
@@ -6,6 +6,7 @@
 
 #include "zeek/Event.h"
 #include "zeek/file_analysis/Manager.h"
+#include "zeek/file_analysis/analyzer/entropy/events.bif.h"
 #include "zeek/util.h"
 
 namespace zeek::file_analysis::detail {

--- a/src/file_analysis/analyzer/entropy/Entropy.h
+++ b/src/file_analysis/analyzer/entropy/Entropy.h
@@ -2,13 +2,10 @@
 
 #pragma once
 
-#include <string>
-
 #include "zeek/OpaqueVal.h"
 #include "zeek/Val.h"
 #include "zeek/file_analysis/Analyzer.h"
 #include "zeek/file_analysis/File.h"
-#include "zeek/file_analysis/analyzer/entropy/events.bif.h"
 
 namespace zeek::file_analysis::detail {
 

--- a/src/file_analysis/analyzer/extract/Extract.cc
+++ b/src/file_analysis/analyzer/extract/Extract.cc
@@ -5,8 +5,8 @@
 #include <fcntl.h>
 #include <string>
 
-#include "zeek/Event.h"
 #include "zeek/file_analysis/Manager.h"
+#include "zeek/file_analysis/analyzer/extract/events.bif.h"
 #include "zeek/util.h"
 
 namespace zeek::file_analysis::detail {

--- a/src/file_analysis/analyzer/extract/Extract.h
+++ b/src/file_analysis/analyzer/extract/Extract.h
@@ -8,7 +8,6 @@
 #include "zeek/Val.h"
 #include "zeek/file_analysis/Analyzer.h"
 #include "zeek/file_analysis/File.h"
-#include "zeek/file_analysis/analyzer/extract/events.bif.h"
 
 namespace zeek::file_analysis::detail {
 

--- a/src/file_analysis/analyzer/hash/Hash.cc
+++ b/src/file_analysis/analyzer/hash/Hash.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/file_analysis/analyzer/hash/Hash.h"
 
-#include <string>
-
 #include "zeek/Event.h"
 #include "zeek/file_analysis/Manager.h"
 #include "zeek/util.h"

--- a/src/file_analysis/analyzer/hash/Hash.h
+++ b/src/file_analysis/analyzer/hash/Hash.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <string>
-
 #include "zeek/OpaqueVal.h"
 #include "zeek/Val.h"
 #include "zeek/file_analysis/Analyzer.h"

--- a/src/file_analysis/analyzer/pe/PE.h
+++ b/src/file_analysis/analyzer/pe/PE.h
@@ -2,9 +2,6 @@
 
 #pragma once
 
-#include <string>
-
-#include "zeek/File.h"
 #include "zeek/Val.h"
 
 #include "file_analysis/analyzer/pe/pe_pac.h"

--- a/src/file_analysis/analyzer/x509/OCSP.cc
+++ b/src/file_analysis/analyzer/x509/OCSP.cc
@@ -15,7 +15,6 @@
 #include "zeek/file_analysis/Manager.h"
 #include "zeek/file_analysis/analyzer/x509/X509.h"
 #include "zeek/file_analysis/analyzer/x509/ocsp_events.bif.h"
-#include "zeek/file_analysis/analyzer/x509/types.bif.h"
 
 // helper function of sk_X509_value to avoid namespace problem
 // sk_X509_value(X,Y) = > SKM_sk_value(X509,X,Y)

--- a/src/file_analysis/analyzer/x509/X509Common.cc
+++ b/src/file_analysis/analyzer/x509/X509Common.cc
@@ -9,7 +9,6 @@
 #include <openssl/x509v3.h>
 
 #include "zeek/Reporter.h"
-#include "zeek/file_analysis/analyzer/x509/events.bif.h"
 #include "zeek/file_analysis/analyzer/x509/ocsp_events.bif.h"
 #include "zeek/file_analysis/analyzer/x509/types.bif.h"
 #include "zeek/file_analysis/analyzer/x509/x509-extension_pac.h"

--- a/src/input/Component.h
+++ b/src/input/Component.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/Tag.h"
 #include "zeek/plugin/Component.h"
 
 namespace zeek::input {

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -12,8 +12,6 @@
 #include "zeek/EventHandler.h"
 #include "zeek/Expr.h"
 #include "zeek/Func.h"
-#include "zeek/NetVar.h"
-#include "zeek/RunState.h"
 #include "zeek/file_analysis/Manager.h"
 #include "zeek/input/ReaderBackend.h"
 #include "zeek/input/ReaderFrontend.h"

--- a/src/input/ReaderBackend.cc
+++ b/src/input/ReaderBackend.cc
@@ -2,7 +2,6 @@
 
 #include "zeek/input/ReaderBackend.h"
 
-#include "zeek/Desc.h"
 #include "zeek/input/Manager.h"
 #include "zeek/input/ReaderFrontend.h"
 

--- a/src/input/ReaderBackend.h
+++ b/src/input/ReaderBackend.h
@@ -2,10 +2,8 @@
 
 #pragma once
 
-#include "zeek/ZeekString.h"
 #include "zeek/input/Component.h"
 #include "zeek/threading/MsgThread.h"
-#include "zeek/threading/SerialTypes.h"
 
 namespace zeek::detail {
 class Location;

--- a/src/input/readers/ascii/Ascii.cc
+++ b/src/input/readers/ascii/Ascii.cc
@@ -9,6 +9,7 @@
 
 #include "zeek/input/readers/ascii/ascii.bif.h"
 #include "zeek/threading/SerialTypes.h"
+#include "zeek/threading/formatters/Ascii.h"
 
 using namespace std;
 using zeek::threading::Field;

--- a/src/input/readers/ascii/Ascii.h
+++ b/src/input/readers/ascii/Ascii.h
@@ -4,13 +4,13 @@
 
 #include <sys/types.h>
 #include <fstream>
-#include <iostream>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "zeek/Obj.h"
 #include "zeek/input/ReaderBackend.h"
-#include "zeek/threading/formatters/Ascii.h"
+#include "zeek/threading/Formatter.h"
 
 namespace zeek::input::reader::detail {
 

--- a/src/input/readers/benchmark/Benchmark.cc
+++ b/src/input/readers/benchmark/Benchmark.cc
@@ -8,7 +8,6 @@
 #include <cerrno>
 
 #include "zeek/input/readers/benchmark/benchmark.bif.h"
-#include "zeek/threading/Manager.h"
 #include "zeek/threading/SerialTypes.h"
 
 using zeek::threading::Field;

--- a/src/input/readers/config/Config.cc
+++ b/src/input/readers/config/Config.cc
@@ -7,13 +7,13 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <cerrno>
-#include <sstream>
 #include <unordered_set>
 
 #include "zeek/Desc.h"
 #include "zeek/input/Manager.h"
 #include "zeek/input/readers/config/config.bif.h"
 #include "zeek/threading/SerialTypes.h"
+#include "zeek/threading/formatters/Ascii.h"
 
 using zeek::threading::Field;
 using zeek::threading::Value;

--- a/src/input/readers/config/Config.h
+++ b/src/input/readers/config/Config.h
@@ -4,14 +4,11 @@
 
 #include <sys/types.h>
 #include <fstream>
-#include <iostream>
-#include <memory>
 #include <unordered_map>
-#include <vector>
 
 #include "zeek/ID.h"
 #include "zeek/input/ReaderBackend.h"
-#include "zeek/threading/formatters/Ascii.h"
+#include "zeek/threading/Formatter.h"
 
 namespace zeek::input::reader::detail {
 

--- a/src/input/readers/raw/Plugin.cc
+++ b/src/input/readers/raw/Plugin.cc
@@ -2,6 +2,9 @@
 
 #include "zeek/input/readers/raw/Plugin.h"
 
+#include "zeek/input/Component.h"
+#include "zeek/input/readers/raw/Raw.h"
+
 namespace zeek::plugin::detail::Zeek_RawReader {
 
 Plugin plugin;

--- a/src/input/readers/raw/Plugin.h
+++ b/src/input/readers/raw/Plugin.h
@@ -4,7 +4,6 @@
 
 #include <mutex>
 
-#include "zeek/input/readers/raw/Raw.h"
 #include "zeek/plugin/Plugin.h"
 
 namespace zeek::plugin::detail::Zeek_RawReader {

--- a/src/input/readers/raw/Raw.cc
+++ b/src/input/readers/raw/Raw.cc
@@ -17,6 +17,7 @@
 
 extern char** environ;
 
+#include "zeek/input/Component.h"
 #include "zeek/input/readers/raw/Plugin.h"
 #include "zeek/input/readers/raw/raw.bif.h"
 #include "zeek/threading/SerialTypes.h"

--- a/src/input/readers/raw/Raw.h
+++ b/src/input/readers/raw/Raw.h
@@ -5,7 +5,6 @@
 #include <sys/types.h>
 #include <memory>
 #include <mutex>
-#include <vector>
 
 #include "zeek/input/ReaderBackend.h"
 

--- a/src/input/readers/sqlite/SQLite.cc
+++ b/src/input/readers/sqlite/SQLite.cc
@@ -2,13 +2,9 @@
 
 #include "zeek/input/readers/sqlite/SQLite.h"
 
-#include "zeek/zeek-config.h"
-
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <fstream>
-#include <sstream>
 
 #include "zeek/input/readers/sqlite/sqlite.bif.h"
 #include "zeek/logging/writers/ascii/ascii.bif.h"

--- a/src/input/readers/sqlite/SQLite.h
+++ b/src/input/readers/sqlite/SQLite.h
@@ -2,10 +2,7 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
-#include <iostream>
-#include <vector>
+#include <string>
 
 #include "zeek/3rdparty/sqlite3.h"
 #include "zeek/input/ReaderBackend.h"

--- a/src/iosource/BPF_Program.cc
+++ b/src/iosource/BPF_Program.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/iosource/BPF_Program.h"
 
-#include "zeek/zeek-config.h"
-
 // clang-format off
 // Include order is required here for a working build on Windows.
 #include <unistd.h>

--- a/src/iosource/Manager.cc
+++ b/src/iosource/Manager.cc
@@ -12,7 +12,6 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-#include "zeek/NetVar.h"
 #include "zeek/RunState.h"
 #include "zeek/iosource/Component.h"
 #include "zeek/iosource/IOSource.h"

--- a/src/iosource/Manager.h
+++ b/src/iosource/Manager.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <map>
 #include <string>
 #include <vector>

--- a/src/iosource/Packet.cc
+++ b/src/iosource/Packet.cc
@@ -16,12 +16,8 @@ extern "C" {
 #endif
 }
 
-#include "zeek/Desc.h"
 #include "zeek/IP.h"
-#include "zeek/TunnelEncapsulation.h"
 #include "zeek/Var.h"
-#include "zeek/iosource/Manager.h"
-#include "zeek/packet_analysis/Manager.h"
 
 namespace zeek {
 

--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <sys/types.h> // for u_char
 #include <cstdint>
 #include <string>

--- a/src/iosource/PktDumper.cc
+++ b/src/iosource/PktDumper.cc
@@ -3,8 +3,6 @@
 
 #include "zeek/iosource/PktDumper.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/DebugLogger.h"
 
 namespace zeek::iosource {

--- a/src/iosource/PktDumper.h
+++ b/src/iosource/PktDumper.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <string>
 
 namespace zeek {

--- a/src/iosource/pcap/Source.cc
+++ b/src/iosource/pcap/Source.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/iosource/pcap/Source.h"
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/3rdparty/doctest.h"
 
 #ifdef HAVE_PCAP_INT_H

--- a/src/logging/Component.h
+++ b/src/logging/Component.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/Tag.h"
 #include "zeek/plugin/Component.h"
 
 namespace zeek::logging {

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -14,7 +14,6 @@
 #include "zeek/File.h"
 #include "zeek/Func.h"
 #include "zeek/IntrusivePtr.h"
-#include "zeek/NetVar.h"
 #include "zeek/OpaqueVal.h"
 #include "zeek/RunState.h"
 #include "zeek/Timer.h"

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -22,6 +22,7 @@
 #include "zeek/logging/WriterBackend.h"
 #include "zeek/logging/WriterFrontend.h"
 #include "zeek/logging/logging.bif.h"
+#include "zeek/module_util.h"
 #include "zeek/plugin/Manager.h"
 #include "zeek/plugin/Plugin.h"
 #include "zeek/telemetry/Manager.h"

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -20,6 +20,8 @@
 #include "zeek/logging/Manager.h"
 #include "zeek/logging/writers/ascii/ascii.bif.h"
 #include "zeek/threading/SerialTypes.h"
+#include "zeek/threading/formatters/Ascii.h"
+#include "zeek/threading/formatters/JSON.h"
 #include "zeek/util.h"
 
 #include "zeek/3rdparty/doctest.h"

--- a/src/logging/writers/ascii/Ascii.h
+++ b/src/logging/writers/ascii/Ascii.h
@@ -5,11 +5,11 @@
 #pragma once
 
 #include <zlib.h>
+#include <string>
 
 #include "zeek/Desc.h"
 #include "zeek/logging/WriterBackend.h"
-#include "zeek/threading/formatters/Ascii.h"
-#include "zeek/threading/formatters/JSON.h"
+#include "zeek/threading/Formatter.h"
 
 namespace zeek::plugin::detail::Zeek_AsciiWriter {
 class Plugin;

--- a/src/logging/writers/sqlite/SQLite.cc
+++ b/src/logging/writers/sqlite/SQLite.cc
@@ -2,12 +2,10 @@
 
 #include "zeek/logging/writers/sqlite/SQLite.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cerrno>
 #include <string>
-#include <vector>
 
+#include "zeek/Desc.h"
 #include "zeek/logging/writers/sqlite/sqlite.bif.h"
 #include "zeek/threading/SerialTypes.h"
 #include "zeek/util.h"

--- a/src/logging/writers/sqlite/SQLite.h
+++ b/src/logging/writers/sqlite/SQLite.h
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include "zeek/3rdparty/sqlite3.h"
-#include "zeek/Desc.h"
 #include "zeek/logging/WriterBackend.h"
 #include "zeek/threading/formatters/Ascii.h"
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,7 +1,5 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek/zeek-config.h"
-
 #include <unistd.h>
 #include <cinttypes>
 
@@ -10,6 +8,8 @@
 #include "zeek/iosource/Manager.h"
 #include "zeek/supervisor/Supervisor.h"
 #include "zeek/zeek-setup.h"
+
+#include "const.bif.netvar_h"
 
 #ifdef _MSC_VER
 #include <fcntl.h> // For _O_BINARY.

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,6 +3,7 @@
 #include <unistd.h>
 #include <cinttypes>
 
+#include "zeek/NetVar.h"
 #include "zeek/RunState.h"
 #include "zeek/Stats.h"
 #include "zeek/iosource/Manager.h"

--- a/src/module_util.cc
+++ b/src/module_util.cc
@@ -4,7 +4,6 @@
 #include "zeek/module_util.h"
 
 #include <cstring>
-#include <iostream>
 #include <string>
 
 #include "zeek/3rdparty/doctest.h"

--- a/src/net_util.cc
+++ b/src/net_util.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/net_util.h"
 
-#include "zeek/zeek-config.h"
-
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>

--- a/src/packet_analysis/Component.h
+++ b/src/packet_analysis/Component.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <functional>
 
 #include "zeek/Tag.h"

--- a/src/packet_analysis/Dispatcher.h
+++ b/src/packet_analysis/Dispatcher.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <vector>
 

--- a/src/packet_analysis/Manager.cc
+++ b/src/packet_analysis/Manager.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/packet_analysis/Manager.h"
 
+#include "zeek/Event.h"
 #include "zeek/RunState.h"
 #include "zeek/Stats.h"
 #include "zeek/iosource/Manager.h"
@@ -9,7 +10,6 @@
 #include "zeek/packet_analysis/Analyzer.h"
 #include "zeek/packet_analysis/Dispatcher.h"
 #include "zeek/plugin/Manager.h"
-#include "zeek/zeek-bif.h"
 
 using namespace zeek::packet_analysis;
 

--- a/src/packet_analysis/Manager.h
+++ b/src/packet_analysis/Manager.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/Func.h"
 #include "zeek/PacketFilter.h"
 #include "zeek/Tag.h"
 #include "zeek/iosource/Packet.h"

--- a/src/packet_analysis/protocol/ayiya/AYIYA.h
+++ b/src/packet_analysis/protocol/ayiya/AYIYA.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::AYIYA {
 

--- a/src/packet_analysis/protocol/fddi/FDDI.h
+++ b/src/packet_analysis/protocol/fddi/FDDI.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::FDDI {
 

--- a/src/packet_analysis/protocol/geneve/Geneve.h
+++ b/src/packet_analysis/protocol/geneve/Geneve.h
@@ -2,11 +2,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 
 #include "zeek/Span.h"
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::Geneve {
 

--- a/src/packet_analysis/protocol/gre/GRE.cc
+++ b/src/packet_analysis/protocol/gre/GRE.cc
@@ -4,7 +4,6 @@
 
 #include <pcap.h> // For DLT_ constants
 
-#include "zeek/IP.h"
 #include "zeek/Reporter.h"
 #include "zeek/RunState.h"
 #include "zeek/session/Manager.h"

--- a/src/packet_analysis/protocol/gre/GRE.h
+++ b/src/packet_analysis/protocol/gre/GRE.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::GRE {
 

--- a/src/packet_analysis/protocol/icmp/ICMP.cc
+++ b/src/packet_analysis/protocol/icmp/ICMP.cc
@@ -11,7 +11,6 @@
 #include "zeek/Val.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/Manager.h"
-#include "zeek/analyzer/protocol/conn-size/ConnSize.h"
 #include "zeek/packet_analysis/protocol/icmp/ICMPSessionAdapter.h"
 #include "zeek/packet_analysis/protocol/icmp/events.bif.h"
 #include "zeek/session/Manager.h"

--- a/src/packet_analysis/protocol/icmp/ICMPSessionAdapter.cc
+++ b/src/packet_analysis/protocol/icmp/ICMPSessionAdapter.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/packet_analysis/protocol/icmp/ICMPSessionAdapter.h"
 
+#include "zeek/Conn.h"
 #include "zeek/analyzer/Manager.h"
 #include "zeek/analyzer/protocol/conn-size/ConnSize.h"
 

--- a/src/packet_analysis/protocol/icmp/Plugin.cc
+++ b/src/packet_analysis/protocol/icmp/Plugin.cc
@@ -5,7 +5,6 @@
 #include "zeek/analyzer/Component.h"
 #include "zeek/packet_analysis/Component.h"
 #include "zeek/packet_analysis/protocol/icmp/ICMP.h"
-#include "zeek/packet_analysis/protocol/icmp/ICMPSessionAdapter.h"
 
 namespace zeek::plugin::Zeek_ICMP {
 

--- a/src/packet_analysis/protocol/ieee802_11/IEEE802_11.h
+++ b/src/packet_analysis/protocol/ieee802_11/IEEE802_11.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::IEEE802_11 {
 

--- a/src/packet_analysis/protocol/ieee802_11_radio/IEEE802_11_Radio.h
+++ b/src/packet_analysis/protocol/ieee802_11_radio/IEEE802_11_Radio.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::IEEE802_11_Radio {
 

--- a/src/packet_analysis/protocol/ip/IP.cc
+++ b/src/packet_analysis/protocol/ip/IP.cc
@@ -8,7 +8,6 @@
 #include "zeek/Event.h"
 #include "zeek/Frag.h"
 #include "zeek/IP.h"
-#include "zeek/IPAddr.h"
 #include "zeek/NetVar.h"
 #include "zeek/PacketFilter.h"
 #include "zeek/RunState.h"

--- a/src/packet_analysis/protocol/ip/IPBasedAnalyzer.h
+++ b/src/packet_analysis/protocol/ip/IPBasedAnalyzer.h
@@ -5,7 +5,6 @@
 #include <map>
 #include <set>
 
-#include "zeek/ID.h"
 #include "zeek/Tag.h"
 #include "zeek/packet_analysis/Analyzer.h"
 

--- a/src/packet_analysis/protocol/linux_sll2/LinuxSLL2.h
+++ b/src/packet_analysis/protocol/linux_sll2/LinuxSLL2.h
@@ -2,8 +2,10 @@
 
 #pragma once
 
+#include <cstdint>
+
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::LinuxSLL2 {
 

--- a/src/packet_analysis/protocol/llc/LLC.h
+++ b/src/packet_analysis/protocol/llc/LLC.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::LLC {
 

--- a/src/packet_analysis/protocol/mpls/MPLS.h
+++ b/src/packet_analysis/protocol/mpls/MPLS.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::MPLS {
 

--- a/src/packet_analysis/protocol/nflog/NFLog.h
+++ b/src/packet_analysis/protocol/nflog/NFLog.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::NFLog {
 

--- a/src/packet_analysis/protocol/novell_802_3/Novell_802_3.h
+++ b/src/packet_analysis/protocol/novell_802_3/Novell_802_3.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::Novell_802_3 {
 

--- a/src/packet_analysis/protocol/ppp/PPP.h
+++ b/src/packet_analysis/protocol/ppp/PPP.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::PPP {
 

--- a/src/packet_analysis/protocol/ppp_serial/PPPSerial.h
+++ b/src/packet_analysis/protocol/ppp_serial/PPPSerial.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::PPPSerial {
 

--- a/src/packet_analysis/protocol/pppoe/PPPoE.h
+++ b/src/packet_analysis/protocol/pppoe/PPPoE.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::PPPoE {
 

--- a/src/packet_analysis/protocol/tcp/Stats.cc
+++ b/src/packet_analysis/protocol/tcp/Stats.cc
@@ -3,7 +3,6 @@
 #include "zeek/packet_analysis/protocol/tcp/Stats.h"
 
 #include "zeek/File.h"
-#include "zeek/analyzer/protocol/tcp/events.bif.h"
 
 namespace zeek::packet_analysis::TCP {
 

--- a/src/packet_analysis/protocol/tcp/TCP.cc
+++ b/src/packet_analysis/protocol/tcp/TCP.cc
@@ -4,8 +4,6 @@
 
 #include "zeek/RunState.h"
 #include "zeek/analyzer/protocol/pia/PIA.h"
-#include "zeek/analyzer/protocol/tcp/events.bif.h"
-#include "zeek/analyzer/protocol/tcp/types.bif.h"
 #include "zeek/packet_analysis/protocol/tcp/TCPSessionAdapter.h"
 
 using namespace zeek;

--- a/src/packet_analysis/protocol/tcp/TCP.h
+++ b/src/packet_analysis/protocol/tcp/TCP.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "zeek/analyzer/protocol/tcp/TCP_Flags.h"
 #include "zeek/packet_analysis/Analyzer.h"
 #include "zeek/packet_analysis/Component.h"
 #include "zeek/packet_analysis/protocol/ip/IPBasedAnalyzer.h"

--- a/src/packet_analysis/protocol/tcp/TCPSessionAdapter.h
+++ b/src/packet_analysis/protocol/tcp/TCPSessionAdapter.h
@@ -5,8 +5,6 @@
 #include "zeek/Tag.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Endpoint.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Flags.h"
-#include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 #include "zeek/packet_analysis/protocol/ip/SessionAdapter.h"
 #include "zeek/session/Manager.h"
 

--- a/src/packet_analysis/protocol/teredo/Teredo.h
+++ b/src/packet_analysis/protocol/teredo/Teredo.h
@@ -5,7 +5,6 @@
 #include <map>
 
 #include "zeek/Conn.h"
-#include "zeek/NetVar.h"
 #include "zeek/RE.h"
 #include "zeek/Reporter.h"
 #include "zeek/packet_analysis/Analyzer.h"

--- a/src/packet_analysis/protocol/udp/Plugin.cc
+++ b/src/packet_analysis/protocol/udp/Plugin.cc
@@ -5,7 +5,6 @@
 #include "zeek/analyzer/Component.h"
 #include "zeek/packet_analysis/Component.h"
 #include "zeek/packet_analysis/protocol/udp/UDP.h"
-#include "zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h"
 
 namespace zeek::plugin::Zeek_UDP {
 

--- a/src/packet_analysis/protocol/vntag/VNTag.h
+++ b/src/packet_analysis/protocol/vntag/VNTag.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::VNTag {
 

--- a/src/packet_analysis/protocol/vxlan/VXLAN.h
+++ b/src/packet_analysis/protocol/vxlan/VXLAN.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/Analyzer.h"
-#include "zeek/packet_analysis/Component.h"
 
 namespace zeek::packet_analysis::VXLAN {
 

--- a/src/plugin/ComponentManager.h
+++ b/src/plugin/ComponentManager.h
@@ -6,7 +6,6 @@
 #include <map>
 #include <string>
 
-#include "zeek/Attr.h"
 #include "zeek/DebugLogger.h"
 #include "zeek/Expr.h"
 #include "zeek/Reporter.h"
@@ -16,7 +15,6 @@
 #include "zeek/Val.h"
 #include "zeek/Var.h" // for add_type()
 #include "zeek/ZeekString.h"
-#include "zeek/module_util.h"
 #include "zeek/zeekygen/Manager.h"
 
 namespace zeek::plugin {

--- a/src/plugin/Manager.cc
+++ b/src/plugin/Manager.cc
@@ -9,7 +9,6 @@
 #endif
 #include <sys/stat.h>
 #include <cerrno>
-#include <climits> // for PATH_MAX
 #include <cstdlib>
 #include <fstream>
 #include <optional>

--- a/src/plugin/Manager.h
+++ b/src/plugin/Manager.h
@@ -9,7 +9,6 @@
 
 #include "zeek/Reporter.h"
 #include "zeek/ZeekArgs.h"
-#include "zeek/plugin/Component.h"
 #include "zeek/plugin/Plugin.h"
 
 namespace zeek {

--- a/src/probabilistic/BloomFilter.h
+++ b/src/probabilistic/BloomFilter.h
@@ -2,11 +2,8 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "zeek/probabilistic/BitVector.h"
 #include "zeek/probabilistic/Hasher.h"

--- a/src/probabilistic/CounterVector.cc
+++ b/src/probabilistic/CounterVector.cc
@@ -8,7 +8,6 @@
 
 #include "zeek/broker/Data.h"
 #include "zeek/probabilistic/BitVector.h"
-#include "zeek/util.h"
 
 namespace zeek::probabilistic::detail {
 

--- a/src/probabilistic/CounterVector.h
+++ b/src/probabilistic/CounterVector.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/src/probabilistic/Hasher.cc
+++ b/src/probabilistic/Hasher.cc
@@ -6,7 +6,6 @@
 #include <openssl/evp.h>
 #include <typeinfo>
 
-#include "zeek/NetVar.h"
 #include "zeek/Var.h"
 #include "zeek/broker/Data.h"
 #include "zeek/digest.h"

--- a/src/script_opt/CPP/Compile.h
+++ b/src/script_opt/CPP/Compile.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+// Most of these headers are needed for the block of #includes later
 #include "zeek/Desc.h"
 #include "zeek/script_opt/CPP/Func.h"
 #include "zeek/script_opt/CPP/InitsInfo.h"

--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -1,8 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "zeek/RE.h"
 #include "zeek/script_opt/CPP/Compile.h"
-#include "zeek/script_opt/ProfileFunc.h"
 
 namespace zeek::detail {
 

--- a/src/script_opt/CPP/RuntimeInitSupport.h
+++ b/src/script_opt/CPP/RuntimeInitSupport.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "zeek/Val.h"
-#include "zeek/script_opt/CPP/AttrExprType.h"
 #include "zeek/script_opt/CPP/Func.h"
 
 namespace zeek {

--- a/src/script_opt/CPP/RuntimeInits.cc
+++ b/src/script_opt/CPP/RuntimeInits.cc
@@ -6,6 +6,8 @@
 #include "zeek/File.h"
 #include "zeek/RE.h"
 #include "zeek/ZeekString.h"
+#include "zeek/module_util.h"
+#include "zeek/script_opt/CPP/AttrExprType.h"
 #include "zeek/script_opt/CPP/RuntimeInitSupport.h"
 
 using namespace std;

--- a/src/script_opt/CPP/RuntimeInits.h
+++ b/src/script_opt/CPP/RuntimeInits.h
@@ -7,7 +7,6 @@
 // associated strategies for dealing with them.
 
 #include "zeek/Expr.h"
-#include "zeek/module_util.h"
 #include "zeek/script_opt/CPP/RuntimeInitSupport.h"
 
 #pragma once

--- a/src/script_opt/CPP/Vars.cc
+++ b/src/script_opt/CPP/Vars.cc
@@ -2,7 +2,6 @@
 
 #include "zeek/script_opt/CPP/Compile.h"
 #include "zeek/script_opt/IDOptInfo.h"
-#include "zeek/script_opt/ProfileFunc.h"
 
 namespace zeek::detail {
 

--- a/src/script_opt/FuncInfo.cc
+++ b/src/script_opt/FuncInfo.cc
@@ -2,7 +2,7 @@
 
 #include "zeek/script_opt/FuncInfo.h"
 
-#include <unordered_set>
+#include <unordered_map>
 
 namespace zeek::detail {
 

--- a/src/script_opt/FuncInfo.h
+++ b/src/script_opt/FuncInfo.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "zeek/Func.h"
+#include <string>
 
 namespace zeek::detail {
 

--- a/src/script_opt/IDOptInfo.cc
+++ b/src/script_opt/IDOptInfo.cc
@@ -4,7 +4,6 @@
 
 #include "zeek/Desc.h"
 #include "zeek/Expr.h"
-#include "zeek/Stmt.h"
 #include "zeek/script_opt/StmtOptInfo.h"
 
 namespace zeek::detail {

--- a/src/script_opt/Inline.cc
+++ b/src/script_opt/Inline.cc
@@ -2,7 +2,6 @@
 
 #include "zeek/script_opt/Inline.h"
 
-#include "zeek/Desc.h"
 #include "zeek/EventRegistry.h"
 #include "zeek/module_util.h"
 #include "zeek/script_opt/Expr.h"

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -5,7 +5,6 @@
 #include "zeek/Desc.h"
 #include "zeek/EventHandler.h"
 #include "zeek/EventRegistry.h"
-#include "zeek/Options.h"
 #include "zeek/Reporter.h"
 #include "zeek/module_util.h"
 #include "zeek/script_opt/CPP/Compile.h"

--- a/src/script_opt/ScriptOpt.h
+++ b/src/script_opt/ScriptOpt.h
@@ -4,9 +4,10 @@
 
 #pragma once
 
-#include <optional>
 #include <regex>
 #include <string>
+#include <unordered_set>
+#include <vector>
 
 #include "zeek/Expr.h"
 #include "zeek/Func.h"

--- a/src/script_opt/UsageAnalyzer.cc
+++ b/src/script_opt/UsageAnalyzer.cc
@@ -3,7 +3,6 @@
 #include "zeek/script_opt/UsageAnalyzer.h"
 
 #include "zeek/EventRegistry.h"
-#include "zeek/module_util.h"
 #include "zeek/script_opt/IDOptInfo.h"
 
 namespace zeek::detail {

--- a/src/script_opt/ZAM/Branches.cc
+++ b/src/script_opt/ZAM/Branches.cc
@@ -2,7 +2,6 @@
 
 // Methods for dealing with ZAM branches.
 
-#include "zeek/Desc.h"
 #include "zeek/Reporter.h"
 #include "zeek/script_opt/ZAM/Compile.h"
 

--- a/src/script_opt/ZAM/BuiltInSupport.h
+++ b/src/script_opt/ZAM/BuiltInSupport.h
@@ -2,8 +2,12 @@
 
 #pragma once
 
+#include <optional>
+#include <string>
+
 #include "zeek/Desc.h"
-#include "zeek/Expr.h"
+#include "zeek/Val.h"
+#include "zeek/ZVal.h"
 
 namespace zeek::detail {
 

--- a/src/script_opt/ZAM/Compile.h
+++ b/src/script_opt/ZAM/Compile.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "zeek/Event.h"
 #include "zeek/script_opt/Expr.h"
 #include "zeek/script_opt/ProfileFunc.h"
 #include "zeek/script_opt/UseDefs.h"

--- a/src/script_opt/ZAM/Driver.cc
+++ b/src/script_opt/ZAM/Driver.cc
@@ -2,12 +2,9 @@
 
 // Driver (and other high-level) methods for ZAM compilation.
 
-#include "zeek/CompHash.h"
 #include "zeek/Frame.h"
-#include "zeek/RE.h"
 #include "zeek/Reporter.h"
 #include "zeek/Scope.h"
-#include "zeek/module_util.h"
 #include "zeek/script_opt/ScriptOpt.h"
 #include "zeek/script_opt/ZAM/Compile.h"
 

--- a/src/script_opt/ZAM/Frame.h
+++ b/src/script_opt/ZAM/Frame.h
@@ -4,6 +4,12 @@
 
 #pragma once
 
+#include <vector>
+
+#include "zeek/Attr.h"
+#include "zeek/ID.h"
+#include "zeek/util.h"
+
 namespace zeek::detail {
 
 using AttributesPtr = IntrusivePtr<Attributes>;

--- a/src/script_opt/ZAM/Low-Level.cc
+++ b/src/script_opt/ZAM/Low-Level.cc
@@ -4,7 +4,6 @@
 
 #include "zeek/Desc.h"
 #include "zeek/Reporter.h"
-#include "zeek/script_opt/ScriptOpt.h"
 #include "zeek/script_opt/ZAM/Compile.h"
 
 namespace zeek::detail {

--- a/src/script_opt/ZAM/Profile.cc
+++ b/src/script_opt/ZAM/Profile.cc
@@ -2,12 +2,8 @@
 
 #include "zeek/script_opt/ZAM/Profile.h"
 
-#include <unordered_map>
-#include <unordered_set>
-
 #include "zeek/Obj.h"
 #include "zeek/script_opt/ProfileFunc.h"
-#include "zeek/script_opt/ZAM/ZBody.h"
 
 namespace zeek::detail {
 

--- a/src/script_opt/ZAM/Vars.cc
+++ b/src/script_opt/ZAM/Vars.cc
@@ -4,7 +4,6 @@
 
 #include "zeek/Desc.h"
 #include "zeek/Reporter.h"
-#include "zeek/script_opt/Reduce.h"
 #include "zeek/script_opt/ZAM/Compile.h"
 
 namespace zeek::detail {

--- a/src/script_opt/ZAM/ZBody.cc
+++ b/src/script_opt/ZAM/ZBody.cc
@@ -4,11 +4,9 @@
 
 #include "zeek/Conn.h"
 #include "zeek/Desc.h"
-#include "zeek/Dict.h"
-#include "zeek/EventHandler.h"
+#include "zeek/Event.h"
 #include "zeek/File.h"
 #include "zeek/Frame.h"
-#include "zeek/IPAddr.h"
 #include "zeek/OpaqueVal.h"
 #include "zeek/Overflow.h"
 #include "zeek/RE.h"

--- a/src/script_opt/ZAM/ZInst.h
+++ b/src/script_opt/ZAM/ZInst.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "zeek/script_opt/ZAM/BuiltInSupport.h"
 #include "zeek/script_opt/ZAM/Support.h"
 #include "zeek/script_opt/ZAM/ZInstAux.h"
 #include "zeek/script_opt/ZAM/ZOp.h"

--- a/src/script_opt/ZAM/ZInstAux.h
+++ b/src/script_opt/ZAM/ZInstAux.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "zeek/Expr.h"
 #include "zeek/Func.h"
 #include "zeek/TraverseTypes.h"
 #include "zeek/script_opt/ZAM/BuiltInSupport.h"

--- a/src/session/Manager.cc
+++ b/src/session/Manager.cc
@@ -11,7 +11,6 @@
 #include "zeek/Conn.h"
 #include "zeek/Func.h"
 #include "zeek/IP.h"
-#include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/RuleMatcher.h"
 #include "zeek/RunState.h"

--- a/src/session/Manager.h
+++ b/src/session/Manager.h
@@ -4,11 +4,8 @@
 
 #include <sys/types.h> // for u_char
 #include <unordered_map>
-#include <utility>
 
 #include "zeek/Frag.h"
-#include "zeek/Hash.h"
-#include "zeek/NetVar.h"
 #include "zeek/session/Session.h"
 
 namespace zeek {

--- a/src/session/Session.cc
+++ b/src/session/Session.cc
@@ -4,7 +4,6 @@
 
 #include "zeek/Desc.h"
 #include "zeek/Event.h"
-#include "zeek/IP.h"
 #include "zeek/Reporter.h"
 #include "zeek/Stats.h"
 #include "zeek/Val.h"

--- a/src/session/Session.h
+++ b/src/session/Session.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <map>
-#include <memory>
 
 #include "zeek/EventHandler.h"
 #include "zeek/Hash.h"

--- a/src/spicy/manager.cc
+++ b/src/spicy/manager.cc
@@ -27,6 +27,7 @@
 #include "zeek/Event.h"
 #include "zeek/analyzer/Manager.h"
 #include "zeek/file_analysis/Manager.h"
+#include "zeek/module_util.h"
 #include "zeek/packet_analysis/Manager.h"
 #include "zeek/spicy/file-analyzer.h"
 #include "zeek/spicy/packet-analyzer.h"

--- a/src/spicy/manager.cc
+++ b/src/spicy/manager.cc
@@ -24,6 +24,7 @@
 
 #include <hilti/autogen/config.h>
 
+#include "zeek/Event.h"
 #include "zeek/analyzer/Manager.h"
 #include "zeek/file_analysis/Manager.h"
 #include "zeek/packet_analysis/Manager.h"

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -29,6 +29,7 @@ extern "C" {
 #include "zeek/Dict.h"
 #include "zeek/Event.h"
 #include "zeek/EventHandler.h"
+#include "zeek/EventRegistry.h"
 #include "zeek/ID.h"
 #include "zeek/NetVar.h"
 #include "zeek/RE.h"

--- a/src/supervisor/Supervisor.h
+++ b/src/supervisor/Supervisor.h
@@ -2,11 +2,8 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <sys/types.h>
 #include <chrono>
-#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
@@ -17,8 +14,6 @@
 
 #include "zeek/Flare.h"
 #include "zeek/Func.h"
-#include "zeek/IntrusivePtr.h"
-#include "zeek/NetVar.h"
 #include "zeek/Options.h"
 #include "zeek/Pipe.h"
 #include "zeek/Timer.h"

--- a/src/telemetry/Counter.h
+++ b/src/telemetry/Counter.h
@@ -7,7 +7,7 @@
 #include <initializer_list>
 #include <memory>
 
-#include "zeek/NetVar.h"
+#include "zeek/NetVar.h" // For BifEnum::Telemetry value
 #include "zeek/Span.h"
 #include "zeek/telemetry/MetricFamily.h"
 #include "zeek/telemetry/Utils.h"

--- a/src/telemetry/Gauge.h
+++ b/src/telemetry/Gauge.h
@@ -8,7 +8,7 @@
 #include <initializer_list>
 #include <memory>
 
-#include "zeek/NetVar.h"
+#include "zeek/NetVar.h" // For BifEnum::Telemetry value
 #include "zeek/Span.h"
 #include "zeek/telemetry/MetricFamily.h"
 #include "zeek/telemetry/Utils.h"

--- a/src/telemetry/Histogram.h
+++ b/src/telemetry/Histogram.h
@@ -4,11 +4,10 @@
 
 #include <prometheus/family.h>
 #include <prometheus/histogram.h>
-#include <cstdint>
 #include <initializer_list>
 #include <memory>
 
-#include "zeek/NetVar.h"
+#include "zeek/NetVar.h" // For BifEnum::Telemetry values
 #include "zeek/Span.h"
 #include "zeek/telemetry/MetricFamily.h"
 #include "zeek/telemetry/Utils.h"

--- a/src/telemetry/Opaques.cc
+++ b/src/telemetry/Opaques.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "Opaques.h"
+#include "zeek/telemetry/Opaques.h"
 
 #include "zeek/telemetry/Counter.h"
 #include "zeek/telemetry/Gauge.h"

--- a/src/telemetry/ProcessStats.cc
+++ b/src/telemetry/ProcessStats.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/telemetry/ProcessStats.h"
 
-#include "zeek/util.h"
-
 #ifdef __APPLE__
 
 #include <libproc.h>
@@ -63,7 +61,13 @@ process_stats get_process_stats() {
 
 #elif defined(HAVE_LINUX)
 
+#include <dirent.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include <atomic>
+#include <cstdio>
+#include <cstring>
+
 std::atomic<long> global_ticks_per_second;
 std::atomic<long> global_page_size;
 
@@ -172,9 +176,10 @@ process_stats get_process_stats() {
 // Force these includes into a specific order so that the libraries can find
 // all of the required types.
 // clang-format off
+#include <sys/types.h>
+#include <sys/cdefs.h>
 #include <sys/queue.h>
 #include <sys/sysctl.h>
-#include <sys/types.h>
 #include <sys/user.h>
 #include <unistd.h>
 #include <libprocstat.h>

--- a/src/telemetry/ProcessStats.h
+++ b/src/telemetry/ProcessStats.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
+#include "zeek/zeek-config.h" // Needed for HAVE_LINUX
 
 #include <cstdint>
 

--- a/src/telemetry/Utils.cc
+++ b/src/telemetry/Utils.cc
@@ -1,6 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#include "Utils.h"
+#include "zeek/telemetry/Utils.h"
 
 #include "zeek/ID.h"
 #include "zeek/Reporter.h"

--- a/src/threading/BasicThread.cc
+++ b/src/threading/BasicThread.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/threading/BasicThread.h"
 
-#include "zeek/zeek-config.h"
-
 #include <pthread.h>
 #include <cinttypes>
 #include <csignal>

--- a/src/threading/BasicThread.h
+++ b/src/threading/BasicThread.h
@@ -7,7 +7,6 @@
 #include <unistd.h>
 #include <atomic>
 #include <cstdint>
-#include <iosfwd>
 #include <thread>
 
 namespace zeek::threading {

--- a/src/threading/Formatter.cc
+++ b/src/threading/Formatter.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/threading/Formatter.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cerrno>
 
 #include "zeek/3rdparty/zeek_inet_ntop.h"

--- a/src/threading/Manager.cc
+++ b/src/threading/Manager.cc
@@ -9,7 +9,6 @@
 
 #include "zeek/Event.h"
 #include "zeek/IPAddr.h"
-#include "zeek/NetVar.h"
 #include "zeek/RunState.h"
 #include "zeek/telemetry/Manager.h"
 

--- a/src/threading/MsgThread.cc
+++ b/src/threading/MsgThread.cc
@@ -11,7 +11,6 @@
 #include "zeek/Obj.h"
 #include "zeek/RunState.h"
 #include "zeek/iosource/Manager.h"
-#include "zeek/telemetry/Manager.h"
 #include "zeek/threading/Manager.h"
 
 // Set by Zeek's main signal handler.

--- a/src/threading/Queue.h
+++ b/src/threading/Queue.h
@@ -5,7 +5,6 @@
 #include <sys/time.h>
 #include <condition_variable>
 #include <cstdint>
-#include <deque>
 #include <mutex>
 #include <queue>
 

--- a/src/threading/formatters/Ascii.cc
+++ b/src/threading/formatters/Ascii.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/threading/formatters/Ascii.h"
 
-#include "zeek/zeek-config.h"
-
 #include <cerrno>
 #include <sstream>
 

--- a/src/threading/formatters/JSON.cc
+++ b/src/threading/formatters/JSON.cc
@@ -2,8 +2,6 @@
 
 #include "zeek/threading/formatters/JSON.h"
 
-#include "zeek/zeek-config.h"
-
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif
@@ -14,7 +12,6 @@
 #include <cerrno>
 #include <cmath>
 #include <cstdint>
-#include <sstream>
 
 #include "zeek/Desc.h"
 #include "zeek/threading/MsgThread.h"

--- a/src/threading/formatters/JSON.h
+++ b/src/threading/formatters/JSON.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <memory>
+#include <string>
 
 #include "zeek/threading/Formatter.h"
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -41,23 +41,24 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
-#include <random>
 #include <string>
 #include <vector>
 
 #include "zeek/3rdparty/ConvertUTF.h"
 #include "zeek/Desc.h"
 #include "zeek/Hash.h"
-#include "zeek/NetVar.h"
 #include "zeek/Obj.h"
 #include "zeek/Reporter.h"
 #include "zeek/RunState.h"
-#include "zeek/ScannedFile.h"
 #include "zeek/Val.h"
 #include "zeek/digest.h"
 #include "zeek/input.h"
 #include "zeek/iosource/Manager.h"
 #include "zeek/iosource/PktSrc.h"
+
+#ifdef _MSC_VER
+#include "zeek/ScannedFile.h"
+#endif
 
 #include "zeek/3rdparty/doctest.h"
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -23,6 +23,8 @@
 #include "zeek/3rdparty/sqlite3.h"
 #endif
 
+#include <binpac.h>
+
 #include "zeek/DNS_Mgr.h"
 #include "zeek/Debug.h"
 #include "zeek/Desc.h"
@@ -49,7 +51,6 @@
 #include "zeek/Trigger.h"
 #include "zeek/Var.h"
 #include "zeek/analyzer/Manager.h"
-#include "zeek/binpac_zeek.h"
 #include "zeek/broker/Manager.h"
 #include "zeek/cluster/Backend.h"
 #include "zeek/cluster/Manager.h"

--- a/src/zeekygen/IdentifierInfo.h
+++ b/src/zeekygen/IdentifierInfo.h
@@ -9,8 +9,6 @@
 #include <vector>
 
 #include "zeek/ID.h"
-#include "zeek/IntrusivePtr.h"
-#include "zeek/util.h"
 #include "zeek/zeekygen/Info.h"
 
 namespace zeek {

--- a/src/zeekygen/Manager.h
+++ b/src/zeekygen/Manager.h
@@ -11,7 +11,6 @@
 
 #include "zeek/ID.h"
 #include "zeek/Reporter.h"
-#include "zeek/util.h"
 #include "zeek/zeekygen/Configuration.h"
 #include "zeek/zeekygen/SpicyModuleInfo.h"
 

--- a/src/zeekygen/ScriptInfo.h
+++ b/src/zeekygen/ScriptInfo.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <ctime> // for time_t
 #include <list>
 #include <map>

--- a/src/zeekygen/SpicyModuleInfo.h
+++ b/src/zeekygen/SpicyModuleInfo.h
@@ -5,7 +5,6 @@
 #include <ctime> // for time_t
 #include <list>
 #include <string>
-#include <vector>
 
 #include "zeek/plugin/Plugin.h"
 #include "zeek/zeekygen/Info.h"

--- a/src/zeekygen/Target.h
+++ b/src/zeekygen/Target.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <cstdio>
 #include <map>
 #include <string>

--- a/src/zeekygen/utils.h
+++ b/src/zeekygen/utils.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "zeek/zeek-config.h"
-
 #include <ctime> // for time_t
 #include <optional>
 #include <string>

--- a/testing/btest/plugins/protocol-plugin/src/Foo.cc
+++ b/testing/btest/plugins/protocol-plugin/src/Foo.cc
@@ -2,6 +2,7 @@
 #include "Foo.h"
 
 #include "zeek/EventRegistry.h"
+#include "zeek/Func.h"
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
 #include "events.bif.h"


### PR DESCRIPTION
This is the second of two PRs (started in https://github.com/zeek/zeek/pull/4434) to clean up a ton of #include usage across the entire codebase. This one covers everything where a single change didn't spread to a bunch of other files.