### PR TITLE
EventTrace: Fix operator==() UBSAN downcast error

### DIFF
--- a/src/EventTrace.cc
+++ b/src/EventTrace.cc
@@ -95,7 +95,7 @@ bool ValTrace::operator==(const ValTrace& vt) const {
 
         case TYPE_SUBNET: return v->AsSubNet() == vt_v->AsSubNet();
 
-        case TYPE_FUNC: return v->AsFile() == vt_v->AsFile();
+        case TYPE_FUNC: return v->AsFunc() == vt_v->AsFunc();
 
         case TYPE_FILE: return v->AsFile() == vt_v->AsFile();
 


### PR DESCRIPTION
New test from #4473 triggeres the following error:

    runtime error: downcast of address 0x57021a323ea0 which does not point to an object of type 'const FileVal' 0x57021a323ea0: note: object is of type 'zeek::FuncVal'