### PR TITLE
Fix some follow-up issues with the sqlite cluster test

### DIFF
--- a/src/storage/backend/sqlite/SQLite.cc
+++ b/src/storage/backend/sqlite/SQLite.cc
@@ -97,6 +97,11 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
         return open_res;
     }
 
+    // TODO: Should we use sqlite3_busy_timeout here instead of using the pragma? That would
+    // at least let us skip over one. The busy timeout is per-connection as well, so it'll
+    // never fail to run like the other pragmas can.
+    //    sqlite3_busy_timeout(db, 2000);
+
     auto pragmas = backend_options->GetField<TableVal>("pragma_commands");
     for ( const auto& iter : *(pragmas->Get()) ) {
         auto k = iter.GetHashKey();

--- a/src/storage/backend/sqlite/SQLite.cc
+++ b/src/storage/backend/sqlite/SQLite.cc
@@ -85,8 +85,8 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
     auto pragma_timeout_val = backend_options->GetField<IntervalVal>("pragma_timeout");
     pragma_timeout = std::chrono::milliseconds(static_cast<int64_t>(pragma_timeout_val->Get() * 1000));
 
-    auto pragma_wof_val = backend_options->GetField<IntervalVal>("pragma_wait_on_busy");
-    pragma_wait_on_busy = std::chrono::milliseconds(static_cast<int64_t>(pragma_timeout_val->Get() * 1000));
+    auto pragma_wait_val = backend_options->GetField<IntervalVal>("pragma_wait_on_busy");
+    pragma_wait_on_busy = std::chrono::milliseconds(static_cast<int64_t>(pragma_wait_val->Get() * 1000));
 
     if ( auto open_res =
              CheckError(sqlite3_open_v2(full_path.c_str(), &db,

--- a/testing/btest/scripts/base/frameworks/storage/sqlite-cluster.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite-cluster.zeek
@@ -1,5 +1,3 @@
-# @TEST-IGNORE
-
 # @TEST-DOC: Tests SQLite storage in a cluster environment
 
 # @TEST-PORT: BROKER_MANAGER_PORT


### PR DESCRIPTION
- Adds a bunch of debug logging around executing pragmas
- Use the iteration from TableVal when looping over the pragmas. The table is defined with `&ordered`. Converting it to a map first caused the keys to be reordered based on the process's map hashing, which might not have been the same order.
- Fixes a variable name typo that was keeping busy pragmas from retrying
- Reenables the btest