### PR TITLE
CI: Modify task to run clang-tidy as part of builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -300,8 +300,8 @@ ubuntu24_clang_libcpp_task:
   << : *CI_TEMPLATE
   << : *SKIP_TASK_ON_PR
   env:
-    CC: clang-18
-    CXX: clang++-18
+    CC: clang-19
+    CXX: clang++-19
     CXXFLAGS: -stdlib=libc++
 
 ubuntu22_task:
@@ -445,8 +445,8 @@ ubsan_sanitizer_task:
   << : *SKIP_TASK_ON_PR
   test_fuzzers_script: ./ci/test-fuzzers.sh
   env:
-    CC: clang-18
-    CXX: clang++-18
+    CC: clang-19
+    CXX: clang++-19
     CXXFLAGS: -DZEEK_DICT_DEBUG
     ZEEK_CI_CONFIGURE_FLAGS: *UBSAN_SANITIZER_CONFIG
     ZEEK_TAILORED_UB_CHECKS: 1
@@ -459,8 +459,8 @@ ubsan_sanitizer_zam_task:
 
   << : *CI_TEMPLATE
   env:
-    CC: clang-18
-    CXX: clang++-18
+    CC: clang-19
+    CXX: clang++-19
     ZEEK_CI_CONFIGURE_FLAGS: *UBSAN_SANITIZER_CONFIG
     ZEEK_TAILORED_UB_CHECKS: 1
     UBSAN_OPTIONS: print_stacktrace=1
@@ -480,8 +480,8 @@ tsan_sanitizer_task:
   << : *CI_TEMPLATE
   << : *SKIP_TASK_ON_PR
   env:
-    CC: clang-18
-    CXX: clang++-18
+    CC: clang-19
+    CXX: clang++-19
     ZEEK_CI_CONFIGURE_FLAGS: *TSAN_SANITIZER_CONFIG
     ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1
     # If this is defined directly in the environment, configure fails to find

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,6 +19,7 @@ asan_sanitizer_config: &ASAN_SANITIZER_CONFIG --build-type=debug --disable-broke
 ubsan_sanitizer_config: &UBSAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=undefined --enable-fuzzers --ccache --enable-werror
 tsan_sanitizer_config: &TSAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=thread --enable-fuzzers --ccache --enable-werror
 macos_config: &MACOS_CONFIG --build-type=release --disable-broker-tests --prefix=$CIRRUS_WORKING_DIR/install --ccache --enable-werror --with-krb5=/opt/homebrew/opt/krb5
+clang_tidy_config: &CLANG_TIDY_CONFIG --build-type=debug --disable-broker-tests --prefix=$CIRRUS_WORKING_DIR/install --ccache --enable-werror --enable-clang-tidy
 
 resources_template: &RESOURCES_TEMPLATE
   cpu: *CPUS
@@ -303,6 +304,24 @@ ubuntu24_clang_libcpp_task:
     CC: clang-19
     CXX: clang++-19
     CXXFLAGS: -stdlib=libc++
+
+ubuntu24_clang_tidy_task:
+  container:
+    # Ubuntu 24.04 EOL: Jun 2029
+    dockerfile: ci/ubuntu-24.04/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  # Run on merges to master and release/.* and benchmark-nightly cron.
+  only_if: >
+    ( $CIRRUS_REPO_NAME == 'zeek' || $CIRRUS_REPO_NAME == 'zeek-security' ) &&
+      $CIRRUS_BRANCH == 'master' ||
+      $CIRRUS_BRANCH =~ 'release/.*' ||
+      $CIRRUS_CRON == 'benchmark-nightly'
+  env:
+    CC: clang-19
+    CXX: clang++-19
+    ZEEK_CI_CONFIGURE_FLAGS: *CLANG_TIDY_CONFIG
+
 
 ubuntu22_task:
   container:

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -4,15 +4,16 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20241024
+ENV DOCKERFILE_VERSION 20250522
 
 RUN apt-get update && apt-get -y install \
     bc \
     bison \
     bsdmainutils \
     ccache \
-    clang-18 \
-    clang++-18 \
+    clang-19 \
+    clang++-19 \
+    clang-tidy-19 \
     cmake \
     cppzmq-dev \
     curl \
@@ -46,6 +47,10 @@ RUN apt-get update && apt-get -y install \
 
 RUN pip3 install --break-system-packages websockets junit2html
 RUN gem install coveralls-lcov
+
+# Ubuntu installs clang versions with the binaries having the version number
+# appended. Create a symlink for clang-tidy so cmake finds it correctly.
+RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-19 1000
 
 # Download a newer pre-built ccache version that recognizes -fprofile-update=atomic
 # which is used when building with --coverage.


### PR DESCRIPTION
This modifies the ubuntu24_clang_libcpp task to run the build with `--enable-clang-tidy` enabled. It removes the skip-on-PR option for that task as well so that it always runs. As part of this, update the clang version installed on the ubuntu 24.04 VM to 19.x. I'd update to 20.x but there aren't packages for that version on ubuntu.

This depends on the changes to .clang-tidy that start in https://github.com/zeek/zeek/pull/4486, so that PR needs to be merged first. Otherwise it will report a lot of warnings that aren't fixed yet.