### PR TITLE
CI: Add PR labels for running cluster tests and skipping all tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,13 +68,13 @@ skip_task_on_pr: &SKIP_TASK_ON_PR
   # Skip this task on PRs if it does not have the CI: Full label,
   # it continues to run for direct pushes to master/release.
   skip: >
-    ! ( $CIRRUS_PR == '' || $CIRRUS_PR_LABELS =~ '.*CI: Full.*' )
+    ( ! ($CIRRUS_PR == '' || $CIRRUS_PR_LABELS =~ '.*CI: Full.*') || $CIRRUS_PR_LABELS =~ '.*CI: Skip All' )
 
 skip_cluster_test_on_pr: &SKIP_CLUSTER_TEST_ON_PR
   # Skip this task on PRs if it does not have the CI: Full label,
   # it continues to run for direct pushes to master/release.
   skip: >
-    ! ( $CIRRUS_PR == '' || $CIRRUS_PR_LABELS =~ '.*CI: (Full|Cluster Test).*')
+    ( ! ($CIRRUS_PR == '' || $CIRRUS_PR_LABELS =~ '.*CI: (Full|Cluster Test).*') || $CIRRUS_PR_LABELS =~ '.*CI: Skip All' )
 
 zam_skip_task_on_pr: &ZAM_SKIP_TASK_ON_PR
   # Skip this task on PRs unless it has the "CI: Full" or "CI: ZAM" label
@@ -82,7 +82,7 @@ zam_skip_task_on_pr: &ZAM_SKIP_TASK_ON_PR
   # It continues to run for direct pushes to master/release, as
   # CIRRUS_PR will be empty.
   skip: >
-    ! ( $CIRRUS_PR == '' || $CIRRUS_PR_LABELS =~ '.*CI: (Full|ZAM).*' || changesInclude('src/script_opt/**') )
+    ( ! ($CIRRUS_PR == '' || $CIRRUS_PR_LABELS =~ '.*CI: (Full|ZAM).*' || changesInclude('src/script_opt/**')) || $CIRRUS_PR_LABELS =~ '.*CI: Skip All' )
 
 benchmark_only_if_template: &BENCHMARK_ONLY_IF_TEMPLATE
   # only_if condition for cron-triggered benchmarking tests.
@@ -135,6 +135,10 @@ ci_template: &CI_TEMPLATE
     ccache_prune_script:
       # Evit some of the cached build artifacts not used in this build.
       CCACHE_MAXSIZE=${ZEEK_CCACHE_PRUNE_SIZE} ccache -c
+
+  # Always skip all tasks on a PR if the "CI: Skip All" label is applied.
+  skip: >
+    $CIRRUS_PR != '' && $CIRRUS_PR_LABELS =~ '.*CI: Skip All.*'
 
 env:
   CIRRUS_WORKING_DIR: /zeek
@@ -532,6 +536,8 @@ windows_task:
     # Give verbose error output on a test failure.
     CTEST_OUTPUT_ON_FAILURE: 1
   << : *BUILDS_ONLY_IF_TEMPLATE
+  skip: >
+    $CIRRUS_PR != '' && $CIRRUS_PR_LABELS =~ '.*CI: Skip All.*'
 
 
 # Container images

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,6 +70,12 @@ skip_task_on_pr: &SKIP_TASK_ON_PR
   skip: >
     ! ( $CIRRUS_PR == '' || $CIRRUS_PR_LABELS =~ '.*CI: Full.*' )
 
+skip_cluster_test_on_pr: &SKIP_CLUSTER_TEST_ON_PR
+  # Skip this task on PRs if it does not have the CI: Full label,
+  # it continues to run for direct pushes to master/release.
+  skip: >
+    ! ( $CIRRUS_PR == '' || $CIRRUS_PR_LABELS =~ '.*CI: (Full|Cluster Test).*')
+
 zam_skip_task_on_pr: &ZAM_SKIP_TASK_ON_PR
   # Skip this task on PRs unless it has the "CI: Full" or "CI: ZAM" label
   # or files in src/script_opt/** were modified.
@@ -612,7 +618,7 @@ amd64_container_image_docker_builder:
   env:
     CIRRUS_ARCH: amd64
   << : *DOCKER_BUILD_TEMPLATE
-  << : *SKIP_TASK_ON_PR
+  << : *SKIP_CLUSTER_TEST_ON_PR
 
 container_image_manifest_docker_builder:
   cpu: 1
@@ -741,7 +747,7 @@ cluster_testing_docker_builder:
       path: "testing/external/zeek-testing-cluster/.tmp/**"
   depends_on:
     - amd64_container_image
-  << : *SKIP_TASK_ON_PR
+  << : *SKIP_CLUSTER_TEST_ON_PR
 
 
 # Test zeekctl upon master and release pushes and also when

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -16,7 +16,7 @@ jobs:
   generate:
     permissions:
       contents: write  # for Git to git push
-    if: github.repository == 'zeek/zeek'
+    if: "github.repository == 'zeek/zeek' && contains(github.event.pull_request.labels.*.name, 'CI: Skip All') == false"
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
Adding the following github labels:

- `CI: Cluster Test`: causes the `cluster_testing` task to run on a normal PR, which would get skipped otherwise. Tested in https://cirrus-ci.com/build/5766964687142912.
- `CI: Skip All`: effectively follows the same semantics as adding `[skip ci]` to the HEAD commit on your branch. Skips all tasks on Cirrus and the docs generation github workflow. The pre-commit workflow will continue to run. Tested in https://cirrus-ci.com/build/4570549470363648.

`CI: Full` and `CI: Cluster Test` both override `CI: Skip All` for Cirrus jobs, as those labels are tested first.

The combination of the two was tested in https://cirrus-ci.com/build/5869547699306496