### PR TITLE
Update Windows CI image to Visual Studio 2022

### DIFF
--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -5,7 +5,7 @@ SHELL [ "powershell" ]
 
 # A version field to invalidatea Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20230801
+ENV DOCKERFILE_VERSION 20250528
 
 RUN Set-ExecutionPolicy Unrestricted -Force
 
@@ -14,8 +14,8 @@ RUN [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePoin
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # Install prerequisites
-RUN choco install -y --no-progress visualstudio2019buildtools --version=16.11.11.0
-RUN choco install -y --no-progress visualstudio2019-workload-vctools --version=1.0.0 --package-parameters '--add Microsoft.VisualStudio.Component.VC.ATLMFC'
+RUN choco install -y --no-progress visualstudio2022buildtools --version=117.14.1
+RUN choco install -y --no-progress visualstudio2022-workload-vctools --version=1.0.0 --package-parameters '--add Microsoft.VisualStudio.Component.VC.ATLMFC'
 RUN choco install -y --no-progress sed
 RUN choco install -y --no-progress winflexbison3
 RUN choco install -y --no-progress msysgit
@@ -30,4 +30,4 @@ RUN mkdir C:\build
 WORKDIR C:\build
 
 # This entry point starts the developer command prompt and launches the PowerShell shell.
-ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "-arch=x64", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Unrestricted"]
+ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "-arch=x64", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Unrestricted"]

--- a/ci/windows/build.cmd
+++ b/ci/windows/build.cmd
@@ -2,7 +2,7 @@
 :: cmd current shell. This path is hard coded to the one on the CI image, but
 :: can be adjusted if running builds locally. Unfortunately, the initial path
 :: isn't in the environment so we have to hardcode the whole path.
-call "c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+call "c:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 
 mkdir build
 cd build

--- a/ci/windows/test.cmd
+++ b/ci/windows/test.cmd
@@ -1,5 +1,5 @@
 :: See build.cmd for documentation on this call.
-call "c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+call "c:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 
 cd build
 


### PR DESCRIPTION
This PR updates the Windows CI image with two things:

- Updates the base image from `4.8-windowsservercore-ltsc2019` to `4.8.1-windowsservercore-ltsc2022`
- Updates the version of Visual Studio installed from 2019 to 2022