### PR TITLE
Clang-tidy Part 3: `cppcoreguidelines` fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,8 @@ Checks: [-*,
          bugprone-*,
          performance-*,
 
+         cppcoreguidelines-virtual-class-destructor,
+
          # Skipping these temporarily because they are very noisy
          -bugprone-narrowing-conversions,
          -bugprone-unchecked-optional-access,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,8 @@ Checks: [-*,
          bugprone-*,
          performance-*,
 
+         # Enable a very limited number of the cppcoreguidelines checkers.
+         # See the notes for some of the rest of them below.
          cppcoreguidelines-macro-usage,
          cppcoreguidelines-misleading-capture-default-by-value,
          cppcoreguidelines-virtual-class-destructor,
@@ -33,4 +35,14 @@ Checks: [-*,
          # This one returns a bunch of findings in DFA and the sqlite library.
          # We're unlikely to fix either of them.
          -performance-no-int-to-ptr,
+
+         # These cppcoreguidelines checkers are things we should investigate
+         # and possibly fix, but there are so many findings that we're holding
+         # off doing it for now.
+         #cppcoreguidelines-init-variables,
+         #cppcoreguidelines-prefer-member-initializer,
+         #cppcoreguidelines-pro-type-member-init,
+         #cppcoreguidelines-pro-type-cstyle-cast,
+         #cppcoreguidelines-pro-type-static-cast-downcast,
+         #cppcoreguidelines-special-member-functions,
 ]

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,8 @@ Checks: [-*,
          bugprone-*,
          performance-*,
 
+         cppcoreguidelines-macro-usage,
+         cppcoreguidelines-misleading-capture-default-by-value,
          cppcoreguidelines-virtual-class-destructor,
 
          # Skipping these temporarily because they are very noisy

--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -11,8 +11,8 @@
 #include "zeek/IPAddr.h"
 #include "zeek/Reporter.h"
 
-#define DEFAULT_SIZE 128
-#define SLOP 10
+constexpr unsigned int DEFAULT_SIZE = 128;
+constexpr int SLOP = 10;
 
 namespace zeek {
 

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -742,6 +742,8 @@ ValPtr BinaryExpr::Fold(Val* v1, Val* v2) const {
         RuntimeErrorWithCallStack("bad type in BinaryExpr::Fold");
 
     switch ( tag ) {
+        // Once we have C++20, these macros can become templated lambdas.
+        // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define DO_INT_FOLD(op)                                                                                                \
     if ( is_integral )                                                                                                 \
         i3 = i1 op i2;                                                                                                 \
@@ -771,6 +773,7 @@ ValPtr BinaryExpr::Fold(Val* v1, Val* v2) const {
         i3 = u1 op u2;                                                                                                 \
     else                                                                                                               \
         i3 = d1 op d2;
+            // NOLINTEND(cppcoreguidelines-macro-usage)
 
         case EXPR_ADD:
         case EXPR_ADD_TO: DO_FOLD(+); break;
@@ -892,13 +895,13 @@ ValPtr BinaryExpr::StringFold(Val* v1, Val* v2) const {
 
     switch ( tag ) {
 #undef DO_FOLD
-// NOLINTBEGIN(bugprone-macro-parentheses)
+// NOLINTBEGIN(bugprone-macro-parentheses, cppcoreguidelines-macro-usage)
 #define DO_FOLD(sense)                                                                                                 \
     {                                                                                                                  \
         result = Bstr_cmp(s1, s2) sense 0;                                                                             \
         break;                                                                                                         \
     }
-            // NOLINTEND(bugprone-macro-parentheses)
+            // NOLINTEND(bugprone-macro-parentheses, cppcoreguidelines-macro-usage)
 
         case EXPR_LT: DO_FOLD(<)
         case EXPR_LE: DO_FOLD(<=)

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -69,6 +69,7 @@ Type::Type(TypeTag t, bool arg_base_type)
       is_network_order(zeek::is_network_order(t)),
       base_type(arg_base_type) {}
 
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CHECK_TYPE_TAG(tag_type, func_name) CHECK_TAG(tag, tag_type, func_name, type_name)
 
 const TypeList* Type::AsTypeList() const {

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -6,6 +6,7 @@
 
 #include <netdb.h>
 #include <netinet/in.h>
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define RAPIDJSON_HAS_STDSTRING 1
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -53,6 +53,8 @@ Val::~Val() {
 #endif
 }
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
 #define CONVERTER(tag, ctype, name)                                                                                    \
     ctype name() {                                                                                                     \
         CHECK_TAG(type->Tag(), tag, "Val::CONVERTER", type_name)                                                       \
@@ -68,6 +70,8 @@ Val::~Val() {
 #define CONVERTERS(tag, ctype, name)                                                                                   \
     CONVERTER(tag, ctype, name)                                                                                        \
     CONST_CONVERTER(tag, ctype, name)
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 CONVERTERS(TYPE_FUNC, FuncVal*, Val::AsFuncVal)
 CONVERTERS(TYPE_FILE, FileVal*, Val::AsFileVal)

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -456,7 +456,7 @@ void BitTorrentTracker_Analyzer::ResponseBody(void) {
     }
 }
 
-int BitTorrentTracker_Analyzer::ResponseParseBenc(void) {
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define VIOLATION_IF(expr, msg)                                                                                        \
     {                                                                                                                  \
         if ( expr ) {                                                                                                  \
@@ -466,12 +466,12 @@ int BitTorrentTracker_Analyzer::ResponseParseBenc(void) {
         }                                                                                                              \
     }
 
-#define INC_COUNT                                                                                                      \
-    {                                                                                                                  \
-        unsigned int count = benc_count.back();                                                                        \
-        benc_count.pop_back();                                                                                         \
-        benc_count.push_back(count + 1);                                                                               \
-    }
+int BitTorrentTracker_Analyzer::ResponseParseBenc(void) {
+    auto INC_COUNT = [this]() {
+        unsigned int count = benc_count.back();
+        benc_count.pop_back();
+        benc_count.push_back(count + 1);
+    };
 
     for ( unsigned int len = res_buf_len - (res_buf_pos - res_buf); len; --len, ++res_buf_pos ) {
         switch ( benc_state ) {
@@ -551,7 +551,7 @@ int BitTorrentTracker_Analyzer::ResponseParseBenc(void) {
                         benc_count.pop_back();
 
                         if ( benc_stack.size() )
-                            INC_COUNT
+                            INC_COUNT();
                         else { // benc parsing successful
                             ++res_buf_pos;
                             return 0;
@@ -612,7 +612,7 @@ int BitTorrentTracker_Analyzer::ResponseParseBenc(void) {
                     else
                         VIOLATION_IF(1, "BitTorrentTracker: no valid bencoding")
 
-                    INC_COUNT
+                    INC_COUNT();
                     benc_state = detail::BENC_STATE_EMPTY;
                 }
 
@@ -686,7 +686,7 @@ int BitTorrentTracker_Analyzer::ResponseParseBenc(void) {
                         ++len;
                     }
 
-                    INC_COUNT
+                    INC_COUNT();
                     benc_state = detail::BENC_STATE_EMPTY;
                 }
                 break;

--- a/src/analyzer/protocol/login/Login.cc
+++ b/src/analyzer/protocol/login/Login.cc
@@ -133,10 +133,11 @@ void Login_Analyzer::NewLine(bool orig, char* line) {
     }
 }
 
+constexpr char VMS_REPEAT_SEQ[] = "\x1b[A";
+
 void Login_Analyzer::AuthenticationDialog(bool orig, char* line) {
     if ( orig ) {
         if ( is_VMS ) {
-#define VMS_REPEAT_SEQ "\x1b[A"
             char* repeat_prev_line = strstr(line, VMS_REPEAT_SEQ);
             if ( repeat_prev_line ) {
                 if ( repeat_prev_line[strlen(VMS_REPEAT_SEQ)] ) {

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -11,27 +11,22 @@
 
 #define IS_3_BYTE_OPTION(c) ((c) >= 251 && (c) <= 254)
 
-#define TELNET_OPT_SB 250
-#define TELNET_OPT_SE 240
+static constexpr uint8_t TELNET_OPT_SB = 250;
+static constexpr uint8_t TELNET_OPT_SE = 240;
 
-#define TELNET_OPT_IS 0
-#define TELNET_OPT_SEND 1
+static constexpr uint8_t TELNET_OPT_IS = 0;
+static constexpr uint8_t TELNET_OPT_SEND = 1;
 
-#define TELNET_OPT_WILL 251
-#define TELNET_OPT_WONT 252
-#define TELNET_OPT_DO 253
-#define TELNET_OPT_DONT 254
+static constexpr uint8_t TELNET_OPT_WILL = 251;
+static constexpr uint8_t TELNET_OPT_WONT = 252;
+static constexpr uint8_t TELNET_OPT_DO = 253;
+static constexpr uint8_t TELNET_OPT_DONT = 254;
 
-#define TELNET_IAC 255
+static constexpr uint8_t TELNET_IAC = 255;
 
 namespace zeek::analyzer::login {
 
-TelnetOption::TelnetOption(NVT_Analyzer* arg_endp, unsigned int arg_code) {
-    endp = arg_endp;
-    code = arg_code;
-    flags = 0;
-    active = 0;
-}
+TelnetOption::TelnetOption(NVT_Analyzer* arg_endp, unsigned int arg_code) : endp(arg_endp), code(arg_code) {}
 
 void TelnetOption::RecvOption(unsigned int type) {
     TelnetOption* peer = endp->FindPeerOption(code);
@@ -114,15 +109,17 @@ void TelnetTerminalOption::RecvSubOption(u_char* data, int len) {
     endp->SetTerminal(data + 1, len - 1);
 }
 
-#define ENCRYPT_SET_ALGORITHM 0
-#define ENCRYPT_SUPPORT_ALGORITHM 1
-#define ENCRYPT_REPLY 2
-#define ENCRYPT_STARTING_TO_ENCRYPT 3
-#define ENCRYPT_NO_LONGER_ENCRYPTING 4
-#define ENCRYPT_REQUEST_START_TO_ENCRYPT 5
-#define ENCRYPT_REQUEST_NO_LONGER_ENCRYPT 6
-#define ENCRYPT_ENCRYPT_KEY 7
-#define ENCRYPT_DECRYPT_KEY 8
+enum EncryptOptions : uint8_t {
+    ENCRYPT_SET_ALGORITHM = 0,
+    ENCRYPT_SUPPORT_ALGORITHM = 1,
+    ENCRYPT_REPLY = 2,
+    ENCRYPT_STARTING_TO_ENCRYPT = 3,
+    ENCRYPT_NO_LONGER_ENCRYPTING = 4,
+    ENCRYPT_REQUEST_START_TO_ENCRYPT = 5,
+    ENCRYPT_REQUEST_NO_LONGER_ENCRYPT = 6,
+    ENCRYPT_ENCRYPT_KEY = 7,
+    ENCRYPT_DECRYPT_KEY = 8,
+};
 
 void TelnetEncryptOption::RecvSubOption(u_char* data, int len) {
     if ( ! active ) {
@@ -157,13 +154,15 @@ void TelnetEncryptOption::RecvSubOption(u_char* data, int len) {
     }
 }
 
-#define HERE_IS_AUTHENTICATION 0
-#define SEND_ME_AUTHENTICATION 1
-#define AUTHENTICATION_STATUS 2
-#define AUTHENTICATION_NAME 3
+enum AuthOptions : uint8_t {
+    HERE_IS_AUTHENTICATION = 0,
+    SEND_ME_AUTHENTICATION = 1,
+    AUTHENTICATION_STATUS = 2,
+    AUTHENTICATION_NAME = 3,
+};
 
-#define AUTH_REJECT 1
-#define AUTH_ACCEPT 2
+constexpr int AUTH_REJECT = 1;
+constexpr int AUTH_ACCEPT = 2;
 
 void TelnetAuthenticateOption::RecvSubOption(u_char* data, int len) {
     if ( len <= 0 ) {
@@ -212,14 +211,14 @@ void TelnetAuthenticateOption::RecvSubOption(u_char* data, int len) {
     }
 }
 
-#define ENVIRON_IS 0
-#define ENVIRON_SEND 1
-#define ENVIRON_INFO 2
+constexpr uint8_t ENVIRON_IS = 0;
+constexpr uint8_t ENVIRON_SEND = 1;
+constexpr uint8_t ENVIRON_INFO = 2;
 
-#define ENVIRON_VAR 0
-#define ENVIRON_VAL 1
-#define ENVIRON_ESC 2
-#define ENVIRON_USERVAR 3
+constexpr uint8_t ENVIRON_VAR = 0;
+constexpr uint8_t ENVIRON_VAL = 1;
+constexpr uint8_t ENVIRON_ESC = 2;
+constexpr uint8_t ENVIRON_USERVAR = 3;
 
 void TelnetEnvironmentOption::RecvSubOption(u_char* data, int len) {
     if ( len <= 0 ) {
@@ -386,7 +385,7 @@ void NVT_Analyzer::SetEncrypting(int mode) {
         Event(activating_encryption);
 }
 
-#define MAX_DELIVER_UNIT 128
+constexpr int MAX_DELIVER_UNIT = 128;
 
 void NVT_Analyzer::DoDeliver(int len, const u_char* data) {
     while ( len > 0 ) {

--- a/src/analyzer/protocol/login/NVT.h
+++ b/src/analyzer/protocol/login/NVT.h
@@ -4,12 +4,12 @@
 
 #include "zeek/analyzer/protocol/tcp/ContentLine.h"
 
-#define TELNET_OPTION_BINARY 0
-#define TELNET_OPTION_TERMINAL 24
-#define TELNET_OPTION_AUTHENTICATE 37
-#define TELNET_OPTION_ENCRYPT 38
-#define TELNET_OPTION_ENVIRON 39
-#define NUM_TELNET_OPTIONS 5
+constexpr uint8_t TELNET_OPTION_BINARY = 0;
+constexpr uint8_t TELNET_OPTION_TERMINAL = 24;
+constexpr uint8_t TELNET_OPTION_AUTHENTICATE = 37;
+constexpr uint8_t TELNET_OPTION_ENCRYPT = 38;
+constexpr uint8_t TELNET_OPTION_ENVIRON = 39;
+constexpr uint8_t NUM_TELNET_OPTIONS = 5;
 
 namespace zeek::analyzer::login {
 
@@ -20,11 +20,8 @@ public:
     TelnetOption(NVT_Analyzer* endp, unsigned int code);
     virtual ~TelnetOption() {}
 
-// Whether we told the other side WILL/WONT/DO/DONT.
-#define OPT_SAID_WILL 0x1
-#define OPT_SAID_WONT 0x2
-#define OPT_SAID_DO 0x4
-#define OPT_SAID_DONT 0x8
+    // Whether we told the other side WILL/WONT/DO/DONT.
+    enum SaidOptions : uint8_t { OPT_SAID_WILL = 0x1, OPT_SAID_WONT = 0x2, OPT_SAID_DO = 0x4, OPT_SAID_DONT = 0x8 };
 
     unsigned int Code() const { return code; }
 
@@ -52,10 +49,10 @@ protected:
     virtual void InconsistentOption(unsigned int type);
     virtual void BadOption();
 
-    NVT_Analyzer* endp;
+    NVT_Analyzer* endp = nullptr;
     unsigned int code;
-    int flags;
-    int active;
+    int flags = 0;
+    bool active = false;
 };
 
 namespace detail {

--- a/src/analyzer/protocol/ncp/NCP.cc
+++ b/src/analyzer/protocol/ncp/NCP.cc
@@ -9,11 +9,6 @@
 
 using namespace std;
 
-#define xbyte(b, n) (((const u_char*)(b))[n])
-#define extract_uint16(little_endian, bytes)                                                                           \
-    ((little_endian) ? uint16(xbyte(bytes, 0)) | ((uint16(xbyte(bytes, 1))) << 8) :                                    \
-                       uint16(xbyte(bytes, 1)) | ((uint16(xbyte(bytes, 0))) << 8))
-
 namespace zeek::analyzer::ncp {
 namespace detail {
 

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -10,14 +10,15 @@
 #include "zeek/analyzer/protocol/netbios/events.bif.h"
 #include "zeek/session/Manager.h"
 
-constexpr double netbios_ssn_session_timeout = 15.0;
+static constexpr double netbios_ssn_session_timeout = 15.0;
 
-#define MAKE_INT16(dest, src)                                                                                          \
-    (dest) = *(src);                                                                                                   \
-    (dest) <<= 8;                                                                                                      \
-    (src)++;                                                                                                           \
-    (dest) |= *(src);                                                                                                  \
-    (src)++;
+static constexpr void MAKE_INT16(uint16_t& dest, const u_char*& src) {
+    dest = *src;
+    dest <= 8;
+    src++;
+    dest |= *src;
+    src++;
+}
 
 namespace zeek::analyzer::netbios_ssn {
 namespace detail {

--- a/src/analyzer/protocol/pop3/POP3.cc
+++ b/src/analyzer/protocol/pop3/POP3.cc
@@ -24,8 +24,6 @@ static const char* pop3_cmd_word[] = {
 #include "POP3_cmd.def"
 };
 
-#define POP3_CMD_WORD(code) (((code) >= 0) ? pop3_cmd_word[code] : "(UNKNOWN)")
-
 POP3_Analyzer::POP3_Analyzer(Connection* conn) : analyzer::tcp::TCP_ApplicationAnalyzer("POP3", conn) {
     masterState = detail::POP3_START;
     subState = detail::POP3_WOK;

--- a/src/analyzer/protocol/rpc/Portmap.cc
+++ b/src/analyzer/protocol/rpc/Portmap.cc
@@ -5,12 +5,14 @@
 #include "zeek/analyzer/protocol/rpc/XDR.h"
 #include "zeek/analyzer/protocol/rpc/events.bif.h"
 
-#define PMAPPROC_NULL 0
-#define PMAPPROC_SET 1
-#define PMAPPROC_UNSET 2
-#define PMAPPROC_GETPORT 3
-#define PMAPPROC_DUMP 4
-#define PMAPPROC_CALLIT 5
+enum PortmapperProcs : uint8_t {
+    PMAPPROC_NULL = 0,
+    PMAPPROC_SET = 1,
+    PMAPPROC_UNSET = 2,
+    PMAPPROC_GETPORT = 3,
+    PMAPPROC_DUMP = 4,
+    PMAPPROC_CALLIT = 5,
+};
 
 namespace zeek::analyzer::rpc {
 namespace detail {

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -19,7 +19,7 @@ const bool DEBUG_rpc_resync = false;
 // TODO: Should we add start_time and last_time to the rpc_* events??
 
 // TODO: make this configurable
-#define MAX_RPC_LEN 65536
+constexpr uint32_t MAX_RPC_LEN = 65536;
 
 namespace zeek::analyzer::rpc {
 namespace detail {

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -14,13 +14,15 @@
 #undef SMTP_CMD_DEF
 #define SMTP_CMD_DEF(cmd) #cmd,
 
+// This could be constexpr too but it would require changing the macro above. It doesn't
+// matter that much though.
 static const char* smtp_cmd_word[] = {
 #include "SMTP_cmd.def"
 };
 
-static const char* unknown_cmd = "(UNKNOWN)";
+static constexpr char unknown_cmd[] = "(UNKNOWN)";
 
-#define SMTP_CMD_WORD(code) (((code) >= 0) ? smtp_cmd_word[code] : unknown_cmd)
+static constexpr const char* SMTP_CMD_WORD(int code) { return code >= 0 ? smtp_cmd_word[code] : unknown_cmd; }
 
 namespace zeek::analyzer::smtp {
 

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -400,8 +400,6 @@ struct opt_mapping {
     }
 };
 
-#define WITH_OPT_MAPPING(broker_name, zeek_name) if ( auto opt = opt_mapping{&config, broker_name, zeek_name}; true )
-
 } // namespace
 
 class BrokerState {

--- a/src/broker/WebSocketShim.cc
+++ b/src/broker/WebSocketShim.cc
@@ -12,6 +12,7 @@
 #include "zeek/iosource/IOSource.h"
 #include "zeek/iosource/Manager.h"
 
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define BROKER_WS_DEBUG(...)                                                                                           \
     do {                                                                                                               \
         DBG_LOG(DBG_BROKER, __VA_ARGS__);                                                                              \

--- a/src/cluster/backend/zeromq/ZeroMQ.cc
+++ b/src/cluster/backend/zeromq/ZeroMQ.cc
@@ -52,6 +52,8 @@ enum class InprocTag : uint8_t {
 
 constexpr DebugFlag operator&(uint8_t x, DebugFlag y) { return static_cast<DebugFlag>(x & static_cast<uint8_t>(y)); }
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
 #define ZEROMQ_DEBUG(...) PLUGIN_DBG_LOG(zeek::plugin::Zeek_Cluster_Backend_ZeroMQ::plugin, __VA_ARGS__)
 
 #define ZEROMQ_THREAD_PRINTF(...)                                                                                      \
@@ -65,6 +67,8 @@ constexpr DebugFlag operator&(uint8_t x, DebugFlag y) { return static_cast<Debug
             ZEROMQ_THREAD_PRINTF(__VA_ARGS__);                                                                         \
         }                                                                                                              \
     } while ( 0 )
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 ZeroMQBackend::ZeroMQBackend(std::unique_ptr<EventSerializer> es, std::unique_ptr<LogSerializer> ls,
                              std::unique_ptr<detail::EventHandlingStrategy> ehs)

--- a/src/cluster/serializer/binary-serialization-format/Serializer.cc
+++ b/src/cluster/serializer/binary-serialization-format/Serializer.cc
@@ -22,6 +22,7 @@ extern Plugin plugin;
 
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define SERIALIZER_DEBUG(...) PLUGIN_DBG_LOG(zeek::plugin::Zeek_Binary_Serializer::plugin, __VA_ARGS__)
 
 bool detail::BinarySerializationFormatLogSerializer::SerializeLogWrite(byte_buffer& buf,

--- a/src/cluster/websocket/WebSocket.cc
+++ b/src/cluster/websocket/WebSocket.cc
@@ -27,7 +27,7 @@
 #include "rapidjson/document.h"
 #include "rapidjson/rapidjson.h"
 
-
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define WS_DEBUG(...) PLUGIN_DBG_LOG(zeek::plugin::Cluster_WebSocket::plugin, __VA_ARGS__)
 
 namespace zeek {

--- a/src/file_analysis/analyzer/x509/OCSP.cc
+++ b/src/file_analysis/analyzer/x509/OCSP.cc
@@ -23,7 +23,7 @@ X509* helper_sk_X509_value(const STACK_OF(X509) * certs, int i) { return sk_X509
 
 namespace zeek::file_analysis::detail {
 
-#define OCSP_STRING_BUF_SIZE 2048
+static constexpr size_t OCSP_STRING_BUF_SIZE = 2048;
 
 static bool OCSP_RESPID_bio(OCSP_BASICRESP* basic_resp, BIO* bio) {
 #if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)

--- a/src/iosource/Manager.cc
+++ b/src/iosource/Manager.cc
@@ -19,8 +19,6 @@
 #include "zeek/iosource/PktSrc.h"
 #include "zeek/plugin/Manager.h"
 
-#define DEFAULT_PREFIX "pcap"
-
 extern int signal_val;
 
 namespace zeek::iosource {
@@ -368,6 +366,10 @@ void Manager::Register(PktSrc* src) {
         poll_interval = 1;
 }
 
+/**
+ * Checks if the path comes with a prefix telling us which type of PktSrc to use. If no
+ * prefix exists, return "pcap" as a default.
+ */
 static std::pair<std::string, std::string> split_prefix(std::string path) {
     // See if the path comes with a prefix telling us which type of
     // PktSrc to use. If not, choose default.
@@ -378,9 +380,8 @@ static std::pair<std::string, std::string> split_prefix(std::string path) {
         prefix = path.substr(0, i);
         path = path.substr(i + 2, std::string::npos);
     }
-
     else
-        prefix = DEFAULT_PREFIX;
+        prefix = "pcap";
 
     return std::make_pair(prefix, path);
 }

--- a/src/net_util.cc
+++ b/src/net_util.cc
@@ -129,8 +129,8 @@ constexpr uint32_t CLASS_C = 0xc0000000;
 constexpr uint32_t CLASS_D = 0xe0000000;
 constexpr uint32_t CLASS_E = 0xf0000000;
 
-#define CHECK_CLASS(addr, class) (((addr) & (class)) == (class))
 char addr_to_class(uint32_t addr) {
+    auto CHECK_CLASS = [](uint32_t addr, uint32_t cls) { return (addr & cls) == cls; };
     if ( CHECK_CLASS(addr, CLASS_E) )
         return 'E';
     else if ( CHECK_CLASS(addr, CLASS_D) )

--- a/src/net_util.cc
+++ b/src/net_util.cc
@@ -123,11 +123,11 @@ int icmp6_checksum(const struct icmp* icmpp, const IP_Hdr* ip, int len) {
                                 len);
 }
 
-#define CLASS_A 0x00000000
-#define CLASS_B 0x80000000
-#define CLASS_C 0xc0000000
-#define CLASS_D 0xe0000000
-#define CLASS_E 0xf0000000
+constexpr uint32_t CLASS_A = 0x00000000;
+constexpr uint32_t CLASS_B = 0x80000000;
+constexpr uint32_t CLASS_C = 0xc0000000;
+constexpr uint32_t CLASS_D = 0xe0000000;
+constexpr uint32_t CLASS_E = 0xf0000000;
 
 #define CHECK_CLASS(addr, class) (((addr) & (class)) == (class))
 char addr_to_class(uint32_t addr) {

--- a/src/packet_analysis/protocol/arp/ARP.cc
+++ b/src/packet_analysis/protocol/arp/ARP.cc
@@ -25,6 +25,8 @@ ARPAnalyzer::ARPAnalyzer() : zeek::packet_analysis::Analyzer("ARP") {}
 // ... and on Solaris we are missing half of the ARPOP codes, so define
 // them here as necessary:
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
 #ifndef ARPOP_REQUEST
 #define ARPOP_REQUEST 1 // ARP request.
 #endif
@@ -83,6 +85,8 @@ ARPAnalyzer::ARPAnalyzer() : zeek::packet_analysis::Analyzer("ARP") {}
 #ifndef ARPHRD_IEEE802
 #define ARPHRD_IEEE802 6
 #endif
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 bool ARPAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet) {
     packet->l3_proto = L3_ARP;

--- a/src/packet_analysis/protocol/tcp/Stats.cc
+++ b/src/packet_analysis/protocol/tcp/Stats.cc
@@ -41,6 +41,8 @@ void TCPStateStats::PrintStats(File* file, const char* prefix) {
         file->Write(prefix);
 
         switch ( i ) {
+// This macro really doesn't save us much typing, if that was the intention
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define STATE_STRING(state, str)                                                                                       \
     case state: file->Write(str); break;
 

--- a/src/script_opt/CPP/RuntimeInits.h
+++ b/src/script_opt/CPP/RuntimeInits.h
@@ -174,6 +174,8 @@ public:
         inits_vec.resize(num_inits);
     }
 
+    virtual ~CPP_AbstractInits() = default;
+
     // Initialize the given cohort of elements.
     void InitializeCohort(InitsManager* im, int cohort) {
         // Get this object's vector-of-vector-of-indices.

--- a/src/script_opt/CPP/RuntimeVec.cc
+++ b/src/script_opt/CPP/RuntimeVec.cc
@@ -42,6 +42,8 @@ static VectorTypePtr base_vector_type__CPP(const VectorTypePtr& vt, bool is_bool
     }
 }
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
 // The kernel used for unary vector operations.
 #define VEC_OP1_KERNEL(accessor, type, op)                                                                             \
     for ( unsigned int i = 0; i < v->Size(); ++i ) {                                                                   \
@@ -90,6 +92,8 @@ static VectorTypePtr base_vector_type__CPP(const VectorTypePtr& vt, bool is_bool
             break;                                                                                                     \
         })
 
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
 // The unary operations supported for vectors.
 VEC_OP1_WITH_DOUBLE(pos, +)
 VEC_OP1_WITH_DOUBLE(neg, -)
@@ -98,6 +102,7 @@ VEC_OP1(comp, ~, )
 
 // A kernel for applying a binary operation element-by-element to two
 // vectors of a given low-level type.
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define VEC_OP2_KERNEL(accessor, type, op, zero_check)                                                                 \
     for ( unsigned int i = 0; i < v1->Size(); ++i ) {                                                                  \
@@ -167,6 +172,7 @@ VEC_OP1(comp, ~, )
 			break;                                                                                 \
 		},                                                                                         \
 		zero_check)
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 // The binary operations supported for vectors.
 VEC_OP2_WITH_DOUBLE(add, +, 0)
@@ -184,6 +190,7 @@ VEC_OP2_WITH_INT(rshift, >>, , 0)
 
 // A version of VEC_OP2 that instead supports relational operations, so
 // the result type is always vector-of-bool.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define VEC_REL_OP(name, op)                                                                                           \
     VectorValPtr vec_op_##name##__CPP(const VectorValPtr& v1, const VectorValPtr& v2) {                                \
         if ( ! check_vec_sizes__CPP(v1, v2) )                                                                          \

--- a/src/script_opt/FuncInfo.cc
+++ b/src/script_opt/FuncInfo.cc
@@ -20,29 +20,29 @@ namespace zeek::detail {
 // to the event engine.
 
 // Does not change script-level state (though may change internal state).
-#define ATTR_NO_SCRIPT_SIDE_EFFECTS 0x1
+constexpr unsigned int ATTR_NO_SCRIPT_SIDE_EFFECTS = 0x1;
 
 // Does not change any Zeek state, internal or external. (May change
 // state outside of Zeek, such as file system elements.) Implies
 // ATTR_NO_SCRIPT_SIDE_EFFECTS.
-#define ATTR_NO_ZEEK_SIDE_EFFECTS 0x2
+constexpr unsigned int ATTR_NO_ZEEK_SIDE_EFFECTS = 0x2;
 
 // Calls made with the same arguments yield the same results, if made
 // after full Zeek initialization. Implies ATTR_NO_ZEEK_SIDE_EFFECTS.
-#define ATTR_IDEMPOTENT 0x4
+constexpr unsigned int ATTR_IDEMPOTENT = 0x4;
 
 // Calls with constant arguments can always be folded, even prior to
 // full Zeek initialization. Such functions must not have the potential
 // to generate errors. Implies ATTR_IDEMPOTENT.
-#define ATTR_FOLDABLE 0x8
+constexpr unsigned int ATTR_FOLDABLE = 0x8;
 
 // The event engine knows about this script function and may call it
 // during its processing.
-#define ATTR_SPECIAL_SCRIPT_FUNC 0x10
+constexpr unsigned int ATTR_SPECIAL_SCRIPT_FUNC = 0x10;
 
 // ZAM knows about this script function and will replace it with specialized
 // instructions.
-#define ATTR_ZAM_REPLACEABLE_SCRIPT_FUNC 0x20
+constexpr unsigned int ATTR_ZAM_REPLACEABLE_SCRIPT_FUNC = 0x20;
 
 static std::unordered_map<std::string, unsigned int> func_attrs = {
     // Script functions.

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -718,8 +718,12 @@ bool has_AST_node_unknown_to_script_opt(const ProfileFunc* prof, bool /* is_ZAM 
         STMT_ASSERT,
         // STMT_EXTERN,
         // STMT_STD_FUNCTION,
-#define SCRIPT_OPT_NUM_STMTS 24
     };
+
+    // This should be the total number of entries in the set above, including
+    // the commented values.
+    constexpr int SCRIPT_OPT_NUM_STMTS = 24;
+
     // clang-format on
 
     // Fail compilation if NUM_STMT in StmtEnums.h changes.
@@ -803,8 +807,12 @@ bool has_AST_node_unknown_to_script_opt(const ProfileFunc* prof, bool /* is_ZAM 
         // EXPR_ANY_INDEX,
         // EXPR_SCRIPT_OPT_BUILTIN,
         // EXPR_NOP,
-#define SCRIPT_OPT_NUM_EXPRS  70
     };
+
+    // This should be the total number of entries in the set above, including
+    // the commented values.
+    constexpr int SCRIPT_OPT_NUM_EXPRS = 70;
+
     // clang-format on
 
     // Fail compilation if NUM_EXPRS in Expr.h changes.

--- a/src/script_opt/ZAM/ZBody.cc
+++ b/src/script_opt/ZAM/ZBody.cc
@@ -188,6 +188,8 @@ static void vec_exec(ZOp op, TypePtr t, VectorVal*& v1, const VectorVal* v2, con
 
 static void vec_exec(ZOp op, TypePtr t, VectorVal*& v1, const VectorVal* v2, const VectorVal* v3, const ZInst& z);
 
+auto false_func = [](double x) { return false; };
+
 // Vector coercion.
 #define VEC_COERCE(tag, lhs_type, cast, rhs_accessor, ov_check, ov_err)                                                \
     VectorVal* vec_coerce_##tag(VectorVal* vec, std::shared_ptr<ZAMLocInfo> z_loc) {                                   \
@@ -215,8 +217,6 @@ static void vec_exec(ZOp op, TypePtr t, VectorVal*& v1, const VectorVal* v2, con
                 res[i] = std::nullopt;                                                                                 \
         return res_zv;                                                                                                 \
     }
-
-#define false_func(x) false
 
 VEC_COERCE(DI, TYPE_DOUBLE, double, AsInt(), false_func, "")
 VEC_COERCE(DU, TYPE_DOUBLE, double, AsCount(), false_func, "")

--- a/src/spicy/file-analyzer.cc
+++ b/src/spicy/file-analyzer.cc
@@ -13,11 +13,13 @@ using namespace zeek;
 using namespace zeek::spicy;
 using namespace zeek::spicy::rt;
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #ifdef DEBUG
 #define STATE_DEBUG_MSG(...) DebugMsg(__VA_ARGS__)
 #else
 #define STATE_DEBUG_MSG(...)
 #endif
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 void FileState::debug(const std::string& msg) { spicy::rt::debug(_cookie, msg); }
 

--- a/src/spicy/packet-analyzer.cc
+++ b/src/spicy/packet-analyzer.cc
@@ -9,11 +9,13 @@ using namespace zeek;
 using namespace zeek::spicy;
 using namespace zeek::spicy::rt;
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #ifdef DEBUG
 #define STATE_DEBUG_MSG(...) DebugMsg(__VA_ARGS__)
 #else
 #define STATE_DEBUG_MSG(...)
 #endif
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 void PacketState::debug(const std::string& msg) { spicy::rt::debug(_cookie, msg); }
 

--- a/src/spicy/protocol-analyzer.cc
+++ b/src/spicy/protocol-analyzer.cc
@@ -9,11 +9,13 @@ using namespace zeek;
 using namespace zeek::spicy;
 using namespace zeek::spicy::rt;
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #ifdef DEBUG
 #define STATE_DEBUG_MSG(...) DebugMsg(__VA_ARGS__)
 #else
 #define STATE_DEBUG_MSG(...)
 #endif
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 void EndpointState::debug(const std::string& msg) { spicy::rt::debug(_cookie, msg); }
 

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -16,6 +16,7 @@
 #include <utility>
 #include <variant>
 
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define RAPIDJSON_HAS_STDSTRING 1
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -44,11 +44,13 @@ extern "C" {
 #include "zeek/util.h"
 #include "zeek/zeek-affinity.h"
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #ifdef DEBUG
 #define DBG_STEM(...) stem->LogDebug(__VA_ARGS__);
 #else
 #define DBG_STEM(...)
 #endif
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 using namespace zeek;
 using zeek::detail::SupervisedNode;

--- a/src/telemetry/Manager.cc
+++ b/src/telemetry/Manager.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/telemetry/Manager.h"
 
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define RAPIDJSON_HAS_STDSTRING 1
 
 // CivetServer is from the civetweb submodule in prometheus-cpp

--- a/src/threading/formatters/JSON.cc
+++ b/src/threading/formatters/JSON.cc
@@ -6,6 +6,7 @@
 #define __STDC_LIMIT_MACROS
 #endif
 
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define RAPIDJSON_HAS_STDSTRING 1
 
 #include <rapidjson/internal/ieee754.h>


### PR DESCRIPTION
This is the third in a series of PRs to fix a large number of clang-tidy findings. This one fixes findings from a few of the `cppcoreguidelines` checkers. A lot of them are very noisy or are things that we simply don't/shouldn't care to do. I left a list of some that we could possibly investigate later in the last commit.