### PR TITLE
CI: Force rebuild of opensuse tumbleweed docker image

### DIFF
--- a/ci/opensuse-tumbleweed/Dockerfile
+++ b/ci/opensuse-tumbleweed/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/tumbleweed
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20250311
+ENV DOCKERFILE_VERSION 20250502
 
 # Remove the repo-openh264 repository, it caused intermittent issues
 # and we should not be needing any packages from it.


### PR DESCRIPTION
Something is off with the libhiredis package that's installed as part of the current image, and 'zypper patch' is failing to update it during the prepare step. Force a rebuild so the updated package is part of the image to start with.

This was causing a few broken builds this morning. https://cirrus-ci.com/task/4557887806111744 seems like it fixed it with an image rebuild though.