### PR TITLE
Fix Spicy re-enable builtin analyzer debug message

### DIFF
--- a/src/spicy/manager.cc
+++ b/src/spicy/manager.cc
@@ -354,7 +354,7 @@ bool Manager::toggleProtocolAnalyzer(const Tag& tag, bool enable) {
         analyzer_mgr->DisableAnalyzer(tag);
 
         if ( analyzer.replaces ) {
-            SPICY_DEBUG(hilti::rt::fmt("Re-enabling standard protocol analyzer %s", analyzer.name_analyzer));
+            SPICY_DEBUG(hilti::rt::fmt("Re-enabling standard protocol analyzer %s", analyzer.name_replaces));
             analyzer_mgr->EnableAnalyzer(analyzer.replaces);
         }
     }


### PR DESCRIPTION
This came from some Slack discussion about reenabling analyzers, where they get reenabled but the `zeek_init` is run before so they don't get properly get registered to a port. Not sure that's fixable at the moment, but at least I can fix this incorrect debug log :)

looks like:

```
         0.000000/1748962068.800679 [spicy] Disabling Spicy protocol analyzer MY_SSH
         0.000000/1748962068.800684 [dpd] Disabling analyzer MY_SSH
         0.000000/1748962068.800688 [spicy] Re-enabling standard protocol analyzer SSH
         0.000000/1748962068.800691 [dpd] Enabling analyzer SSH
```