### PR TITLE
Parallelize coverage/bare-mode-errors

### DIFF
--- a/testing/btest/coverage/bare-mode-errors.test
+++ b/testing/btest/coverage/bare-mode-errors.test
@@ -9,5 +9,5 @@
 # @TEST-REQUIRES: have-zeromq
 #
 # @TEST-EXEC: test -d $DIST/scripts
-# @TEST-EXEC: for script in `find $DIST/scripts/ -name \*\.zeek`; do zeek -b --parse-only $script >>errors 2>&1; done
+# @TEST-EXEC: find $DIST/scripts/ -name "*.zeek" -print0 | xargs -0 -n1 -P 20 -- zeek -b --parse-only >>errors 2>&1
 # @TEST-EXEC: TEST_DIFF_CANONIFIER="$SCRIPTS/diff-remove-abspath | $SCRIPTS/diff-sort" btest-diff errors


### PR DESCRIPTION
Currently, coverage/bare-mode-errors is one of the slowest tests in the entire test suite. This is caused by the fact that it has to repeatedly launch Zeek for every script that we ship. This is done sequentially.

This commit changes this test to use xargs to spawn 20 parallell processes.

This admittedly doesn't feel entirely optimal, as it is a hardcoded value. I might say that this is better than the status quo, assuming that this passes on cirrus :)