### PR TITLE
docker: Add `net-tools` and `procps` dependencies

### DIFF
--- a/docker/final.Dockerfile
+++ b/docker/final.Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get -q update \
      libuv1 \
      libz1 \
      libzmq5 \
+     net-tools \
+     procps \
      python3-git \
      python3-minimal \
      python3-semantic-version \


### PR DESCRIPTION
Add `iproute2` and `procps` to the final.Dockerfile, to avoid warning in zeekctl commands like: "failed to find local IP addresses [...]" and the error in `zeekctl top` command caused because `top` is not installed.