### PR TITLE
Mark ZeekString vector helper methods deprecated

### DIFF
--- a/src/ZeekString.cc
+++ b/src/ZeekString.cc
@@ -587,7 +587,10 @@ TEST_CASE("searching/modification") {
     CHECK_EQ(s, *s3);
     delete s3;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     char* temp = zeek::String::VecToString(splits);
+#pragma GCC diagnostic pop
     CHECK_EQ(std::string(temp), "[this, is, a, test,]");
     free(temp);
 

--- a/src/ZeekString.h
+++ b/src/ZeekString.h
@@ -166,8 +166,11 @@ public:
     Vec* Split(const IdxVec& indices) const;
 
     // Helper functions for vectors:
+    [[deprecated("Remove in v8.1. The ZeekString vector methods are unused.")]]
     static VectorVal* VecToPolicy(Vec* vec);
+    [[deprecated("Remove in v8.1. The ZeekString vector methods are unused.")]]
     static Vec* VecFromPolicy(VectorVal* vec);
+    [[deprecated("Remove in v8.1. The ZeekString vector methods are unused.")]]
     static char* VecToString(const Vec* vec);
 
 protected:


### PR DESCRIPTION
These methods aren't used anywhere in the code base. Mark them as deprecated to remove in v8.1.