### PR TITLE
Move netbios_ssn_session_timeout to a script-level constant

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -579,6 +579,10 @@ const io_poll_interval_live = 10 &redef;
 ## while testing, but should be used sparingly.
 const running_under_test: bool = F &redef;
 
+## The amount of time before a connection created by the netbios analyzer times
+## out and is removed.
+const netbios_ssn_session_timeout: interval = 15 sec &redef;
+
 module EventMetadata;
 
 export {

--- a/src/const.bif
+++ b/src/const.bif
@@ -12,6 +12,7 @@ const report_gaps_for_partial: bool;
 const exit_only_after_terminate: bool;
 const digest_salt: string;
 const max_analyzer_violations: count;
+const netbios_ssn_session_timeout: interval;
 
 const io_poll_interval_default: count;
 const io_poll_interval_live: count;


### PR DESCRIPTION
This moves a hard-coded constant out of the Netbios analyzer into a constant that can be redef'd in script land. This code analyzer has almost zero test coverage, unfortunately. This PR is basically untested other than to make sure it builds and the script-land change doesn't break anything.