### PR TITLE
btest/opt/ZAM-bif-tracking: Disable by default

### DIFF
--- a/testing/btest/opt/ZAM-bif-tracking.zeek
+++ b/testing/btest/opt/ZAM-bif-tracking.zeek
@@ -2,6 +2,9 @@
 #
 # @TEST-REQUIRES: have-spicy
 #
+# Only run this test when ZEEK_ZAM_MAINTENANCE env is set and not "0".
+# @TEST-REQUIRES: test "${ZEEK_ZAM_MAINTENANCE}" != "" && test "${ZEEK_ZAM_MAINTENANCE}" != "0"
+#
 # @TEST-EXEC: zeek -b %INPUT >output
 # @TEST-EXEC: btest-diff output
 


### PR DESCRIPTION
After a public discussion and also chatting with Vern directly, disable the ZAM bif tracking test to avoid an update every time new functions are added. Usually these aren't performance critical and the defaults characterization is fine. If they are performance critical, then Vern is currently best positioned to properly integrate an optimized version.

---

@vpax - does this work for you?