### PR TITLE
Bugfix: AsString() on an EnumVal will segfault

### DIFF
--- a/src/plugin/ComponentManager.h
+++ b/src/plugin/ComponentManager.h
@@ -267,7 +267,8 @@ const std::string& ComponentManager<C>::GetComponentName(EnumValPtr val) const {
     if ( C* c = Lookup(val.get()) )
         return c->CanonicalName();
 
-    reporter->InternalWarning("requested name of unknown component tag %s", val->AsString()->CheckString());
+    reporter->InternalWarning("requested name of unknown component tag %s",
+                              val->GetType()->AsEnumType()->Lookup(val->Get()));
     return error;
 }
 
@@ -295,7 +296,8 @@ StringValPtr ComponentManager<C>::GetComponentNameVal(EnumValPtr val) const {
     if ( C* c = Lookup(val.get()) )
         return c->CanonicalNameVal();
 
-    reporter->InternalWarning("requested name of unknown component tag %s", val->AsString()->CheckString());
+    reporter->InternalWarning("requested name of unknown component tag %s",
+                              val->GetType()->AsEnumType()->Lookup(val->Get()));
     return error;
 }
 


### PR DESCRIPTION
If you force a component lookup via an unrelated enum, for example by saying ...
```
event zeek_init() {
        Files::__analyzer_name(udp);
}
```
... you get:
```
(gdb) run ./test.zeek
Thread 1 "zeek" received signal SIGSEGV, Segmentation fault.
0x000000000122f9c8 in zeek::String::CheckStringWithSize (this=0x2) at /home/christian/devel/zeek/zeek/src/ZeekString.cc:157
(gdb) bt
#0  0x000000000122f9c8 in zeek::String::CheckStringWithSize (this=0x2) at /home/christian/devel/zeek/zeek/src/ZeekString.cc:157
#1  0x000000000122fb28 in zeek::String::CheckString (this=0x2) at /home/christian/devel/zeek/zeek/src/ZeekString.cc:178
#2  0x000000000111438a in zeek::plugin::ComponentManager<zeek::file_analysis::Component>::GetComponentNameVal (this=0x48c9de0, val=...)
    at /home/christian/devel/zeek/zeek/src/include/zeek/plugin/ComponentManager.h:298
#3  0x00000000010db1ef in zeek::BifFunc::Files::__analyzer_name_bif (frame=0x665d110, BiF_ARGS=0x7fffffffb8a0) at /home/christian/devel/zeek/zeek/src/file_analysis/file_analysis.bif:106
```
With this tweak:
```
$ zeek ./test.zeek
internal warning: requested name of unknown component tag udp
```

This was previously in #4355 which is plenty big and about to get revamped, so I'm opening a separate PR here.