### PR TITLE
Deprecate the --with-bifcl and --with-binpac configure options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,10 @@ if (MSVC)
         #set(WERROR_FLAG "/WX")
         #set(WERROR_FLAG "/WX")
     endif ()
+
+    # Always build binpac in static mode if building on Windows
+    set(BUILD_STATIC_BINPAC true)
+
 else ()
     include(GNUInstallDirs)
     if (BUILD_WITH_WERROR)
@@ -866,42 +870,33 @@ endif ()
 set(PY_MOD_INSTALL_DIR ${py_mod_install_dir} CACHE STRING "Installation path for Python modules"
                                                    FORCE)
 
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/auxil/binpac/CMakeLists.txt)
+# BinPAC uses the same 'ENABLE_STATIC_ONLY' variable to define whether
+# to build statically. Save a local copy so it can be set based on the
+# configure flag before we add the subdirectory.
+set(ENABLE_STATIC_ONLY_SAVED ${ENABLE_STATIC_ONLY})
 
-    set(ENABLE_STATIC_ONLY_SAVED ${ENABLE_STATIC_ONLY})
-    if (MSVC)
-        set(BUILD_STATIC_BINPAC true)
-    endif ()
-
-    if (BUILD_STATIC_BINPAC)
-        set(ENABLE_STATIC_ONLY true)
-    endif ()
-
-    add_subdirectory(auxil/binpac)
-    set(ENABLE_STATIC_ONLY ${ENABLE_STATIC_ONLY_SAVED})
-
-    # FIXME: avoid hard-coding a path for multi-config generator support. See the
-    # TODO in ZeekPluginConfig.cmake.in.
-    set(BINPAC_EXE_PATH "${CMAKE_BINARY_DIR}/auxil/binpac/src/binpac${CMAKE_EXECUTABLE_SUFFIX}")
+if (BUILD_STATIC_BINPAC)
+    set(ENABLE_STATIC_ONLY true)
 endif ()
 
-find_package(BinPAC REQUIRED)
+add_subdirectory(auxil/binpac)
+set(ENABLE_STATIC_ONLY ${ENABLE_STATIC_ONLY_SAVED})
 
-# Add an alias (used by our plugin setup).
+# FIXME: avoid hard-coding a path for multi-config generator support. See the
+# TODO in ZeekPluginConfig.cmake.in.
+set(BINPAC_EXE_PATH "${CMAKE_BINARY_DIR}/auxil/binpac/src/binpac${CMAKE_EXECUTABLE_SUFFIX}")
+set(_binpac_exe_path "included")
+
+# Need to call find_package so it sets up the include paths used by plugin builds.
+find_package(BinPAC REQUIRED)
 add_executable(Zeek::BinPAC ALIAS binpac)
 
-if (NOT BIFCL_EXE_PATH)
-    add_subdirectory(auxil/bifcl)
-    add_executable(Zeek::BifCl ALIAS bifcl)
-    # FIXME: avoid hard-coding a path for multi-config generator support. See the
-    # TODO in ZeekPluginConfig.cmake.in.
-    set(BIFCL_EXE_PATH "${CMAKE_BINARY_DIR}/auxil/bifcl/bifcl${CMAKE_EXECUTABLE_SUFFIX}")
-    set(_bifcl_exe_path "included")
-else ()
-    add_executable(Zeek::BifCl IMPORTED)
-    set_property(TARGET Zeek::BifCl PROPERTY IMPORTED_LOCATION "${BIFCL_EXE_PATH}")
-    set(_bifcl_exe_path "BIFCL_EXE_PATH")
-endif ()
+add_subdirectory(auxil/bifcl)
+add_executable(Zeek::BifCl ALIAS bifcl)
+# FIXME: avoid hard-coding a path for multi-config generator support. See the
+# TODO in ZeekPluginConfig.cmake.in.
+set(BIFCL_EXE_PATH "${CMAKE_BINARY_DIR}/auxil/bifcl/bifcl${CMAKE_EXECUTABLE_SUFFIX}")
+set(_bifcl_exe_path "included")
 
 if (NOT GEN_ZAM_EXE_PATH)
     add_subdirectory(auxil/gen-zam)
@@ -1240,11 +1235,7 @@ endif ()
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink "." "${CMAKE_CURRENT_BINARY_DIR}/zeek")
 
-if (BinPAC_ROOT_DIR)
-    set(ZEEK_CONFIG_BINPAC_ROOT_DIR ${BinPAC_ROOT_DIR})
-else ()
-    set(ZEEK_CONFIG_BINPAC_ROOT_DIR ${ZEEK_ROOT_DIR})
-endif ()
+set(ZEEK_CONFIG_BINPAC_ROOT_DIR ${BinPAC_ROOT_DIR})
 
 if (BROKER_ROOT_DIR)
     set(ZEEK_CONFIG_BROKER_ROOT_DIR ${BROKER_ROOT_DIR})
@@ -1460,11 +1451,6 @@ if (INSTALL_BTEST_PCAPS)
     set(_install_btest_tools_msg "all")
 else ()
     set(_install_btest_tools_msg "no pcaps")
-endif ()
-
-set(_binpac_exe_path "included")
-if (BINPAC_EXE_PATH)
-    set(_binpac_exe_path ${BINPAC_EXE_PATH})
 endif ()
 
 set(_gen_zam_exe_path "included")

--- a/configure
+++ b/configure
@@ -327,9 +327,6 @@ while [ $# -ne 0 ]; do
         --disable-af-packet)
             append_cache_entry DISABLE_AF_PACKET BOOL true
             ;;
-        --disable-archiver)
-            has_disable_archiver=1
-            ;;
         --disable-auxtools)
             append_cache_entry INSTALL_AUX_TOOLS BOOL false
             ;;
@@ -509,8 +506,3 @@ eval ${cmake} 2>&1
 echo "# This is the command used to configure this build" >config.status
 echo $command >>config.status
 chmod u+x config.status
-
-if [ $has_disable_archiver -eq 1 ]; then
-    echo
-    echo "NOTE: The --disable-archiver argument no longer has any effect and will be removed in v7.1. zeek-archiver is now part of zeek-aux, so consider --disable-auxtools instead."
-fi

--- a/configure
+++ b/configure
@@ -184,6 +184,8 @@ builddir=build
 CMakeCacheEntries=""
 display_cmake=0
 has_disable_archiver=0
+has_with_binpac=0
+has_with_bifcl=0
 
 # parse arguments
 while [ $# -ne 0 ]; do
@@ -368,13 +370,13 @@ while [ $# -ne 0 ]; do
             append_cache_entry INSTALL_ZKG BOOL false
             ;;
         --with-bifcl=*)
-            append_cache_entry BIFCL_EXE_PATH PATH $optarg
+            has_with_bifcl=1
             ;;
         --with-bind=*)
             append_cache_entry BIND_ROOT_DIR PATH $optarg
             ;;
         --with-binpac=*)
-            append_cache_entry BINPAC_EXE_PATH PATH $optarg
+            has_with_binpac=1
             ;;
         --with-bison=*)
             append_cache_entry BISON_EXECUTABLE PATH $optarg
@@ -506,3 +508,15 @@ eval ${cmake} 2>&1
 echo "# This is the command used to configure this build" >config.status
 echo $command >>config.status
 chmod u+x config.status
+
+if [ $has_with_bifcl -eq 1 ]; then
+    echo
+    echo "The --with-bifcl option has been deprecated and will be removed in v8.1."
+    echo "The bundled version of bifcl will always be used."
+fi
+
+if [ $has_with_binpac -eq 1 ]; then
+    echo
+    echo "The --with-binpac option has been deprecated and will be removed in v8.1."
+    echo "The bundled version of BinPAC will always be used.\n"
+fi


### PR DESCRIPTION
Binpac was already always building the included version even if the argument was passed. We don't do individual releases of binpac or bifcl anymore anyways, so people should already be using the included version all the time.

This also removes another deprecated option that I missed with the v7.1 removals.