### PR TITLE
Remove unneeded include dirs in zeromq CMakeLists.txt

### DIFF
--- a/src/cluster/backend/zeromq/CMakeLists.txt
+++ b/src/cluster/backend/zeromq/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(ZeroMQ REQUIRED)
 
 zeek_add_plugin(
     Zeek Cluster_Backend_ZeroMQ
-    INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${ZeroMQ_INCLUDE_DIRS}
+    INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIRS}
     DEPENDENCIES ${ZeroMQ_LIBRARIES}
     SOURCES Plugin.cc ZeroMQ-Proxy.cc ZeroMQ.cc
     BIFS cluster_backend_zeromq.bif)

--- a/src/cluster/backend/zeromq/cluster_backend_zeromq.bif
+++ b/src/cluster/backend/zeromq/cluster_backend_zeromq.bif
@@ -1,5 +1,5 @@
 %%{
-#include "ZeroMQ.h"
+#include "zeek/cluster/backend/zeromq/ZeroMQ.h"
 %%}
 
 function Cluster::Backend::ZeroMQ::spawn_zmq_proxy_thread%(%): bool


### PR DESCRIPTION
I did the same thing in the Redis storage backend as part of https://github.com/zeek/zeek/pull/4567, but left this for a separate PR. This changes the ZeroMQ CMakeLists.txt to not directly add `CMAKE_CURRENT_SOURCE_DIR` and `CMAKE_CURRENT_BINARY_DIR` to the target for these reasons:

- `CMAKE_CURRENT_BINARY_DIR` is already added by default in `cmake/ZeekPluginStatic.cmake`.
- Files included that are in the zeek repo should be included with their full path (see the change to `cluster_backend_zeromq.bif`), so we don't need to include `CMAKE_CURRENT_SOURCE_DIR` either.