### PR TITLE
IOSource: Remove IsPacketSource

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -48,6 +48,9 @@ Breaking Changes
 
 	redef EventMetadata::add_missing_remote_network_timestamp = T;
 
+- The ``IsPacketSource()`` method on ``IOSource`` was removed. It was unused
+  and incorrectly returned ``false`` on all packet sources.
+
 New Functionality
 -----------------
 

--- a/src/iosource/IOSource.h
+++ b/src/iosource/IOSource.h
@@ -33,11 +33,6 @@ public:
     bool IsOpen() const { return ! closed; }
 
     /**
-     * Returns true if this is a packet source.
-     */
-    virtual bool IsPacketSource() const { return false; }
-
-    /**
      * Initializes the source. Can be overwritten by derived classes.
      */
     virtual void InitSource() {}


### PR DESCRIPTION
This wasn't used in tree and even the PktSrc class doesn't override this to return true, so just remove it outright without deprecation.

Closes #4573