### PR TITLE
Spicy SSL analyzer: make record layer version parsing more strict

### DIFF
--- a/src/analyzer/protocol/ssl/spicy/SSL.spicy
+++ b/src/analyzer/protocol/ssl/spicy/SSL.spicy
@@ -740,7 +740,7 @@ type SSL2ClientMasterKey = unit(length: uint16, inout sh: Share) {
 # For TLS-y protocols - determine how to continue
 type TLSRecordFragmentChoice = unit(content_type: uint8, handshakesink: sink&, alertsink: sink&, inout msg: Message, inout sh: Share) {
     # content_type: uint8; # &convert=ContentType($$);
-    version: uint16;
+    version: uint16 &requires=($$ == SSLv3 || $$ == TLSv10 || $$ == TLSv11 || $$ == TLSv12 : "Invalid version in record layer. Version: %s" % $$);
 
     switch (is_dtls_version(self.version)) {
         True -> dtlsfragment: DTLSRecordFragment(content_type, handshakesink, alertsink, msg, sh);

--- a/testing/btest/core/pppoe-over-qinq.zeek
+++ b/testing/btest/core/pppoe-over-qinq.zeek
@@ -1,5 +1,2 @@
-# Disable test temporarily - see GH-4547
-# @TEST-REQUIRES: ! have-spicy-ssl
-
 # @TEST-EXEC: zeek -r $TRACES/pppoe-over-qinq.pcap
 # @TEST-EXEC: btest-diff conn.log


### PR DESCRIPTION
The Spicy based SSL analyzer was, so far, more permissive with the record layer versions that it would accept.

This change brings the parsing of record layer versions in line with the binpac based analyzer. This behavioral difference was discovered due to a test that changed with the recent dpd log changes.