### PR TITLE
Fix clang-tidy readability-isolate-declaration warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@ Checks: [-*,
          bugprone-*,
          performance-*,
          modernize-*,
+         readability-isolate-declaration,
 
          # Enable a very limited number of the cppcoreguidelines checkers.
          # See the notes for some of the rest of them below.

--- a/src/Base64.cc
+++ b/src/Base64.cc
@@ -217,17 +217,19 @@ String* decode_base64(const String* s, const String* a, Connection* conn) {
     }
 
     int buf_len = int((s->Len() + 3) / 4) * 3 + 1;
-    int rlen2, rlen = buf_len;
-    char *rbuf2, *rbuf = new char[rlen];
+    int rlen = buf_len;
+    char* rbuf = new char[rlen];
 
     Base64Converter dec(conn, a ? a->CheckString() : "");
     dec.Decode(s->Len(), (const char*)s->Bytes(), &rlen, &rbuf);
 
-    if ( dec.Errored() )
-        goto err;
+    if ( dec.Errored() ) {
+        delete[] rbuf;
+        return nullptr;
+    }
 
-    rlen2 = buf_len - rlen;
-    rbuf2 = rbuf + rlen;
+    int rlen2 = buf_len - rlen;
+    char* rbuf2 = rbuf + rlen;
     // Done() returns -1 if there isn't enough padding, but we just ignore
     // it.
     dec.Done(&rlen2, &rbuf2);
@@ -235,10 +237,6 @@ String* decode_base64(const String* s, const String* a, Connection* conn) {
 
     rbuf[rlen] = '\0';
     return new String(true, (u_char*)rbuf, rlen);
-
-err:
-    delete[] rbuf;
-    return nullptr;
 }
 
 String* encode_base64(const String* s, const String* a, Connection* conn) {

--- a/src/DNS_Mapping.cc
+++ b/src/DNS_Mapping.cc
@@ -43,7 +43,8 @@ DNS_Mapping::DNS_Mapping(FILE* f) {
         return;
     }
 
-    char req_buf[512 + 1], name_buf[512 + 1];
+    char req_buf[512 + 1];
+    char name_buf[512 + 1];
     int is_req_host;
     int failed_local;
     int num_addrs;

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -872,9 +872,9 @@ void DNS_Mgr::Lookup(const std::string& name, int request_type, LookupCallback* 
 
 void DNS_Mgr::Resolve() {
     int nfds = 0;
-    struct timeval *tvp, tv;
     struct pollfd pollfds[1024];
 
+    struct timeval tv;
     tv.tv_sec = DNS_TIMEOUT;
     tv.tv_usec = 0;
 
@@ -903,7 +903,7 @@ void DNS_Mgr::Resolve() {
         }
 
         // poll() timeout is in milliseconds.
-        tvp = ares_timeout(channel, &tv, &tv);
+        struct timeval* tvp = ares_timeout(channel, &tv, &tv);
         int timeout_ms = tvp->tv_sec * 1000 + tvp->tv_usec / 1000;
 
         int res = poll(pollfds, nfds, timeout_ms);

--- a/src/Dict.h
+++ b/src/Dict.h
@@ -582,7 +582,8 @@ public:
         // Look to see if this key is already in the table. If found, insert_position is the
         // position of the existing element. If not, insert_position is where it'll be inserted
         // and insert_distance is the distance of the key for the position.
-        int insert_position = -1, insert_distance = -1;
+        int insert_position = -1;
+        int insert_distance = -1;
         int position = LookupIndex(key, key_size, hash, &insert_position, &insert_distance);
         if ( position >= 0 ) {
             v = table[position].value;

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -718,9 +718,15 @@ ValPtr BinaryExpr::Fold(Val* v1, Val* v2) const {
     if ( it == TYPE_INTERNAL_SUBNET )
         return SubNetFold(v1, v2);
 
-    zeek_int_t i1 = 0, i2 = 0, i3 = 0;
-    zeek_uint_t u1 = 0, u2 = 0, u3 = 0;
-    double d1 = 0.0, d2 = 0.0, d3 = 0.0;
+    zeek_int_t i1 = 0;
+    zeek_int_t i2 = 0;
+    zeek_int_t i3 = 0;
+    zeek_uint_t u1 = 0;
+    zeek_uint_t u2 = 0;
+    zeek_uint_t u3 = 0;
+    double d1 = 0.0;
+    double d2 = 0.0;
+    double d3 = 0.0;
     bool is_integral = false;
     bool is_unsigned = false;
 
@@ -1382,7 +1388,8 @@ AddExpr::AddExpr(ExprPtr arg_op1, ExprPtr arg_op2) : BinaryExpr(EXPR_ADD, std::m
     if ( IsError() )
         return;
 
-    TypeTag bt1, bt2;
+    TypeTag bt1;
+    TypeTag bt2;
     if ( ! get_types_from_scalars_or_vectors(this, bt1, bt2) )
         return;
 
@@ -1572,7 +1579,8 @@ SubExpr::SubExpr(ExprPtr arg_op1, ExprPtr arg_op2) : BinaryExpr(EXPR_SUB, std::m
     const auto& t1 = op1->GetType();
     const auto& t2 = op2->GetType();
 
-    TypeTag bt1, bt2;
+    TypeTag bt1;
+    TypeTag bt2;
     if ( ! get_types_from_scalars_or_vectors(this, bt1, bt2) )
         return;
 
@@ -1663,7 +1671,8 @@ TimesExpr::TimesExpr(ExprPtr arg_op1, ExprPtr arg_op2)
 
     Canonicalize();
 
-    TypeTag bt1, bt2;
+    TypeTag bt1;
+    TypeTag bt2;
     if ( ! get_types_from_scalars_or_vectors(this, bt1, bt2) )
         return;
 
@@ -1690,7 +1699,8 @@ DivideExpr::DivideExpr(ExprPtr arg_op1, ExprPtr arg_op2)
     if ( IsError() )
         return;
 
-    TypeTag bt1, bt2;
+    TypeTag bt1;
+    TypeTag bt2;
     if ( ! get_types_from_scalars_or_vectors(this, bt1, bt2) )
         return;
 
@@ -1718,7 +1728,8 @@ MaskExpr::MaskExpr(ExprPtr arg_op1, ExprPtr arg_op2) : BinaryExpr(EXPR_MASK, std
     if ( IsError() )
         return;
 
-    TypeTag bt1, bt2;
+    TypeTag bt1;
+    TypeTag bt2;
     if ( ! get_types_from_scalars_or_vectors(this, bt1, bt2) )
         return;
 
@@ -1754,7 +1765,8 @@ ModExpr::ModExpr(ExprPtr arg_op1, ExprPtr arg_op2) : BinaryExpr(EXPR_MOD, std::m
     if ( IsError() )
         return;
 
-    TypeTag bt1, bt2;
+    TypeTag bt1;
+    TypeTag bt2;
     if ( ! get_types_from_scalars_or_vectors(this, bt1, bt2) )
         return;
 
@@ -1769,7 +1781,8 @@ BoolExpr::BoolExpr(ExprTag arg_tag, ExprPtr arg_op1, ExprPtr arg_op2)
     if ( IsError() )
         return;
 
-    TypeTag bt1, bt2;
+    TypeTag bt1;
+    TypeTag bt2;
     if ( ! get_types_from_scalars_or_vectors(this, bt1, bt2) )
         return;
 
@@ -1958,7 +1971,8 @@ EqExpr::EqExpr(ExprTag arg_tag, ExprPtr arg_op1, ExprPtr arg_op2)
     const auto& t1 = op1->GetType();
     const auto& t2 = op2->GetType();
 
-    TypeTag bt1, bt2;
+    TypeTag bt1;
+    TypeTag bt2;
     if ( ! get_types_from_scalars_or_vectors(this, bt1, bt2) )
         return;
 
@@ -2048,7 +2062,8 @@ RelExpr::RelExpr(ExprTag arg_tag, ExprPtr arg_op1, ExprPtr arg_op2)
     const auto& t1 = op1->GetType();
     const auto& t2 = op2->GetType();
 
-    TypeTag bt1, bt2;
+    TypeTag bt1;
+    TypeTag bt2;
     if ( ! get_types_from_scalars_or_vectors(this, bt1, bt2) )
         return;
 

--- a/src/IP.cc
+++ b/src/IP.cc
@@ -463,8 +463,8 @@ IPv6_Hdr_Chain::~IPv6_Hdr_Chain() {
 
 void IPv6_Hdr_Chain::Init(const struct ip6_hdr* ip6, uint64_t total_len, bool set_next, uint16_t next) {
     length = 0;
-    uint8_t current_type, next_type;
-    next_type = IPPROTO_IPV6;
+    uint8_t current_type;
+    uint8_t next_type = IPPROTO_IPV6;
     const u_char* hdrs = (const u_char*)ip6;
 
     if ( total_len < (int)sizeof(struct ip6_hdr) ) {

--- a/src/IPAddr.cc
+++ b/src/IPAddr.cc
@@ -59,8 +59,12 @@ ConnKey::ConnKey(Val* v) {
     RecordType* vr = vt->AsRecordType();
     auto vl = v->As<RecordVal*>();
 
-    int orig_h, orig_p; // indices into record's value list
-    int resp_h, resp_p;
+    // indices into record's value list
+    int orig_h;
+    int orig_p;
+
+    int resp_h;
+    int resp_p;
     int proto;
 
     if ( vr == id::conn_id ) {

--- a/src/ScriptProfile.cc
+++ b/src/ScriptProfile.cc
@@ -44,7 +44,10 @@ void ScriptProfile::Report(FILE* f, bool with_traces) const {
     std::string call_stacks;
 
     if ( with_traces ) {
-        std::string calls, counts, cpu, memory;
+        std::string calls;
+        std::string counts;
+        std::string cpu;
+        std::string memory;
 
         for ( const auto& [s, stats] : Stacks() ) {
             calls += util::fmt("%s|", s.c_str());

--- a/src/SmithWaterman.cc
+++ b/src/SmithWaterman.cc
@@ -227,7 +227,8 @@ private:
 //
 static void sw_collect_single(Substring::Vec* result, SWNodeMatrix& matrix, SWNode* node, SWParams& params) {
     std::string substring("");
-    int row = 0, col = 0;
+    int row = 0;
+    int col = 0;
 
     while ( node ) {
         //		printf("NODE: %i\n", node->id);
@@ -346,10 +347,11 @@ Substring::Vec* smith_waterman(const String* s1, const String* s2, SWParams& par
     // Length of both strings, plus one because SW needs
     // an extra row and column.
     //
-    int i, len1 = s1->Len() + 1;
-    int j, len2 = s2->Len() + 1;
+    int len1 = s1->Len() + 1;
+    int len2 = s2->Len() + 1;
 
-    int row = 0, col = 0;
+    int row = 0;
+    int col = 0;
 
     byte_vec string1 = s1->Bytes();
     byte_vec string2 = s2->Bytes();
@@ -374,14 +376,14 @@ Substring::Vec* smith_waterman(const String* s1, const String* s2, SWParams& par
 
     int counter = 1;
 
-    for ( i = 1; i < len1; ++i )
-        for ( j = 1; j < len2; ++j )
+    for ( int i = 1; i < len1; ++i )
+        for ( int j = 1; j < len2; ++j )
             matrix(i, j)->id = counter++;
 
     // Subsequence calculation --------------------------------------------
 
-    for ( i = 1; i < len1; ++i ) {
-        for ( j = 1; j < len2; ++j ) {
+    for ( int i = 1; i < len1; ++i ) {
+        for ( int j = 1; j < len2; ++j ) {
             // Current node, top/left neighbours.
             //
             SWNode* current = matrix(i, j);

--- a/src/Stats.cc
+++ b/src/Stats.cc
@@ -87,7 +87,8 @@ void ProfileLogger::Log() {
     struct timeval tv_utime = r.ru_utime;
     struct timeval tv_stime = r.ru_stime;
 
-    uint64_t total, malloced;
+    uint64_t total;
+    uint64_t malloced;
     util::get_memory_usage(&total, &malloced);
 
     static unsigned int first_total = 0;

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -375,7 +375,8 @@ void HTTP_Entity::SubmitHeader(analyzer::mime::MIME_Header* h) {
             DEBUG_MSG("Parsed Content-Range: %s %s-%s/%s\n", byte_unit.c_str(), first_byte_pos.c_str(),
                       last_byte_pos.c_str(), instance_length_str.c_str());
 
-        int64_t f, l;
+        int64_t f;
+        int64_t l;
         int fr = util::atoi_n(first_byte_pos.size(), first_byte_pos.c_str(), nullptr, 10, f);
         int lr = util::atoi_n(last_byte_pos.size(), last_byte_pos.c_str(), nullptr, 10, l);
         if ( fr != 1 || lr != 1 ) {

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -39,7 +39,6 @@ void Ident_Analyzer::Done() {
 void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig) {
     analyzer::tcp::TCP_ApplicationAnalyzer::DeliverStream(length, data, is_orig);
 
-    int remote_port, local_port;
     const char* line = (const char*)data;
     const char* orig_line = line;
     const char* end_of_line = line + length;
@@ -56,7 +55,10 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
         if ( ! ident_request )
             return;
 
+        int remote_port;
+        int local_port;
         line = ParsePair(line, end_of_line, remote_port, local_port);
+
         if ( ! line ) {
             if ( s && s->state == analyzer::tcp::TCP_ENDPOINT_CLOSED &&
                  (s->prev_state == analyzer::tcp::TCP_ENDPOINT_INACTIVE ||
@@ -83,6 +85,8 @@ void Ident_Analyzer::DeliverStream(int length, const u_char* data, bool is_orig)
         if ( ! ident_reply )
             return;
 
+        int remote_port;
+        int local_port;
         line = ParsePair(line, end_of_line, remote_port, local_port);
 
         if ( ! line || line == end_of_line || line[0] != ':' ) {

--- a/src/analyzer/protocol/login/Login.cc
+++ b/src/analyzer/protocol/login/Login.cc
@@ -76,8 +76,8 @@ void Login_Analyzer::DeliverStream(int length, const u_char* line, bool orig) {
     char* str = new char[length + 1];
 
     // Eliminate NUL characters.
-    int i, j;
-    for ( i = 0, j = 0; i < length; ++i )
+    int j = 0;
+    for ( int i = 0; i < length; ++i )
         if ( line[i] != '\0' )
             str[j++] = line[i];
         else {

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -239,7 +239,8 @@ void TelnetEnvironmentOption::RecvSubOption(u_char* data, int len) {
     ++data;
 
     while ( len > 0 ) {
-        int code1, code2;
+        int code1;
+        int code2;
         char* var_name = ExtractEnv(data, len, code1);
         char* var_val = ExtractEnv(data, len, code2);
 

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -681,10 +681,10 @@ bool MIME_Entity::ParseContentTypeField(MIME_Header* h) {
     int len = val.length;
     const char* data = val.data;
 
-    data_chunk_t ty, subty;
-    int offset;
+    data_chunk_t ty;
+    data_chunk_t subty;
+    int offset = MIME_get_slash_token_pair(len, data, &ty, &subty);
 
-    offset = MIME_get_slash_token_pair(len, data, &ty, &subty);
     if ( offset < 0 ) {
         IllegalFormat("media type/subtype not found in content type");
         return false;
@@ -930,9 +930,8 @@ void MIME_Entity::DecodeQuotedPrintable(int len, const char* data) {
             else {
                 int legal = 0;
                 if ( i + 2 < len ) {
-                    int a, b;
-                    a = util::decode_hex(data[i + 1]);
-                    b = util::decode_hex(data[i + 2]);
+                    int a = util::decode_hex(data[i + 1]);
+                    int b = util::decode_hex(data[i + 2]);
 
                     if ( a >= 0 && b >= 0 ) {
                         DataOctet((a << 4) + b);

--- a/src/analyzer/protocol/quic/decrypt_crypto.cc
+++ b/src/analyzer/protocol/quic/decrypt_crypto.cc
@@ -151,7 +151,8 @@ Function that calls the AEAD decryption routine, and returns the decrypted data.
 */
 hilti::rt::Bytes decrypt(const std::vector<uint8_t>& client_key, const hilti::rt::Bytes& data, uint64_t payload_length,
                          const DecryptionInformation& decryptInfo) {
-    int out, out2;
+    int out = 0;
+    int out2 = 0;
 
     if ( payload_length < decryptInfo.packet_number_length + AEAD_TAG_LENGTH )
         throw hilti::rt::RuntimeError(hilti::rt::fmt("payload too small %ld < %ld", payload_length,

--- a/src/file_analysis/analyzer/entropy/Entropy.cc
+++ b/src/file_analysis/analyzer/entropy/Entropy.cc
@@ -45,8 +45,11 @@ void Entropy::Finalize() {
     if ( ! file_entropy )
         return;
 
-    double montepi, scc, ent, mean, chisq;
-    montepi = scc = ent = mean = chisq = 0.0;
+    double montepi = 0;
+    double scc = 0;
+    double ent = 0;
+    double mean = 0;
+    double chisq = 0;
     entropy->Get(&ent, &chisq, &mean, &montepi, &scc);
 
     static auto entropy_test_result = id::find_type<RecordType>("entropy_test_result");

--- a/src/file_analysis/analyzer/x509/OCSP.cc
+++ b/src/file_analysis/analyzer/x509/OCSP.cc
@@ -392,7 +392,8 @@ void OCSP::ParseResponse(OCSP_RESPONSE* resp) {
     const ASN1_GENERALIZEDTIME* produced_at = nullptr;
     const STACK_OF(X509)* certs = nullptr;
 
-    int resp_count, num_ext = 0;
+    int resp_count;
+    int num_ext = 0;
     VectorVal* certs_vector = nullptr;
     int len = 0;
 

--- a/src/packet_analysis/protocol/icmp/ICMP.cc
+++ b/src/packet_analysis/protocol/icmp/ICMP.cc
@@ -250,13 +250,17 @@ TransportProto ICMPAnalyzer::GetContextProtocol(const IP_Hdr* ip_hdr, uint32_t* 
 }
 
 zeek::RecordValPtr ICMPAnalyzer::ExtractICMP4Context(int len, const u_char*& data) {
-    uint32_t ip_len, frag_offset;
+    uint32_t ip_len;
+    uint32_t frag_offset;
     bool bad_hdr_len = false;
     bool bad_checksum = false;
     TransportProto proto = TRANSPORT_UNKNOWN;
-    int DF, MF;
-    IPAddr src_addr, dst_addr;
-    uint32_t src_port, dst_port;
+    int DF;
+    int MF;
+    IPAddr src_addr;
+    IPAddr dst_addr;
+    uint32_t src_port;
+    uint32_t dst_port;
 
     if ( len < (int)sizeof(struct ip) ) {
         // We don't have an entire IP header.
@@ -322,13 +326,17 @@ zeek::RecordValPtr ICMPAnalyzer::ExtractICMP4Context(int len, const u_char*& dat
 }
 
 zeek::RecordValPtr ICMPAnalyzer::ExtractICMP6Context(int len, const u_char*& data) {
-    int DF = 0, MF = 0, bad_hdr_len = 0;
+    int DF = 0;
+    int MF = 0;
+    int bad_hdr_len = 0;
     TransportProto proto = TRANSPORT_UNKNOWN;
 
     IPAddr src_addr;
     IPAddr dst_addr;
-    uint32_t ip_len, frag_offset = 0;
-    uint32_t src_port, dst_port;
+    uint32_t ip_len;
+    uint32_t frag_offset = 0;
+    uint32_t src_port;
+    uint32_t dst_port;
 
     if ( len < (int)sizeof(struct ip6_hdr) ) {
         bad_hdr_len = 1;
@@ -408,7 +416,8 @@ void ICMPAnalyzer::RouterAdvert(double t, const struct icmp* icmpp, int len, int
     if ( ! f )
         return;
 
-    uint32_t reachable = 0, retrans = 0;
+    uint32_t reachable = 0;
+    uint32_t retrans = 0;
 
     if ( caplen >= (int)sizeof(reachable) )
         memcpy(&reachable, data, sizeof(reachable));
@@ -480,7 +489,8 @@ void ICMPAnalyzer::Redirect(double t, const struct icmp* icmpp, int len, int cap
     if ( ! f )
         return;
 
-    IPAddr tgtaddr, dstaddr;
+    IPAddr tgtaddr;
+    IPAddr dstaddr;
 
     if ( caplen >= (int)sizeof(in6_addr) )
         tgtaddr = IPAddr(*((const in6_addr*)data));

--- a/src/packet_analysis/protocol/ip/conn_key/fivetuple/Factory.cc
+++ b/src/packet_analysis/protocol/ip/conn_key/fivetuple/Factory.cc
@@ -25,7 +25,11 @@ zeek::expected<zeek::ConnKeyPtr, std::string> Factory::DoConnKeyFromVal(const ze
     auto vl = v.AsRecordVal();
 
     // Indices into conn_id's record field value list:
-    int orig_h = 0, orig_p = 1, resp_h = 2, resp_p = 3, proto = 4;
+    int orig_h = 0;
+    int orig_p = 1;
+    int resp_h = 2;
+    int resp_p = 3;
+    int proto = 4;
 
     if ( vr != id::conn_id ) {
         // While it's not a conn_id, it may have equivalent fields.

--- a/src/packet_analysis/protocol/ip/conn_key/vlan_fivetuple/Factory.cc
+++ b/src/packet_analysis/protocol/ip/conn_key/vlan_fivetuple/Factory.cc
@@ -54,7 +54,8 @@ protected:
     };
 
     std::pair<int, int> GetConnIdFieldOffsets() {
-        static int vlan_offset = -2, inner_vlan_offset = -2;
+        static int vlan_offset = -2;
+        static int inner_vlan_offset = -2;
 
         if ( vlan_offset == -2 && inner_vlan_offset == -2 ) {
             vlan_offset = id::conn_id->FieldOffset("vlan");
@@ -101,7 +102,8 @@ zeek::expected<zeek::ConnKeyPtr, std::string> Factory::DoConnKeyFromVal(const ze
     auto rt = v.GetType()->AsRecordType();
     auto vl = v.AsRecordVal();
 
-    int vlan_offset, inner_vlan_offset;
+    int vlan_offset;
+    int inner_vlan_offset;
     if ( rt == id::conn_id ) {
         std::tie(vlan_offset, inner_vlan_offset) = k->GetConnIdFieldOffsets();
     }

--- a/src/packet_analysis/protocol/iptunnel/IPTunnel.cc
+++ b/src/packet_analysis/protocol/iptunnel/IPTunnel.cc
@@ -82,8 +82,8 @@ bool IPTunnelAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* pa
 bool IPTunnelAnalyzer::ProcessEncapsulatedPacket(double t, Packet* pkt, const std::shared_ptr<IP_Hdr>& inner,
                                                  std::shared_ptr<EncapsulationStack> prev,
                                                  const EncapsulatingConn& ec) {
-    uint32_t caplen, len;
-    caplen = len = inner->TotalLen();
+    uint32_t caplen = inner->TotalLen();
+    uint32_t len = caplen;
 
     pkt_timeval ts;
     int link_type;

--- a/src/probabilistic/CounterVector.cc
+++ b/src/probabilistic/CounterVector.cc
@@ -70,7 +70,8 @@ void CounterVector::Reset() { bits->Reset(); }
 CounterVector::count_type CounterVector::Count(size_type cell) const {
     assert(cell < Size());
 
-    size_t cnt = 0, order = 1;
+    size_t cnt = 0;
+    size_t order = 1;
     size_t lsb = cell * width;
 
     for ( size_t i = lsb; i < lsb + width; ++i, order <<= 1 )

--- a/src/script_opt/ZAM/AM-Opt.cc
+++ b/src/script_opt/ZAM/AM-Opt.cc
@@ -480,7 +480,10 @@ void ZAMCompiler::ComputeFrameLifetimes() {
                 break;
         }
 
-        int s1, s2, s3, s4;
+        int s1;
+        int s2;
+        int s3;
+        int s4;
 
         if ( ! inst->UsesSlots(s1, s2, s3, s4) )
             continue;

--- a/src/script_opt/ZAM/Driver.cc
+++ b/src/script_opt/ZAM/Driver.cc
@@ -385,7 +385,8 @@ void ZAMCompiler::Dump() {
 
         for ( auto i = 0U; i < insts2.size(); ++i ) {
             auto& inst = insts2[i];
-            std::string liveness, depth;
+            std::string liveness;
+            std::string depth;
 
             if ( inst->live )
                 liveness = util::fmt("(labels %d)", inst->num_labels);
@@ -460,7 +461,8 @@ void ZAMCompiler::DumpInsts1(const FrameReMap* remappings) {
             // we need to concretize the branch slots
             ConcretizeBranch(inst, inst->target, inst->target_slot);
 
-        std::string liveness, depth;
+        std::string liveness;
+        std::string depth;
 
         if ( inst->live )
             liveness = util::fmt("(labels %d)", inst->num_labels);

--- a/src/threading/SerialTypes.cc
+++ b/src/threading/SerialTypes.cc
@@ -203,7 +203,8 @@ bool Value::IsCompatibleType(Type* t, bool atomic_only) {
 }
 
 bool Value::Read(detail::SerializationFormat* fmt) {
-    int ty, sty;
+    int ty;
+    int sty;
 
     if ( ! (fmt->Read(&ty, "type") && fmt->Read(&sty, "subtype") && fmt->Read(&present, "present")) )
         return false;

--- a/src/util.cc
+++ b/src/util.cc
@@ -1335,7 +1335,6 @@ char* uitoa_n(uint64_t value, char* str, int n, int base, const char* prefix) {
 
     int i = 0;
     uint64_t v;
-    char *p, *q;
     char c;
 
     if ( prefix ) {


### PR DESCRIPTION
I missed one of these in review so a machine is probably better at catching them.

I fixed the existing instances which where largely in code which look dated. Where possible I slightly reorganized the code so we do not have to leave values uninitialized, but did not touch up anything else.