### PR TITLE
scripts: Use tpe instead of type_, again

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -85,6 +85,7 @@ ot2 = "ot2"
 uses_seh = "uses_seh"
 ect0 = "ect0"
 ect1 = "ect1"
+tpe = "tpe"
 
 [default.extend-words]
 caf = "caf"

--- a/scripts/base/frameworks/config/input.zeek
+++ b/scripts/base/frameworks/config/input.zeek
@@ -30,7 +30,7 @@ type EventFields: record {
 	option_val: string;
 };
 
-event config_line(description: Input::EventDescription, type_: Input::Event, p: EventFields)
+event config_line(description: Input::EventDescription, tpe: Input::Event, p: EventFields)
 	{
 	}
 

--- a/scripts/base/frameworks/intel/input.zeek
+++ b/scripts/base/frameworks/intel/input.zeek
@@ -27,11 +27,11 @@ export {
 	##
 	## desc: The :zeek:type:`Input::EventDescription` record which generated the event.
 	##
-	## type_: The type of input event.
+	## tpe: The type of input event.
 	##
 	## item: The intel item being read (of type :zeek:type:`Intel::Item`).
 	##
-	global read_entry: event(desc: Input::EventDescription, type_: Input::Event, item: Intel::Item);
+	global read_entry: event(desc: Input::EventDescription, tpe: Input::Event, item: Intel::Item);
 
 	## This event is raised each time the input framework detects an error
 	## while reading the intel file. It can be used to implement further checks
@@ -46,7 +46,7 @@ export {
 	global read_error: event(desc: Input::EventDescription, message: string, level: Reporter::Level);
 }
 
-event Intel::read_entry(desc: Input::EventDescription, type_: Input::Event, item: Intel::Item)
+event Intel::read_entry(desc: Input::EventDescription, tpe: Input::Event, item: Intel::Item)
 	{
 	Intel::insert(item);
 	}

--- a/scripts/base/frameworks/openflow/cluster.zeek
+++ b/scripts/base/frameworks/openflow/cluster.zeek
@@ -76,16 +76,16 @@ event OpenFlow::cluster_flow_clear(name: string)
 	}
 @endif
 
-function register_controller(type_: OpenFlow::Plugin, name: string, controller: Controller)
+function register_controller(tpe: OpenFlow::Plugin, name: string, controller: Controller)
 	{
-	controller$state$_name = cat(type_, name);
-	controller$state$_plugin = type_;
+	controller$state$_name = cat(tpe, name);
+	controller$state$_plugin = tpe;
 
 	# we only run the init functions on the manager.
 	if ( Cluster::local_node_type() != Cluster::MANAGER )
 		return;
 
-	register_controller_impl(type_, name, controller);
+	register_controller_impl(tpe, name, controller);
 	}
 
 function unregister_controller(controller: Controller)

--- a/scripts/base/frameworks/openflow/main.zeek
+++ b/scripts/base/frameworks/openflow/main.zeek
@@ -113,12 +113,12 @@ export {
 	## Function to register a controller instance. This function
 	## is called automatically by the plugin _new functions.
 	##
-	## type_: Type of this plugin.
+	## tpe: Type of this plugin.
 	##
 	## name: Unique name of this controller instance.
 	##
 	## controller: The controller to register.
-	global register_controller: function(type_: OpenFlow::Plugin, name: string, controller: Controller);
+	global register_controller: function(tpe: OpenFlow::Plugin, name: string, controller: Controller);
 
 	## Function to unregister a controller instance. This function
 	## should be called when a specific controller should no longer
@@ -253,7 +253,7 @@ function controller_init_done(controller: Controller)
 
 # Functions that are called from cluster.zeek and non-cluster.zeek
 
-function register_controller_impl(type_: OpenFlow::Plugin, name: string, controller: Controller)
+function register_controller_impl(tpe: OpenFlow::Plugin, name: string, controller: Controller)
 	{
 	if ( controller$state$_name in name_to_controller )
 		{

--- a/scripts/base/frameworks/openflow/non-cluster.zeek
+++ b/scripts/base/frameworks/openflow/non-cluster.zeek
@@ -25,12 +25,12 @@ function flow_clear(controller: Controller): bool
 		return F;
 	}
 
-function register_controller(type_: OpenFlow::Plugin, name: string, controller: Controller)
+function register_controller(tpe: OpenFlow::Plugin, name: string, controller: Controller)
 	{
-	controller$state$_name = cat(type_, name);
-	controller$state$_plugin = type_;
+	controller$state$_name = cat(tpe, name);
+	controller$state$_plugin = tpe;
 
-	register_controller_impl(type_, name, controller);
+	register_controller_impl(tpe, name, controller);
 	}
 
 function unregister_controller(controller: Controller)

--- a/scripts/base/utils/exec.zeek
+++ b/scripts/base/utils/exec.zeek
@@ -58,7 +58,7 @@ type FileLine: record {
 	s: string;
 };
 
-event Exec::line(description: Input::EventDescription, type_: Input::Event, s: string, is_stderr: bool)
+event Exec::line(description: Input::EventDescription, tpe: Input::Event, s: string, is_stderr: bool)
 	{
 	local result = results[description$name];
 	if ( is_stderr )
@@ -77,7 +77,7 @@ event Exec::line(description: Input::EventDescription, type_: Input::Event, s: s
 		}
 	}
 
-event Exec::file_line(description: Input::EventDescription, type_: Input::Event, s: string)
+event Exec::file_line(description: Input::EventDescription, tpe: Input::Event, s: string)
 	{
 	local parts = split_string1(description$name, /_/);
 	local name = parts[0];


### PR DESCRIPTION
The .rst generation doesn't escape the trailing `_` and the docs build gets upset due to using `type` as a reference target then.

For the better or worse, revert to using tpe. Though I acknowledge this means we need to be careful with trailing underscores because our docs build is so fragile.

Partly reverts b9eabbabbab912c8f45c49013865a88c1256f342.