### PR TITLE
Fix line number misordering in Location objects, and remove column information

### DIFF
--- a/src/DbgBreakpoint.cc
+++ b/src/DbgBreakpoint.cc
@@ -133,7 +133,8 @@ bool DbgBreakpoint::SetLocation(ParseLocationRec plr, std::string_view loc_str) 
         function_name = make_full_var_name(current_module.c_str(), loc_s.c_str());
         at_stmt = plr.stmt;
         const Location* loc = at_stmt->GetLocationInfo();
-        snprintf(description, sizeof(description), "%s at %s:%d", function_name.c_str(), loc->filename, loc->last_line);
+        snprintf(description, sizeof(description), "%s at %s:%d", function_name.c_str(), loc->FileName(),
+                 loc->LastLine());
 
         debug_msg("Breakpoint %d set at %s\n", GetID(), Description());
     }
@@ -154,7 +155,7 @@ bool DbgBreakpoint::SetLocation(Stmt* stmt) {
     AddToGlobalMap();
 
     const Location* loc = stmt->GetLocationInfo();
-    snprintf(description, sizeof(description), "%s:%d", loc->filename, loc->last_line);
+    snprintf(description, sizeof(description), "%s:%d", loc->FileName(), loc->LastLine());
 
     debug_msg("Breakpoint %d set at %s\n", GetID(), Description());
 
@@ -261,7 +262,7 @@ BreakCode DbgBreakpoint::ShouldBreak(Stmt* s) {
             break;
 
         case BP_LINE:
-            assert(s->GetLocationInfo()->first_line <= source_line && s->GetLocationInfo()->last_line >= source_line);
+            assert(s->GetLocationInfo()->FirstLine() <= source_line && s->GetLocationInfo()->LastLine() >= source_line);
             break;
 
         case BP_TIME: assert(false);
@@ -310,7 +311,7 @@ void DbgBreakpoint::PrintHitMsg() {
 
             const Location* loc = at_stmt->GetLocationInfo();
 
-            debug_msg("Breakpoint %d, %s at %s:%d\n", GetID(), d.Description(), loc->filename, loc->first_line);
+            debug_msg("Breakpoint %d, %s at %s:%d\n", GetID(), d.Description(), loc->FileName(), loc->FirstLine());
         }
             return;
 

--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -84,8 +84,8 @@ bool StmtLocMapping::StartsAfter(const StmtLocMapping* m2) {
     if ( ! m2 )
         reporter->InternalError("Assertion failed: m2 != 0");
 
-    return loc.first_line > m2->loc.first_line ||
-           (loc.first_line == m2->loc.first_line && loc.first_column > m2->loc.first_column);
+    return loc.FirstLine() > m2->loc.FirstLine() ||
+           (loc.FirstLine() == m2->loc.FirstLine() && loc.FirstColumn() > m2->loc.FirstColumn());
 }
 
 // Generic debug message output.
@@ -143,7 +143,6 @@ int TraceState::LogTrace(const char* fmt, ...) {
 
     const Stmt* stmt;
     Location loc;
-    loc.filename = nullptr;
 
     if ( g_frame_stack.size() > 0 && g_frame_stack.back() ) {
         stmt = g_frame_stack.back()->GetNextStmt();
@@ -156,13 +155,13 @@ int TraceState::LogTrace(const char* fmt, ...) {
         }
     }
 
-    if ( ! loc.filename ) {
+    if ( ! loc.FileName() ) {
         static constexpr const char str[] = "<no filename>";
-        loc.filename = str;
-        loc.last_line = 0;
+        loc.SetFile(str);
+        loc.SetLastLine(0);
     }
 
-    fprintf(trace_file, "%s:%d", loc.filename, loc.last_line);
+    fprintf(trace_file, "%s:%d", loc.FileName(), loc.LastLine());
 
     // Each stack frame is indented.
     for ( int i = 0; i < int(g_frame_stack.size()); ++i )
@@ -239,7 +238,7 @@ static void parse_function_name(vector<ParseLocationRec>& result, ParseLocationR
                 Stmt* first;
                 Location stmt_loc;
                 get_first_statement(bodies[i].stmts.get(), first, stmt_loc);
-                debug_msg("[%d] %s:%d\n", i + 1, stmt_loc.filename, stmt_loc.first_line);
+                debug_msg("[%d] %s:%d\n", i + 1, stmt_loc.FileName(), stmt_loc.FirstLine());
             }
 
             debug_msg("[a] All of the above\n");
@@ -283,8 +282,8 @@ static void parse_function_name(vector<ParseLocationRec>& result, ParseLocationR
         get_first_statement(body, first, stmt_loc);
         if ( first ) {
             plr.stmt = first;
-            plr.filename = stmt_loc.filename;
-            plr.line = stmt_loc.last_line;
+            plr.filename = stmt_loc.FileName();
+            plr.line = stmt_loc.LastLine();
         }
     }
 
@@ -299,8 +298,8 @@ static void parse_function_name(vector<ParseLocationRec>& result, ParseLocationR
 
             result_plr.type = PLR_FUNCTION;
             result_plr.stmt = first;
-            result_plr.filename = stmt_loc.filename;
-            result_plr.line = stmt_loc.last_line;
+            result_plr.filename = stmt_loc.FileName();
+            result_plr.line = stmt_loc.LastLine();
             result.push_back(result_plr);
         }
     }
@@ -317,7 +316,7 @@ vector<ParseLocationRec> parse_location_string(const string& s) {
     std::string loc_filename;
 
     if ( sscanf(s.c_str(), "%d", &plr.line) ) { // just a line number (implicitly referring to the current file)
-        loc_filename = g_debugger_state.last_loc.filename;
+        loc_filename = g_debugger_state.last_loc.FileName();
         plr.type = PLR_FILE_AND_LINE;
     }
 
@@ -360,12 +359,12 @@ vector<ParseLocationRec> parse_location_string(const string& s) {
 
         StmtLocMapping* hit = nullptr;
         for ( const auto entry : *(iter->second) ) {
-            plr.filename = entry->Loc().filename;
+            plr.filename = entry->Loc().FileName();
 
-            if ( entry->Loc().first_line > plr.line )
+            if ( entry->Loc().FirstLine() > plr.line )
                 break;
 
-            if ( plr.line >= entry->Loc().first_line && plr.line <= entry->Loc().last_line ) {
+            if ( plr.line >= entry->Loc().FirstLine() && plr.line <= entry->Loc().LastLine() ) {
                 hit = entry;
                 break;
             }
@@ -677,13 +676,13 @@ string get_context_description(const Stmt* stmt, const Frame* frame) {
         loc = *stmt->GetLocationInfo();
     else {
         static constexpr const char str[] = "<no filename>";
-        loc.filename = str;
-        loc.last_line = 0;
+        loc.SetFile(str);
+        loc.SetLastLine(0);
     }
 
-    size_t buf_size = strlen(d.Description()) + strlen(loc.filename) + 1024;
+    size_t buf_size = strlen(d.Description()) + strlen(loc.FileName()) + 1024;
     char* buf = new char[buf_size];
-    snprintf(buf, buf_size, "In %s at %s:%d", d.Description(), loc.filename, loc.last_line);
+    snprintf(buf, buf_size, "In %s at %s:%d", d.Description(), loc.FileName(), loc.LastLine());
 
     string retval(buf);
     delete[] buf;
@@ -720,7 +719,7 @@ int dbg_handle_debug_input() {
 
     step_or_next_pending = false;
 
-    PrintLines(loc.filename, loc.first_line, loc.last_line - loc.first_line + 1, true);
+    PrintLines(loc.FileName(), loc.FirstLine(), loc.LastLine() - loc.FirstLine() + 1, true);
     g_debugger_state.last_loc = loc;
 
     do {
@@ -872,8 +871,8 @@ ValPtr dbg_eval_expr(const char* expr) {
     // Fix filename and line number for the lexer/parser, which record it.
     filename = "<interactive>";
     line_number = 1;
-    yylloc.filename = filename;
-    yylloc.first_line = yylloc.last_line = line_number = 1;
+    yylloc.SetFile(filename);
+    yylloc.SetLine(1);
 
     // Parse the thing into an expr.
     ValPtr result;

--- a/src/Debug.cc
+++ b/src/Debug.cc
@@ -84,8 +84,7 @@ bool StmtLocMapping::StartsAfter(const StmtLocMapping* m2) {
     if ( ! m2 )
         reporter->InternalError("Assertion failed: m2 != 0");
 
-    return loc.FirstLine() > m2->loc.FirstLine() ||
-           (loc.FirstLine() == m2->loc.FirstLine() && loc.FirstColumn() > m2->loc.FirstColumn());
+    return loc.FirstLine() > m2->loc.FirstLine();
 }
 
 // Generic debug message output.

--- a/src/DebugCmds.cc
+++ b/src/DebugCmds.cc
@@ -561,22 +561,22 @@ int dbg_cmd_list(DebugCmd cmd, const vector<string>& args) {
             return false;
         }
 
-        g_debugger_state.last_loc.filename = plr.filename;
-        g_debugger_state.last_loc.first_line = plr.line;
+        g_debugger_state.last_loc.SetFile(plr.filename);
+        g_debugger_state.last_loc.SetFirstLine(plr.line);
         pre_offset = 0;
     }
 
-    if ( (int)pre_offset + (int)g_debugger_state.last_loc.first_line - (int)CENTER_IDX < 0 )
-        pre_offset = CENTER_IDX - g_debugger_state.last_loc.first_line;
+    if ( (int)pre_offset + (int)g_debugger_state.last_loc.FirstLine() - (int)CENTER_IDX < 0 )
+        pre_offset = CENTER_IDX - g_debugger_state.last_loc.FirstLine();
 
-    g_debugger_state.last_loc.first_line += pre_offset;
+    g_debugger_state.last_loc.IncrementLine(pre_offset);
 
-    int last_line_in_file = how_many_lines_in(g_debugger_state.last_loc.filename);
+    int last_line_in_file = how_many_lines_in(g_debugger_state.last_loc.FileName());
 
-    if ( g_debugger_state.last_loc.first_line > last_line_in_file )
-        g_debugger_state.last_loc.first_line = last_line_in_file;
+    if ( g_debugger_state.last_loc.FirstLine() > last_line_in_file )
+        g_debugger_state.last_loc.SetLine(last_line_in_file);
 
-    PrintLines(g_debugger_state.last_loc.filename, g_debugger_state.last_loc.first_line - CENTER_IDX, 10, true);
+    PrintLines(g_debugger_state.last_loc.FileName(), g_debugger_state.last_loc.FirstLine() - CENTER_IDX, 10, true);
 
     g_debugger_state.already_did_list = true;
 

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -111,7 +111,7 @@ std::string render_call_stack() {
 
         if ( ci.call ) {
             auto loc = ci.call->GetLocationInfo();
-            rval += util::fmt(" at %s:%d", loc->filename, loc->first_line);
+            rval += util::fmt(" at %s:%d", loc->FileName(), loc->FirstLine());
         }
 
         ++lvl;
@@ -919,8 +919,8 @@ zeek::RecordValPtr make_backtrace_element(std::string_view name, const VectorVal
     elem->Assign(function_args_idx, args);
 
     if ( loc ) {
-        elem->Assign(file_location_idx, loc->filename);
-        elem->Assign(line_location_idx, loc->first_line);
+        elem->Assign(file_location_idx, loc->FileName());
+        elem->Assign(line_location_idx, loc->FirstLine());
     }
 
     return elem;

--- a/src/Obj.cc
+++ b/src/Obj.cc
@@ -12,8 +12,8 @@
 namespace zeek {
 namespace detail {
 
-Location start_location("<start uninitialized>", 0, 0, 0, 0);
-Location end_location("<end uninitialized>", 0, 0, 0, 0);
+Location start_location("<start uninitialized>", 0, 0);
+Location end_location("<end uninitialized>", 0, 0);
 
 void Location::Describe(ODesc* d) const {
     if ( FileName() ) {
@@ -132,8 +132,7 @@ bool Obj::SetLocationInfo(const detail::Location* start, const detail::Location*
         // We already have a better location, so don't use this one.
         return true;
 
-    auto new_location = new detail::Location(start->FileName(), start->FirstLine(), end->LastLine(),
-                                             start->FirstColumn(), end->LastColumn());
+    auto new_location = new detail::Location(start->FileName(), start->FirstLine(), end->LastLine());
 
     // Don't delete this until we've constructed the new location, in case
     // "start" or "end" are our own location.
@@ -148,7 +147,6 @@ void Obj::UpdateLocationEndInfo(const detail::Location& end) {
         SetLocationInfo(&end, &end);
 
     location->SetLastLine(end.LastLine());
-    location->SetLastColumn(end.LastColumn());
 }
 
 void Obj::DoMsg(ODesc* d, const char s1[], const Obj* obj2, bool pinpoint_only,

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <climits>
+#include <string>
 
 namespace zeek {
 
@@ -13,7 +14,9 @@ namespace detail {
 class Location final {
 public:
     constexpr Location(const char* fname, int line_f, int line_l, int col_f, int col_l) noexcept
-        : filename(fname), first_line(line_f), last_line(line_l), first_column(col_f), last_column(col_l) {}
+        : filename(fname), first_column(col_f), last_column(col_l) {
+        SetLines(line_f, line_l);
+    }
 
     Location() = default;
 
@@ -22,9 +25,42 @@ public:
     bool operator==(const Location& l) const;
     bool operator!=(const Location& l) const { return ! (*this == l); }
 
+    const char* FileName() const { return filename; }
+    int FirstLine() const { return first_line; }
+    int LastLine() const { return last_line; }
+
+    // Columns are actually not currently maintained.
+    auto FirstColumn() const { return first_column; }
+    auto LastColumn() const { return last_column; }
+
+    void SetFile(const char* fname) { filename = fname; }
+    void SetLine(int line) { SetLines(line, line); }
+    constexpr void SetLines(int first, int last) {
+        if ( first > last ) {
+            // We don't use std::swap() here because it's not
+            // constexpr-enabled on older versions of C++.
+            auto tmp = first;
+            first = last;
+            last = tmp;
+        }
+        first_line = first;
+        last_line = last;
+    }
+    void SetFirstLine(int line) { SetLines(line, last_line); }
+    void SetLastLine(int line) { SetLines(first_line, line); }
+    void IncrementLine(int incr = 1) {
+        first_line += incr;
+        last_line += incr;
+    }
+
+    void SetFirstColumn(int col) { first_column = col; }
+    void SetLastColumn(int col) { last_column = col; }
+
+
+private:
     const char* filename = nullptr;
     int first_line = 0, last_line = 0;
-    int first_column = 0, last_column = 0;
+    int first_column = 0, last_column = 0; // not currently maintained
 };
 
 #define YYLTYPE zeek::detail::yyltype
@@ -73,7 +109,7 @@ public:
         // of 0, which should only happen if it's been assigned
         // to no_location (or hasn't been initialized at all).
         location = nullptr;
-        if ( detail::start_location.first_line != 0 )
+        if ( detail::start_location.FirstLine() != 0 )
             SetLocationInfo(&detail::start_location, &detail::end_location);
     }
 

--- a/src/Obj.h
+++ b/src/Obj.h
@@ -13,8 +13,7 @@ namespace detail {
 
 class Location final {
 public:
-    constexpr Location(const char* fname, int line_f, int line_l, int col_f, int col_l) noexcept
-        : filename(fname), first_column(col_f), last_column(col_l) {
+    constexpr Location(const char* fname, int line_f, int line_l) noexcept : filename(fname) {
         SetLines(line_f, line_l);
     }
 
@@ -28,10 +27,6 @@ public:
     const char* FileName() const { return filename; }
     int FirstLine() const { return first_line; }
     int LastLine() const { return last_line; }
-
-    // Columns are actually not currently maintained.
-    auto FirstColumn() const { return first_column; }
-    auto LastColumn() const { return last_column; }
 
     void SetFile(const char* fname) { filename = fname; }
     void SetLine(int line) { SetLines(line, line); }
@@ -53,14 +48,9 @@ public:
         last_line += incr;
     }
 
-    void SetFirstColumn(int col) { first_column = col; }
-    void SetLastColumn(int col) { last_column = col; }
-
-
 private:
     const char* filename = nullptr;
     int first_line = 0, last_line = 0;
-    int first_column = 0, last_column = 0; // not currently maintained
 };
 
 #define YYLTYPE zeek::detail::yyltype
@@ -69,7 +59,7 @@ YYLTYPE GetCurrentLocation();
 void SetCurrentLocation(YYLTYPE currloc);
 
 // Used to mean "no location associated with this object".
-inline constexpr Location no_location("<no location>", 0, 0, 0, 0);
+inline constexpr Location no_location("<no location>", 0, 0);
 
 // Current start/end location.
 extern Location start_location;

--- a/src/ScriptProfile.cc
+++ b/src/ScriptProfile.cc
@@ -32,13 +32,13 @@ void ScriptProfile::ChildFinished(const ScriptProfile* child) {
 void ScriptProfile::Report(FILE* f, bool with_traces) const {
     std::string l;
 
-    if ( loc.first_line == 0 )
+    if ( loc.FirstLine() == 0 )
         // Rather than just formatting the no-location loc, we'd like
         // a version that doesn't have a funky "line 0" in it, nor
         // an embedded blank.
         l = "<no-location>";
     else
-        l = std::string(loc.filename) + ":" + std::to_string(loc.first_line);
+        l = util::fmt("%s:%d", loc.FileName(), loc.FirstLine());
 
     std::string ftype = is_BiF ? "BiF" : func->GetType()->FlavorString();
     std::string call_stacks;

--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -152,7 +152,7 @@ bool Stmt::SetLocationInfo(const Location* start, const Location* end) {
 
     // Update the Filemap of line number -> statement mapping for
     // breakpoints (Debug.h).
-    auto map_iter = g_dbgfilemaps.find(location->filename);
+    auto map_iter = g_dbgfilemaps.find(location->FileName());
     if ( map_iter == g_dbgfilemaps.end() )
         return false;
 

--- a/src/Trigger.cc
+++ b/src/Trigger.cc
@@ -109,7 +109,7 @@ Trigger::Trigger(std::shared_ptr<WhenInfo> wi, const IDSet& _globals, std::vecto
     attached = nullptr;
 
     if ( loc )
-        name = util::fmt("%s:%d-%d", loc->filename, loc->first_line, loc->last_line);
+        name = util::fmt("%s:%d-%d", loc->FileName(), loc->FirstLine(), loc->LastLine());
     else
         name = "<no-trigger-location>";
 

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -2626,7 +2626,7 @@ const TypePtr& base_type(TypeTag tag) {
     if ( ! base_types[tag] ) {
         base_types[tag] = make_intrusive<Type>(tag, true);
         // Give the base types a pseudo-location for easier identification.
-        detail::Location l(type_name(tag), 0, 0, 0, 0);
+        detail::Location l(type_name(tag), 0, 0);
         base_types[tag]->SetLocationInfo(&l);
     }
 

--- a/src/cluster/Telemetry.cc
+++ b/src/cluster/Telemetry.cc
@@ -155,9 +155,9 @@ std::string_view determine_script_location() {
         // remove wrapper function.
 
         const auto* loc = ce->GetLocationInfo();
-        std::string normalized_location = zeek::util::detail::without_zeekpath_component(loc->filename);
+        std::string normalized_location = zeek::util::detail::without_zeekpath_component(loc->FileName());
         normalized_location.append(":");
-        normalized_location.append(std::to_string(loc->first_line));
+        normalized_location.append(std::to_string(loc->FirstLine()));
 
         auto [it, inserted] = location_cache.emplace(ce, std::move(normalized_location));
         assert(inserted);

--- a/src/input/readers/ascii/Ascii.cc
+++ b/src/input/readers/ascii/Ascii.cc
@@ -149,7 +149,7 @@ bool Ascii::OpenFile() {
 
     if ( ! read_location ) {
         read_location = LocationPtr(new zeek::detail::Location());
-        read_location->filename = util::copy_string(fname.c_str(), fname.size());
+        read_location->SetFile(util::copy_string(fname.c_str(), fname.size()));
     }
 
     StopWarningSuppression();
@@ -228,8 +228,7 @@ bool Ascii::ReadHeader(bool useCached) {
 bool Ascii::GetLine(string& str) {
     while ( getline(file, str) ) {
         if ( read_location ) {
-            read_location->first_line++;
-            read_location->last_line++;
+            read_location->IncrementLine();
         }
 
         if ( str.empty() )
@@ -255,10 +254,8 @@ bool Ascii::DoUpdate() {
     if ( ! OpenFile() )
         return ! fail_on_file_problem;
 
-    if ( read_location ) {
-        read_location->first_line = 0;
-        read_location->last_line = 0;
-    }
+    if ( read_location )
+        read_location->SetLine(0);
 
     switch ( Info().mode ) {
         case MODE_REREAD: {
@@ -331,7 +328,7 @@ bool Ascii::DoUpdate() {
                 // add non-present field
                 fields[fpos] = new Value(fit.type, false);
                 if ( read_location )
-                    fields[fpos]->SetFileLineNumber(read_location->first_line);
+                    fields[fpos]->SetFileLineNumber(read_location->FirstLine());
                 fpos++;
                 continue;
             }
@@ -367,7 +364,7 @@ bool Ascii::DoUpdate() {
             }
 
             if ( read_location )
-                val->SetFileLineNumber(read_location->first_line);
+                val->SetFileLineNumber(read_location->FirstLine());
 
             if ( fit.secondary_position != -1 ) {
                 // we have a port definition :)

--- a/src/input/readers/ascii/Ascii.h
+++ b/src/input/readers/ascii/Ascii.h
@@ -94,7 +94,7 @@ private:
     // correctly when the unique_ptr gets reset.
     struct LocationDeleter {
         void operator()(zeek::detail::Location* loc) const {
-            delete[] loc->filename;
+            delete[] loc->FileName();
             delete loc;
         }
     };

--- a/src/parse.y
+++ b/src/parse.y
@@ -369,7 +369,7 @@ zeek:
 			// associated with the last @load'd file rather than
 			// the script that includes the global statements.
 			auto loc = zeek::detail::GetCurrentLocation();
-			if ( loc.filename )
+			if ( loc.FileName() )
 				set_location(loc);
 			}
 		stmt_list

--- a/src/rule-parse.y
+++ b/src/rule-parse.y
@@ -456,7 +456,7 @@ void rules_error(const char* msg, const char* addl) {
 
 void rules_error(zeek::detail::Rule* r, const char* msg) {
     const zeek::detail::Location& l = r->GetLocation();
-    zeek::reporter->Error("Error in signature %s (%s:%d): %s", r->ID(), l.filename, l.first_line, msg);
+    zeek::reporter->Error("Error in signature %s (%s:%d): %s", r->ID(), l.FileName(), l.FirstLine(), msg);
     zeek::detail::rule_matcher->SetParseError();
 }
 

--- a/src/rule-parse.y
+++ b/src/rule-parse.y
@@ -108,7 +108,7 @@ rule_list:
 rule:
 		TOK_SIGNATURE TOK_IDENT
 			{
-			zeek::detail::Location l(current_rule_file, rules_line_number+1, 0, 0, 0);
+			zeek::detail::Location l(current_rule_file, rules_line_number+1, 0);
 			current_rule = new zeek::detail::Rule(yylval.str, l);
 			}
 		'{' rule_attr_list '}'

--- a/src/scan.l
+++ b/src/scan.l
@@ -53,7 +53,7 @@
 
 using namespace zeek::detail;
 
-extern YYLTYPE yylloc;	// holds start line and column of token
+extern YYLTYPE yylloc;	// holds location of token
 extern zeek::EnumType* cur_enum_type;
 
 // Track the @if... depth.
@@ -218,8 +218,6 @@ static int switch_to(const char* file, YY_BUFFER_STATE buffer);
 // for error reporting and debugging).
 static zeek::name_list input_files;
 static zeek::name_list essential_input_files;
-
-// ### TODO: columns too - use yyless with '.' action?
 %}
 
 %option nounput nodefault

--- a/src/scan.l
+++ b/src/scan.l
@@ -273,8 +273,7 @@ ESCSEQ	(\\([^\r\n]|[0-7]+|x[[:xdigit:]]+))
 
 <INITIAL,IGNORE>\r?\n	{
 			++line_number;
-			++yylloc.first_line;
-			++yylloc.last_line;
+			yylloc.IncrementLine();
 			}
 
 	/* IPv6 literal constant patterns */
@@ -748,24 +747,26 @@ F	RET_CONST(zeek::val_mgr->False()->Ref())
 YYLTYPE zeek::detail::GetCurrentLocation() {
     static YYLTYPE currloc;
 
-    currloc.filename = filename;
-    currloc.first_line = currloc.last_line = line_number;
+    currloc.SetFile(filename);
+    currloc.SetLine(line_number);
 
     return currloc;
 }
 
 void zeek::detail::SetCurrentLocation(YYLTYPE currloc) {
-    ::filename = currloc.filename;
-    line_number = currloc.first_line;
+    ::filename = currloc.FileName();
+    line_number = currloc.FirstLine();
 }
 
 static int switch_to(const char* file, YY_BUFFER_STATE buffer) {
     yy_switch_to_buffer(buffer);
-    yylloc.first_line = yylloc.last_line = line_number = 1;
+    line_number = 1;
+    yylloc.SetLine(1);
 
     // Don't delete the old filename - it's pointed to by
     // every Obj created when parsing it.
-    yylloc.filename = filename = zeek::util::copy_string(file);
+    filename = zeek::util::copy_string(file);
+    yylloc.SetFile(filename);
 
     current_file_has_conditionals = files_with_conditionals.count(filename) > 0;
 
@@ -866,7 +867,8 @@ static int load_files(const char* orig_file) {
     }
 
     yy_switch_to_buffer(buffer);
-    yylloc.first_line = yylloc.last_line = line_number = 1;
+    line_number = 1;
+    yylloc.SetLine(1);
 
     return switch_to(file_path.c_str(), buffer);
 }
@@ -1178,7 +1180,8 @@ int yywrap() {
         }
 
         zeek::detail::params.clear();
-        yylloc.filename = filename = "<params>";
+        filename = "<params>";
+        yylloc.SetFile(filename);
         yy_scan_string(policy.c_str());
         return 0;
     }
@@ -1192,7 +1195,8 @@ int yywrap() {
         int tmp_len = strlen(zeek::detail::command_line_policy) + 32;
         char* tmp = new char[tmp_len];
         snprintf(tmp, tmp_len, "%s\n;\n", zeek::detail::command_line_policy);
-        yylloc.filename = filename = "<command line>";
+        filename = "<command line>";
+        yylloc.SetFile(filename);
 
         yy_scan_string(tmp);
         delete[] tmp;
@@ -1219,8 +1223,10 @@ FileInfo::~FileInfo() {
         fclose(yyin);
 
     yy_switch_to_buffer(buffer_state);
-    yylloc.filename = filename = name;
-    yylloc.first_line = yylloc.last_line = line_number = line;
+    filename = name;
+    line_number = line;
+    yylloc.SetFile(filename);
+    yylloc.SetLine(line);
 
     if ( restore_module != "" )
         zeek::detail::current_module = restore_module;

--- a/src/script_opt/CPP/DeclFunc.cc
+++ b/src/script_opt/CPP/DeclFunc.cc
@@ -148,7 +148,7 @@ void CPPCompile::DeclareSubclass(const FuncTypePtr& ft, const ProfileFunc* pf, c
         stmts = pf->ProfiledExpr();
 
     auto loc = stmts->GetLocationInfo();
-    auto loc_info = string("\"") + loc->filename + "\", " + Fmt(loc->first_line);
+    auto loc_info = string("\"") + loc->FileName() + "\", " + Fmt(loc->FirstLine());
     Emit("%s_cl(const char* name%s) : CPPStmt(name, %s)%s { }", fname, addl_args, loc_info, inits);
 
     // An additional constructor just used to generate place-holder

--- a/src/script_opt/CPP/Driver.cc
+++ b/src/script_opt/CPP/Driver.cc
@@ -193,7 +193,7 @@ bool CPPCompile::AnalyzeFuncBody(FuncInfo& fi, unordered_set<string>& filenames_
     const auto& f = fi.Func();
     auto& body = fi.Body();
 
-    string fn = body->GetLocationInfo()->filename;
+    string fn = body->GetLocationInfo()->FileName();
 
     if ( ! analysis_options.allow_cond && ! fi.ShouldSkip() ) {
         if ( ! analysis_options.only_files.empty() && files_with_conditionals.count(fn) > 0 ) {
@@ -358,7 +358,7 @@ void CPPCompile::RegisterCompiledBody(const string& f) {
     auto h = body_hashes[f];
     auto p = body_priorities[f];
     auto loc = body_locs[f];
-    auto body_info = Fmt(p) + ", " + Fmt(h) + ", \"" + loc->filename + " (C++)\", " + Fmt(loc->first_line);
+    auto body_info = Fmt(p) + ", " + Fmt(h) + ", \"" + loc->FileName() + " (C++)\", " + Fmt(loc->FirstLine());
 
     Emit("\tCPP_RegisterBody(\"%s\", (void*) %s, %s, %s, std::vector<std::string>(%s)),", f, f, Fmt(type_signature),
          body_info, events);

--- a/src/script_opt/CPP/Func.cc
+++ b/src/script_opt/CPP/Func.cc
@@ -37,7 +37,7 @@ CPPStmt::CPPStmt(const char* _name, const char* filename, int line_num) : Stmt(S
     auto empty_args = make_intrusive<ListExpr>();
 
     ce = make_intrusive<CallExpr>(make_intrusive<ConstExpr>(fv), empty_args);
-    Location loc(filename, line_num, line_num, 1, 1);
+    Location loc(filename, line_num, line_num);
     ce->SetLocationInfo(&loc);
 }
 

--- a/src/script_opt/CPP/GenFunc.cc
+++ b/src/script_opt/CPP/GenFunc.cc
@@ -182,8 +182,8 @@ string CPPCompile::BodyName(const FuncInfo& func) {
 
     // Extend name with location information.
     auto loc = body->GetLocationInfo();
-    if ( loc->filename ) {
-        auto fn = loc->filename;
+    if ( loc->FileName() ) {
+        auto fn = loc->FileName();
 
         // Skip leading goop that gets added by search paths.
         while ( *fn == '.' || *fn == '/' )

--- a/src/script_opt/CPP/Stmts.cc
+++ b/src/script_opt/CPP/Stmts.cc
@@ -11,7 +11,7 @@ using namespace std;
 void CPPCompile::GenStmt(const Stmt* s) {
     auto loc = s->GetLocationInfo();
     if ( loc != &detail::no_location && s->Tag() != STMT_LIST )
-        Emit("// %s:%s", loc->filename, to_string(loc->first_line));
+        Emit("// %s:%d", loc->FileName(), loc->FirstLine());
 
     switch ( s->Tag() ) {
         case STMT_INIT: GenInitStmt(s->AsInitStmt()); break;
@@ -498,8 +498,8 @@ void CPPCompile::GenAssertStmt(const AssertStmt* a) {
         Emit("auto msg_val = zeek::val_mgr->EmptyString();");
 
     auto loc = a->GetLocationInfo();
-    Emit("static Location loc(\"%s\", %s, %s, %s, %s);", loc->filename, std::to_string(loc->first_line),
-         std::to_string(loc->last_line), std::to_string(loc->first_column), std::to_string(loc->last_column));
+    Emit("static Location loc(\"%s\", %s, %s, %s, %s);", loc->FileName(), std::to_string(loc->FirstLine()),
+         std::to_string(loc->LastLine()), std::to_string(loc->FirstColumn()), std::to_string(loc->LastColumn()));
     Emit("report_assert(assert_result, \"%s\", msg_val, &loc);", CPPEscape(a->CondDesc().c_str()).c_str());
     EndBlock();
 

--- a/src/script_opt/CPP/Stmts.cc
+++ b/src/script_opt/CPP/Stmts.cc
@@ -498,8 +498,8 @@ void CPPCompile::GenAssertStmt(const AssertStmt* a) {
         Emit("auto msg_val = zeek::val_mgr->EmptyString();");
 
     auto loc = a->GetLocationInfo();
-    Emit("static Location loc(\"%s\", %s, %s, %s, %s);", loc->FileName(), std::to_string(loc->FirstLine()),
-         std::to_string(loc->LastLine()), std::to_string(loc->FirstColumn()), std::to_string(loc->LastColumn()));
+    Emit("static Location loc(\"%s\", %s, %s);", loc->FileName(), std::to_string(loc->FirstLine()),
+         std::to_string(loc->LastLine()));
     Emit("report_assert(assert_result, \"%s\", msg_val, &loc);", CPPEscape(a->CondDesc().c_str()).c_str());
     EndBlock();
 

--- a/src/script_opt/CPP/Types.cc
+++ b/src/script_opt/CPP/Types.cc
@@ -205,7 +205,7 @@ shared_ptr<CPP_InitInfo> CPPCompile::RegisterType(const TypePtr& tp) {
             auto tr = tp->AsRecordType();
             for ( auto i = tr->NumOrigFields(); i < tr->NumFields(); ++i ) {
                 auto fd = tr->FieldDecl(i);
-                if ( filename_matches_opt_files(fd->GetLocationInfo()->filename) ) {
+                if ( filename_matches_opt_files(fd->GetLocationInfo()->FileName()) ) {
                     if ( addl_fields == 0 )
                         addl_fields = i;
                 }

--- a/src/script_opt/ProfileFunc.h
+++ b/src/script_opt/ProfileFunc.h
@@ -686,17 +686,17 @@ private:
     // Return the key used to associate a Location object with its full
     // descriptiion.
     std::string LocKey(const Location* loc) const {
-        return std::string(loc->filename) + ":" + std::to_string(loc->first_line) + "-" +
-               std::to_string(loc->last_line);
+        return std::string(loc->FileName()) + ":" + std::to_string(loc->FirstLine()) + "-" +
+               std::to_string(loc->LastLine());
     }
 
     // Return the description of a location including its the function
     // in which it's embedded.
     std::string LocWithFunc(const Location* loc) const {
-        auto res = func_name_prefix + std::to_string(loc->first_line);
+        auto res = func_name_prefix + std::to_string(loc->FirstLine());
 
-        if ( loc->first_line != loc->last_line )
-            res += "-" + std::to_string(loc->last_line);
+        if ( loc->FirstLine() != loc->LastLine() )
+            res += "-" + std::to_string(loc->LastLine());
 
         return res;
     }

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -139,7 +139,7 @@ bool filename_matches_opt_files(const char* filename) {
     return false;
 }
 
-bool obj_matches_opt_files(const Obj* obj) { return filename_matches_opt_files(obj->GetLocationInfo()->filename); }
+bool obj_matches_opt_files(const Obj* obj) { return filename_matches_opt_files(obj->GetLocationInfo()->FileName()); }
 
 static bool optimize_AST(ScriptFuncPtr f, std::shared_ptr<ProfileFunc>& pf, std::shared_ptr<Reducer>& rc,
                          ScopePtr scope, StmtPtr& body) {

--- a/src/script_opt/ZAM/Driver.cc
+++ b/src/script_opt/ZAM/Driver.cc
@@ -23,8 +23,7 @@ ZAMCompiler::ZAMCompiler(ScriptFuncPtr f, std::shared_ptr<ProfileFuncs> _pfs, st
 
     auto loc = body->GetLocationInfo();
     ASSERT(loc->FirstLine() != 0 || body->Tag() == STMT_NULL);
-    auto loc_copy = std::make_shared<Location>(loc->FileName(), loc->FirstLine(), loc->LastLine(), loc->FirstColumn(),
-                                               loc->LastColumn());
+    auto loc_copy = std::make_shared<Location>(loc->FileName(), loc->FirstLine(), loc->LastLine());
     ZAM::curr_func = func->GetName();
     ZAM::curr_loc = std::make_shared<ZAMLocInfo>(ZAM::curr_func, std::move(loc_copy), nullptr);
 

--- a/src/script_opt/ZAM/Driver.cc
+++ b/src/script_opt/ZAM/Driver.cc
@@ -22,9 +22,9 @@ ZAMCompiler::ZAMCompiler(ScriptFuncPtr f, std::shared_ptr<ProfileFuncs> _pfs, st
     frame_sizeI = 0;
 
     auto loc = body->GetLocationInfo();
-    ASSERT(loc->first_line != 0 || body->Tag() == STMT_NULL);
-    auto loc_copy =
-        std::make_shared<Location>(loc->filename, loc->first_line, loc->last_line, loc->first_column, loc->last_column);
+    ASSERT(loc->FirstLine() != 0 || body->Tag() == STMT_NULL);
+    auto loc_copy = std::make_shared<Location>(loc->FileName(), loc->FirstLine(), loc->LastLine(), loc->FirstColumn(),
+                                               loc->LastColumn());
     ZAM::curr_func = func->GetName();
     ZAM::curr_loc = std::make_shared<ZAMLocInfo>(ZAM::curr_func, std::move(loc_copy), nullptr);
 

--- a/src/script_opt/ZAM/Profile.cc
+++ b/src/script_opt/ZAM/Profile.cc
@@ -39,9 +39,9 @@ std::string ZAMLocInfo::Describe(bool include_lines) const {
             desc = func_name;
 
         if ( include_lines ) {
-            desc += ";" + func_name + ":" + std::to_string(loc->first_line);
-            if ( loc->last_line > loc->first_line )
-                desc += "-" + std::to_string(loc->last_line);
+            desc += ";" + func_name + ":" + std::to_string(loc->FirstLine());
+            if ( loc->LastLine() > loc->FirstLine() )
+                desc += "-" + std::to_string(loc->LastLine());
         }
     }
 

--- a/src/script_opt/ZAM/Stmt.cc
+++ b/src/script_opt/ZAM/Stmt.cc
@@ -13,8 +13,7 @@ namespace zeek::detail {
 const ZAMStmt ZAMCompiler::CompileStmt(const Stmt* s) {
     auto loc = s->GetLocationInfo();
     ASSERT(loc->FirstLine() != 0 || s->Tag() == STMT_NULL);
-    auto loc_copy = std::make_shared<Location>(loc->FileName(), loc->FirstLine(), loc->LastLine(), loc->FirstColumn(),
-                                               loc->LastColumn());
+    auto loc_copy = std::make_shared<Location>(loc->FileName(), loc->FirstLine(), loc->LastLine());
     ASSERT(! AST_blocks || s->Tag() == STMT_NULL || AST_blocks->HaveExpDesc(loc_copy.get()));
     auto loc_parent = ZAM::curr_loc->Parent();
     ZAM::curr_loc = std::make_shared<ZAMLocInfo>(ZAM::curr_func, std::move(loc_copy), ZAM::curr_loc->Parent());

--- a/src/script_opt/ZAM/Stmt.cc
+++ b/src/script_opt/ZAM/Stmt.cc
@@ -12,9 +12,9 @@ namespace zeek::detail {
 
 const ZAMStmt ZAMCompiler::CompileStmt(const Stmt* s) {
     auto loc = s->GetLocationInfo();
-    ASSERT(loc->first_line != 0 || s->Tag() == STMT_NULL);
-    auto loc_copy =
-        std::make_shared<Location>(loc->filename, loc->first_line, loc->last_line, loc->first_column, loc->last_column);
+    ASSERT(loc->FirstLine() != 0 || s->Tag() == STMT_NULL);
+    auto loc_copy = std::make_shared<Location>(loc->FileName(), loc->FirstLine(), loc->LastLine(), loc->FirstColumn(),
+                                               loc->LastColumn());
     ASSERT(! AST_blocks || s->Tag() == STMT_NULL || AST_blocks->HaveExpDesc(loc_copy.get()));
     auto loc_parent = ZAM::curr_loc->Parent();
     ZAM::curr_loc = std::make_shared<ZAMLocInfo>(ZAM::curr_func, std::move(loc_copy), ZAM::curr_loc->Parent());

--- a/src/spicy/manager.cc
+++ b/src/spicy/manager.cc
@@ -859,7 +859,7 @@ void Manager::searchModules(const std::string& paths) {
 
 detail::Location Manager::makeLocation(const std::string& fname) {
     auto x = _locations.insert(fname);
-    return {x.first->c_str(), 0, 0, 0, 0};
+    return {x.first->c_str(), 0, 0};
 }
 
 void Manager::autoDiscoverModules() {

--- a/src/spicy/manager.cc
+++ b/src/spicy/manager.cc
@@ -488,16 +488,14 @@ static std::unique_ptr<detail::Location> _makeLocation(const std::string& locati
             return nullptr;
 
         auto loc = std::make_unique<detail::Location>();
-        loc->filename = filenames.insert(std::string(x[0])).first->c_str(); // we retain ownership
+        loc->SetFile(filenames.insert(std::string(x[0])).first->c_str()); // we retain ownership
 
         if ( x.size() >= 2 ) {
             auto y = hilti::rt::split(x[1], "-");
-            if ( y.size() >= 2 ) {
-                loc->first_line = std::stoi(std::string(y[0]));
-                loc->last_line = std::stoi(std::string(y[1]));
-            }
+            if ( y.size() >= 2 )
+                loc->SetLines(std::stoi(std::string(y[0])), std::stoi(std::string(y[1])));
             else if ( y[0].size() )
-                loc->first_line = loc->last_line = std::stoi(std::string(y[0]));
+                loc->SetLine(std::stoi(std::string(y[0])));
         }
 
         return loc;

--- a/src/zeekygen/Manager.cc
+++ b/src/zeekygen/Manager.cc
@@ -239,7 +239,7 @@ void Manager::StartType(zeek::detail::IDPtr id) {
         return;
     }
 
-    string script = normalize_script_path(id->GetLocationInfo()->filename);
+    string script = normalize_script_path(id->GetLocationInfo()->FileName());
     ScriptInfo* script_info = scripts.GetInfo(script);
 
     if ( ! script_info ) {
@@ -291,7 +291,7 @@ void Manager::Identifier(zeek::detail::IDPtr id, bool from_redef) {
         return;
     }
 
-    string script = normalize_script_path(id->GetLocationInfo()->filename);
+    string script = normalize_script_path(id->GetLocationInfo()->FileName());
     ScriptInfo* script_info = scripts.GetInfo(script);
 
     if ( ! script_info ) {

--- a/src/zeekygen/utils.cc
+++ b/src/zeekygen/utils.cc
@@ -173,7 +173,7 @@ std::optional<std::string> source_code_range(const zeek::detail::ID* id) {
             if ( id->IsType() ) {
                 loc = type->GetLocationInfo();
 
-                if ( zeek::util::ends_with(loc->filename, ".bif.zeek") )
+                if ( zeek::util::ends_with(loc->FileName(), ".bif.zeek") )
                     // Source code won't be available to reference, so fall back
                     // to identifier location which may actually be in a regular
                     // .zeek script.
@@ -191,8 +191,8 @@ std::optional<std::string> source_code_range(const zeek::detail::ID* id) {
     if ( loc == &zeek::detail::no_location )
         return {};
 
-    return util::fmt("%s %d %d", normalize_script_path(loc->filename).data(), loc->first_line,
-                     loc->last_line + extra_lines);
+    return util::fmt("%s %d %d", normalize_script_path(loc->FileName()).data(), loc->FirstLine(),
+                     loc->LastLine() + extra_lines);
 }
 
 } // namespace zeek::zeekygen::detail

--- a/testing/btest/plugins/plugin-load-file-extended/src/Plugin.cc
+++ b/testing/btest/plugins/plugin-load-file-extended/src/Plugin.cc
@@ -24,7 +24,7 @@ std::pair<int, std::optional<std::string>> Plugin::HookLoadFileExtended(const Lo
                                                                         const std::string& resolved) {
     // Zeek implicitly provides the location where the current '@load'
     // originated. If no location is available, filename will be a nullptr.
-    auto src = zeek::detail::GetCurrentLocation().filename;
+    auto src = zeek::detail::GetCurrentLocation().FileName();
     if ( ! src )
         src = "n/a";
 


### PR DESCRIPTION
For some types of scripting objects, the associated line numbers can be reordered; for example, they can be reported as "lines 49-48" rather than "lines 48-49". This PR fixes that problem and, in a separate commit, removes tracking of column information (which never had actual support, just vestigial hooks).

To fix this robustly, the PR makes the `Location` variables `private` so they can only be manipulated through a set of new methods. Those methods ensure that any changes made to line numbers associated with a `Location` object maintain monotonicity.

Because of introducing the new methods, the PR touches quite a few files, but only in minor ways.