### PR TITLE
Bump `spicy-format` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
       exclude: '^(.typos.toml|src/SmithWaterman.cc|testing/.*|auxil/.*|scripts/base/frameworks/files/magic/.*|CHANGES|scripts/base/protocols/ssl/mozilla-ca-list.zeek)$'
 
 - repo: https://github.com/bbannier/spicy-format
-  rev: v0.24.2
+  rev: v0.25.0
   hooks:
     - id: spicy-format
       # TODO: Reformat existing large analyzers just before 8.0.


### PR DESCRIPTION
pre-commit ignores `Cargo.lock` files for Rust projects, so any movement in a Rust project's dependencies can break a hook, even if no code in the hook changed. I have tried to work with upstream on a fix, but they basically told me they weren't interested and to get lost.

This bumps the `spicy-format` pre-commit hook to a new version which explicitly deals with bumps of its dependencies. Having to do this semi-regularly is not fun, and ideally somebody interested in using this hook would help set up infrastructure in the hook so it just pulls pre-built binaries. This is not directly supported by pre-commit, but many projects work around this by declaring a Python module which then pulls pre-build binaries which already exist for spicy-format.