### PR TITLE
Remove ghc::filesystem submodule, switch to std::filesystem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,9 +58,6 @@
 [submodule "auxil/spicy"]
 	path = auxil/spicy
 	url = https://github.com/zeek/spicy
-[submodule "auxil/filesystem"]
-	path = auxil/filesystem
-	url = https://github.com/gulrak/filesystem.git
 [submodule "auxil/zeek-af_packet-plugin"]
 	path = auxil/zeek-af_packet-plugin
 	url = https://github.com/zeek/zeek-af_packet-plugin.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1057,9 +1057,6 @@ include(BuiltInSpicyAnalyzer)
 include_directories(BEFORE ${PCAP_INCLUDE_DIR} ${BIND_INCLUDE_DIR} ${BinPAC_INCLUDE_DIR}
                     ${ZLIB_INCLUDE_DIR} ${JEMALLOC_INCLUDE_DIR})
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/auxil/filesystem/include/ghc
-        DESTINATION include/zeek/3rdparty/)
-
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/auxil/prometheus-cpp/core/include/prometheus
         DESTINATION include/zeek/3rdparty/prometheus-cpp/include)
 
@@ -1069,15 +1066,8 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/auxil/prometheus-cpp/core/include/
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/auxil/expected-lite/include/nonstd
         DESTINATION include/zeek/3rdparty/)
 
-# Create 3rdparty/ghc within the build directory so that the include for
-# "zeek/3rdparty/ghc/filesystem.hpp" works within the build tree.
 execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory
                         "${CMAKE_CURRENT_BINARY_DIR}/3rdparty/")
-execute_process(
-    COMMAND
-        "${CMAKE_COMMAND}" -E create_symlink
-        "${CMAKE_CURRENT_SOURCE_DIR}/auxil/filesystem/include/ghc"
-        "${CMAKE_CURRENT_BINARY_DIR}/3rdparty/ghc")
 
 # Do the same for nonstd.
 execute_process(

--- a/COPYING-3rdparty
+++ b/COPYING-3rdparty
@@ -533,32 +533,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 ==============================================================================
 
-%%% auxil/filesystem
-
-==============================================================================
-
-Copyright (c) 2018, Steffen Schümann <s.schuemann@pobox.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-==============================================================================
-
 %%% auxil/highwayhash
 
 ==============================================================================

--- a/NEWS
+++ b/NEWS
@@ -333,6 +333,12 @@ Deprecated Functionality
   tuples. The ConnTuple struct, used by this deprecated Connection constructor,
   is now deprecated as well.
 
+- The ``zeek::filesystem`` namespace alias is deprecated in favor of using
+  ``std::filesystem`` directly. Similarly, the ``ghc::filesystem`` submodule stored in
+  ``auxil/filessytem`` has been removed and the files included from it in the Zeek
+  installation will no longer be installed. Builds won't warn about the deprecation of
+  ``zeek::filesystem`` due to limitations of how we can mark deprecations in C++.
+
 Zeek 7.2.0
 ==========
 

--- a/src/MMDB.h
+++ b/src/MMDB.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <sys/stat.h>
+
 #include "zeek/Val.h"
 
 namespace zeek {

--- a/src/ScannedFile.cc
+++ b/src/ScannedFile.cc
@@ -3,6 +3,7 @@
 #include "zeek/ScannedFile.h"
 
 #include <cerrno>
+#include <filesystem>
 
 #include "zeek/DebugLogger.h"
 #include "zeek/Reporter.h"
@@ -22,7 +23,7 @@ ScannedFile::ScannedFile(int arg_include_level, std::string arg_name, bool arg_s
         canonical_path = canonical_stdin_path;
     else if ( ! arg_is_canonical ) {
         std::error_code ec;
-        auto canon = filesystem::canonical(name, ec);
+        auto canon = std::filesystem::canonical(name, ec);
         if ( ec )
             zeek::reporter->FatalError("failed to get canonical path of %s: %s", name.data(), ec.message().c_str());
 

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/Type.h"
 
+#include <algorithm>
 #include <cinttypes>
 #include <map>
 #include <string>

--- a/src/analyzer/protocol/conn-size/Plugin.cc
+++ b/src/analyzer/protocol/conn-size/Plugin.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/plugin/Plugin.h"
 
+#include <algorithm>
+
 #include "zeek/Val.h"
 #include "zeek/analyzer/Component.h"
 #include "zeek/analyzer/protocol/conn-size/ConnSize.h"

--- a/src/analyzer/protocol/imap/imap-analyzer.pac
+++ b/src/analyzer/protocol/imap/imap-analyzer.pac
@@ -1,3 +1,7 @@
+%extern{
+#include <algorithm>
+%}
+
 refine connection IMAP_Conn += {
 
 	%member{

--- a/src/cluster/backend/zeromq/ZeroMQ.cc
+++ b/src/cluster/backend/zeromq/ZeroMQ.cc
@@ -5,6 +5,7 @@
 #include <array>
 #include <cerrno>
 #include <chrono>
+#include <csignal>
 #include <cstddef>
 #include <cstdio>
 #include <functional>

--- a/src/input/readers/ascii/Ascii.cc
+++ b/src/input/readers/ascii/Ascii.cc
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <algorithm>
 #include <cerrno>
 
 #include "zeek/input/readers/ascii/ascii.bif.h"

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -10,6 +10,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <ctime>
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <string>
@@ -88,7 +89,7 @@ struct LeftoverLog {
      * Return the "path" (logging framework parlance) of the log without the
      * directory or file extension. E.g. the "path" of "logs/conn.log" is just "conn".
      */
-    std::string Path() const { return zeek::filesystem::path(filename).stem().string(); }
+    std::string Path() const { return std::filesystem::path(filename).stem().string(); }
 
     /**
      * Deletes the shadow file and returns whether it succeeded.
@@ -102,7 +103,7 @@ struct LeftoverLog {
  * prefix_basename_with("logs/conn.log", ".shadow") -> logs/.shadow.conn.log"
  */
 static std::string prefix_basename_with(const std::string& path, const std::string& prefix) {
-    auto fspath = zeek::filesystem::path(path);
+    auto fspath = std::filesystem::path(path);
     auto new_filename = prefix + fspath.filename().string();
     return (fspath.parent_path() / new_filename).string();
 }
@@ -440,7 +441,7 @@ bool Ascii::DoInit(const WriterInfo& info, int num_fields, const threading::Fiel
         }
 
         if ( fname.front() != '/' && ! logdir.empty() )
-            fname = (zeek::filesystem::path(logdir) / fname).string();
+            fname = (std::filesystem::path(logdir) / fname).string();
 
         fname += ext;
 
@@ -679,10 +680,10 @@ static std::vector<LeftoverLog> find_leftover_logs() {
 
     // Find any .shadow files within Log::default_logdir or otherwise search in
     // the current working directory.
-    auto logdir = zeek::filesystem::current_path();
+    auto logdir = std::filesystem::current_path();
 
     if ( ! default_logdir.empty() )
-        logdir = zeek::filesystem::absolute(default_logdir);
+        logdir = std::filesystem::absolute(default_logdir);
 
     auto d = opendir(logdir.string().c_str());
     struct dirent* dp;

--- a/src/logging/writers/sqlite/SQLite.cc
+++ b/src/logging/writers/sqlite/SQLite.cc
@@ -3,6 +3,7 @@
 #include "zeek/logging/writers/sqlite/SQLite.h"
 
 #include <cerrno>
+#include <filesystem>
 #include <string>
 
 #include "zeek/Desc.h"
@@ -111,7 +112,7 @@ bool SQLite::DoInit(const WriterInfo& info, int arg_num_fields, const Field* con
     num_fields = arg_num_fields;
     fields = arg_fields;
 
-    auto fullpath = zeek::filesystem::path(zeek::id::find_const<StringVal>("Log::default_logdir")->ToStdString());
+    auto fullpath = std::filesystem::path(zeek::id::find_const<StringVal>("Log::default_logdir")->ToStdString());
 
     fullpath /= info.path;
     fullpath += ".sqlite";

--- a/src/packet_analysis/protocol/udp/UDP.cc
+++ b/src/packet_analysis/protocol/udp/UDP.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/packet_analysis/protocol/udp/UDP.h"
 
+#include <algorithm>
+
 #include "zeek/Conn.h"
 #include "zeek/RunState.h"
 #include "zeek/analyzer/Manager.h"

--- a/src/scan.l
+++ b/src/scan.l
@@ -12,6 +12,7 @@
 #include <cerrno>
 #include <climits>
 #include <cstdlib>
+#include <filesystem>
 
 #include <stack>
 #include <list>
@@ -504,7 +505,7 @@ when	return TOK_WHEN;
 			// confused by any ZEEKPATH settings. Also, plugin files
 			// containing any relative @loads themselves will work.
 			std::error_code ec;
-			auto canonical = zeek::filesystem::canonical(input_files[0]);
+			auto canonical = std::filesystem::canonical(input_files[0]);
 			if ( ec )
 				zeek::reporter->FatalError("plugin script %s not found: %s",
 				                           input_files[0], ec.message().c_str());

--- a/src/session/Manager.cc
+++ b/src/session/Manager.cc
@@ -6,6 +6,7 @@
 #include <netinet/in.h>
 #include <pcap.h>
 #include <unistd.h>
+#include <algorithm>
 #include <cstdlib>
 
 #include "zeek/Conn.h"

--- a/src/storage/backend/redis/Redis.h
+++ b/src/storage/backend/redis/Redis.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <deque>
 #include <mutex>
 
 #include "zeek/iosource/IOSource.h"

--- a/src/storage/backend/sqlite/SQLite.cc
+++ b/src/storage/backend/sqlite/SQLite.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/storage/backend/sqlite/SQLite.h"
 
+#include <filesystem>
 #include <thread>
 
 #include "zeek/3rdparty/sqlite3.h"
@@ -81,7 +82,7 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
 
     RecordValPtr backend_options = options->GetField<RecordVal>("sqlite");
     StringValPtr path = backend_options->GetField<StringVal>("database_path");
-    full_path = zeek::filesystem::path(path->ToStdString()).string();
+    full_path = std::filesystem::path(path->ToStdString()).string();
     table_name = backend_options->GetField<StringVal>("table_name")->ToStdString();
 
     auto busy_timeout = backend_options->GetField<IntervalVal>("busy_timeout")->Get();

--- a/src/storage/serializer/json/JSON.cc
+++ b/src/storage/serializer/json/JSON.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/storage/serializer/json/JSON.h"
 
+#include <algorithm>
+
 #include "zeek/Func.h"
 
 namespace zeek::storage::serializer::json {

--- a/src/telemetry/Counter.cc
+++ b/src/telemetry/Counter.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/telemetry/Counter.h"
 
+#include <algorithm>
+
 using namespace zeek::telemetry;
 
 Counter::Counter(FamilyType* family, const prometheus::Labels& labels, detail::CollectCallbackPtr callback) noexcept

--- a/src/telemetry/Gauge.cc
+++ b/src/telemetry/Gauge.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/telemetry/Gauge.h"
 
+#include <algorithm>
+
 using namespace zeek::telemetry;
 
 double Gauge::Value() const noexcept {

--- a/src/telemetry/Histogram.cc
+++ b/src/telemetry/Histogram.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/telemetry/Histogram.h"
 
+#include <algorithm>
+
 using namespace zeek::telemetry;
 
 double Histogram::Sum() const noexcept {

--- a/src/telemetry/Utils.cc
+++ b/src/telemetry/Utils.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/telemetry/Utils.h"
 
+#include <algorithm>
+
 #include "zeek/ID.h"
 #include "zeek/Reporter.h"
 #include "zeek/Val.h"

--- a/src/util.cc
+++ b/src/util.cc
@@ -25,7 +25,6 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
-#include <sstream>
 
 #if defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)
 #include <malloc.h>
@@ -40,7 +39,9 @@
 
 #include <algorithm>
 #include <array>
+#include <filesystem>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -601,7 +602,7 @@ string normalize_path(std::string_view path) {
     if ( stringPath._Starts_with("//") ) {
         stringPath.erase(0, 2);
     }
-    return zeek::filesystem::path(stringPath).lexically_normal().string();
+    return std::filesystem::path(stringPath).lexically_normal().string();
 #else
     if ( path.find("/.") == std::string_view::npos && path.find("//") == std::string_view::npos ) {
         // no need to normalize anything
@@ -691,7 +692,7 @@ string without_zeekpath_component(std::string_view path) {
 std::string get_exe_path(const std::string& invocation) {
     if ( invocation.empty() )
         return "";
-    zeek::filesystem::path invocation_path(invocation);
+    std::filesystem::path invocation_path(invocation);
 
     if ( invocation_path.is_absolute() || invocation_path.root_directory() == "~" )
         // Absolute path
@@ -706,7 +707,7 @@ std::string get_exe_path(const std::string& invocation) {
             exit(1);
         }
 
-        return (zeek::filesystem::path(cwd) / invocation_path).string();
+        return (std::filesystem::path(cwd) / invocation_path).string();
     }
 
     auto path = getenv("PATH");
@@ -1719,7 +1720,7 @@ static string find_file_in_path(const string& filename, const string& path, cons
     if ( filename.empty() )
         return {};
 
-    zeek::filesystem::path filepath(filename);
+    std::filesystem::path filepath(filename);
 
     // If file name is an absolute path, searching within *path* is pointless.
     if ( filepath.is_absolute() ) {
@@ -1729,7 +1730,7 @@ static string find_file_in_path(const string& filename, const string& path, cons
             return {};
     }
 
-    auto abs_path = (zeek::filesystem::path(path) / filepath).string();
+    auto abs_path = (std::filesystem::path(path) / filepath).string();
 
     if ( ! opt_ext.empty() ) {
         for ( const string& ext : opt_ext ) {
@@ -2425,19 +2426,19 @@ TEST_CASE("util filesystem") {
 #ifdef _MSC_VER
     // TODO: adapt these tests to Windows paths
 #else
-    zeek::filesystem::path path1("/a/b");
+    std::filesystem::path path1("/a/b");
     CHECK(path1.is_absolute());
     CHECK(! path1.is_relative());
     CHECK(path1.filename() == "b");
     CHECK(path1.parent_path() == "/a");
 
-    zeek::filesystem::path path2("/a//b//conn.log");
+    std::filesystem::path path2("/a//b//conn.log");
     CHECK(path2.lexically_normal() == "/a/b/conn.log");
 
-    zeek::filesystem::path path3("a//b//");
+    std::filesystem::path path3("a//b//");
     CHECK(path3.lexically_normal() == "a/b/");
 
-    auto info = zeek::filesystem::space(".");
+    auto info = std::filesystem::space(".");
     CHECK(info.capacity > 0);
 #endif
 }

--- a/src/util.h
+++ b/src/util.h
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem> // Remove in v8.1.
 #include <string>
 #include <string_view>
 #include <vector>
@@ -79,18 +80,8 @@ extern "C" {
 
 #ifdef _MSC_VER
 #include <pthread.h>
-#include <filesystem>
-namespace zeek {
-namespace filesystem = std::filesystem;
-}
 inline constexpr std::string_view path_list_separator = ";";
 #else
-// Expose ghc::filesystem as zeek::filesystem until we can
-// switch to std::filesystem on all platforms.
-#include "zeek/3rdparty/ghc/filesystem.hpp"
-namespace zeek {
-namespace filesystem = ghc::filesystem;
-}
 inline constexpr std::string_view path_list_separator = ":";
 #endif
 
@@ -108,6 +99,10 @@ constexpr int UID_POOL_DEFAULT_SCRIPT = 2;
 constexpr int UID_POOL_CUSTOM_SCRIPT = 10; // First available custom script level pool.
 
 namespace zeek {
+
+// This alias is deprecated and should be removed in v8.1. There isn't a way to mark
+// it so the compiler will flag it.
+namespace filesystem = std::filesystem;
 
 class ODesc;
 class RecordVal;

--- a/src/zeekygen/Manager.cc
+++ b/src/zeekygen/Manager.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/zeekygen/Manager.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <utility>
 


### PR DESCRIPTION
Now that C++20 support is official there's no reason we can't switch to `std::filesystem` everywhere. This removes the `auxil/filesystem` submodule and deprectates the `zeek::filesystem` alias in `util.h`. It also replaces all of the uses of `zeek::filesystem` with `std::filesystem` directly.