### PR TITLE
Output more information when cloning repos for include_plugins CI task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -803,9 +803,13 @@ include_plugins_debian12_task:
   sync_submodules_script: git submodule update --recursive --init
   fetch_external_plugins_script:
     - cd /zeek/testing/builtin-plugins/external && git clone https://github.com/zeek/zeek-perf-support.git
+    - cd zeek-perf-support && echo "Cloned $(git rev-parse HEAD) for $(basename $(pwd))"
     - cd /zeek/testing/builtin-plugins/external && git clone https://github.com/zeek/zeek-more-hashes.git
+    - cd zeek-more-hashes && echo "Cloned $(git rev-parse HEAD) for $(basename $(pwd))"
     - cd /zeek/testing/builtin-plugins/external && git clone https://github.com/zeek/zeek-cluster-backend-nats.git
+    - cd zeek-cluster-backend-nats && echo "Cloned $(git rev-parse HEAD) for $(basename $(pwd))"
     - cd /zeek/testing/builtin-plugins/external && git clone https://github.com/SeisoLLC/zeek-kafka.git
+    - cd zeek-kafka && echo "Cloned $(git rev-parse HEAD) for $(basename $(pwd))"
   always:
     ccache_cache:
       folder: /tmp/ccache


### PR DESCRIPTION
This came up while trying to figure out what commit was building for one of the plugins. Cirrus automatically masks the output of `git clone` from log output, even if you redirect it to `stdout`.

This changes the output of the `Run fetch_external_plugins` to look like this:

```
cd /zeek/testing/builtin-plugins/external && git clone https://github.com/zeek/zeek-perf-support.git 2>&1
Cloning into 'zeek-perf-support'...
cd zeek-perf-support && echo "Cloned $(git rev-parse HEAD) for $(basename $(pwd))"
Cloned 72d6183ae2c3dd423831a937d5e0be932f72e8d2 for zeek-perf-support
cd /zeek/testing/builtin-plugins/external && git clone https://github.com/zeek/zeek-more-hashes.git 2>&1
Cloning into 'zeek-more-hashes'...
cd zeek-more-hashes && echo "Cloned $(git rev-parse HEAD) for $(basename $(pwd))"
Cloned 6e669d4c19bcacda42c273042ecf2739d34cc10c for zeek-more-hashes
cd /zeek/testing/builtin-plugins/external && git clone https://github.com/zeek/zeek-cluster-backend-nats.git 2>&1
Cloning into 'zeek-cluster-backend-nats'...
cd zeek-cluster-backend-nats && echo "Cloned $(git rev-parse HEAD) for $(basename $(pwd))"
Cloned 64b03d68cd7613fdf40e6aa9d977336761cf8864 for zeek-cluster-backend-nats
cd /zeek/testing/builtin-plugins/external && git clone https://github.com/SeisoLLC/zeek-kafka.git 2>&1
Cloning into 'zeek-kafka'...
cd zeek-kafka && echo "Cloned $(git rev-parse HEAD) for $(basename $(pwd))"
Cloned efb9d803625e9d43efd952d874c6f3187a009086 for zeek-kafka
```