### PR TITLE
Add missing header to allow std::sort() on GCC 15.1

### DIFF
--- a/src/DebugLogger.cc
+++ b/src/DebugLogger.cc
@@ -5,6 +5,7 @@
 #include "zeek/DebugLogger.h"
 
 #include <unistd.h>
+#include <algorithm>
 #include <cstdlib>
 
 #include "zeek/RunState.h"


### PR DESCRIPTION
I ran into this on my local system:
```
/home/christian/devel/zeek/zeek/src/DebugLogger.cc: In member function ‘void zeek::detail::DebugLogger::ShowStreamsHelp()’:
/home/christian/devel/zeek/zeek/src/DebugLogger.cc:62:10: error: ‘sort’ is not a member of ‘std’; did you mean ‘qsort’?
   62 |     std::sort(prefixes.begin(), prefixes.end());
      |          ^~~~
      |          qsort
make[3]: *** [src/CMakeFiles/zeek_objs.dir/build.make:757: src/CMakeFiles/zeek_objs.dir/DebugLogger.cc.o] Error 1
```
Likely just a permutation in the build config & compiler space that we're somehow not hitting in CI.