### PR TITLE
Stop hardcoding the agent->controller connection address

### DIFF
--- a/scripts/policy/frameworks/management/agent/config.zeek
+++ b/scripts/policy/frameworks/management/agent/config.zeek
@@ -76,9 +76,9 @@ export {
 	## like to use that mode, make sure to set
 	## :zeek:see:`Management::Agent::listen_address` and
 	## :zeek:see:`Management::Agent::listen_port` as needed.
-	const controller = Broker::NetworkInfo(
-	    $address=Management::Controller::network_info()$address,
-	    $bound_port=Management::Controller::network_info()$bound_port) &redef;
+        const controller = Broker::NetworkInfo(
+            $address=Management::Controller::connect_network_info()$address,
+            $bound_port=Management::Controller::connect_network_info()$bound_port) &redef;
 
 	## An optional working directory for the agent. Agent and controller
 	## currently only log locally, not via the Zeek cluster's logger

--- a/scripts/policy/frameworks/management/agent/config.zeek
+++ b/scripts/policy/frameworks/management/agent/config.zeek
@@ -76,7 +76,8 @@ export {
 	## like to use that mode, make sure to set
 	## :zeek:see:`Management::Agent::listen_address` and
 	## :zeek:see:`Management::Agent::listen_port` as needed.
-	const controller = Broker::NetworkInfo($address="127.0.0.1",
+	const controller = Broker::NetworkInfo(
+	    $address=Management::Controller::network_info()$address,
 	    $bound_port=Management::Controller::network_info()$bound_port) &redef;
 
 	## An optional working directory for the agent. Agent and controller

--- a/scripts/policy/frameworks/management/controller/config.zeek
+++ b/scripts/policy/frameworks/management/controller/config.zeek
@@ -101,6 +101,10 @@ export {
 	## controller's Broker connectivity.
 	global network_info: function(): Broker::NetworkInfo;
 
+        ## Returns a :zeek:see:`Broker::NetworkInfo` record describing how
+        ## to connect to the controller's Broker connectivity 
+        global connect_network_info: function(): Broker::NetworkInfo;
+
 	## Returns a :zeek:see:`Broker::NetworkInfo` record describing the
 	## controller's websocket connectivity.
 	global network_info_websocket: function(): Broker::NetworkInfo;
@@ -140,6 +144,25 @@ function network_info(): Broker::NetworkInfo
 
 	return ni;
 	}
+
+function connect_network_info(): Broker::NetworkInfo
+        {
+        local ni: Broker::NetworkInfo;
+
+        if ( Management::Controller::listen_address != "" )
+                ni$address = Management::Controller::listen_address;
+        else if ( Management::default_address != "" )
+                ni$address = Management::default_address;
+        else
+                ni$address = "127.0.0.1";
+
+        if ( Management::Controller::listen_port != "" )
+                ni$bound_port = to_port(Management::Controller::listen_port);
+        else
+                ni$bound_port = Management::Controller::default_port;
+
+        return ni;
+        }
 
 function network_info_websocket(): Broker::NetworkInfo
 	{


### PR DESCRIPTION
The current implementation ignores if the user redefs Management::Controller::listen_address.  Unfortunately, we can't just re-use Management::Controller::network_info() because that gives us a default listen address of 0.0.0.0 when the agent needs a default address to connect to.

Without this, even if you specify the listen address (or aren't even using it because you're doing websockets), you'll get errors like the following:

`error in /usr/local/zeek/versions/f4357485d2006813fba768aa83e9e1bf8e8bb236/share/zeek/base/frameworks/broker/log.zeek, line 95: Broker error (Broker::PEER_UNAVAILABLE): (00000000-0000-0000-0000-000000000000, *127.0.0.1:2150, "unable to connect to remote peer")`

