### PR TITLE
RFC: dce-rpc: Rename named_pipe to sec_addr

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,19 @@ release.
 Breaking Changes
 ----------------
 
+- The ``named_pipe`` field in ``dce_rpc.log`` was renamed to ``sec_addr`` to better
+  reflect the generic meaning of the field in DCE-RPC (it can be a port number, too).
+
+  The ``named_pipe`` field continues to exist on the ``DCE_RPC::Info`` record, but
+  will be removed with Zeek 8.1.
+
+  This might break your data pipeline. It's possible to re-instantiate the logging
+  of the ``named_pipe`` field with the following snippet:
+
+	redef record DCE_RPC::Info$named_pipe += { &log };
+
+  Not that this will stop working with Zeek 8.1.
+
 - Zeek and all of its associated submodules now require C++20-capable compilers to
   build. This will let us move forward in using more modern C++ features and replace some
   workarounds that we have been carrying. Minimum recommended versions of compilers are

--- a/testing/btest/Baseline/coverage.record-fields/out.default
+++ b/testing/btest/Baseline/coverage.record-fields/out.default
@@ -38,9 +38,10 @@ connection {
         * endpoint: string, log=T, optional=T
         * id: record conn_id, log=T, optional=F
             conn_id { ... }
-        * named_pipe: string, log=T, optional=T
+        * named_pipe: string, log=F, optional=T
         * operation: string, log=T, optional=T
         * rtt: interval, log=T, optional=T
+        * sec_addr: string, log=T, optional=T
         * ts: time, log=T, optional=F
         * uid: string, log=T, optional=F
        }
@@ -52,6 +53,7 @@ connection {
             DCE_RPC::State {
               * ctx_to_uuid: table[count] of string, log=F, optional=T
               * named_pipe: string, log=F, optional=T
+              * sec_addr: string, log=F, optional=T
               * uuid: string, log=F, optional=T
              }
        }

--- a/testing/btest/Baseline/scripts.base.protocols.dce-rpc.context/dce_rpc.log
+++ b/testing/btest/Baseline/scripts.base.protocols.dce-rpc.context/dce_rpc.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	dce_rpc
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	rtt	named_pipe	endpoint	operation
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	rtt	sec_addr	endpoint	operation
 #types	time	string	addr	port	addr	port	interval	string	string	string
 XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	192.168.122.145	55614	192.168.122.3	1024	0.005544	\\PIPE\\drsuapi	drsuapi	DRSBind
 XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	192.168.122.145	55614	192.168.122.3	1024	0.000788	\\PIPE\\drsuapi	drsuapi	DRSCrackNames

--- a/testing/btest/Baseline/scripts.base.protocols.dce-rpc.dce_rpc_netlogon/dce_rpc.log
+++ b/testing/btest/Baseline/scripts.base.protocols.dce-rpc.dce_rpc_netlogon/dce_rpc.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	dce_rpc
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	rtt	named_pipe	endpoint	operation
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	rtt	sec_addr	endpoint	operation
 #types	time	string	addr	port	addr	port	interval	string	string	string
 XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	10.10.10.121	58774	10.10.10.100	49676	0.000758	49676	netlogon	NetrLogonSamLogonWithFlags
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/btest/Baseline/scripts.base.protocols.dce-rpc.mapi/dce_rpc.log
+++ b/testing/btest/Baseline/scripts.base.protocols.dce-rpc.mapi/dce_rpc.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	dce_rpc
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	rtt	named_pipe	endpoint	operation
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	rtt	sec_addr	endpoint	operation
 #types	time	string	addr	port	addr	port	interval	string	string	string
 XXXXXXXXXX.XXXXXX	CmES5u32sYpV7JYN	192.168.0.173	1066	192.168.0.2	135	0.000375	135	epmapper	ept_map
 XXXXXXXXXX.XXXXXX	CP5puj4I8PtEU4qzYg	192.168.0.173	1067	192.168.0.2	4997	0.000749	4997	nspi	NspiBind

--- a/testing/btest/Baseline/scripts.base.protocols.smb.smb1-transaction-dcerpc/dce_rpc.log
+++ b/testing/btest/Baseline/scripts.base.protocols.smb.smb1-transaction-dcerpc/dce_rpc.log
@@ -5,7 +5,7 @@
 #unset_field	-
 #path	dce_rpc
 #open XXXX-XX-XX-XX-XX-XX
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	rtt	named_pipe	endpoint	operation
+#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	rtt	sec_addr	endpoint	operation
 #types	time	string	addr	port	addr	port	interval	string	string	string
 XXXXXXXXXX.XXXXXX	CHhAvVGS1DHFjwGM9	205.227.227.226	49467	205.227.227.243	445	0.002138	\\PIPE\\lsass	dssetup	DsRolerGetPrimaryDomainInformation
 #close XXXX-XX-XX-XX-XX-XX


### PR DESCRIPTION
This is in response to #3935. I'm really not sure we should do that, but it was important enough for someone to open an issue.

IMO, Zeek distributors could work around that by extending DCE_RPC::Info with a new sec_addr field and removing `&log` from the original one. We could provide a policy script to do that, but that seems little useful to make progress towards removing the old field. So outright removing and providing an option to add it back is what is proposed here.

Needs updates of external baselines. Skipping on that for now.

---

@ckreibich or others: Thoughts? If it's a NACK, I'm going to close #3935 with suggestion to either  do that change locally, or use the following:
```
redef Log::default_field_name_map += {
        ["named_pipe"] = "sec_addr",
};
```