### PR TITLE
Add process_start_time_seconds and process_pid metrics

### DIFF
--- a/src/telemetry/Manager.cc
+++ b/src/telemetry/Manager.cc
@@ -135,6 +135,10 @@ void Manager::InitPostScript() {
                               []() { return static_cast<double>(get_stats()->fds); });
 #endif
 
+    // These two metrics get set at startup and are never modified after.
+    process_start_time = GaugeInstance("process", "start_time", {}, "Process start time", "seconds");
+    process_start_time->Set(run_state::zeek_start_time);
+
     if ( ! iosource_mgr->RegisterFd(collector_flare.FD(), this) ) {
         reporter->FatalError("Failed to register telemetry collector descriptor");
     }

--- a/src/telemetry/Manager.h
+++ b/src/telemetry/Manager.h
@@ -282,6 +282,7 @@ private:
     CounterPtr cpu_user_counter;
     CounterPtr cpu_system_counter;
     GaugePtr fds_gauge;
+    GaugePtr process_start_time;
 
     std::shared_ptr<prometheus::Registry> prometheus_registry;
     std::unique_ptr<prometheus::Exposer> prometheus_exposer;

--- a/testing/btest/Baseline/scripts.base.frameworks.telemetry.process-collect/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.telemetry.process-collect/out
@@ -5,9 +5,11 @@ process_cpu_system_seconds_total, [], >0.0, good
 process_resident_memory_bytes, [], >0.0, good
 process_virtual_memory_bytes, [], >0.0, good
 process_open_fds, [], >0.0, good
+process_start_time_seconds, [], >0.0, good
 zeek_done
 process_cpu_user_seconds_total, [], >0.0, good
 process_cpu_system_seconds_total, [], >0.0, good
 process_resident_memory_bytes, [], >0.0, good
 process_virtual_memory_bytes, [], >0.0, good
 process_open_fds, [], >0.0, good
+process_start_time_seconds, [], >0.0, good


### PR DESCRIPTION
Add two new metrics that can be used to track the uptime of a Zeek process and whether the process has restarted. These two are:

- `process_start_time_seconds`: The process start time in seconds, using current_time truncated to the second. Note that this might not be the exact start time due to it not being added until after script parsing, but it's likely close enough to not matter.
- `process_pid`: The process' PID

Both are gauges, even though they'll never change after startup, simply to keep the prometheus-cpp library from appending `_total` to the end of the names.

This results in these metrics in the Prometheus output:

```
# HELP process_start_time_seconds Process start time
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1753307631
# HELP process_pid Process PID
# TYPE process_pid gauge
process_pid 65697
```

This is based on @awelzel's comment [here](https://github.com/zeek/zeek/issues/3730#issuecomment-2239510285):

> Tested Prometheus with Zeek and was reminded of this ticket when I came across two process_start_time_seconds produced by the local node exporter process and the prometheus server itself. So if anything, for consistency with those?
>
> Also, searching for that name specifically brings up [results](https://www.robustperception.io/alerting-on-crash-loops-with-prometheus/) indicates one pattern is using [changes()](https://prometheus.io/docs/prometheus/latest/querying/functions/#changes) to detect how often a metric has changed and alert on that (to be fair, there's also resets()).