### PR TITLE
Make conn_id$ctx field a singleton

### DIFF
--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -195,7 +195,17 @@ const RecordValPtr& Connection::GetVal() {
         conn_val = make_intrusive<RecordVal>(id::connection);
 
         auto id_val = make_intrusive<RecordVal>(id::conn_id);
-        auto* ctx = id_val->GetFieldAs<zeek::RecordVal>(5);
+
+        constexpr int ctx_offset = 5;
+
+        // If the conn_id_ctx type has no fields at all, set it to the singleton instance,
+        // otherwise the instance is initialized on first access through GetField() below.
+        if ( conn_id_ctx_singleton ) {
+            assert(id::conn_id_ctx->NumFields() == 0);
+            id_val->Assign(ctx_offset, conn_id_ctx_singleton);
+        }
+
+        auto ctx = id_val->GetField<zeek::RecordVal>(ctx_offset);
 
         // Allow customized ConnKeys to augment conn_id and ctx.
         key->PopulateConnIdVal(*id_val, *ctx);

--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -6,6 +6,7 @@
 #include <cctype>
 
 #include "zeek/Desc.h"
+#include "zeek/ID.h"
 #include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/RunState.h"
@@ -22,6 +23,12 @@ namespace zeek {
 
 uint64_t Connection::total_connections = 0;
 uint64_t Connection::current_connections = 0;
+zeek::RecordValPtr Connection::conn_id_ctx_singleton;
+
+void Connection::InitPostScript() {
+    if ( id::conn_id_ctx->NumFields() == 0 )
+        conn_id_ctx_singleton = zeek::make_intrusive<zeek::RecordVal>(id::conn_id_ctx);
+}
 
 Connection::Connection(zeek::IPBasedConnKeyPtr k, double t, uint32_t flow, const Packet* pkt)
     : Session(t, connection_timeout, connection_status_update, detail::connection_status_update_interval),

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -209,6 +209,9 @@ public:
     // Returns true once Done() is called.
     bool IsFinished() { return finished; }
 
+    // Runs after all scripts have been parsed.
+    static void InitPostScript();
+
 private:
     // Common initialization for the constructors. This can move back into the
     // (sole) constructor when we remove the deprecated one in 8.1.
@@ -244,6 +247,11 @@ private:
     // Count number of connections.
     static uint64_t total_connections;
     static uint64_t current_connections;
+
+    // When the conn_id_ctx record type has no fields,
+    // this holds a singleton record value for it that
+    // is shared among all conn_id record values.
+    static RecordValPtr conn_id_ctx_singleton;
 };
 
 // The following is used by script optimization.

--- a/src/ID.cc
+++ b/src/ID.cc
@@ -24,6 +24,7 @@
 namespace zeek {
 
 RecordTypePtr id::conn_id;
+RecordTypePtr id::conn_id_ctx;
 RecordTypePtr id::endpoint;
 RecordTypePtr id::connection;
 RecordTypePtr id::fa_file;
@@ -81,6 +82,7 @@ FuncPtr id::find_func(std::string_view name) {
 
 void id::detail::init_types() {
     conn_id = id::find_type<RecordType>("conn_id");
+    conn_id_ctx = id::find_type<RecordType>("conn_id_ctx");
     endpoint = id::find_type<RecordType>("endpoint");
     connection = id::find_type<RecordType>("connection");
     fa_file = id::find_type<RecordType>("fa_file");

--- a/src/ID.h
+++ b/src/ID.h
@@ -259,6 +259,7 @@ IntrusivePtr<T> find_const(std::string_view name) {
 FuncPtr find_func(std::string_view name);
 
 extern RecordTypePtr conn_id;
+extern RecordTypePtr conn_id_ctx;
 extern RecordTypePtr endpoint;
 extern RecordTypePtr connection;
 extern RecordTypePtr fa_file;

--- a/src/packet_analysis/protocol/ip/conn_key/vlan_fivetuple/Factory.cc
+++ b/src/packet_analysis/protocol/ip/conn_key/vlan_fivetuple/Factory.cc
@@ -54,18 +54,16 @@ protected:
     };
 
     std::pair<int, int> GetConnCtxFieldOffsets() {
-        static const auto& conn_id_ctx = zeek::id::find_type<zeek::RecordType>("conn_id_ctx");
-
         static int vlan_offset = -2;
         static int inner_vlan_offset = -2;
 
         if ( vlan_offset == -2 && inner_vlan_offset == -2 ) {
-            vlan_offset = conn_id_ctx->FieldOffset("vlan");
-            if ( vlan_offset < 0 || conn_id_ctx->GetFieldType(vlan_offset)->Tag() != TYPE_INT )
+            vlan_offset = id::conn_id_ctx->FieldOffset("vlan");
+            if ( vlan_offset < 0 || id::conn_id_ctx->GetFieldType(vlan_offset)->Tag() != TYPE_INT )
                 vlan_offset = -1;
 
-            inner_vlan_offset = conn_id_ctx->FieldOffset("inner_vlan");
-            if ( inner_vlan_offset < 0 || conn_id_ctx->GetFieldType(inner_vlan_offset)->Tag() != TYPE_INT )
+            inner_vlan_offset = id::conn_id_ctx->FieldOffset("inner_vlan");
+            if ( inner_vlan_offset < 0 || id::conn_id_ctx->GetFieldType(inner_vlan_offset)->Tag() != TYPE_INT )
                 inner_vlan_offset = -1;
         }
 

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -25,6 +25,7 @@
 
 #include <binpac.h>
 
+#include "zeek/Conn.h"
 #include "zeek/DNS_Mgr.h"
 #include "zeek/Debug.h"
 #include "zeek/Desc.h"
@@ -842,6 +843,7 @@ SetupResult setup(int argc, char** argv, Options* zopts) {
             exit(1);
 
         RecordType::InitPostScript();
+        Connection::InitPostScript();
 
         conn_key_mgr->InitPostScript();
         telemetry_mgr->InitPostScript();


### PR DESCRIPTION
For a 200k syn pcap, this reduces memory usage in bare mode with an empty context by ~22MB (1061928 vs 1040744).