### PR TITLE
Lazily allocate the map of option handlers in ID objects

### DIFF
--- a/src/ID.cc
+++ b/src/ID.cc
@@ -576,15 +576,21 @@ void ID::UpdateValID() {
 }
 #endif
 
-void ID::AddOptionHandler(FuncPtr callback, int priority) { option_handlers.emplace(priority, std::move(callback)); }
+void ID::AddOptionHandler(FuncPtr callback, int priority) {
+    if ( ! option_handlers )
+        option_handlers = std::make_unique<OptionHandlerMap>();
+    option_handlers->emplace(priority, std::move(callback));
+}
 
 std::vector<Func*> ID::GetOptionHandlers() const {
     // multimap is sorted
     // It might be worth caching this if we expect it to be called
     // a lot...
     std::vector<Func*> v;
-    for ( auto& element : option_handlers )
-        v.push_back(element.second.get());
+    if ( option_handlers ) {
+        for ( auto& element : *option_handlers )
+            v.push_back(element.second.get());
+    }
     return v;
 }
 

--- a/src/ID.h
+++ b/src/ID.h
@@ -157,9 +157,9 @@ protected:
 #endif
 
     const char* name;
+    TypePtr type;
     IDScope scope;
     bool is_export;
-    TypePtr type;
     bool is_capture = false;
     bool is_const = false;
     bool is_enum_const = false;

--- a/src/ID.h
+++ b/src/ID.h
@@ -141,7 +141,7 @@ public:
 
     TraversalCode Traverse(TraversalCallback* cb) const;
 
-    bool HasOptionHandlers() const { return ! option_handlers.empty(); }
+    bool HasOptionHandlers() const { return option_handlers && ! option_handlers->empty(); }
 
     void AddOptionHandler(FuncPtr callback, int priority);
     std::vector<Func*> GetOptionHandlers() const;
@@ -172,7 +172,8 @@ protected:
     AttributesPtr attrs;
 
     // contains list of functions that are called when an option changes
-    std::multimap<int, FuncPtr> option_handlers;
+    using OptionHandlerMap = std::multimap<int, FuncPtr>;
+    std::unique_ptr<OptionHandlerMap> option_handlers;
 
     // Information managed by script optimization.  We package this
     // up into a separate object for purposes of modularity, and,


### PR DESCRIPTION
While tinkering with fixing up https://github.com/timwoj/struct_layout, I noticed that we allocate a 48-byte `multimap` to hold the change handlers for options. We only actually add handlers 13 times in the base scripts. Instead of allocating it for all of them, lazily allocate it when needed. Local testing don't show a huge change with this, but this reduces the size of a `::zeek::detail::ID` instance from 152 bytes to 104 bytes, and fits it inside of 2 cache lines instead of 3.

This also moves the `type` field up a couple of rows in class definition for better packing. This fills a 6-byte hole after `is_export` and replaces a 1-byte hole after `infer_return_type` and a 4-byte hole after `offset` with a single 3-byte hole after `infer_return_type`.

I'm opening this as a draft to see what the benchmarks think.