### PR TITLE
Deprecate `record_type_to_vector`

### DIFF
--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -2052,7 +2052,7 @@ function bare_mode%(%): bool
 ## rt: The name of the record type.
 ##
 ## Returns: A string vector with the field names of *rt*.
-function record_type_to_vector%(rt: string%): string_vec
+function record_type_to_vector%(rt: string%): string_vec &deprecated="Remove in v8.1: Consider using the ordered table from record_fields"
 	%{
 	auto result = zeek::make_intrusive<zeek::VectorVal>(zeek::id::string_vec);
 


### PR DESCRIPTION
After #4682, `record_fields` is ordered so this is redundant. Furthermore, it is incorrectly documented, as it says nested records are flattened.