### PR TITLE
Fix build failure with std::ranges on Debian 11

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1538,7 +1538,14 @@ TEST_CASE("util strstrip") {
 std::string strstrip(std::string s) {
     auto notspace = [](unsigned char c) { return ! std::isspace(c); };
     s.erase(s.begin(), std::ranges::find_if(s, notspace));
-    s.erase(std::ranges::find_if(std::ranges::reverse_view(s), notspace).base(), s.end());
+
+    // We require `std::reverse_iterator::base` here which in e.g., gcc-10.2.1
+    // is not implemented for the range equivalent of the code
+    // (`borrowed_iterator_t` over a `reverse_view`). Stick to the non-ranges
+    // version for now.
+    // NOLINTNEXTLINE(modernize-use-ranges)
+    s.erase(std::find_if(s.rbegin(), s.rend(), notspace).base(), s.end());
+
     return s;
 }
 


### PR DESCRIPTION
After @bbannier ran into this with https://github.com/zeek/spicy/commit/629bbce97d80c991fe45d5a39ac87f944759acbd, you would think I would have gone to check that I didn't have the same problem. Welp, you would be wrong. This fixes the same problem on the Zeek side, again with Debian 11.