### PR TITLE
Cleanup warnings from plugin btest builds

### DIFF
--- a/testing/btest/plugins/binpac-flowbuffer-frame-length-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/binpac-flowbuffer-frame-length-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Zeek-Plugin-Foo-FOO)
-
 cmake_minimum_required(VERSION 3.15)
+
+project(Zeek-Plugin-Foo-FOO)
 
 if (NOT ZEEK_DIST)
     message(FATAL_ERROR "ZEEK_DIST not set")

--- a/testing/btest/plugins/conflict-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/conflict-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Zeek-Plugin-Conflict-Plugin)
-
 cmake_minimum_required(VERSION 3.15)
+
+project(Zeek-Plugin-Conflict-Plugin)
 
 if (NOT ZEEK_DIST)
     message(FATAL_ERROR "ZEEK_DIST not set")

--- a/testing/btest/plugins/connkey-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/connkey-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Zeek-Plugin-Demo-Foo)
-
 cmake_minimum_required(VERSION 3.15)
+
+project(Zeek-Plugin-Demo-Foo)
 
 if (NOT ZEEK_DIST)
     message(FATAL_ERROR "ZEEK_DIST not set")

--- a/testing/btest/plugins/file-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/file-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Zeek-Plugin-Demo-Foo)
-
 cmake_minimum_required(VERSION 3.15)
+
+project(Zeek-Plugin-Demo-Foo)
 
 if (NOT BRO_DIST)
     message(FATAL_ERROR "BRO_DIST not set")

--- a/testing/btest/plugins/file-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/file-plugin/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 3.15)
 
 project(Zeek-Plugin-Demo-Foo)
 
-if (NOT BRO_DIST)
-    message(FATAL_ERROR "BRO_DIST not set")
+if (NOT ZEEK_DIST)
+    message(FATAL_ERROR "ZEEK_DIST not set")
 endif ()
 
-set(CMAKE_MODULE_PATH ${BRO_DIST}/cmake)
+set(CMAKE_MODULE_PATH ${ZEEK_DIST}/cmake)
 
 include(ZeekPlugin)
 

--- a/testing/btest/plugins/packet-protocol-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/packet-protocol-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Zeek-Packet-Plugin-Demo)
-
 cmake_minimum_required(VERSION 3.15)
+
+project(Zeek-Packet-Plugin-Demo)
 
 if (NOT ZEEK_DIST)
     message(FATAL_ERROR "ZEEK_DIST not set")

--- a/testing/btest/plugins/pktdumper-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/pktdumper-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Zeek-Plugin-Demo-Foo)
-
 cmake_minimum_required(VERSION 3.15)
+
+project(Zeek-Plugin-Demo-Foo)
 
 if (NOT ZEEK_DIST)
     message(FATAL_ERROR "ZEEK_DIST not set")

--- a/testing/btest/plugins/pktsrc-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/pktsrc-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Zeek-Plugin-Demo-Foo)
-
 cmake_minimum_required(VERSION 3.15)
+
+project(Zeek-Plugin-Demo-Foo)
 
 if (NOT ZEEK_DIST)
     message(FATAL_ERROR "ZEEK_DIST not set")

--- a/testing/btest/plugins/protocol-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/protocol-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Zeek-Plugin-Demo-Foo)
-
 cmake_minimum_required(VERSION 3.15)
+
+project(Zeek-Plugin-Demo-Foo)
 
 if (NOT ZEEK_DIST)
     message(FATAL_ERROR "ZEEK_DIST not set")

--- a/testing/btest/plugins/reader-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/reader-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Zeek-Plugin-Demo-Foo)
-
 cmake_minimum_required(VERSION 3.15)
+
+project(Zeek-Plugin-Demo-Foo)
 
 if (NOT ZEEK_DIST)
     message(FATAL_ERROR "ZEEK_DIST not set")

--- a/testing/btest/plugins/writer-plugin/CMakeLists.txt
+++ b/testing/btest/plugins/writer-plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Zeek-Plugin-Demo-Foo)
-
 cmake_minimum_required(VERSION 3.15)
+
+project(Zeek-Plugin-Demo-Foo)
 
 if (NOT ZEEK_DIST)
     message(FATAL_ERROR "ZEEK_DIST not set")


### PR DESCRIPTION
I noticed this on a btest when working on the deprecation removals for 8.1, so I figured I'd take care of it for all of them. This does two things:

- Fix warnings about `BRO_DIST` being unused via https://github.com/zeek/zeek-aux/pull/67
- Fix warnings about the call to `cmake_minimum_required()` needing to appear in CMakeLists.txt before `project()`