### PR TITLE
RFC: management/controller: Add dedicated tls options

### DIFF
--- a/scripts/policy/frameworks/management/controller/config.zeek
+++ b/scripts/policy/frameworks/management/controller/config.zeek
@@ -61,6 +61,17 @@ export {
 	## for websocket clients.
 	const default_port_websocket = 2149/tcp &redef;
 
+	# TLS options to use for the controller's WebSocket server.
+	#
+	# The default value is Broker's cert-less TLS config. To disable
+	# TLS, redef this value to ``Cluster::WebSocketTLSOptions()``.
+	const tls_options_websocket = Cluster::WebSocketTLSOptions(
+		$cert_file="",
+		$key_file="",
+		$ca_file="NONE",
+		$ciphers="AECDH-AES256-SHA@SECLEVEL=0:AECDH-AES256-SHA:P-384",
+	) &redef;
+
 	## Whether the controller should auto-assign Broker listening ports to
 	## cluster nodes that need them and don't have them explicitly specified
 	## in cluster configurations.

--- a/scripts/policy/frameworks/management/controller/main.zeek
+++ b/scripts/policy/frameworks/management/controller/main.zeek
@@ -1646,7 +1646,8 @@ event zeek_init()
 	if ( cni$bound_port != 0/unknown )
 		{
 		local ws_opts = Cluster::WebSocketServerOptions($listen_addr=to_addr(cni$address),
-		                                                $listen_port=cni$bound_port);
+		                                                $listen_port=cni$bound_port,
+		                                                $tls_options=Management::Controller::tls_options_websocket);
 		Cluster::listen_websocket(ws_opts);
 		websocket_info = fmt("websocket port %s:%s", cni$address, cni$bound_port);
 		}


### PR DESCRIPTION
@ckreibich - could you see this, or would you prefer a different direction?

Previously I believe the TLS options were inherited from Broker, but with Cluster::listen_websocket(), these can now be configured per WebSocket server instance.

cc @dopheide-esnet 