### PR TITLE
Follow-up for #4754

### DIFF
--- a/src/cluster/serializer/broker/Serializer.cc
+++ b/src/cluster/serializer/broker/Serializer.cc
@@ -14,7 +14,6 @@
 #include "zeek/broker/Data.h"
 #include "zeek/cluster/Event.h"
 
-#include "broker/data.bif.h"
 #include "broker/data_envelope.hh"
 #include "broker/error.hh"
 #include "broker/format/json.hh"


### PR DESCRIPTION
Clang-tidy reported and unused include while at it.