### PR TITLE
Add a missing header for the broker cluster serializer

### DIFF
--- a/src/cluster/serializer/broker/Serializer.cc
+++ b/src/cluster/serializer/broker/Serializer.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/cluster/serializer/broker/Serializer.h"
 
+#include <cinttypes>
 #include <optional>
 
 #include "zeek/DebugLogger.h"


### PR DESCRIPTION
This fixes the following compiler failure on master:

```
/Users/tim/Desktop/projects/zeek-master/src/cluster/serializer/broker/Serializer.cc:38:61: error: expected ')' [clang-diagnostic-error]
   38 |             DBG_LOG(DBG_BROKER, "Ignoring event metadata %" PRId64 " value=%s", id,
      |                                                             ^
/Users/tim/Desktop/projects/zeek-master/src/cluster/serializer/broker/Serializer.cc:38:13: note: to match this '('
   38 |             DBG_LOG(DBG_BROKER, "Ignoring event metadata %" PRId64 " value=%s", id,
      |             ^
```