### PR TITLE
CI: Update CentOS 9 to Python 3.13

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,8 @@ We would like to thank ... for their contributions to this release.
 Breaking Changes
 ----------------
 
+- Python 3.10 is now required for Zeek and all of its associated subprojects.
+
 - The ``&optional`` script attribute will now error when applied to anything that's
   not a record field. Previously, this would have surprising behavior.
 

--- a/ci/centos-stream-9/Dockerfile
+++ b/ci/centos-stream-9/Dockerfile
@@ -34,9 +34,9 @@ RUN dnf -y --nobest install \
     openssl \
     openssl-devel \
     procps-ng \
-    python3 \
-    python3-devel \
-    python3-pip\
+    python3.13 \
+    python3.13-devel \
+    python3.13-pip\
     sqlite \
     swig \
     tar \
@@ -46,5 +46,9 @@ RUN dnf -y --nobest install \
 
 # Set the crypto policy to allow SHA-1 certificates - which we have in our tests
 RUN dnf -y --nobest install crypto-policies-scripts && update-crypto-policies --set LEGACY
+
+# Override the default python3.9 installation paths with 3.13
+RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 10
+RUN alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.13 10
 
 RUN pip3 install websockets junit2html


### PR DESCRIPTION
This updates the CI Dockerfile for Centos 9 to use Python 3.13. It also adds a NEWS entry about requiring Python 3.10 for Zeek. The NEWS entry isn't *entirely* true in that some subprojects will still work with 3.9, but setting the expectation is good here.

https://cirrus-ci.com/task/5195113661464576 has a build with this included. From the build log:

> [18:08:39.201] -- Found Python: /usr/bin/python3 (found suitable version "3.13.5", minimum required is "3.9") found components: Interpreter Development Development.Module Development.Embed 
