### PR TITLE
Fix Coverity issue with new `Attributes` ctor

### DIFF
--- a/src/Attr.h
+++ b/src/Attr.h
@@ -114,7 +114,7 @@ public:
         : Attributes(std::vector<AttrPtr>{}, std::move(t), in_record, is_global, false) {}
 
     Attributes(std::vector<AttrPtr> a, TypePtr t, bool in_record, bool is_global)
-        : Attributes(a, std::move(t), in_record, is_global, false) {}
+        : Attributes(std::move(a), std::move(t), in_record, is_global, false) {}
 
 
     ~Attributes() override = default;


### PR DESCRIPTION
fixes new copy-instead-of-move in the `Attributes` ctor I added in #4753 