### PR TITLE
testing: Make share/zeek/tests a relative symlink

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -13,8 +13,8 @@ endif ()
 install(
     CODE "execute_process( \
     COMMAND ${CMAKE_COMMAND} -E create_symlink \
-    ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/data \
-    ${CMAKE_INSTALL_PREFIX}/share/zeek/tests \
+    ../btest/data \
+    \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/share/zeek/tests \
     )")
 
 install(DIRECTORY scripts/spicy/ DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/data/Scripts


### PR DESCRIPTION
ZEEK_CONFIG_BTEST_TOOLS_DIR is just <ZEEK_ROOT_DIR>/share/btest and ZEEK_ROOT_DIR is just CMAKE_INSTALL_PREFIX, so this should work out.

Closes #3266