### PR TITLE
Fix installation of symlink with `DESTDIR`

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -14,7 +14,7 @@ install(
     CODE "execute_process( \
     COMMAND ${CMAKE_COMMAND} -E create_symlink \
     ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/data \
-    ${CMAKE_INSTALL_PREFIX}/share/zeek/tests \
+    \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX}/share/zeek/tests \
     )")
 
 install(DIRECTORY scripts/spicy/ DESTINATION ${ZEEK_CONFIG_BTEST_TOOLS_DIR}/data/Scripts


### PR DESCRIPTION
We install test data which we also make available under an alternative path for backwards compatibility. The installation of this symlink did not take `DESTDIR` installs like used by Zeek's packaging into account which caused installations from packages to behave different from installs from source.

This patch fixes the symlink to respect a possible `DESTDIR`.

Closes #3266.