### PR TITLE
Default to 127.0.0.1 for metrics address

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -67,6 +67,9 @@ Changed Functionality
 - The var-extraction-uri.zeek policy does not include the path in the ``uri_vars``
   field anymore.
 
+- By default, the Prometheus HTTP server now listens on ``127.0.0.1`` instead
+  of ``0.0.0.0``.
+
 Removed Functionality
 ---------------------
 

--- a/src/telemetry/Manager.cc
+++ b/src/telemetry/Manager.cc
@@ -53,7 +53,7 @@ void Manager::InitPostScript() {
     auto metrics_port = id::find_val("Telemetry::metrics_port")->AsPortVal();
     auto metrics_address = id::find_val("Telemetry::metrics_address")->AsStringVal()->ToStdString();
     if ( metrics_address.empty() )
-        metrics_address = "0.0.0.0";
+        metrics_address = "127.0.0.1";
     if ( metrics_port->Port() != 0 )
         prometheus_url = util::fmt("%s:%u", metrics_address.data(), metrics_port->Port());
 


### PR DESCRIPTION
This goes with: https://github.com/zeek/zeekctl/pull/89