### PR TITLE
Proposal: Document UID pivoting via its type

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -230,6 +230,10 @@ type conn_id: record {
 	ctx: conn_id_ctx &log &default=conn_id_ctx();  ##< The context in which this connection exists.
 };
 
+## A connection's unique identifier. This can be used to pivot between logs
+## with the same connection (TODO expand on this?)
+type conn_uid: string;
+
 ## The identifying 4-tuple of a uni-directional flow.
 ##
 ## .. note:: It's actually a 5-tuple: the transport-layer protocol is stored as
@@ -885,7 +889,7 @@ type connection: record {
 	## creates an ID that is very likely unique across independent Zeek runs.
 	## These IDs can thus be used to tag and locate information associated
 	## with that connection.
-	uid: string;
+	uid: conn_uid;
 	## If the connection is tunneled, this field contains information about
 	## the encapsulating "connection(s)" with the outermost one starting
 	## at index zero.  It's also always the first such encapsulation seen

--- a/scripts/base/protocols/conn/main.zeek
+++ b/scripts/base/protocols/conn/main.zeek
@@ -22,7 +22,7 @@ export {
 		## This is the time of the first packet.
 		ts:           time            &log;
 		## A unique identifier of the connection.
-		uid:          string          &log;
+		uid:          conn_uid        &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:           conn_id         &log;
 		## The transport layer protocol of the connection.

--- a/scripts/base/protocols/dce-rpc/main.zeek
+++ b/scripts/base/protocols/dce-rpc/main.zeek
@@ -12,7 +12,7 @@ export {
 		## Timestamp for when the event happened.
 		ts         : time     &log;
 		## Unique ID for the connection.
-		uid        : string   &log;
+		uid        : conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id         : conn_id  &log;
 		## Round trip time from the request to the response.

--- a/scripts/base/protocols/dhcp/main.zeek
+++ b/scripts/base/protocols/dhcp/main.zeek
@@ -24,7 +24,7 @@ export {
 		## DHCP is occurring.  This behavior with multiple connections is
 		## unique to DHCP because of the way it uses broadcast packets
 		## on local networks.
-		uids:           set[string] &log;
+		uids:           set[conn_uid] &log;
 
 		## IP address of the client.  If a transaction
 		## is only a client sending INFORM messages then

--- a/scripts/base/protocols/dnp3/main.zeek
+++ b/scripts/base/protocols/dnp3/main.zeek
@@ -14,7 +14,7 @@ export {
 		## Time of the request.
 		ts:         time           &log;
 		## Unique identifier for the connection.
-		uid:        string         &log;
+		uid:        conn_uid       &log;
 		## Identifier for the connection.
 		id:         conn_id        &log;
 		## The name of the function message in the request.

--- a/scripts/base/protocols/dns/main.zeek
+++ b/scripts/base/protocols/dns/main.zeek
@@ -21,7 +21,7 @@ export {
 		ts:            time               &log;
 		## A unique identifier of the connection over which DNS messages
 		## are being transferred.
-		uid:           string             &log;
+		uid:           conn_uid           &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:            conn_id            &log;
 		## The transport layer protocol of the connection.

--- a/scripts/base/protocols/ftp/info.zeek
+++ b/scripts/base/protocols/ftp/info.zeek
@@ -27,7 +27,7 @@ export {
 		## Time when the command was sent.
 		ts:               time        &log;
 		## Unique ID for the connection.
-		uid:              string      &log;
+		uid:              conn_uid    &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:               conn_id     &log;
 		## User name for the current FTP session.

--- a/scripts/base/protocols/http/main.zeek
+++ b/scripts/base/protocols/http/main.zeek
@@ -29,7 +29,7 @@ export {
 		## Timestamp for when the request happened.
 		ts:                      time      &log;
 		## Unique ID for the connection.
-		uid:                     string    &log;
+		uid:                     conn_uid  &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:                      conn_id   &log;
 		## Represents the pipelined depth into the connection of this

--- a/scripts/base/protocols/irc/main.zeek
+++ b/scripts/base/protocols/irc/main.zeek
@@ -14,7 +14,7 @@ export {
 		## Timestamp when the command was seen.
 		ts:       time        &log;
 		## Unique ID for the connection.
-		uid:      string      &log;
+		uid:      conn_uid    &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:       conn_id     &log;
 		## Nickname given for the connection.

--- a/scripts/base/protocols/krb/main.zeek
+++ b/scripts/base/protocols/krb/main.zeek
@@ -15,7 +15,7 @@ export {
 		## Timestamp for when the event happened.
 		ts:            time     &log;
 		## Unique ID for the connection.
-		uid:           string   &log;
+		uid:           conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:            conn_id  &log;
 

--- a/scripts/base/protocols/ldap/main.zeek
+++ b/scripts/base/protocols/ldap/main.zeek
@@ -39,7 +39,7 @@ export {
     ts: time &log;
 
     # Unique ID for the connection.
-    uid: string &log;
+    uid: conn_uid &log;
 
     # The connection's 4-tuple of endpoint addresses/ports.
     id: conn_id &log;
@@ -74,7 +74,7 @@ export {
     ts: time &log;
 
     # Unique ID for the connection.
-    uid: string &log;
+    uid: conn_uid &log;
 
     # The connection's 4-tuple of endpoint addresses/ports.
     id: conn_id &log;

--- a/scripts/base/protocols/modbus/main.zeek
+++ b/scripts/base/protocols/modbus/main.zeek
@@ -13,7 +13,7 @@ export {
 		## Time of the request.
 		ts:        time           &log;
 		## Unique identifier for the connection.
-		uid:       string         &log;
+		uid:       conn_uid       &log;
 		## Identifier for the connection.
 		id:        conn_id        &log;
 		## Modbus transaction ID

--- a/scripts/base/protocols/mqtt/main.zeek
+++ b/scripts/base/protocols/mqtt/main.zeek
@@ -25,7 +25,7 @@ export {
 		## Timestamp for when the event happened
 		ts:             time    &log;
 		## Unique ID for the connection
-		uid:            string  &log;
+		uid:            conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports
 		id:             conn_id &log;
 
@@ -48,7 +48,7 @@ export {
 		## Timestamp for when the subscribe or unsubscribe request started
 		ts:                time     &log;
 		## UID for the connection
-		uid:               string   &log;
+		uid:               conn_uid   &log;
 		## ID fields for the connection
 		id:                conn_id  &log;
 
@@ -68,7 +68,7 @@ export {
 		## Timestamp for when the publish message started
 		ts:          time    &log;
 		## UID for the connection
-		uid:         string  &log;
+		uid:         conn_uid  &log;
 		## ID fields for the connection
 		id:          conn_id &log;
 

--- a/scripts/base/protocols/mysql/main.zeek
+++ b/scripts/base/protocols/mysql/main.zeek
@@ -14,7 +14,7 @@ export {
 		## Timestamp for when the event happened.
 		ts:     time    &log;
 		## Unique ID for the connection.
-		uid:    string  &log;
+		uid:    conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:     conn_id &log;
 		## The command that was issued

--- a/scripts/base/protocols/ntlm/main.zeek
+++ b/scripts/base/protocols/ntlm/main.zeek
@@ -11,7 +11,7 @@ export {
 		## Timestamp for when the event happened.
 		ts         : time     &log;
 		## Unique ID for the connection.
-		uid        : string   &log;
+		uid        : conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id         : conn_id  &log;
 

--- a/scripts/base/protocols/ntp/main.zeek
+++ b/scripts/base/protocols/ntp/main.zeek
@@ -9,7 +9,7 @@ export {
 		## Timestamp for when the event happened.
 		ts:         time	&log;
 		## Unique ID for the connection.
-		uid:        string  &log;
+		uid:        conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:         conn_id &log;
 		## The NTP version number (1, 2, 3, 4).

--- a/scripts/base/protocols/postgresql/main.zeek
+++ b/scripts/base/protocols/postgresql/main.zeek
@@ -21,7 +21,7 @@ export {
 		## Timestamp for when the activity happened.
 		ts: time &log;
 		## Unique ID for the connection.
-		uid: string &log;
+		uid: conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id: conn_id &log;
 

--- a/scripts/base/protocols/quic/main.zeek
+++ b/scripts/base/protocols/quic/main.zeek
@@ -14,7 +14,7 @@ export {
 		## Timestamp of first QUIC packet for this entry.
 		ts:          time    &log;
 		## Unique ID for the connection.
-		uid:         string  &log;
+		uid:         conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:          conn_id &log;
 

--- a/scripts/base/protocols/radius/main.zeek
+++ b/scripts/base/protocols/radius/main.zeek
@@ -15,7 +15,7 @@ export {
 		## Timestamp for when the event happened.
 		ts           : time     &log;
 		## Unique ID for the connection.
-		uid          : string   &log;
+		uid          : conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id           : conn_id  &log;
 		## The username, if present.

--- a/scripts/base/protocols/rdp/main.zeek
+++ b/scripts/base/protocols/rdp/main.zeek
@@ -14,7 +14,7 @@ export {
 		## Timestamp for when the event happened.
 		ts:                    time    &log;
 		## Unique ID for the connection.
-		uid:                   string  &log;
+		uid:                   conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:                    conn_id &log;
 		## Cookie value used by the client machine.

--- a/scripts/base/protocols/redis/main.zeek
+++ b/scripts/base/protocols/redis/main.zeek
@@ -17,7 +17,7 @@ export {
 		## Timestamp for when the activity happened.
 		ts: time &log;
 		## Unique ID for the connection.
-		uid: string &log;
+		uid: conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id: conn_id &log;
 		## The Redis command.

--- a/scripts/base/protocols/rfb/main.zeek
+++ b/scripts/base/protocols/rfb/main.zeek
@@ -12,7 +12,7 @@ export {
 		## Timestamp for when the event happened.
 		ts:     time    &log;
 		## Unique ID for the connection.
-		uid:    string  &log;
+		uid:    conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:     conn_id &log;
 

--- a/scripts/base/protocols/sip/main.zeek
+++ b/scripts/base/protocols/sip/main.zeek
@@ -18,7 +18,7 @@ export {
 		## Timestamp for when the request happened.
 		ts:                      time              &log;
 		## Unique ID for the connection.
-		uid:                     string            &log;
+		uid:                     conn_uid          &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:                      conn_id           &log;
 		## Represents the pipelined depth into the connection of this

--- a/scripts/base/protocols/smb/main.zeek
+++ b/scripts/base/protocols/smb/main.zeek
@@ -56,7 +56,7 @@ export {
 		## Time when the file was first discovered.
 		ts				: time    &log &default=network_time();
 		## Unique ID of the connection the file was sent over.
-		uid				: string  &log;
+		uid				: conn_uid &log;
 		## ID of the connection the file was sent over.
 		id				: conn_id &log;
 		## Unique ID of the file.
@@ -82,7 +82,7 @@ export {
 		## Time when the tree was mapped.
 		ts                  : time   &log &default=network_time();
 		## Unique ID of the connection the tree was mapped over.
-		uid                 : string  &log;
+		uid                 : conn_uid  &log;
 		## ID of the connection the tree was mapped over.
 		id                  : conn_id &log;
 
@@ -102,7 +102,7 @@ export {
 		## Timestamp of the command request.
 		ts				: time &log &default=network_time();
 		## Unique ID of the connection the request was sent over.
-		uid				: string &log;
+		uid				: conn_uid &log;
 		## ID of the connection the request was sent over.
 		id				: conn_id &log;
 

--- a/scripts/base/protocols/smtp/main.zeek
+++ b/scripts/base/protocols/smtp/main.zeek
@@ -15,7 +15,7 @@ export {
 		## Time when the message was first seen.
 		ts:                time            &log;
 		## Unique ID for the connection.
-		uid:               string          &log;
+		uid:               conn_uid        &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:                conn_id         &log;
 		## A count to represent the depth of this message transaction in

--- a/scripts/base/protocols/snmp/main.zeek
+++ b/scripts/base/protocols/snmp/main.zeek
@@ -14,7 +14,7 @@ export {
 		## Timestamp of first packet belonging to the SNMP session.
 		ts: time &log;
 		## The unique ID for the connection.
-		uid: string &log;
+		uid: conn_uid &log;
 		## The connection's 5-tuple of addresses/ports (ports inherently
 		## include transport protocol information)
 		id: conn_id &log;

--- a/scripts/base/protocols/socks/main.zeek
+++ b/scripts/base/protocols/socks/main.zeek
@@ -18,7 +18,7 @@ export {
 		ts:               time            &log;
 		## Unique ID for the tunnel - may correspond to connection uid
 		## or be nonexistent.
-		uid:              string          &log;
+		uid:              conn_uid        &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:               conn_id         &log;
 		## Protocol version of SOCKS.

--- a/scripts/base/protocols/ssh/main.zeek
+++ b/scripts/base/protocols/ssh/main.zeek
@@ -17,7 +17,7 @@ export {
 		## Time when the SSH connection began.
 		ts:              time         &log;
 		## Unique ID for the connection.
-		uid:             string       &log;
+		uid:             conn_uid     &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:              conn_id      &log;
 		## SSH major version (1, 2, or unset). The version can be unset if the

--- a/scripts/base/protocols/ssl/main.zeek
+++ b/scripts/base/protocols/ssl/main.zeek
@@ -17,7 +17,7 @@ export {
 		## Time when the SSL connection was first detected.
 		ts:               time             &log;
 		## Unique ID for the connection.
-		uid:              string           &log;
+		uid:              conn_uid         &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:               conn_id          &log;
 		## Numeric SSL/TLS version that the server chose.

--- a/scripts/base/protocols/syslog/main.zeek
+++ b/scripts/base/protocols/syslog/main.zeek
@@ -15,7 +15,7 @@ export {
 		## Timestamp when the syslog message was seen.
 		ts:        time            &log;
 		## Unique ID for the connection.
-		uid:       string          &log;
+		uid:       conn_uid        &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:        conn_id         &log;
 		## Protocol over which the message was seen.

--- a/scripts/base/protocols/websocket/main.zeek
+++ b/scripts/base/protocols/websocket/main.zeek
@@ -23,7 +23,7 @@ export {
 		## Timestamp
 		ts:                time    &log;
 		## Unique ID for the connection.
-		uid:               string  &log;
+		uid:               conn_uid &log;
 		## The connection's 4-tuple of endpoint addresses/ports.
 		id:                conn_id &log;
 		## Same as in the HTTP log.


### PR DESCRIPTION
This relates to #4775 - I didn't actually know for sure that my suggestion would work, so I tried it in code and it worked fine. This is a draft as it's more of an RFC (I didn't meticulously get every case nor fix whitespace).

This changes a connection's UID to be a `conn_uid` type rather than a `string` type. This way, documentation will link to this new type, which may explain pivoting better. Then, users can rest assured that every `conn_uid` is meant to correlate with a connection's UID.

The one caveat that I don't know about (maybe @ckreibich can help inform me) is if this would play nicely with the log schema stuff, which was indeed the initial motivation. I just threw this together in 5 minutes to try it and figured a draft PR would be the easiest way :) - update, it might be collapsed so in logschema it just says it's `string` - maybe that's a deal breaker.

I personally like this more than a Zeekygen annotation for a few reasons:

1) It's in the type system, so if we want to make this more strict in the future in some way, we can
2) It's basically self-documenting, so you don't need to care about the doc comments etc.
3) It's easier to coerce the user to use the `conn_uid` type rather than keep a doc comment around

In docs this would just be a `conn_uid` type on the `uid` field:

<img width="588" height="125" alt="Screenshot 2025-08-25 at 10 03 42 AM" src="https://github.com/user-attachments/assets/c241e28d-71de-49d3-b7db-d26098501687" />

You can click the type and get to the explanation, which will include info about "pivoting" via this type:

<img width="650" height="158" alt="Screenshot 2025-08-25 at 10 05 00 AM" src="https://github.com/user-attachments/assets/6ef61b52-e3bf-4bd8-90de-6d134fc54c65" />

Then other logs are essentially self-documenting, since a `conn_uid` will link back to explain pivoting, so even DHCP makes sense:

<img width="593" height="123" alt="Screenshot 2025-08-25 at 10 05 57 AM" src="https://github.com/user-attachments/assets/c52ce1f0-3783-4f10-bbdd-3b2607f1f869" />