### PR TITLE
Link Prometheus symbols via Broker instead of directly

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -240,6 +240,8 @@ fedora42_task:
   << : *CI_TEMPLATE
   << : *ONLY_IF_PR_MASTER_RELEASE
   << : *SKIP_IF_PR_SKIP_ALL
+  env:
+    ZEEK_CI_CONFIGURE_FLAGS: *BINARY_CONFIG
 
 fedora41_task:
   container:


### PR DESCRIPTION
This pulls in the change in https://github.com/zeek/cmake/pull/141, and also modifies the Fedora 42 build to link statically. Hopefully this lets us catch problems like this without having to look at OBS status.