### PR TITLE
Fix ruff check legacy alias for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,8 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.12.8
   hooks:
-    - id: ruff
-      args: [--fix]
+    - id: ruff-check
+      args: ["--fix"]
     - id: ruff-format
 
 - repo: https://github.com/cheshirekow/cmake-format-precommit


### PR DESCRIPTION
Pre-commit's output looks like this:

```
ruff (legacy alias)........................................................Passed
```

This is because we're calling `ruff` directly in .pre-commit-config.yaml. The correct way to call it is `ruff-check`. This causes the pre-commit output to look like:

```
ruff check.................................................................Passed
```