### PR TITLE
Switch Zeek Spicy builds to Ubuntu 24

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -365,7 +365,7 @@ ubuntu25_04_task:
   << : *ONLY_IF_PR_MASTER_RELEASE
   << : *SKIP_IF_PR_NOT_FULL_CI
 
-ubuntu24_task:
+ubuntu24_04_task:
   container:
     # Ubuntu 24.04 EOL: Jun 2029
     dockerfile: ci/ubuntu-24.04/Dockerfile
@@ -375,7 +375,7 @@ ubuntu24_task:
   << : *SKIP_IF_PR_NOT_FULL_CI
 
 # Same as above, but running the ZAM tests instead of the regular tests.
-ubuntu24_zam_task:
+ubuntu24_04_zam_task:
   container:
     # Ubuntu 24.04 EOL: Jun 2029
     dockerfile: ci/ubuntu-24.04/Dockerfile
@@ -391,7 +391,7 @@ ubuntu24_zam_task:
     ZEEK_CI_BTEST_JOBS: 3
 
 # Same as above, but using Clang and libc++
-ubuntu24_clang_libcpp_task:
+ubuntu24_04_clang_libcpp_task:
   container:
     # Ubuntu 24.04 EOL: Jun 2029
     dockerfile: ci/ubuntu-24.04/Dockerfile
@@ -404,7 +404,7 @@ ubuntu24_clang_libcpp_task:
     CXX: clang++-19
     CXXFLAGS: -stdlib=libc++
 
-ubuntu24_clang_tidy_task:
+ubuntu24_04_clang_tidy_task:
   container:
     # Ubuntu 24.04 EOL: Jun 2029
     dockerfile: ci/ubuntu-24.04/Dockerfile
@@ -417,7 +417,7 @@ ubuntu24_clang_tidy_task:
     CXX: clang++-19
     ZEEK_CI_CONFIGURE_FLAGS: *CLANG_TIDY_CONFIG
 
-ubuntu22_task:
+ubuntu22_04_task:
   container:
     # Ubuntu 22.04 EOL: June 2027
     dockerfile: ci/ubuntu-22.04/Dockerfile
@@ -432,7 +432,7 @@ ubuntu22_task:
   benchmark_script: ./ci/benchmark.sh
 
 # Also enable Spicy SSL for this
-ubuntu24_spicy_task:
+ubuntu24_04_spicy_task:
   container:
     # Ubuntu 24.04 EOL: Jun 2029
     dockerfile: ci/ubuntu-24.04/Dockerfile
@@ -448,7 +448,7 @@ ubuntu24_spicy_task:
     path: build.tgz
   benchmark_script: ./ci/benchmark.sh
 
-ubuntu24_spicy_head_task:
+ubuntu24_04_spicy_head_task:
   container:
     # Ubuntu 24.04 EOL: Jun 2029
     dockerfile: ci/ubuntu-24.04/Dockerfile

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -372,7 +372,12 @@ ubuntu24_04_task:
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *ONLY_IF_PR_MASTER_RELEASE
-  << : *SKIP_IF_PR_NOT_FULL_CI
+  << : *SKIP_IF_PR_SKIP_ALL
+  env:
+    ZEEK_CI_CREATE_ARTIFACT: 1
+  upload_binary_artifacts:
+    path: build.tgz
+  benchmark_script: ./ci/benchmark.sh
 
 # Same as above, but running the ZAM tests instead of the regular tests.
 ubuntu24_04_zam_task:
@@ -459,12 +464,7 @@ ubuntu22_04_task:
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *ONLY_IF_PR_MASTER_RELEASE
-  << : *SKIP_IF_PR_NOT_FULL_OR_BENCHMARK
-  env:
-    ZEEK_CI_CREATE_ARTIFACT: 1
-  upload_binary_artifacts:
-    path: build.tgz
-  benchmark_script: ./ci/benchmark.sh
+  << : *SKIP_IF_PR_NOT_FULL_CI
 
 alpine_task:
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -432,10 +432,10 @@ ubuntu22_task:
   benchmark_script: ./ci/benchmark.sh
 
 # Also enable Spicy SSL for this
-ubuntu22_spicy_task:
+ubuntu24_spicy_task:
   container:
-    # Ubuntu 22.04 EOL: April 2027
-    dockerfile: ci/ubuntu-22.04/Dockerfile
+    # Ubuntu 24.04 EOL: Jun 2029
+    dockerfile: ci/ubuntu-24.04/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *ONLY_IF_PR_MASTER_RELEASE
@@ -448,10 +448,10 @@ ubuntu22_spicy_task:
     path: build.tgz
   benchmark_script: ./ci/benchmark.sh
 
-ubuntu22_spicy_head_task:
+ubuntu24_spicy_head_task:
   container:
-    # Ubuntu 22.04 EOL: April 2027
-    dockerfile: ci/ubuntu-22.04/Dockerfile
+    # Ubuntu 24.04 EOL: Jun 2029
+    dockerfile: ci/ubuntu-24.04/Dockerfile
     << : *RESOURCES_TEMPLATE
   << : *CI_TEMPLATE
   << : *ONLY_IF_PR_MASTER_RELEASE_NIGHTLY

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -417,20 +417,6 @@ ubuntu24_04_clang_tidy_task:
     CXX: clang++-19
     ZEEK_CI_CONFIGURE_FLAGS: *CLANG_TIDY_CONFIG
 
-ubuntu22_04_task:
-  container:
-    # Ubuntu 22.04 EOL: June 2027
-    dockerfile: ci/ubuntu-22.04/Dockerfile
-    << : *RESOURCES_TEMPLATE
-  << : *CI_TEMPLATE
-  << : *ONLY_IF_PR_MASTER_RELEASE
-  << : *SKIP_IF_PR_NOT_FULL_OR_BENCHMARK
-  env:
-    ZEEK_CI_CREATE_ARTIFACT: 1
-  upload_binary_artifacts:
-    path: build.tgz
-  benchmark_script: ./ci/benchmark.sh
-
 # Also enable Spicy SSL for this
 ubuntu24_04_spicy_task:
   container:
@@ -462,6 +448,20 @@ ubuntu24_04_spicy_head_task:
     # Pull auxil/spicy to the latest head version. May or may not build.
     ZEEK_CI_PREBUILD_COMMAND: 'cd auxil/spicy && git fetch && git reset --hard origin/main && git submodule update --init --recursive'
   spicy_install_analyzers_script: ./ci/spicy-install-analyzers.sh
+  upload_binary_artifacts:
+    path: build.tgz
+  benchmark_script: ./ci/benchmark.sh
+
+ubuntu22_04_task:
+  container:
+    # Ubuntu 22.04 EOL: June 2027
+    dockerfile: ci/ubuntu-22.04/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *ONLY_IF_PR_MASTER_RELEASE
+  << : *SKIP_IF_PR_NOT_FULL_OR_BENCHMARK
+  env:
+    ZEEK_CI_CREATE_ARTIFACT: 1
   upload_binary_artifacts:
     path: build.tgz
   benchmark_script: ./ci/benchmark.sh

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field to invalidate Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION 20250522
+ENV DOCKERFILE_VERSION=20250522
 
 RUN apt-get update && apt-get -y install \
     bc \
@@ -32,7 +32,9 @@ RUN apt-get update && apt-get -y install \
     make \
     python3 \
     python3-dev \
+    python3-git \
     python3-pip \
+    python3-semantic-version \
     redis-server \
     ruby \
     sqlite3 \


### PR DESCRIPTION
Continuing with the work on reworking our CI layout, this PR switches all of the Zeek spicy builds from Ubuntu 22 to 24. It also renames the Ubuntu builds to have the full version in their names to be more descriptive.