### PR TITLE
Topic/timw/windows zeromq support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -143,6 +143,12 @@ skip_if_pr_not_full_or_zeekctl: &SKIP_IF_PR_NOT_FULL_OR_ZEEKCTL
       ( $CIRRUS_PR_LABELS =~ ".*CI: Skip All.*" )
     )
 
+skip_if_pr_not_full_or_windows: &SKIP_IF_PR_NOT_FULL_OR_WINDOWS
+  skip: >
+    ( ( $CIRRUS_PR != '' && $CIRRUS_PR_LABELS !=~ ".*CI: (Full|Windows).*" ) ||
+      ( $CIRRUS_PR_LABELS =~ ".*CI: Skip All.*" )
+    )
+
 ci_template: &CI_TEMPLATE
   # Default timeout is 60 minutes, Cirrus hard limit is 120 minutes for free
   # tasks, so may as well ask for full time.
@@ -624,7 +630,7 @@ windows_task:
   build_script: ci/windows/build.cmd
   test_script: ci/windows/test.cmd
   << : *ONLY_IF_PR_MASTER_RELEASE
-  << : *SKIP_IF_PR_NOT_FULL_CI
+  << : *SKIP_IF_PR_NOT_FULL_OR_WINDOWS
   env:
     ZEEK_CI_CPUS: 8
     # Give verbose error output on a test failure.

--- a/ci/windows/build.cmd
+++ b/ci/windows/build.cmd
@@ -7,5 +7,5 @@ call "c:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliar
 mkdir build
 cd build
 
-cmake.exe .. -DCMAKE_BUILD_TYPE=release -DVCPKG_TARGET_TRIPLET="x64-windows-static" -DENABLE_ZEEK_UNIT_TESTS=yes -DENABLE_CLUSTER_BACKEND_ZEROMQ=no -G Ninja
+cmake.exe .. -DCMAKE_BUILD_TYPE=release -DVCPKG_TARGET_TRIPLET="x64-windows-static" -DENABLE_ZEEK_UNIT_TESTS=yes -G Ninja
 cmake.exe --build .

--- a/src/cluster/backend/CMakeLists.txt
+++ b/src/cluster/backend/CMakeLists.txt
@@ -1,7 +1,5 @@
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/zeromq/cmake")
 
-find_package(ZeroMQ)
-
 # Default to building ZeroMQ only if ZeroMQ was found.
 #
 # If a user enabled the cluster backend explicitly (-D ENABLE_CLUSTER_BACKEND_ZEROMQ:bool=ON),
@@ -9,6 +7,8 @@ find_package(ZeroMQ)
 option(ENABLE_CLUSTER_BACKEND_ZEROMQ "Enable the ZeroMQ cluster backend" ON)
 
 if (ENABLE_CLUSTER_BACKEND_ZEROMQ)
+    find_package(ZeroMQ CONFIG)
+
     if (NOT ZeroMQ_FOUND)
         message(FATAL_ERROR "ENABLE_CLUSTER_BACKEND_ZEROMQ set, but ZeroMQ library not available")
     endif ()

--- a/src/cluster/backend/zeromq/CMakeLists.txt
+++ b/src/cluster/backend/zeromq/CMakeLists.txt
@@ -5,6 +5,6 @@ find_package(ZeroMQ REQUIRED)
 zeek_add_plugin(
     Zeek Cluster_Backend_ZeroMQ
     INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIRS}
-    DEPENDENCIES ${ZeroMQ_LIBRARIES}
+    DEPENDENCIES libzmq
     SOURCES Plugin.cc ZeroMQ-Proxy.cc ZeroMQ.cc
     BIFS cluster_backend_zeromq.bif)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,9 @@
   "version-string": "latest",
   "dependencies": [
     "c-ares",
+    "cppzmq",
     "libpcap",
+    "zeromq",
     "zlib"
   ]
 }


### PR DESCRIPTION
This adds `zeromq` and `cppzmq` to the vcpkg configuration for Windows and re-enables building it as part of the Windows CI build. It also adds a new label to the CI configuration for enabling just the Windows task as part of a PR build.