### PR TITLE
Switch types used in DNS analyzer to be more consistent

### DIFF
--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -52,9 +52,7 @@ namespace detail {
 // since it's similar to DNS but does some things differently.
 constexpr int NETBIOS_PORT = 137;
 
-DNS_Interpreter::DNS_Interpreter(analyzer::Analyzer* arg_analyzer) {
-    analyzer = arg_analyzer;
-    first_message = true;
+DNS_Interpreter::DNS_Interpreter(analyzer::Analyzer* arg_analyzer) : analyzer(arg_analyzer) {
     is_netbios =
         ntohs(analyzer->Conn()->OrigPort()) == NETBIOS_PORT || ntohs(analyzer->Conn()->RespPort()) == NETBIOS_PORT;
 }
@@ -2184,8 +2182,6 @@ DNS_Analyzer::DNS_Analyzer(Connection* conn) : analyzer::tcp::TCP_ApplicationAna
 }
 
 DNS_Analyzer::~DNS_Analyzer() { delete interp; }
-
-void DNS_Analyzer::Init() {}
 
 void DNS_Analyzer::Done() {
     analyzer::tcp::TCP_ApplicationAnalyzer::Done();

--- a/src/analyzer/protocol/dns/DNS.h
+++ b/src/analyzer/protocol/dns/DNS.h
@@ -393,9 +393,9 @@ protected:
     void SendReplyOrRejectEvent(detail::DNS_MsgInfo* msg, EventHandlerPtr event, const u_char*& data, int& len,
                                 String* question_name, String* original_name);
 
-    analyzer::Analyzer* analyzer;
-    bool first_message;
-    bool is_netbios;
+    analyzer::Analyzer* analyzer = nullptr;
+    bool first_message = true;
+    bool is_netbios = false;
 };
 
 enum TCP_DNS_state : uint8_t {
@@ -438,7 +438,6 @@ public:
 
     void DeliverPacket(int len, const u_char* data, bool orig, uint64_t seq, const IP_Hdr* ip, int caplen) override;
 
-    void Init() override;
     void Done() override;
     void ConnectionClosed(analyzer::tcp::TCP_Endpoint* endpoint, analyzer::tcp::TCP_Endpoint* peer,
                           bool gen_event) override;


### PR DESCRIPTION
I'm starting work on the DNS Dynamic Update work and this was all bothering me about working on the DNS analyzer. This PR switches the types in the code to use the standard `uint*_t` types consistently instead of switching between them and regular `unsigned {short,int}` types. It also cleans up the init of the analyzer a little bit. There are probably some opportunities for packing the structures a bit better, but I'll leave that for later.