### PR TITLE
CI: Add tasks for reporting cron status to email

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -912,3 +912,68 @@ include_plugins_debian12_task:
       path: "testing/builtin-plugins/.tmp/**"
   << : *ONLY_IF_PR_MASTER_RELEASE
   << : *SKIP_IF_PR_NOT_FULL_CI
+
+nightly_status:
+  container:
+    dockerfile: ci/debian-13/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  depends_on:
+    - macos_sequoia
+    - freebsd14
+    - freebsd13
+    - arm64_container_image
+    - amd64_container_image
+    - fedora42
+    - fedora41
+    - centosstream9
+    - debian13
+    - arm_debian13
+    - debian13_static
+    - debian13_binary
+    - debian12
+    - opensuse_leap_15_6
+    - opensuse_tumbleweed
+    - ubuntu25_04
+    - ubuntu24_04
+    - ubuntu24_04_zam
+    - ubuntu24_04_clang_libcpp
+    - ubuntu24_04_clang_tidy
+    - ubuntu24_04_spicy
+    - ubuntu24_04_spicy_head
+    - ubuntu22_04
+    - alpine
+    - asan_sanitizer
+    - asan_sanitizer_zam
+    - ubsan_sanitizer
+    - ubsan_sanitizer_zam
+    - tsan_sanitizer
+    - windows
+    - container_image_manifest
+    - cluster_testing
+    - zeekctl_debian12
+    - include_plugins_debian12
+    - public_ecr_cleanup
+  on_failure: ./ci/send_cron_status_email.sh
+  env:
+    ZEEK_SMTP_HOST: ENCRYPTED[7cbf4159bd4a2f2d3df23fed2761d685f564f5ab08a1c55cade870520be1808946608118a6bc819748fca31fe8df31b8]
+    ZEEK_SMTP_PORT: ENCRYPTED[a3154dc7d236b30aae12b0eef3ef403285f84c301bc8bdfbd6f6ad10e6512a33d6ebc450bf7b635865d9f5ee4a4dc3b6]
+    ZEEK_SMTP_USERNAME: ENCRYPTED[a9d089453c8baa4240509a35744bf671d19336a43ad7d4fac2b797971715e3ce449397b877ecfd1a3129672e1bf4b641]
+    ZEEK_SMTP_PASSWORD: ENCRYPTED[56a73a6bd1bbf686ea1d3780492dae1339f86d1d0f6d4bf7e31238b88eb4147d1cedb09f2f9800df6e62ba297b110fa0]
+    ZEEK_CIRRUS_GRAPHQL_TOKEN: ENCRYPTED[80270bf79e19b9ccd6ba23e53ffbf64057cbdbb1c53987dfb4ea13ce87f91293e7508a9bf6bad831597fba7ffe9e7e5d]
+  << : *ONLY_IF_NIGHTLY
+
+weekly_status:
+  container:
+    dockerfile: ci/debian-13/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  depends_on:
+    - weekly_current_clang_task
+    - weekly_current_gcc_task
+  on_failure: ./ci/send_cron_status_email.sh
+  env:
+    ZEEK_SMTP_HOST: ENCRYPTED[7cbf4159bd4a2f2d3df23fed2761d685f564f5ab08a1c55cade870520be1808946608118a6bc819748fca31fe8df31b8]
+    ZEEK_SMTP_PORT: ENCRYPTED[a3154dc7d236b30aae12b0eef3ef403285f84c301bc8bdfbd6f6ad10e6512a33d6ebc450bf7b635865d9f5ee4a4dc3b6]
+    ZEEK_SMTP_USERNAME: ENCRYPTED[a9d089453c8baa4240509a35744bf671d19336a43ad7d4fac2b797971715e3ce449397b877ecfd1a3129672e1bf4b641]
+    ZEEK_SMTP_PASSWORD: ENCRYPTED[56a73a6bd1bbf686ea1d3780492dae1339f86d1d0f6d4bf7e31238b88eb4147d1cedb09f2f9800df6e62ba297b110fa0]
+    ZEEK_CIRRUS_GRAPHQL_TOKEN: ENCRYPTED[80270bf79e19b9ccd6ba23e53ffbf64057cbdbb1c53987dfb4ea13ce87f91293e7508a9bf6bad831597fba7ffe9e7e5d]
+  << : *ONLY_IF_WEEKLY

--- a/ci/debian-13/Dockerfile
+++ b/ci/debian-13/Dockerfile
@@ -41,4 +41,4 @@ RUN apt-get update && apt-get -y install \
 
 # Debian trixie really doesn't like using pip to install system wide stuff, but
 # doesn't seem there's a python3-junit2html package, so not sure what we'd break.
-RUN pip3 install --break-system-packages junit2html
+RUN pip3 install --break-system-packages junit2html gql

--- a/ci/send-cron-status-email.py
+++ b/ci/send-cron-status-email.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import os
+import smtplib
+import ssl
+from email.mime.text import MIMEText
+
+from gql import Client, gql
+from gql.transport import exceptions
+from gql.transport.aiohttp import AIOHTTPTransport
+
+# This is hardcoded because it doesn't make sense to set as a Cirrus secret
+# and it doesn't come as part of the Cirrus build environment.
+CIRRUS_GRAPHQL_ENDPOINT = "https://api.cirrus-ci.com/graphql"
+
+# These are all defined as secrets in the Cirrus Zeek project, and imported
+# via the Cirrus environment.
+SMTP_HOST = os.getenv("ZEEK_SMTP_HOST")
+SMTP_PORT = os.getenv("ZEEK_SMTP_PORT")
+SMTP_USER = os.getenv("ZEEK_SMTP_USERNAME")
+SMTP_PASS = os.getenv("ZEEK_SMTP_PASSWORD")
+CIRRUS_GRAPHQL_TOKEN = os.getenv("ZEEK_CIRRUS_GRAPHQL_TOKEN")
+
+# These are defined as part of the Cirrus build environment.
+CIRRUS_CRON = os.getenv("CIRRUS_CRON")
+CIRRUS_BUILD_ID = os.getenv("CIRRUS_BUILD_ID")
+
+graphql_headers = {"Authorization": f"Bearer {CIRRUS_GRAPHQL_TOKEN}"}
+gql_transport = AIOHTTPTransport(url=CIRRUS_GRAPHQL_ENDPOINT, headers=graphql_headers)
+gql_client = Client(transport=gql_transport)
+
+query = gql("""
+    query GetFailedBuild {
+      ownerInfoByName(platform: "github", name: "zeek") {
+        builds(last: 20, status: FAILED) {
+          edges {
+            node {
+              id
+              repository {
+                name
+              }
+              tasks {
+                id
+                name
+                status
+              }
+            }
+          }
+        }
+      }
+    }
+""")
+
+msg_text = f"The Cirrus build started by the {CIRRUS_CRON} cron job failed.\n\n"
+
+try:
+    result = gql_client.execute(query)
+except exceptions.TransportQueryError as tqe:
+    msg_text += f"Query error while requesting GraphQL data: {tqe}"
+except exceptions.TransportProtocolError as tpe:
+    msg_text += f"Protocol error while requesting GraphQL data: {tpe}"
+except exceptions.TransportServerError as tse:
+    msg_text += f"Server error while requesting GraphQL data: {tse}"
+else:
+    failed_tasks = []
+
+    # Find the build we care about. We get all of the builds for the zeek org
+    # here so we have to filter both by repository and by build ID. Once we
+    # have it, find the failed tasks from it.
+    found_build = False
+    builds = result.get("ownerInfoByName", {}).get("builds", {}).get("edges", {})
+    for b in builds:
+        node = b.get("node", {})
+        if not node:
+            continue
+
+        repo_name = node.get("repository", {}).get("name", "")
+        if repo_name != "zeek":
+            continue
+
+        if node.get("id", "") != f"{CIRRUS_BUILD_ID}":
+            continue
+
+        found_build = True
+
+        tasks = node.get("tasks", {})
+        for t in tasks:
+            if t.get("status", "") != "FAILED":
+                continue
+
+            failed_tasks.append(t)
+
+    if not found_build:
+        msg_text += f"Failed to find build {CIRRUS_BUILD_ID} in the GraphQL output!"
+    else:
+        msg_text += "The following tasks failed: \n\n"
+        for t in failed_tasks:
+            msg_text += (
+                f"\t{t.get('name', '')}: https://cirrus-ci.com/task/{t.get('id', '')}\n"
+            )
+
+msg = MIMEText(msg_text)
+msg["Subject"] = f"Cirrus {CIRRUS_CRON} task failed"
+msg["From"] = "noreply@zeek.org"
+msg["To"] = "zeek-commits-internal@zeek.org"
+
+# This should get logged into the Cirrus output.
+print(msg_text)
+
+try:
+    context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+
+    smtp = smtplib.SMTP(SMTP_HOST, SMTP_PORT)
+    smtp.ehlo()
+    smtp.starttls(context=context)
+    smtp.ehlo()
+    smtp.login(SMTP_USER, SMTP_PASS)
+    smtp.send_message(msg)
+    smtp.quit()
+except Exception as e:
+    print(f"Failed to send email: {e}")


### PR DESCRIPTION
We currently have no way to know that a build started by one of the nightly or weekly cron jobs failed. This adds two new builds to the nightly/weekly builds that report status on failures via email, similar to the regular PR/master builds. I'm not a big fan of the `depends_on` section in the nightly one, but it's the only way to do it that I can see.