### PR TITLE
Make uncompilable functions for standalone-compilation-to-C++ a fatal error

### DIFF
--- a/src/script_opt/CPP/Driver.cc
+++ b/src/script_opt/CPP/Driver.cc
@@ -25,6 +25,13 @@ CPPCompile::CPPCompile(vector<FuncInfo>& _funcs, std::shared_ptr<ProfileFuncs> _
     }
 
     Compile(report_uncompilable);
+
+    if ( standalone && skipped_uncompilable_func && ! analysis_options.allow_cond ) {
+        reporter->Error(
+            "standalone C++ compilation incomplete due to having to skip some functions; use \"-O allow-cond\" to "
+            "override");
+        exit(1);
+    }
 }
 
 CPPCompile::~CPPCompile() { fclose(write_file); }
@@ -208,6 +215,7 @@ bool CPPCompile::AnalyzeFuncBody(FuncInfo& fi, unordered_set<string>& filenames_
             }
 
             fi.SetSkip(true);
+            skipped_uncompilable_func = true;
         }
     }
 
@@ -252,6 +260,8 @@ bool CPPCompile::AnalyzeFuncBody(FuncInfo& fi, unordered_set<string>& filenames_
         }
 
         not_fully_compilable.insert(f->GetName());
+        skipped_uncompilable_func = true;
+
         return false;
     }
 

--- a/src/script_opt/CPP/Driver.h
+++ b/src/script_opt/CPP/Driver.h
@@ -104,6 +104,9 @@ std::unordered_map<std::string, std::string> hashed_funcs;
 // If true, the generated code should run "standalone".
 bool standalone = false;
 
+// If true, compilation skipped at least one function due to non-compilability.
+bool skipped_uncompilable_func = false;
+
 // Hash over the functions in this compilation.  This is only needed for
 // "seatbelts", to ensure that we can produce a unique hash relating to this
 // compilation (*and* its compilation time, which is why these are "seatbelts"


### PR DESCRIPTION
Currently, `-O gen-standalone-C++` warns about uncompilable functions (due to presence of conditional code), but only treats them as warnings. That behavior has proven problematic when scripting up such compilation, where the warnings can be overlooked and then the generated code behaves incorrectly. This PR changes the presence of uncompilable functions in standalone compilation to result in a fatal compile-time error. This can be overridden using the (already present) `-O allow-cond` option.