### PR TITLE
Removing SetType

### DIFF
--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -1410,7 +1410,7 @@ TableValPtr DNS_Mgr::empty_addr_set() {
     auto addr_t = base_type(TYPE_ADDR);
     auto set_index = make_intrusive<TypeList>(addr_t);
     set_index->Append(std::move(addr_t));
-    auto s = make_intrusive<SetType>(std::move(set_index), nullptr);
+    auto s = make_intrusive<TableType>(std::move(set_index), nullptr);
     return make_intrusive<TableVal>(std::move(s));
 }
 

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -3366,7 +3366,7 @@ SetConstructorExpr::SetConstructorExpr(ListExprPtr constructor_list, std::unique
     }
     else {
         if ( op->AsListExpr()->Exprs().empty() )
-            SetType(make_intrusive<zeek::SetType>(make_intrusive<TypeList>(base_type(TYPE_ANY)), nullptr));
+            SetType(make_intrusive<TableType>(make_intrusive<TypeList>(base_type(TYPE_ANY)), nullptr));
         else
             SetType(init_type(op));
     }
@@ -4626,7 +4626,7 @@ TypePtr ListExpr::InitType() const {
 
             // Collapse any embedded sets or lists.
             if ( ti->IsSet() || ti->Tag() == TYPE_LIST ) {
-                TypeList* til = ti->IsSet() ? ti->AsSetType()->GetIndices().get() : ti->AsTypeList();
+                TypeList* til = ti->IsSet() ? ti->AsTableType()->GetIndices().get() : ti->AsTypeList();
 
                 if ( ! til->IsPure() || ! til->AllMatch(til->GetPureType(), true) )
                     tl->Append({NewRef{}, til});

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -93,6 +93,10 @@ TableType* Type::AsTableType() {
     return (TableType*)this;
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 const SetType* Type::AsSetType() const {
     if ( ! IsSet() )
         BadTag("Type::AsSetType", type_name(tag));
@@ -104,6 +108,9 @@ SetType* Type::AsSetType() {
         BadTag("Type::AsSetType", type_name(tag));
     return (SetType*)this;
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 const RecordType* Type::AsRecordType() const {
     CHECK_TYPE_TAG(TYPE_RECORD, "Type::AsRecordType");
@@ -561,50 +568,6 @@ bool TableType::DoExpireCheck(const detail::AttrPtr& attr) {
 
     return true;
 }
-
-SetType::SetType(TypeListPtr ind, detail::ListExprPtr arg_elements)
-    : TableType(std::move(ind), nullptr), elements(std::move(arg_elements)) {
-    if ( elements ) {
-        if ( indices ) { // We already have a type.
-            if ( ! check_and_promote_exprs(elements.get(), indices) )
-                SetError();
-        }
-        else {
-            TypeList* tl_type = elements->GetType()->AsTypeList();
-            const auto& tl = tl_type->GetTypes();
-
-            if ( tl.size() < 1 ) {
-                Error("no type given for set");
-                SetError();
-            }
-
-            else if ( tl.size() == 1 ) {
-                TypePtr ft{NewRef{}, flatten_type(tl[0].get())};
-                indices = make_intrusive<TypeList>(ft);
-                indices->Append(std::move(ft));
-            }
-
-            else {
-                auto t = merge_types(tl[0], tl[1]);
-
-                for ( size_t i = 2; t && i < tl.size(); ++i )
-                    t = merge_types(t, tl[i]);
-
-                if ( ! t ) {
-                    Error("bad set type");
-                    return;
-                }
-
-                indices = make_intrusive<TypeList>(t);
-                indices->Append(std::move(t));
-            }
-        }
-    }
-}
-
-TypePtr SetType::ShallowClone() { return make_intrusive<SetType>(indices, elements); }
-
-SetType::~SetType() = default;
 
 FuncType::Capture::Capture(detail::IDPtr _id, bool _deep_copy) : id(std::move(_id)), deep_copy(_deep_copy) {
     is_managed = id ? ZVal::IsManagedType(id->GetType()) : false;
@@ -1891,7 +1854,7 @@ static bool is_init_compat(const Type& t1, const Type& t2) {
     }
 
     if ( t1.IsSet() )
-        return same_type(*t1.AsSetType()->GetIndices(), t2, true);
+        return same_type(*t1.AsTableType()->GetIndices(), t2, true);
 
     return false;
 }
@@ -2331,10 +2294,7 @@ TypePtr merge_table_types(const Type* t1, const Type* t2) {
             return nullptr;
     }
 
-    if ( t1->IsSet() )
-        return make_intrusive<SetType>(std::move(tl3), nullptr);
-    else
-        return make_intrusive<TableType>(std::move(tl3), std::move(y3));
+    return make_intrusive<TableType>(std::move(tl3), std::move(y3));
 }
 
 TypePtr merge_func_types(const Type* t1, const Type* t2) {
@@ -2599,7 +2559,7 @@ static TableTypePtr init_table_type(detail::ListExpr* l) {
     return make_intrusive<TableType>(cast_intrusive<TypeList>(index), yield);
 }
 
-static SetTypePtr init_set_type(detail::ListExpr* l) {
+static TableTypePtr init_set_type(detail::ListExpr* l) {
     auto& elems = l->Exprs();
     TypePtr index;
 
@@ -2626,7 +2586,7 @@ static SetTypePtr init_set_type(detail::ListExpr* l) {
         ind_list->Append(index);
     }
 
-    return make_intrusive<SetType>(ind_list, nullptr);
+    return make_intrusive<TableType>(ind_list, nullptr);
 }
 
 TypePtr init_type(const detail::ExprPtr& init) {

--- a/src/Type.h
+++ b/src/Type.h
@@ -214,7 +214,10 @@ public:
     const TableType* AsTableType() const;
     TableType* AsTableType();
 
+    [[deprecated("Remove in v9.1. Use AsTableType() instead.")]]
     const SetType* AsSetType() const;
+
+    [[deprecated("Remove in v9.1. Use AsTableType() instead.")]]
     SetType* AsSetType();
 
     const RecordType* AsRecordType() const;
@@ -438,7 +441,7 @@ private:
     bool reported_error = false;
 };
 
-class SetType final : public TableType {
+class [[deprecated("Remove in v9.1. Use TableType instead.")]] SetType final : public TableType {
 public:
     SetType(TypeListPtr ind, detail::ListExprPtr arg_elements);
     ~SetType() override;

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1436,7 +1436,7 @@ TableValPtr ListVal::ToSetVal() const {
     const auto& pt = type->AsTypeList()->GetPureType();
     auto set_index = make_intrusive<TypeList>(pt);
     set_index->Append(base_type(tag));
-    auto s = make_intrusive<SetType>(std::move(set_index), nullptr);
+    auto s = make_intrusive<TableType>(std::move(set_index), nullptr);
     auto t = make_intrusive<TableVal>(std::move(s));
 
     for ( const auto& val : vals )
@@ -3915,7 +3915,7 @@ ValPtr cast_value_to_type(Val* v, Type* t) {
 
     // Allow casting between sets and vectors if the yield types are the same.
     if ( v->GetType()->IsSet() && IsVector(t->Tag()) ) {
-        auto set_type = v->GetType<SetType>();
+        auto set_type = v->GetType<TableType>();
         auto indices = set_type->GetIndices();
 
         if ( indices->GetTypes().size() > 1 )
@@ -3938,7 +3938,7 @@ ValPtr cast_value_to_type(Val* v, Type* t) {
         return ret;
     }
     else if ( IsVector(v->GetType()->Tag()) && t->IsSet() ) {
-        auto ret_type = IntrusivePtr<TableType>{NewRef{}, t->AsSetType()};
+        auto ret_type = IntrusivePtr<TableType>{NewRef{}, t->AsTableType()};
         auto ret = make_intrusive<TableVal>(ret_type);
 
         auto vv = v->AsVectorVal();
@@ -3960,11 +3960,11 @@ static bool can_cast_set_and_vector(const Type* t1, const Type* t2) {
     const VectorType* vt = nullptr;
 
     if ( t1->IsSet() && IsVector(t2->Tag()) ) {
-        st = t1->AsSetType();
+        st = t1->AsTableType();
         vt = t2->AsVectorType();
     }
     else if ( IsVector(t1->Tag()) && t2->IsSet() ) {
-        st = t2->AsSetType();
+        st = t2->AsTableType();
         vt = t1->AsVectorType();
     }
 

--- a/src/Var.cc
+++ b/src/Var.cc
@@ -216,20 +216,6 @@ static void make_var(const IDPtr& id, TypePtr t, InitClass c, ExprPtr init, std:
         }
     }
 
-    if ( t && t->IsSet() ) { // Check for set with explicit elements.
-        SetType* st = t->AsTableType()->AsSetType();
-        const auto& elements = st->Elements();
-
-        if ( elements ) {
-            if ( init ) {
-                id->Error("double initialization", init.get());
-                return;
-            }
-
-            init = elements;
-        }
-    }
-
     if ( ! t ) { // Take type from initialization.
         if ( ! init ) {
             id->Error("no type given");

--- a/src/broker/messaging.bif
+++ b/src/broker/messaging.bif
@@ -20,7 +20,7 @@ static bool is_string_set(const zeek::Type* type)
 	if ( ! type->IsSet() )
 		return false;
 
-	const auto& index_types = type->AsSetType()->GetIndexTypes();
+	const auto& index_types = type->AsTableType()->GetIndexTypes();
 
 	if ( index_types.size() != 1 )
 		return false;

--- a/src/input/Manager.cc
+++ b/src/input/Manager.cc
@@ -789,7 +789,7 @@ bool Manager::IsCompatibleType(Type* t, bool atomic_only) {
             if ( ! t->IsSet() )
                 return false;
 
-            const auto& indices = t->AsSetType()->GetIndices();
+            const auto& indices = t->AsTableType()->GetIndices();
 
             if ( indices->GetTypes().size() != 1 )
                 return false;
@@ -902,7 +902,7 @@ bool Manager::UnrollRecordType(vector<Field*>* fields, const RecordType* rec, co
             bool optional = false;
 
             if ( ty == TYPE_TABLE )
-                st = rec->GetFieldType(i)->AsSetType()->GetIndices()->GetPureType()->Tag();
+                st = rec->GetFieldType(i)->AsTableType()->GetIndices()->GetPureType()->Tag();
 
             else if ( ty == TYPE_VECTOR )
                 st = rec->GetFieldType(i)->AsVectorType()->Yield()->Tag();
@@ -2084,7 +2084,7 @@ Val* Manager::ValueToVal(const Stream* i, const Value* val, Type* request_type, 
             const auto& type = request_type->AsTableType()->GetIndices()->GetPureType();
             auto set_index = make_intrusive<TypeList>(type);
             set_index->Append(type);
-            auto s = make_intrusive<SetType>(std::move(set_index), nullptr);
+            auto s = make_intrusive<TableType>(std::move(set_index), nullptr);
             auto t = make_intrusive<TableVal>(std::move(s));
             for ( int j = 0; j < val->val.set_val.size; j++ ) {
                 Val* assignval = ValueToVal(i, val->val.set_val.vals[j], type.get(), have_error);

--- a/src/input/readers/config/Config.cc
+++ b/src/input/readers/config/Config.cc
@@ -41,7 +41,7 @@ Config::Config(ReaderFrontend* frontend) : ReaderBackend(frontend) {
         TypeTag primary = id->GetType()->Tag();
         TypeTag secondary = TYPE_VOID;
         if ( primary == TYPE_TABLE )
-            secondary = id->GetType()->AsSetType()->GetIndices()->GetPureType()->Tag();
+            secondary = id->GetType()->AsTableType()->GetIndices()->GetPureType()->Tag();
         else if ( primary == TYPE_VECTOR )
             secondary = id->GetType()->AsVectorType()->Yield()->Tag();
 

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -852,7 +852,7 @@ bool Manager::TraverseRecord(Stream* stream, Filter* filter, RecordType* rt, Tab
         TypeTag st = TYPE_VOID;
 
         if ( t->Tag() == TYPE_TABLE )
-            st = t->AsSetType()->GetIndices()->GetPureType()->Tag();
+            st = t->AsTableType()->GetIndices()->GetPureType()->Tag();
 
         else if ( t->Tag() == TYPE_VECTOR )
             st = t->AsVectorType()->Yield()->Tag();

--- a/src/parse.y
+++ b/src/parse.y
@@ -1211,7 +1211,7 @@ simple_type:
 	|	TOK_SET '[' type_list ']'
 			{
 			set_location(@1, @4);
-			$$ = new SetType({AdoptRef{}, $3}, nullptr);
+			$$ = new TableType({AdoptRef{}, $3}, nullptr);
 			}
 
 	|	TOK_RECORD '{'

--- a/src/threading/SerialTypes.cc
+++ b/src/threading/SerialTypes.cc
@@ -186,7 +186,7 @@ bool Value::IsCompatibleType(Type* t, bool atomic_only) {
             if ( ! t->IsSet() )
                 return false;
 
-            return IsCompatibleType(t->AsSetType()->GetIndices()->GetPureType().get(), true);
+            return IsCompatibleType(t->AsTableType()->GetIndices()->GetPureType().get(), true);
         }
 
         case TYPE_VECTOR: {
@@ -518,7 +518,7 @@ Val* Value::ValueToVal(const std::string& source, const Value* val, bool& have_e
                 set_index->Append(std::move(index_type));
             }
 
-            auto s = make_intrusive<SetType>(std::move(set_index), nullptr);
+            auto s = make_intrusive<TableType>(std::move(set_index), nullptr);
             auto t = make_intrusive<TableVal>(std::move(s));
             for ( int j = 0; j < val->val.set_val.size; j++ ) {
                 Val* assignval = ValueToVal(source, val->val.set_val.vals[j], have_error);

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -1437,7 +1437,7 @@ function table_keys%(t: any%): any
 		}
 
 	auto tl = t->GetType()->AsTableType()->GetIndices();
-	auto st = zeek::make_intrusive<zeek::SetType>(std::move(tl), nullptr);
+	auto st = zeek::make_intrusive<zeek::TableType>(std::move(tl), nullptr);
 	auto sv = zeek::make_intrusive<zeek::TableVal>(std::move(st));
 	auto th = t->AsTableVal()->GetTableHash();
 	for ( const auto& iter : *t->AsTable() )


### PR DESCRIPTION
Internally, Zeek doesn't track sets separately from tables (i.e., both types of values are represented by `TableVal`s and there is no analogous `SetVal`). This doesn't extend to the type system, however, which has `SetType` derived from `TableType` (peculiar, as Zeek `set`s are more restrictive than `table`s). This PR removes the type and replaces instances with `TableType`.

There are two nuances. The first is that `SetType` actually has a separate "elements" member not present in `TableType`. However, that value isn't actually provided anywhere (it's always `nullptr`), and also is only used for error-checking (which will never happen, given it's always `nullptr`). The second is that `SetType` isn't in `detail::` so this requires deprecation. I've included that, with the one caveat that for functions returning `SetType*` pointers, I've changed them to `TableType*` because otherwise Zeek's own compilation throws deprecation warnings. This change should be harmless given that in practice the two types are already the same.