### PR TITLE
-O gen-standalone-C++ fixes for tracking identifiers and aggregates

### DIFF
--- a/src/script_opt/CPP/Consts.cc
+++ b/src/script_opt/CPP/Consts.cc
@@ -43,16 +43,11 @@ shared_ptr<CPP_InitInfo> CPPCompile::RegisterConstant(const ValPtr& vp, int& con
         // render the same.
         t->Describe(&d);
 
-        // Likewise, tables that have attributes.
-        if ( t->Tag() == TYPE_TABLE ) {
-            const auto& attrs = v->AsTableVal()->GetAttrs();
-            if ( attrs )
-                attrs->Describe(&d);
-            else
-                d.Add("<no-attrs>");
-        }
-
         c_desc = d.Description();
+
+        // Aggregates need to be pointer-unique.
+        if ( IsAggr(t) )
+            c_desc += util::fmt("pointer %p", static_cast<void*>(v));
     }
 
     auto c = constants.find(c_desc);

--- a/src/script_opt/ProfileFunc.cc
+++ b/src/script_opt/ProfileFunc.cc
@@ -196,6 +196,8 @@ TraversalCode ProfileFunc::PreExpr(const Expr* e) {
             auto n = e->AsNameExpr();
             auto id = n->IdPtr();
 
+            TrackID(id);
+
             // Turns out that NameExpr's can be constructed using a
             // different Type* than that of the identifier itself,
             // so be sure we track the latter too.

--- a/src/script_opt/ProfileFunc.h
+++ b/src/script_opt/ProfileFunc.h
@@ -107,7 +107,6 @@ public:
     const std::vector<ExprPtr>& Exprs() const { return exprs; }
     const std::vector<const LambdaExpr*>& Lambdas() const { return lambdas; }
     const std::vector<const ConstExpr*>& Constants() const { return constants; }
-    const IDSet& UnorderedIdentifiers() const { return ids; }
     const std::vector<IDPtr>& OrderedIdentifiers() const { return ordered_ids; }
     const TypeSet& UnorderedTypes() const { return types; }
     const std::vector<const Type*>& OrderedTypes() const { return ordered_types; }


### PR DESCRIPTION
This PR fixes a couple of bugs in `-O gen-standalone-C++` where either (1) globals were not properly tracked, including their attributes, or (2) two identical aggregates were tracked as a single entity rather than as distinct entities. I also removed an unused accessor that is a bit confusing since there's already also an interface to a better version of the same information.