### PR TITLE
'?' operator precedence fix for -O gen-C++

### DIFF
--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -260,7 +260,7 @@ string CPPCompile::GenCondExpr(const Expr* e, GenType gt) {
     if ( op1->GetType()->Tag() == TYPE_VECTOR )
         return string("vector_select__CPP(") + gen1 + ", " + gen2 + ", " + gen3 + ")";
 
-    return string("(") + gen1 + ") ? (" + gen2 + ") : (" + gen3 + ")";
+    return string("((") + gen1 + ") ? (" + gen2 + ") : (" + gen3 + "))";
 }
 
 string CPPCompile::GenCallExpr(const CallExpr* c, GenType gt, bool top_level) {


### PR DESCRIPTION
`-O gen-C++` had a bug in it where it would compile `?` operations without enclosing the resulting C++ expression in parens. This could lead to C++ compilation errors when the C++ expression then had further operations applied to it.