### PR TITLE
Avoid starting up storage expiration thread with zero backends

### DIFF
--- a/src/storage/Manager.cc
+++ b/src/storage/Manager.cc
@@ -22,7 +22,7 @@ void detail::ExpirationTimer::Dispatch(double t, bool is_expire) {
     // start another one running. If this causes us to skip a cycle, that's not
     // a big deal as the next cycle will catch anything that should be expired
     // in the interim.
-    if ( ! expire_running.test_and_set() ) {
+    if ( ! expire_running.test_and_set() && storage_mgr->BackendCount() > 0 ) {
         DBG_LOG(DBG_STORAGE, "Starting new expiration thread");
         storage_mgr->expiration_thread = zeek::jthread([t]() { storage_mgr->Expire(t); });
     }
@@ -144,6 +144,13 @@ void Manager::RegisterBackend(BackendPtr backend) {
 
     backends.push_back(std::move(backend));
     DBG_LOG(DBG_STORAGE, "Registered backends: %zu", backends.size());
+}
+
+size_t Manager::BackendCount() {
+    // Expiration runs on a separate thread and loops over the vector of backends. The mutex
+    // here ensures exclusive access.
+    std::unique_lock<std::mutex> lk(backends_mtx);
+    return backends.size();
 }
 
 } // namespace zeek::storage

--- a/src/storage/Manager.cc
+++ b/src/storage/Manager.cc
@@ -100,8 +100,6 @@ OperationResult Manager::OpenBackend(BackendPtr backend, OpenResultCallback* cb,
 
     RegisterBackend(std::move(backend));
 
-    // TODO: post Storage::backend_opened event
-
     return res;
 }
 
@@ -116,11 +114,7 @@ OperationResult Manager::CloseBackend(BackendPtr backend, ResultCallback* cb) {
             backends.erase(it);
     }
 
-    auto res = backend->Close(cb);
-
-    // TODO: post Storage::backend_lost event
-
-    return res;
+    return backend->Close(cb);
 }
 
 void Manager::Expire(double t) {

--- a/src/storage/Manager.h
+++ b/src/storage/Manager.h
@@ -113,6 +113,7 @@ protected:
     friend class storage::detail::ExpirationTimer;
     void RunExpireThread();
     void StartExpirationTimer();
+    size_t BackendCount();
     zeek::jthread expiration_thread;
 
     friend class storage::OpenResultCallback;

--- a/testing/btest/scripts/base/frameworks/storage/redis-expiration.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis-expiration.zeek
@@ -4,7 +4,7 @@
 # @TEST-PORT: REDIS_PORT
 
 # @TEST-EXEC: btest-bg-run redis-server run-redis-server ${REDIS_PORT%/tcp}
-# @TEST-EXEC: zcat <$TRACES/echo-connections.pcap.gz | zeek -B storage -b -r - %INPUT > out
+# @TEST-EXEC: zeek -B storage -b %INPUT > out
 # @TEST-EXEC: btest-bg-wait -k 1
 
 # @TEST-EXEC: btest-diff out


### PR DESCRIPTION
This could be extended to keep track of what backends are using native expiration and only start up the thread if it would actually need to expire something, but this should do for most workloads.

Fixes #4742 

