### PR TITLE
Full tracking of the characteristics of globals for -O gen-standalone-C++

### DIFF
--- a/src/script_opt/CPP/InitsInfo.cc
+++ b/src/script_opt/CPP/InitsInfo.cc
@@ -390,8 +390,12 @@ GlobalInitInfo::GlobalInitInfo(CPPCompile* c, IDPtr g, string _CPP_name)
     else
         attrs = -1;
 
-    is_exported = g->IsExport();
-    is_option = g->IsOption();
+    gc.is_exported = g->IsExport();
+    gc.is_const = g->IsConst();
+    gc.is_option = g->IsOption();
+    gc.is_enum_const = g->IsEnumConst();
+    gc.is_type = g->IsType();
+
     val = ValElem(c, nullptr); // empty because we initialize dynamically
 
     if ( gt->Tag() == TYPE_FUNC && (! g->GetVal() || g->GetVal()->AsFunc()->GetKind() == Func::BUILTIN_FUNC) )
@@ -407,8 +411,11 @@ void GlobalInitInfo::InitializerVals(std::vector<std::string>& ivs) const {
     ivs.push_back(Fmt(type));
     ivs.push_back(Fmt(attrs));
     ivs.push_back(val);
-    ivs.push_back(Fmt(is_exported));
-    ivs.push_back(Fmt(is_option));
+    ivs.push_back(Fmt(gc.is_exported));
+    ivs.push_back(Fmt(gc.is_const));
+    ivs.push_back(Fmt(gc.is_option));
+    ivs.push_back(Fmt(gc.is_enum_const));
+    ivs.push_back(Fmt(gc.is_type));
     ivs.push_back(Fmt(func_with_no_val));
 }
 

--- a/src/script_opt/CPP/InitsInfo.h
+++ b/src/script_opt/CPP/InitsInfo.h
@@ -500,6 +500,16 @@ protected:
 };
 
 // Information for initializing a Zeek global.
+
+// Tracks all of the characteristics associated with a global.
+struct GlobalCharacteristics {
+    bool is_exported = false;
+    bool is_const = false;
+    bool is_option = false;
+    bool is_enum_const = false;
+    bool is_type = false;
+};
+
 class GlobalInitInfo : public GlobalLookupInitInfo {
 public:
     GlobalInitInfo(CPPCompile* c, IDPtr g, std::string CPP_name);
@@ -511,8 +521,7 @@ protected:
     int type;
     int attrs;
     std::string val;
-    bool is_exported;
-    bool is_option;
+    GlobalCharacteristics gc;
     bool func_with_no_val = false; // needed to handle some error situations
 };
 

--- a/src/script_opt/CPP/RuntimeInitSupport.cc
+++ b/src/script_opt/CPP/RuntimeInitSupport.cc
@@ -135,12 +135,21 @@ void activate_bodies__CPP(const char* fn, const char* module, bool exported, Typ
         event_registry->Register(e);
 }
 
-IDPtr lookup_global__CPP(const char* g, const TypePtr& t, bool exported) {
+IDPtr lookup_global__CPP(const char* g, const TypePtr& t, const GlobalCharacteristics& gc) {
     auto gl = lookup_ID(g, GLOBAL_MODULE_NAME, false, false, false);
 
     if ( ! gl ) {
-        gl = install_ID(g, GLOBAL_MODULE_NAME, true, exported);
+        gl = install_ID(g, GLOBAL_MODULE_NAME, true, gc.is_exported);
         gl->SetType(t);
+
+        if ( gc.is_const )
+            gl->SetConst();
+        if ( gc.is_option )
+            gl->SetOption();
+        if ( gc.is_enum_const )
+            gl->SetEnumConst();
+        if ( gc.is_type )
+            gl->MakeType();
     }
 
     return gl;

--- a/src/script_opt/CPP/RuntimeInitSupport.h
+++ b/src/script_opt/CPP/RuntimeInitSupport.h
@@ -6,6 +6,7 @@
 
 #include "zeek/Val.h"
 #include "zeek/script_opt/CPP/Func.h"
+#include "zeek/script_opt/CPP/InitsInfo.h"
 
 namespace zeek {
 
@@ -65,9 +66,9 @@ extern void register_scripts__CPP(p_hash_type h, void (*callback)());
 extern void activate_bodies__CPP(const char* fn, const char* module, bool exported, TypePtr t,
                                  std::vector<p_hash_type> hashes);
 
-// Looks for a global with the given name.  If not present, creates it
-// with the given type and export setting.
-extern IDPtr lookup_global__CPP(const char* g, const TypePtr& t, bool exported);
+// Looks for a global with the given name.  If not present, creates it with
+// the given type and characteristics.
+extern IDPtr lookup_global__CPP(const char* g, const TypePtr& t, const GlobalCharacteristics& gc);
 
 // Looks for a BiF with the given name.  Returns nil if not present.
 extern Func* lookup_bif__CPP(const char* bif);

--- a/src/script_opt/CPP/RuntimeInits.cc
+++ b/src/script_opt/CPP/RuntimeInits.cc
@@ -481,10 +481,7 @@ void CPP_GlobalLookupInit::Generate(InitsManager* im, std::vector<void*>& /* ini
 
 void CPP_GlobalInit::Generate(InitsManager* im, std::vector<void*>& /* inits_vec */, int /* offset */) const {
     auto& t = im->Types(type);
-    global = lookup_global__CPP(name, t, is_exported);
-
-    if ( is_option )
-        global->SetOption();
+    global = lookup_global__CPP(name, t, gc);
 
     if ( ! global->HasVal() ) {
         if ( val >= 0 )

--- a/src/script_opt/CPP/RuntimeInits.h
+++ b/src/script_opt/CPP/RuntimeInits.h
@@ -401,17 +401,21 @@ protected:
 
 class CPP_GlobalInit : public CPP_Init<void*> {
 public:
-    CPP_GlobalInit(IDPtr& _global, const char* _name, int _type, int _attrs, int _val, bool _is_exported,
-                   bool _is_option, bool _func_with_no_val)
+    CPP_GlobalInit(IDPtr& _global, const char* _name, int _type, int _attrs, int _val, bool is_exported, bool is_const,
+                   bool is_option, bool is_enum_const, bool is_type, bool _func_with_no_val)
         : CPP_Init<void*>(),
           global(_global),
           name(_name),
           type(_type),
           attrs(_attrs),
           val(_val),
-          is_exported(_is_exported),
-          is_option(_is_option),
-          func_with_no_val(_func_with_no_val) {}
+          func_with_no_val(_func_with_no_val) {
+        gc.is_exported = is_exported;
+        gc.is_const = is_const;
+        gc.is_option = is_option;
+        gc.is_enum_const = is_enum_const;
+        gc.is_type = is_type;
+    }
 
     void Generate(InitsManager* im, std::vector<void*>& /* inits_vec */, int /* offset */) const override;
 
@@ -421,8 +425,7 @@ protected:
     int type;
     int attrs;
     int val;
-    bool is_exported;
-    bool is_option;
+    GlobalCharacteristics gc;
     bool func_with_no_val;
 };
 


### PR DESCRIPTION
Compiling to standalone-C++ requires creating globals with all of their attributes, such as whether they are `option`s or if they represent types. A bunch of this characteristics-tracking was missing; this PR fixes that.