### PR TITLE
Fix for associating attributes with globals for -O gen-standalone-C++

### DIFF
--- a/src/script_opt/CPP/Inits.cc
+++ b/src/script_opt/CPP/Inits.cc
@@ -225,10 +225,9 @@ void CPPCompile::InitializeGlobals() {
 
         const auto& attrs = g->GetAttrs();
         if ( attrs ) {
-            string attr_tags;
-            string attr_vals;
-            BuildAttrs(attrs, attr_tags, attr_vals);
-            Emit("assign_attrs__CPP(%s, %s, %s);", globals[g->Name()], attr_tags, attr_vals);
+            auto attrs_offset = AttributesOffset(attrs);
+            auto attrs_str = "CPP__Attributes__[" + Fmt(attrs_offset) + "]";
+            Emit("%s->SetAttrs(%s);", globals[g->Name()], attrs_str);
         }
     }
 

--- a/src/script_opt/CPP/RuntimeOps.cc
+++ b/src/script_opt/CPP/RuntimeOps.cc
@@ -239,10 +239,6 @@ TableValPtr table_constructor__CPP(vector<ValPtr> indices, vector<ValPtr> vals, 
     return aggr;
 }
 
-void assign_attrs__CPP(IDPtr id, IntVec attr_tags, ValVec attr_vals) {
-    id->SetAttrs(build_attrs__CPP(std::move(attr_tags), std::move(attr_vals)));
-}
-
 RecordValPtr record_constructor__CPP(vector<ValPtr> vals, RecordTypePtr t) {
     auto rv = make_intrusive<RecordVal>(t);
     auto n = vals.size();

--- a/src/script_opt/CPP/RuntimeOps.h
+++ b/src/script_opt/CPP/RuntimeOps.h
@@ -229,9 +229,6 @@ extern TableValPtr set_constructor__CPP(ValVec elements, TableTypePtr t, IntVec 
 extern TableValPtr table_constructor__CPP(ValVec indices, ValVec vals, TableTypePtr t, IntVec attr_tags,
                                           ValVec attr_vals);
 
-// Assigns a set of attributes to an identifier.
-extern void assign_attrs__CPP(IDPtr id, IntVec attr_tags, ValVec attr_vals);
-
 // Constructs a record of the given type, whose (ordered) fields are
 // assigned to the corresponding elements of the given vector of values.
 extern RecordValPtr record_constructor__CPP(ValVec vals, RecordTypePtr t);


### PR DESCRIPTION
When creating globals at initialization time, `-O gen-standalone-C++` needs to associate attributes with them. It previously did this in a way where the value of any attribute with an associated expression was evaluated at initialization time, whereas the actual (um, undocumented) semantics are that it needs to be deferred until just after initialization. The difference between these two can be seen by a snippet like:
```
const delay = 1 min &redef;
global my_tbl: table[count] of string &create_expire = delay;
redef delay = 10 sec;
```
Previously, `-O gen-standalone-C++` would associate a `&create_expire` for `my_tbl` of 1 minute, whereas the interpreter would use the `redef` value of 10 seconds (which it does using [this hack](https://github.com/zeek/zeek/blob/b25a8442102449e7ee12f09e0068231c57cc835d/src/Val.cc#L1801-L1803)). This PR tweaks how `-O gen-standalone-C++` deals with such attributes to defer their evaluation (allowing us to get rid of a simple helper function the process).