### PR TITLE
Force SQLite to be in thread-safe mode during CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -467,8 +467,16 @@ set(THIRD_PARTY_SRCS
     3rdparty/strsep.c
     3rdparty/zeek_inet_ntop.c)
 
-if (USE_SQLITE AND WNOERROR_FLAG)
-    set_source_files_properties(3rdparty/sqlite3.c PROPERTIES COMPILE_FLAGS ${WNOERROR_FLAG})
+if (USE_SQLITE)
+    if (WNOERROR_FLAG)
+        set_source_files_properties(3rdparty/sqlite3.c PROPERTIES COMPILE_FLAGS ${WNOERROR_FLAG})
+    endif ()
+
+    # Always force building SQLite in thread-safe mode. This lets us remove sqlite3_threadsafe()
+    # checks in various places, since the library will always be guaranteed to be in thread-safe
+    # mode. This value is the default, but it's set here to be explicit about it.
+    set_source_files_properties(3rdparty/sqlite3.c PROPERTIES COMPILE_DEFINITIONS
+                                                              SQLITE_THREADSAFE=1)
 endif ()
 
 set_source_files_properties(${THIRD_PARTY_SRCS} PROPERTIES SKIP_LINTING ON)

--- a/src/input/readers/sqlite/SQLite.cc
+++ b/src/input/readers/sqlite/SQLite.cc
@@ -55,13 +55,6 @@ bool SQLite::checkError(int code) {
 }
 
 bool SQLite::DoInit(const ReaderInfo& info, int arg_num_fields, const threading::Field* const* arg_fields) {
-    if ( sqlite3_threadsafe() == 0 ) {
-        Error(
-            "SQLite reports that it is not threadsafe. Zeek needs a threadsafe version of "
-            "SQLite. Aborting");
-        return false;
-    }
-
     // Allow connections to same DB to use single data/schema cache. Also
     // allows simultaneous writes to one file.
 #ifndef ZEEK_TSAN

--- a/src/logging/writers/sqlite/SQLite.cc
+++ b/src/logging/writers/sqlite/SQLite.cc
@@ -96,13 +96,6 @@ bool SQLite::checkError(int code) {
 }
 
 bool SQLite::DoInit(const WriterInfo& info, int arg_num_fields, const Field* const* arg_fields) {
-    if ( sqlite3_threadsafe() == 0 ) {
-        Error(
-            "SQLite reports that it is not threadsafe. Zeek needs a threadsafe version of "
-            "SQLite. Aborting");
-        return false;
-    }
-
     // Allow connections to same DB to use single data/schema cache. Also
     // allows simultaneous writes to one file.
 #ifndef ZEEK_TSAN

--- a/src/storage/backend/sqlite/SQLite.cc
+++ b/src/storage/backend/sqlite/SQLite.cc
@@ -86,14 +86,6 @@ std::string SQLite::DoGetConfigMetricsLabel() const {
  * Called by the manager system to open the backend.
  */
 OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
-    if ( sqlite3_threadsafe() == 0 ) {
-        std::string res =
-            "SQLite reports that it is not threadsafe. Zeek needs a threadsafe version of "
-            "SQLite. Aborting";
-        Error(res.c_str());
-        return {ReturnCode::INITIALIZATION_FAILED, std::move(res)};
-    }
-
     // Allow connections to same DB to use single data/schema cache. Also
     // allows simultaneous writes to one file.
 #ifndef ZEEK_TSAN


### PR DESCRIPTION
This allows us to remove the need to check for thread-safe mode in the various SQLite plugins. See https://www.sqlite.org/compile.html#threadsafe for why `1` is a good choice here.

Fixes #4285 