### PR TITLE
OpaqueVal, OCSP, X509: drop outdated LibreSSL guards to fix OpenBSD build

### DIFF
--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -27,11 +27,11 @@
 #include "zeek/probabilistic/BloomFilter.h"
 #include "zeek/probabilistic/CardinalityCounter.h"
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
 inline void* EVP_MD_CTX_md_data(const EVP_MD_CTX* ctx) { return ctx->md_data; }
 #endif
 
-#if ( OPENSSL_VERSION_NUMBER < 0x30000000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x30000000L )
 #include <openssl/md5.h>
 #endif
 
@@ -225,7 +225,7 @@ constexpr size_t SHA1VAL_STATE_SIZE = sizeof(SHA_CTX);
 
 constexpr size_t SHA256VAL_STATE_SIZE = sizeof(SHA256_CTX);
 
-#if ( OPENSSL_VERSION_NUMBER < 0x30000000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x30000000L )
 
 // -- MD5
 

--- a/src/file_analysis/analyzer/x509/OCSP.cc
+++ b/src/file_analysis/analyzer/x509/OCSP.cc
@@ -26,7 +26,7 @@ namespace zeek::file_analysis::detail {
 static constexpr size_t OCSP_STRING_BUF_SIZE = 2048;
 
 static bool OCSP_RESPID_bio(OCSP_BASICRESP* basic_resp, BIO* bio) {
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
     ASN1_OCTET_STRING* key = nullptr;
     X509_NAME* name = nullptr;
 
@@ -353,7 +353,7 @@ void OCSP::ParseRequest(OCSP_REQUEST* req) {
 
     uint64_t version = 0;
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
     if ( req->tbsRequest->version )
         version = (uint64_t)ASN1_INTEGER_get(req->tbsRequest->version);
 #else
@@ -425,7 +425,7 @@ void OCSP::ParseResponse(OCSP_RESPONSE* resp) {
     if ( ! basic_resp )
         goto clean_up;
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
     resp_data = basic_resp->tbsResponseData;
     if ( ! resp_data )
         goto clean_up;
@@ -434,7 +434,7 @@ void OCSP::ParseResponse(OCSP_RESPONSE* resp) {
     vl.emplace_back(GetFile()->ToVal());
     vl.emplace_back(std::move(status_val));
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
     vl.emplace_back(val_mgr->Count((uint64_t)ASN1_INTEGER_get(resp_data->version)));
 #else
     vl.emplace_back(parse_basic_resp_data_version(basic_resp));
@@ -452,7 +452,7 @@ void OCSP::ParseResponse(OCSP_RESPONSE* resp) {
     }
 
     // producedAt
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
     produced_at = resp_data->producedAt;
 #else
     produced_at = OCSP_resp_get0_produced_at(basic_resp);
@@ -477,7 +477,7 @@ void OCSP::ParseResponse(OCSP_RESPONSE* resp) {
         // cert id
         const OCSP_CERTID* cert_id = nullptr;
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
         cert_id = single_resp->certId;
 #else
         cert_id = OCSP_SINGLERESP_get0_id(single_resp);
@@ -550,7 +550,7 @@ void OCSP::ParseResponse(OCSP_RESPONSE* resp) {
         }
     }
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
     i2a_ASN1_OBJECT(bio, basic_resp->signatureAlgorithm->algorithm);
     len = BIO_read(bio, buf, sizeof(buf));
     vl.emplace_back(make_intrusive<StringVal>(len, buf));
@@ -567,7 +567,7 @@ void OCSP::ParseResponse(OCSP_RESPONSE* resp) {
     certs_vector = new VectorVal(id::find_type<VectorType>("x509_opaque_vector"));
     vl.emplace_back(AdoptRef{}, certs_vector);
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
     certs = basic_resp->certs;
 #else
     certs = OCSP_resp_get0_certs(basic_resp);

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -9,13 +9,13 @@
 #include "zeek/OpaqueVal.h"
 #include "zeek/file_analysis/analyzer/x509/X509Common.h"
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10002000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10002000L )
 
 #define X509_get_signature_nid(x) OBJ_obj2nid((x)->sig_alg->algorithm)
 
 #endif
 
-#if ( OPENSSL_VERSION_NUMBER < 0x1010000fL ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x1010000fL )
 
 #define X509_OBJECT_new() (X509_OBJECT*)malloc(sizeof(X509_OBJECT))
 #define X509_OBJECT_free(a) free(a)

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -65,7 +65,7 @@ X509* x509_get_ocsp_signer(const STACK_OF(X509)* certs,
 	const ASN1_OCTET_STRING* key  = nullptr;
 	const X509_NAME*         name = nullptr;
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
 	OCSP_RESPID* resp_id = basic_resp->tbsResponseData->responderId;
 
 	if ( resp_id->type == V_OCSP_RESPID_NAME )
@@ -359,7 +359,7 @@ function x509_ocsp_verify%(certs: x509_opaque_vector, ocsp_reply: string, root_c
 
 	// Because we actually want to be able to give nice error messages that show why we were
 	// not able to verify the OCSP response - do our own verification logic first.
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
 	signer = x509_get_ocsp_signer(basic->certs, basic);
 #else
 	signer = x509_get_ocsp_signer(OCSP_resp_get0_certs(basic), basic);
@@ -730,7 +730,7 @@ function sct_verify%(cert: opaque of x509, logid: string, log_key: string, signa
 	uint32_t cert_length;
 	if ( precert )
 		{
-#if ( OPENSSL_VERSION_NUMBER < 0x10002000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10002000L )
 		x->cert_info->enc.modified = 1;
 		cert_length = i2d_X509_CINF(x->cert_info, &cert_out);
 #else


### PR DESCRIPTION
Whatever is used with recent OpenSSL is also available under with latest LibreSSL
on OpenBSD 7.8-beta as of today.

Some of these hunks have been in the net/bro port for years, others I
recently added whilst gradually updating from 6.0.5 to 8.0.1.
