### PR TITLE
-O gen-standalone-C++ additional fixes

### DIFF
--- a/src/script_opt/CPP/Driver.cc
+++ b/src/script_opt/CPP/Driver.cc
@@ -83,8 +83,21 @@ void CPPCompile::Compile(bool report_uncompilable) {
                     accessed_globals.insert(g);
                 for ( auto& ag : pf->AllGlobals() )
                     all_accessed_globals.insert(ag);
+                for ( auto& l : pf->Lambdas() )
+                    // We might not have profiled this previously if none
+                    // of the functions refer to the global. This can
+                    // happen for example for a global "const" table that's
+                    // made available for external lookup use.
+                    pfs->ProfileLambda(l);
             }
         }
+
+        for ( auto& g : pfs->BiFGlobals() )
+            all_accessed_globals.insert(g);
+
+        for ( auto& t : pfs->MainTypes() )
+            if ( obj_matches_opt_files(t) == AnalyzeDecision::SHOULD )
+                rep_types.insert(TypeRep(t));
 
         for ( auto& l : pfs->Lambdas() )
             if ( obj_matches_opt_files(l) == AnalyzeDecision::SHOULD )

--- a/src/script_opt/ProfileFunc.cc
+++ b/src/script_opt/ProfileFunc.cc
@@ -622,6 +622,20 @@ ProfileFuncs::ProfileFuncs(std::vector<FuncInfo>& funcs, is_compilable_pred pred
     ComputeSideEffects();
 }
 
+void ProfileFuncs::ProfileLambda(const LambdaExpr* l) {
+    if ( lambdas.contains(l) )
+        return;
+
+    lambdas.insert(l);
+    pending_exprs.push_back(l);
+
+    do
+        DrainPendingExprs();
+    while ( ! pending_exprs.empty() );
+
+    AnalyzeLambdaProfile(l);
+}
+
 bool ProfileFuncs::IsTableWithDefaultAggr(const Type* t) {
     auto analy = tbl_has_aggr_default.find(t);
     if ( analy != tbl_has_aggr_default.end() )
@@ -848,14 +862,22 @@ void ProfileFuncs::ComputeBodyHashes(std::vector<FuncInfo>& funcs) {
             ComputeProfileHash(f.ProfilePtr());
     }
 
-    for ( auto& l : lambdas ) {
-        auto pf = ExprProf(l);
-        func_profs[l->PrimaryFunc().get()] = pf;
-        lambda_primaries[l->Name()] = l->PrimaryFunc().get();
+    for ( auto& l : lambdas )
+        AnalyzeLambdaProfile(l);
+}
 
-        if ( compute_func_hashes || ! pf->HasHashVal() )
-            ComputeProfileHash(pf);
-    }
+void ProfileFuncs::AnalyzeLambdaProfile(const LambdaExpr* l) {
+    if ( processed_lambdas.contains(l) )
+        return;
+
+    processed_lambdas.insert(l);
+
+    auto pf = ExprProf(l);
+    func_profs[l->PrimaryFunc().get()] = pf;
+    lambda_primaries[l->Name()] = l->PrimaryFunc().get();
+
+    if ( compute_func_hashes || ! pf->HasHashVal() )
+        ComputeProfileHash(pf);
 }
 
 void ProfileFuncs::ComputeProfileHash(std::shared_ptr<ProfileFunc> pf) {

--- a/src/script_opt/ProfileFunc.h
+++ b/src/script_opt/ProfileFunc.h
@@ -366,6 +366,10 @@ public:
     ProfileFuncs(std::vector<FuncInfo>& funcs, is_compilable_pred pred, bool compute_func_hashes,
                  bool full_record_hashes);
 
+    // Used to profile additional lambdas that (potentially) weren't part
+    // of the overall function profiling.
+    void ProfileLambda(const LambdaExpr* l);
+
     // The following accessors provide a global profile across all of
     // the (non-skipped) functions in "funcs".  See the comments for
     // the associated member variables for documentation.
@@ -448,6 +452,9 @@ protected:
 
     // Compute hashes to associate with each function
     void ComputeBodyHashes(std::vector<FuncInfo>& funcs);
+
+    // For a given lambda, completes analysis of its profile.
+    void AnalyzeLambdaProfile(const LambdaExpr* l);
 
     // Compute the hash associated with a single function profile.
     void ComputeProfileHash(std::shared_ptr<ProfileFunc> pf);
@@ -539,6 +546,10 @@ protected:
 
     // And for lambda's.
     std::unordered_set<const LambdaExpr*> lambdas;
+
+    // Lambdas that we have already processed. An optimization to avoid
+    // unnecessary work.
+    std::unordered_set<const LambdaExpr*> processed_lambdas;
 
     // Names of generated events.
     std::unordered_set<std::string> events;


### PR DESCRIPTION
Here's a set of fixes for `-O gen-standalone-C++`. They're all oriented around sufficient tracking of compilation objects to ensure proper initialization: attributes associated with globals; types, BiFs and lambdas present in record attributes; and independent globals that the compiled scripts don't themselves refer to other than to export them for use by others.

The changes are collectively small enough that I thought I'd bundle these into a single PR.