### PR TITLE
Remove checks for LibreSSL and old versions of OpenSSL

### DIFF
--- a/src/OpaqueVal.cc
+++ b/src/OpaqueVal.cc
@@ -27,10 +27,6 @@
 #include "zeek/probabilistic/BloomFilter.h"
 #include "zeek/probabilistic/CardinalityCounter.h"
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
-inline void* EVP_MD_CTX_md_data(const EVP_MD_CTX* ctx) { return ctx->md_data; }
-#endif
-
 #if ( OPENSSL_VERSION_NUMBER < 0x30000000L )
 #include <openssl/md5.h>
 #endif

--- a/src/digest.cc
+++ b/src/digest.cc
@@ -12,11 +12,6 @@
 
 #include "zeek/Reporter.h"
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
-#define EVP_MD_CTX_new EVP_MD_CTX_create
-#define EVP_MD_CTX_free EVP_MD_CTX_destroy
-#endif
-
 static_assert(ZEEK_MD5_DIGEST_LENGTH == MD5_DIGEST_LENGTH);
 
 static_assert(ZEEK_SHA_DIGEST_LENGTH == SHA_DIGEST_LENGTH);

--- a/src/digest.cc
+++ b/src/digest.cc
@@ -12,7 +12,7 @@
 
 #include "zeek/Reporter.h"
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
 #define EVP_MD_CTX_new EVP_MD_CTX_create
 #define EVP_MD_CTX_free EVP_MD_CTX_destroy
 #endif

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -349,7 +349,7 @@ void X509::ParseSAN(X509_EXTENSION* ext) {
             }
 
             auto len = ASN1_STRING_length(gen->d.ia5);
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
             const char* name = (const char*)ASN1_STRING_data(gen->d.ia5);
 #else
             const char* name = (const char*)ASN1_STRING_get0_data(gen->d.ia5);

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -161,13 +161,9 @@ RecordValPtr X509::ParseCertificate(X509Val* cert_val, file_analysis::File* f) {
 
     pX509Cert->Assign(7, buf);
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
-    i2a_ASN1_OBJECT(bio, ssl_cert->sig_alg->algorithm);
-#else
     const ASN1_OBJECT* alg;
     X509_ALGOR_get0(&alg, nullptr, nullptr, X509_get0_tbs_sigalg(ssl_cert));
     i2a_ASN1_OBJECT(bio, alg);
-#endif
     len = BIO_gets(bio, buf, sizeof(buf));
     pX509Cert->Assign(13, make_intrusive<StringVal>(len, buf));
     BIO_free(bio);
@@ -349,11 +345,7 @@ void X509::ParseSAN(X509_EXTENSION* ext) {
             }
 
             auto len = ASN1_STRING_length(gen->d.ia5);
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
-            const char* name = (const char*)ASN1_STRING_data(gen->d.ia5);
-#else
             const char* name = (const char*)ASN1_STRING_get0_data(gen->d.ia5);
-#endif
             auto bs = make_intrusive<StringVal>(len, name);
 
             switch ( gen->type ) {

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -9,25 +9,6 @@
 #include "zeek/OpaqueVal.h"
 #include "zeek/file_analysis/analyzer/x509/X509Common.h"
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10002000L )
-
-#define X509_get_signature_nid(x) OBJ_obj2nid((x)->sig_alg->algorithm)
-
-#endif
-
-#if ( OPENSSL_VERSION_NUMBER < 0x1010000fL )
-
-#define X509_OBJECT_new() (X509_OBJECT*)malloc(sizeof(X509_OBJECT))
-#define X509_OBJECT_free(a) free(a)
-
-#define OCSP_resp_get0_certs(x) (x)->certs
-
-#define EVP_PKEY_get0_DSA(p) ((p)->pkey.dsa)
-#define EVP_PKEY_get0_EC_KEY(p) ((p)->pkey.ec)
-#define EVP_PKEY_get0_RSA(p) ((p)->pkey.rsa)
-
-#endif
-
 namespace zeek::file_analysis::detail {
 
 class X509Val;

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -26,36 +26,6 @@
 #define EVP_PKEY_get0_EC_KEY(p) ((p)->pkey.ec)
 #define EVP_PKEY_get0_RSA(p) ((p)->pkey.rsa)
 
-#if ! defined(LIBRESSL_VERSION_NUMBER) || (LIBRESSL_VERSION_NUMBER < 0x2070000fL)
-
-#define OCSP_SINGLERESP_get0_id(s) (s)->certId
-
-static X509* X509_OBJECT_get0_X509(const X509_OBJECT* a) {
-    if ( a == nullptr || a->type != X509_LU_X509 )
-        return nullptr;
-    return a->data.x509;
-}
-
-static void DSA_get0_pqg(const DSA* d, const BIGNUM** p, const BIGNUM** q, const BIGNUM** g) {
-    if ( p != nullptr )
-        *p = d->p;
-    if ( q != nullptr )
-        *q = d->q;
-    if ( g != nullptr )
-        *g = d->g;
-}
-
-static void RSA_get0_key(const RSA* r, const BIGNUM** n, const BIGNUM** e, const BIGNUM** d) {
-    if ( n != nullptr )
-        *n = r->n;
-    if ( e != nullptr )
-        *e = r->e;
-    if ( d != nullptr )
-        *d = r->d;
-}
-
-#endif
-
 #endif
 
 namespace zeek::file_analysis::detail {

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -65,19 +65,8 @@ X509* x509_get_ocsp_signer(const STACK_OF(X509)* certs,
 	const ASN1_OCTET_STRING* key  = nullptr;
 	const X509_NAME*         name = nullptr;
 
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
-	OCSP_RESPID* resp_id = basic_resp->tbsResponseData->responderId;
-
-	if ( resp_id->type == V_OCSP_RESPID_NAME )
-		name = resp_id->value.byName;
-	else if ( resp_id->type == V_OCSP_RESPID_KEY )
-		key = resp_id->value.byKey;
-	else
-		return nullptr;
-#else
 	if ( ! OCSP_resp_get0_id(basic_resp, &key, &name) )
 		return nullptr;
-#endif
 
 	if ( name )
 		return X509_find_by_subject(const_cast<STACK_OF(X509)*>(certs),
@@ -359,11 +348,7 @@ function x509_ocsp_verify%(certs: x509_opaque_vector, ocsp_reply: string, root_c
 
 	// Because we actually want to be able to give nice error messages that show why we were
 	// not able to verify the OCSP response - do our own verification logic first.
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
-	signer = x509_get_ocsp_signer(basic->certs, basic);
-#else
 	signer = x509_get_ocsp_signer(OCSP_resp_get0_certs(basic), basic);
-#endif
 
 	/*
 	Do this perhaps - OpenSSL also cannot do it, so I do not really feel bad about it.
@@ -730,12 +715,7 @@ function sct_verify%(cert: opaque of x509, logid: string, log_key: string, signa
 	uint32_t cert_length;
 	if ( precert )
 		{
-#if ( OPENSSL_VERSION_NUMBER < 0x10002000L )
-		x->cert_info->enc.modified = 1;
-		cert_length = i2d_X509_CINF(x->cert_info, &cert_out);
-#else
 		cert_length = i2d_re_X509_tbs(x, &cert_out);
-#endif
 		data.append(reinterpret_cast<const char*>(issuer_key_hash->Bytes()), issuer_key_hash->Len());
 		}
 	else
@@ -1058,11 +1038,7 @@ function x509_check_cert_hostname%(cert_opaque: opaque of x509, hostname: string
 				continue;
 
 			std::size_t len = ASN1_STRING_length(gen->d.ia5);
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
-			auto* name = reinterpret_cast<const char*>(ASN1_STRING_data(gen->d.ia5));
-#else
 			auto* name = reinterpret_cast<const char*>(ASN1_STRING_get0_data(gen->d.ia5));
-#endif
 			std::string_view nameview {name, len};
 			if ( check_hostname(hostview, nameview) )
 				{

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -1058,7 +1058,7 @@ function x509_check_cert_hostname%(cert_opaque: opaque of x509, hostname: string
 				continue;
 
 			std::size_t len = ASN1_STRING_length(gen->d.ia5);
-#if ( OPENSSL_VERSION_NUMBER < 0x10100000L ) || defined(LIBRESSL_VERSION_NUMBER)
+#if ( OPENSSL_VERSION_NUMBER < 0x10100000L )
 			auto* name = reinterpret_cast<const char*>(ASN1_STRING_data(gen->d.ia5));
 #else
 			auto* name = reinterpret_cast<const char*>(ASN1_STRING_get0_data(gen->d.ia5));


### PR DESCRIPTION
This is a follow-up to https://github.com/zeek/zeek/pull/4843. It removes some LibreSSL checks that were missed in the previous PR, but the primary change is to remove a bunch of checks for OpenSSL 1.x versions. I left checks that were looking at 3.x versions, but those might be able to be removed as well.