### PR TITLE
Supervisor: Make last_signal atomic to squelch data race

### DIFF
--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -415,7 +415,7 @@ static ForkResult fork_with_stdio_redirect(const char* where) {
 
 void Supervisor::HandleChildSignal() {
     if ( last_signal >= 0 ) {
-        DBG_LOG(DBG_SUPERVISOR, "Supervisor received signal %d", last_signal);
+        DBG_LOG(DBG_SUPERVISOR, "Supervisor received signal %d", last_signal.load());
         last_signal = -1;
     }
 

--- a/src/supervisor/Supervisor.h
+++ b/src/supervisor/Supervisor.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <sys/types.h>
+#include <atomic>
 #include <chrono>
 #include <map>
 #include <memory>
@@ -323,7 +324,7 @@ private:
 
     Config config;
     pid_t stem_pid;
-    int last_signal = -1;
+    std::atomic<int> last_signal = -1;
     std::unique_ptr<detail::PipePair> stem_pipe;
     detail::LineBufferedPipe stem_stdout;
     detail::LineBufferedPipe stem_stderr;


### PR DESCRIPTION
When the stem process terminates and SIGCHLD is sent to the supervisor, the signal might be handled by the main thread or any other threads that aren't blocking SIGCHLD explicitly. Convert last_signal to a std::atomic<int> such that non-main threads can safely set last_signal without triggering data race as reported by TSAN. This doesn't make it less racy to work last_signal, but it appears we only use it for debug printing anyhow and another option might have been to just remove last_signal altogether.

Follow-up for #4849