### PR TITLE
Reduce Conn class size

### DIFF
--- a/src/Conn.cc
+++ b/src/Conn.cc
@@ -43,8 +43,8 @@ Connection::Connection(zeek::IPBasedConnKeyPtr k, double t, uint32_t flow, const
 
     orig_flow_label = flow;
     resp_flow_label = 0;
-    saw_first_orig_packet = 1;
-    saw_first_resp_packet = 0;
+    saw_first_orig_packet = true;
+    saw_first_resp_packet = false;
 
     if ( pkt->l2_src )
         memcpy(orig_l2_addr, pkt->l2_src, sizeof(orig_l2_addr));
@@ -59,11 +59,11 @@ Connection::Connection(zeek::IPBasedConnKeyPtr k, double t, uint32_t flow, const
     vlan = pkt->vlan;
     inner_vlan = pkt->inner_vlan;
 
-    weird = 0;
+    weird = false;
 
     suppress_event = 0;
 
-    finished = 0;
+    finished = false;
 
     adapter = nullptr;
     primary_PIA = nullptr;
@@ -119,7 +119,7 @@ void Connection::CheckEncapsulation(const std::shared_ptr<EncapsulationStack>& a
 }
 
 void Connection::Done() {
-    finished = 1;
+    finished = true;
 
     if ( adapter ) {
         if ( ConnTransport() == TRANSPORT_TCP ) {
@@ -273,7 +273,7 @@ void Connection::RemovalEvent() {
 }
 
 void Connection::Weird(const char* name, const char* addl, const char* source) {
-    weird = 1;
+    weird = true;
     reporter->Weird(this, name, addl ? addl : "", source ? source : "");
 }
 
@@ -395,9 +395,9 @@ void Connection::CheckFlowLabel(bool is_orig, uint32_t flow_label) {
     }
 
     if ( is_orig )
-        saw_first_orig_packet = 1;
+        saw_first_orig_packet = true;
     else
-        saw_first_resp_packet = 1;
+        saw_first_resp_packet = true;
 }
 
 bool Connection::PermitWeird(const char* name, uint64_t threshold, uint64_t rate, double duration) {

--- a/src/Conn.h
+++ b/src/Conn.h
@@ -147,7 +147,7 @@ public:
     void RemovalEvent() override;
 
     void Weird(const char* name, const char* addl = "", const char* source = "");
-    bool DidWeird() const { return weird != 0; }
+    bool DidWeird() const { return weird; }
 
     inline bool FlagEvent(ConnEventToFlag e) {
         if ( e >= 0 && e < NUM_EVENTS_TO_FLAG ) {
@@ -199,8 +199,7 @@ private:
 
     IPAddr orig_addr;
     IPAddr resp_addr;
-    uint32_t orig_port, resp_port; // in network order
-    TransportProto proto;
+    uint32_t orig_port, resp_port;             // in network order
     uint32_t orig_flow_label, resp_flow_label; // most recent IPv6 flow labels
     uint32_t vlan, inner_vlan;                 // VLAN this connection traverses, if available
     u_char orig_l2_addr[Packet::L2_ADDR_LEN];  // Link-layer originator address, if available
@@ -208,13 +207,15 @@ private:
     int suppress_event;                        // suppress certain events to once per conn.
     RecordValPtr conn_val;
     std::shared_ptr<EncapsulationStack> encapsulation; // tunnels
-    uint8_t tunnel_changes = 0;
 
     IPBasedConnKeyPtr key;
 
-    unsigned int weird : 1;
-    unsigned int finished : 1;
-    unsigned int saw_first_orig_packet : 1, saw_first_resp_packet : 1;
+    TransportProto proto;
+    uint8_t tunnel_changes = 0;
+    bool weird;
+    bool finished;
+    bool saw_first_orig_packet;
+    bool saw_first_resp_packet;
 
     packet_analysis::IP::SessionAdapter* adapter;
     analyzer::pia::PIA* primary_PIA;


### PR DESCRIPTION
This reduces Conn instances from 408 bytes to 344 bytes of size.

* std::unordered_map for weird_state takes 56 bytes. Replace with unique_ptr and allocate lazily. Not all connections have a need to track weirds
* Some better packing of members, also dropping bitfields and replacing them with `bool`. We didn't pack good enough to justify bitfields anyhow.