### PR TITLE
Use strlcpy() instead of strncpy()

### DIFF
--- a/src/Base64.cc
+++ b/src/Base64.cc
@@ -203,7 +203,7 @@ int Base64Converter::Done(int* pblen, char** pbuf) {
 }
 
 void Base64Converter::IllegalEncoding(const char* msg) {
-    // strncpy(error_msg, msg, sizeof(error_msg));
+    // strlcpy(error_msg, msg, sizeof(error_msg));
     if ( conn )
         conn->Weird("base64_illegal_encoding", msg);
     else

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -419,7 +419,7 @@ static void query_cb(void* arg, ares_status_t status, size_t timeouts, const are
                 }
 
                 he.h_name = new char[abin_len + 1];
-                strncpy(he.h_name, reinterpret_cast<const char*>(abin), abin_len);
+                strlcpy(he.h_name, reinterpret_cast<const char*>(abin), abin_len + 1);
                 he.h_name[abin_len] = 0;
                 he.h_aliases = nullptr;
 

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -203,7 +203,7 @@ void TelnetAuthenticateOption::RecvSubOption(u_char* data, int len) {
 
         case AUTHENTICATION_NAME: {
             char* auth_name = new char[len];
-            util::safe_strncpy(auth_name, (char*)data + 1, len);
+            strlcpy(auth_name, (char*)data + 1, len);
             endp->SetAuthName(auth_name);
         } break;
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -93,7 +93,7 @@ const char* last_tok_filename = 0;
 const char* last_last_tok_filename = 0;
 char last_tok[128];
 
-#define YY_USER_ACTION	strncpy(last_tok, yytext, sizeof(last_tok) - 1); \
+#define YY_USER_ACTION	strlcpy(last_tok, yytext, sizeof(last_tok)); \
                         last_last_tok_filename = last_tok_filename; \
                         last_tok_filename = ::filename;
 #define YY_USER_INIT	last_tok[0] = '\0';

--- a/src/util.cc
+++ b/src/util.cc
@@ -1316,11 +1316,8 @@ char* uitoa_n(uint64_t value, char* str, int n, int base, const char* prefix) {
     uint64_t v;
     char c;
 
-    if ( prefix ) {
-        strncpy(str, prefix, n - 1);
-        str[n - 1] = '\0';
-        i += strlen(prefix);
-    }
+    if ( prefix )
+        i += strlcpy(str, prefix, n - 1);
 
     if ( i >= n - 1 )
         return str;
@@ -2220,7 +2217,7 @@ static void strerror_r_helper(char* result, char* buf, size_t buflen) {
     // Seems the GNU flavor of strerror_r may return a pointer to a static
     // string. So try to copy as much as possible into desired buffer.
     auto len = strlen(result);
-    strncpy(buf, result, buflen);
+    strlcpy(buf, result, buflen);
 
     if ( len >= buflen )
         buf[buflen - 1] = 0;

--- a/src/util.h
+++ b/src/util.h
@@ -470,9 +470,8 @@ inline void* safe_malloc(size_t size) {
 }
 
 inline char* safe_strncpy(char* dest, const char* src, size_t n) {
-    char* result = strncpy(dest, src, n - 1);
-    dest[n - 1] = '\0';
-    return result;
+    size_t last = strlcpy(dest, src, n);
+    return &dest[last];
 }
 
 // Memory alignment helpers.


### PR DESCRIPTION
`strlcpy()` was previously not generally available on Linux, but it was added to glibc in v2.38. This PR switches us away from `strncpy()` calls with that instead, since it's typically safer (in that it forces the null termination). It's also mostly to check if it's available on all of our platforms. It might not be on Windows, but I can add it to `libunistd` if that's the only one missing.