### PR TITLE
Bug fix for --optimize-file/--no-optimize-file

### DIFF
--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -160,15 +160,18 @@ AnalyzeDecision filename_matches_opt_files(const char* filename) {
 
     auto fin = util::detail::normalize_path(filename);
 
-    for ( auto& s : analysis_options.skip_files )
+    for ( auto& s : sfiles )
         if ( std::regex_match(fin, s) )
             return AnalyzeDecision::SHOULD_NOT;
+
+    if ( ofiles.empty() )
+        return AnalyzeDecision::DEFAULT;
 
     for ( auto& o : ofiles )
         if ( std::regex_match(fin, o) )
             return AnalyzeDecision::SHOULD;
 
-    return AnalyzeDecision::DEFAULT;
+    return AnalyzeDecision::SHOULD_NOT;
 }
 
 AnalyzeDecision obj_matches_opt_files(const Obj* obj) {


### PR DESCRIPTION
The logic in deciding whether or not to apply script optimization to an object from a given file could generate incorrect decisions for certain combinations of `--optimize-file`/`--no-optimize-file`. This simple PR corrects that.