### PR TITLE
Fix for standalone C++ code extending enum's

### DIFF
--- a/src/Type.cc
+++ b/src/Type.cc
@@ -1700,8 +1700,11 @@ void EnumType::AddNameInternal(const string& full_name, zeek_int_t val) {
     names[full_name] = val;
     rev_names[val] = full_name;
 
-    if ( ! vals.contains(val) )
+    if ( ! vals.contains(val) ) {
+        if ( counter >= 0 && val == static_cast<zeek_int_t>(vals.size()) )
+            ++counter;
         vals[val] = make_intrusive<EnumVal>(IntrusivePtr{NewRef{}, this}, val);
+    }
 }
 
 zeek_int_t EnumType::Lookup(const string& module_name, const char* name) const {


### PR DESCRIPTION
When initializing, `-O gen-standalone-C++` code can need to extend an `enum` if the compiled scripts used `redef enum X += ...`. This simple PR fixes the internal accounting by the corresponding `EnumType` to permit this.