### PR TITLE
Improvements for gen-standalone-C++ code initializations involving BiFs

### DIFF
--- a/src/script_opt/CPP/Inits.cc
+++ b/src/script_opt/CPP/Inits.cc
@@ -322,7 +322,9 @@ void CPPCompile::GenStandaloneActivation() {
     Emit("void standalone_init__CPP()");
     StartBlock();
     Emit("init__CPP();");
+    Emit("load_BiFs__CPP(); // support initializations that call BiFs ...");
     Emit("standalone_activation__CPP();");
+    Emit("// ... and later use of BiFs from plugins not initially available");
     Emit("standalone_finalizations.push_back(load_BiFs__CPP);");
     EndBlock();
 }

--- a/src/script_opt/ProfileFunc.cc
+++ b/src/script_opt/ProfileFunc.cc
@@ -388,7 +388,10 @@ TraversalCode ProfileFunc::PreExpr(const Expr* e) {
                     auto sf = static_cast<ScriptFunc*>(func_vf);
                     script_calls.insert(sf);
                 }
-                else
+
+                // Track the BiF, though not if we know we're not going to
+                // compile the call to it.
+                else if ( obj_matches_opt_files(e) != AnalyzeDecision::SHOULD_NOT )
                     BiF_globals.insert(func);
             }
             else {

--- a/src/script_opt/ProfileFunc.h
+++ b/src/script_opt/ProfileFunc.h
@@ -256,7 +256,8 @@ protected:
     std::unordered_set<ScriptFunc*> script_calls;
 
     // Same for BiF's, though for them we record the corresponding global
-    // rather than the BuiltinFunc*.
+    // rather than the BuiltinFunc*. In addition, we only track BiFs germane
+    // to code we're compiling.
     IDSet BiF_globals;
 
     // Script functions appearing in "when" clauses.


### PR DESCRIPTION
This PR includes two enhancements for `-O gen-standalone-C++` code initialization: (1) load standard BiFs earlier in case they're needed for initializing globals, (2) only track BiFs that are called from code we're compiling.