### PR TITLE
Reworking initialization of globals for -O gen-standalone-C++ code

### DIFF
--- a/src/script_opt/CPP/Consts.h
+++ b/src/script_opt/CPP/Consts.h
@@ -15,8 +15,12 @@ public:
 // Returns the associated initialization info.  In addition, consts_offset
 // returns an offset into an initialization-time global that tracks all
 // constructed globals, providing general access to them for aggregate
-// constants.
+// constants. The second form is for when this isn't needed.
 std::shared_ptr<CPP_InitInfo> RegisterConstant(const ValPtr& vp, int& consts_offset);
+std::shared_ptr<CPP_InitInfo> RegisterConstant(const ValPtr& vp) {
+    [[maybe_unused]] int consts_offset; // ignored
+    return RegisterConstant(vp, consts_offset);
+}
 
 private:
 // Maps (non-native) constants to associated C++ globals.

--- a/src/script_opt/CPP/Exprs.cc
+++ b/src/script_opt/CPP/Exprs.cc
@@ -176,8 +176,7 @@ string CPPCompile::GenConstExpr(const ConstExpr* c, GenType gt) {
 
     if ( ! IsNativeType(t) ) {
         auto v = c->ValuePtr();
-        int consts_offset; // ignored
-        (void)RegisterConstant(v, consts_offset);
+        (void)RegisterConstant(v);
         return NativeToGT(const_vals[v.get()]->Name(), t, gt);
     }
 
@@ -1294,6 +1293,29 @@ string CPPCompile::GenEnum(const TypePtr& t, const ValPtr& ev) {
     }
 
     return string("enum_mapping[") + Fmt(mapping_slot) + "]";
+}
+
+int CPPCompile::ReadyExpr(const ExprPtr& e) {
+    auto pf = make_unique<ProfileFunc>(e.get());
+    int max_cohort = 0;
+
+    for ( const auto& g : pf->AllGlobals() )
+        max_cohort = max(max_cohort, GenerateGlobalInit(g)->FinalInitCohort() + 1);
+    for ( const auto& c : pf->Constants() )
+        max_cohort = max(max_cohort, RegisterConstant(c->ValuePtr())->FinalInitCohort() + 1);
+
+    for ( const auto& t : pf->OrderedTypes() ) {
+        TypePtr tp{NewRef{}, const_cast<Type*>(t)};
+        max_cohort = max(max_cohort, RegisterType(tp)->FinalInitCohort() + 1);
+    }
+
+    for ( auto& [attrs, t] : pf->ConstructorAttrs() ) {
+        AttributesPtr ap{NewRef{}, const_cast<Attributes*>(attrs)};
+        max_cohort = max(max_cohort, RegisterAttributes(ap)->FinalInitCohort() + 1);
+        max_cohort = max(max_cohort, RegisterType(t)->FinalInitCohort() + 1);
+    }
+
+    return max_cohort;
 }
 
 } // namespace zeek::detail

--- a/src/script_opt/CPP/Exprs.h
+++ b/src/script_opt/CPP/Exprs.h
@@ -117,6 +117,11 @@ std::string GenIntVector(const std::vector<int>& vec);
 std::string GenField(const ExprPtr& rec, int field);
 std::string GenEnum(const TypePtr& et, const ValPtr& ev);
 
+// Creates all the initializations needed to evaluate the given expression.
+// Returns the maximum cohort associated with these.
+friend class GlobalInitInfo;
+int ReadyExpr(const ExprPtr& e);
+
 // For record that are extended via redef's, maps fields beyond the original
 // definition to locations in the global (in the compiled code) "field_mapping"
 // array.

--- a/src/script_opt/CPP/Inits.h
+++ b/src/script_opt/CPP/Inits.h
@@ -93,6 +93,10 @@ void InitializeHashes();
 // Generate code to initialize indirect references to constants.
 void InitializeConsts();
 
+// Generate code to initialize a global (using dynamic statements rather than
+// constants).
+void InitializeGlobal(const IDPtr& g);
+
 // Generate code to initialize globals (using dynamic statements rather than
 // constants).
 void InitializeGlobals();

--- a/src/script_opt/CPP/InitsInfo.h
+++ b/src/script_opt/CPP/InitsInfo.h
@@ -126,6 +126,10 @@ public:
     // to the given cohort c.
     int CohortSize(int c) const { return c > MaxCohort() ? 0 : instances[c].size(); }
 
+    // Populates the given vector with associated identifiers seen
+    // in the cohort, if any.
+    void GetCohortIDs(int c, std::vector<IDPtr>& ids) const;
+
     // Returns the C++ type associated with this collection's run-time vector.
     // This might be, for example, "PatternVal"
     const std::string& CPPType() const { return CPP_type; }
@@ -301,6 +305,9 @@ public:
     // Returns values used for creating this value, one element per
     // constructor parameter.
     virtual void InitializerVals(std::vector<std::string>& ivs) const = 0;
+
+    // Returns any associated identifier, or nil if none.
+    virtual IDPtr InitIdentifier() const { return nullptr; }
 
     const Obj* InitObj() const { return o; }
 
@@ -517,7 +524,10 @@ public:
     std::string InitializerType() const override { return "CPP_GlobalInit"; }
     void InitializerVals(std::vector<std::string>& ivs) const override;
 
+    IDPtr InitIdentifier() const override { return g; }
+
 protected:
+    IDPtr g;
     int type;
     int attrs;
     std::string val;

--- a/src/script_opt/CPP/RuntimeInitSupport.cc
+++ b/src/script_opt/CPP/RuntimeInitSupport.cc
@@ -114,6 +114,12 @@ void activate_bodies__CPP(const char* fn, const char* module, bool exported, Typ
         fg->SetType(ft);
     }
 
+    if ( ! fg->GetType() )
+        // This can happen both because we just installed the ID, but also
+        // because events registered by Spicy don't have types associated
+        // with them initially.
+        fg->SetType(ft);
+
     if ( ! fg->GetAttr(ATTR_IS_USED) )
         fg->AddAttr(make_intrusive<Attr>(ATTR_IS_USED));
 
@@ -178,6 +184,9 @@ IDPtr lookup_global__CPP(const char* g, const TypePtr& t, const GlobalCharacteri
         if ( gc.is_type )
             gl->MakeType();
     }
+
+    else if ( ! gl->GetType() )
+        gl->SetType(t);
 
     return gl;
 }

--- a/src/script_opt/CPP/RuntimeInits.cc
+++ b/src/script_opt/CPP/RuntimeInits.cc
@@ -507,6 +507,9 @@ void CPP_GlobalInit::Generate(InitsManager* im, std::vector<void*>& /* inits_vec
 
     if ( attrs >= 0 )
         global->SetAttrs(im->Attributes(attrs));
+
+    if ( t->Tag() == TYPE_FUNC )
+        global->AddAttr(make_intrusive<Attr>(ATTR_IS_USED));
 }
 
 size_t generate_indices_set(int* inits, std::vector<std::vector<int>>& indices_set) {

--- a/src/script_opt/CPP/Stmts.cc
+++ b/src/script_opt/CPP/Stmts.cc
@@ -87,7 +87,17 @@ void CPPCompile::GenInitStmt(const InitStmt* init) {
             continue;
         }
 
-        Emit("%s = make_intrusive<%s>(cast_intrusive<%s>(%s));", IDName(aggr), type_name, type_type, type_ind);
+        auto aggr_name = IDName(aggr);
+
+        Emit("%s = make_intrusive<%s>(cast_intrusive<%s>(%s));", aggr_name, type_name, type_type, type_ind);
+
+        const auto& attrs = aggr->GetAttrs();
+        if ( ! attrs )
+            continue;
+
+        auto attrs_offset = AttributesOffset(attrs);
+        auto attrs_str = "CPP__Attributes__[" + Fmt(attrs_offset) + "]";
+        Emit("%s->SetAttrs(%s);", aggr_name, attrs_str);
     }
 }
 

--- a/src/script_opt/CPP/Vars.h
+++ b/src/script_opt/CPP/Vars.h
@@ -12,7 +12,10 @@ std::shared_ptr<CPP_InitInfo> RegisterGlobal(IDPtr g);
 private:
 // Generate declarations associated with the given global, and, if it's used
 // as a variable (not just as a function being called), track it as such.
-void CreateGlobal(IDPtr g);
+//
+// Returns true if it needs initialization (which we do separately to avoid
+// tripping across dependencies between globals).
+bool CreateGlobal(IDPtr g);
 
 // Low-level function for generating an initializer for a global. Takes
 // into account differences for standalone-compilation.
@@ -49,10 +52,6 @@ std::string CaptureName(const IDPtr& l) const;
 // Returns a canonicalized name, with various non-alphanumeric characters
 // stripped or transformed, and guaranteed not to conflict with C++ keywords.
 std::string Canonicalize(const std::string& name) const;
-
-// Returns the name of the global corresponding to an expression (which must
-// be a EXPR_NAME).
-std::string GlobalName(const ExprPtr& e) { return globals[e->AsNameExpr()->Id()->Name()]; }
 
 // Globals that are used (appear in the profiles) of the bodies we're
 // compiling. Includes globals just used as functions to call.

--- a/src/script_opt/IDOptInfo.cc
+++ b/src/script_opt/IDOptInfo.cc
@@ -71,6 +71,7 @@ void IDOptInfo::AddInitExpr(ExprPtr init_expr, InitClass ic) {
         global_init_exprs.emplace_back(my_id, init_expr, ic);
 
     init_exprs.emplace_back(std::move(init_expr));
+    init_classes.emplace_back(ic);
 }
 
 void IDOptInfo::SetDefinedAfter(const Stmt* s, const ExprPtr& e, const std::vector<const Stmt*>& conf_blocks,

--- a/src/script_opt/IDOptInfo.h
+++ b/src/script_opt/IDOptInfo.h
@@ -148,8 +148,9 @@ public:
     // be done with the ExprPtr form of ID::SetVal.
     void AddInitExpr(ExprPtr init_expr, InitClass ic = INIT_NONE);
 
-    // Returns the initialization expressions for this identifier.
+    // Returns the initialization expressions or classes for this identifier.
     const std::vector<ExprPtr>& GetInitExprs() const { return init_exprs; }
+    const std::vector<InitClass>& GetInitClasses() const { return init_classes; }
 
     // Returns a list of the initialization expressions seen for all
     // globals, ordered by when they were processed.
@@ -252,6 +253,11 @@ private:
     // because it's possible that a global value gets created using
     // one of the earlier instances rather than the last one.
     std::vector<ExprPtr> init_exprs;
+
+    // A parallel array of the associated initialization classes.
+    // We keep the two separate rather than a std::pair because the
+    // most common use is to just loop over the expressions.
+    std::vector<InitClass> init_classes;
 
     // Tracks initializations of globals in the order they're seen.
     static std::vector<IDInitInfo> global_init_exprs;


### PR DESCRIPTION
Previously, `-O gen-standalone-C++` initialized Zeek global variables after building all of the types, etc. needed for the standalone code. That turns out not to work when for example a record type that's getting built has a `&default` that refers to one of the globals. This PR shifts global initialization into the main initialization framework to address such dependencies.