### PR TITLE
Replace g_frame_stack with call_stack used by ScriptProfiler

### DIFF
--- a/src/DbgBreakpoint.cc
+++ b/src/DbgBreakpoint.cc
@@ -303,17 +303,16 @@ void DbgBreakpoint::PrintHitMsg() {
         case BP_FUNC:
         case BP_LINE: {
             ODesc d;
-            Frame* f = g_frame_stack.back();
-            const ScriptFunc* func = f->GetFunction();
+            const auto& f = call_stack.back().frame;
 
-            if ( func )
+            if ( const Func* func = f->GetFunction() )
                 func->DescribeDebug(&d, f->GetFuncArgs());
 
             const Location* loc = at_stmt->GetLocationInfo();
 
             debug_msg("Breakpoint %d, %s at %s:%d\n", GetID(), d.Description(), loc->FileName(), loc->FirstLine());
-        }
             return;
+        }
 
         case BP_TIME: assert(false);
 

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -20,11 +20,11 @@ using ValPtr = IntrusivePtr<Val>;
 
 class BrokerListView;
 class BrokerData;
+class Func;
 
 namespace detail {
 
 class CallExpr;
-class ScriptFunc;
 using IDPtr = IntrusivePtr<ID>;
 
 namespace trigger {
@@ -47,7 +47,7 @@ public:
      * @param func the function that is creating this frame
      * @param fn_args the arguments being passed to that function.
      */
-    Frame(int size, const ScriptFunc* func, const zeek::Args* fn_args);
+    Frame(int size, const Func* func, const zeek::Args* fn_args);
 
     /**
      * Returns the size of the frame.
@@ -117,7 +117,7 @@ public:
     /**
      * @return the function that the frame is associated with.
      */
-    const ScriptFunc* GetFunction() const { return function; }
+    const Func* GetFunction() const { return function; }
 
     /**
      * @return the arguments passed to the function that this frame
@@ -130,7 +130,7 @@ public:
      *
      * @param func the function for the frame to be associated with.
      */
-    void SetFunction(ScriptFunc* func) { function = func; }
+    void SetFunction(Func* func) { function = func; }
 
     /**
      * Sets the next statement to be executed in the context of the frame.
@@ -239,7 +239,7 @@ private:
     const OffsetMap* captures_offset_map = nullptr;
 
     /** The function this frame is associated with. */
-    const ScriptFunc* function = nullptr;
+    const Func* function = nullptr;
 
     // The following is only needed for the debugger.
     /** The arguments to the function that this Frame is associated with. */
@@ -266,4 +266,4 @@ private:
  * DebugFrame which provides the information that the debugger uses. See:
  * https://stackoverflow.com/a/16211097
  */
-extern std::vector<zeek::detail::Frame*> g_frame_stack;
+// extern std::vector<zeek::detail::Frame*> g_frame_stack;

--- a/src/Func.h
+++ b/src/Func.h
@@ -348,8 +348,7 @@ extern bool check_built_in_call(BuiltinFunc* f, CallExpr* call);
 
 struct CallInfo {
     const CallExpr* call = nullptr;
-    const Func* func = nullptr;
-    const zeek::Args& args;
+    Frame* frame = nullptr;
 };
 
 // Class that collects all the specifics defining a Func.

--- a/src/cluster/Telemetry.cc
+++ b/src/cluster/Telemetry.cc
@@ -7,6 +7,7 @@
 
 #include "zeek/Desc.h"
 #include "zeek/Expr.h"
+#include "zeek/Frame.h"
 #include "zeek/Func.h"
 #include "zeek/IntrusivePtr.h"
 #include "zeek/Reporter.h"
@@ -136,7 +137,7 @@ std::string_view determine_script_location() {
 
     ssize_t sidx = static_cast<ssize_t>(zeek::detail::call_stack.size()) - 1;
     while ( sidx >= 0 ) {
-        const auto* func = zeek::detail::call_stack[sidx].func;
+        const auto* func = zeek::detail::call_stack[sidx].frame->GetFunction();
         const auto* ce = zeek::detail::call_stack[sidx].call;
 
         // Cached?

--- a/src/script_opt/ZAM/OPs/internal.op
+++ b/src/script_opt/ZAM/OPs/internal.op
@@ -41,12 +41,12 @@ eval	auto& v = $$;
 
 internal-op Load-Capture
 class Vi
-eval	$$ = Z_FRAME->GetFunction()->GetCapturesVec()[$1];
+eval	$$ = static_cast<const ScriptFunc*>(Z_FRAME->GetFunction())->GetCapturesVec()[$1];
 
 internal-op Load-Managed-Capture
 class Vi
 eval	auto& lhs = $$;
-	auto& rhs = Z_FRAME->GetFunction()->GetCapturesVec()[$1];
+	auto& rhs = static_cast<const ScriptFunc*>(Z_FRAME->GetFunction())->GetCapturesVec()[$1];
 	zeek::Ref(rhs.ManagedVal());
 	ZVal::DeleteManagedType(lhs);
 	lhs = rhs;
@@ -62,12 +62,12 @@ eval	GlobalID($1)->SetVal(GlobalVal($1).ToVal(Z_TYPE));
 internal-op Store-Capture
 op1-read
 class Vi
-eval	Z_FRAME->GetFunction()->GetCapturesVec()[$2] = $1;
+eval	static_cast<const ScriptFunc*>(Z_FRAME->GetFunction())->GetCapturesVec()[$2] = $1;
 
 internal-op Store-Managed-Capture
 op1-read
 class Vi
-eval	auto& lhs = Z_FRAME->GetFunction()->GetCapturesVec()[$2];
+eval	auto& lhs = static_cast<const ScriptFunc*>(Z_FRAME->GetFunction())->GetCapturesVec()[$2];
 	auto& rhs = $1;
 	zeek::Ref(rhs.ManagedVal());
 	ZVal::DeleteManagedType(lhs);

--- a/src/zeek-setup.cc
+++ b/src/zeek-setup.cc
@@ -1054,7 +1054,7 @@ SetupResult setup(int argc, char** argv, Options* zopts) {
         auto [body, scope] = get_global_stmts();
         StmtFlowType flow;
         Frame f(scope->Length(), nullptr, nullptr);
-        g_frame_stack.push_back(&f);
+        call_stack.emplace_back(nullptr, &f);
 
         try {
             body->Exec(&f, flow);
@@ -1062,7 +1062,7 @@ SetupResult setup(int argc, char** argv, Options* zopts) {
             reporter->FatalError("failed to execute script statements at top-level scope");
         }
 
-        g_frame_stack.pop_back();
+        call_stack.pop_back();
     }
 
     clear_script_analysis();


### PR DESCRIPTION
This is a third try at reducing the CPU time spent in debugger code when not actually use the debugger. @awelzel noted in the last PR that we're currently storing two copies of the call stack: one for the debugger, and one for the script profiler. This PR combines the uses of the former into the latter, and only keeps that copy instead of both.

it also makes a change to how we handle a couple of the script-level statements, abstracting away the code the would be used in the debugger so that it's not used during normal run-times.