### PR TITLE
Add versions of IfStmt and StmtList for use in debugger

### DIFF
--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -102,7 +102,7 @@ protected:
     ExprPtr e;
 };
 
-class IfStmt final : public ExprStmt {
+class IfStmt : public ExprStmt {
 public:
     IfStmt(ExprPtr test, StmtPtr s1, StmtPtr s2);
     ~IfStmt() override;
@@ -133,6 +133,15 @@ protected:
 
     StmtPtr s1;
     StmtPtr s2;
+};
+
+class DebugIfStmt final : public IfStmt {
+public:
+    DebugIfStmt(ExprPtr test, StmtPtr s1, StmtPtr s2) : IfStmt(test, s1, s2) {}
+    ~DebugIfStmt() override = default;
+
+protected:
+    ValPtr DoExec(Frame* f, Val* v, StmtFlowType& flow) override;
 };
 
 class Case final : public Obj {
@@ -450,6 +459,14 @@ protected:
     bool ReduceStmt(unsigned int& s_i, std::vector<StmtPtr>& f_stmts, Reducer* c);
 
     void ResetStmts(std::vector<StmtPtr> new_stmts) { stmts = std::move(new_stmts); }
+};
+
+class DebugStmtList : public StmtList {
+public:
+    DebugStmtList() = default;
+    ~DebugStmtList() override = default;
+
+    ValPtr Exec(Frame* f, StmtFlowType& flow) override;
 };
 
 class InitStmt final : public Stmt {

--- a/src/parse.y
+++ b/src/parse.y
@@ -163,6 +163,10 @@ static int func_hdr_cond_epoch = 0;
 EnumType* cur_enum_type = nullptr;
 static ID* cur_decl_type_id = nullptr;
 
+namespace zeek::detail {
+extern bool g_policy_debug;
+}
+
 static void parse_new_enum(void) {
     // Starting a new enum definition.
     assert(cur_enum_type == nullptr);
@@ -1843,7 +1847,10 @@ stmt:
 			{
 			reject_directive($5);
 			set_location(@1, @4);
-			$$ = new IfStmt({AdoptRef{}, $3}, {AdoptRef{}, $5}, make_intrusive<NullStmt>());
+			if ( g_policy_debug )
+				$$ = new DebugIfStmt({AdoptRef{}, $3}, {AdoptRef{}, $5}, make_intrusive<NullStmt>());
+			else
+				$$ = new IfStmt({AdoptRef{}, $3}, {AdoptRef{}, $5}, make_intrusive<NullStmt>());
 			script_coverage_mgr.AddStmt($$);
 			}
 
@@ -1852,7 +1859,10 @@ stmt:
 			reject_directive($5);
 			reject_directive($7);
 			set_location(@1, @4);
-			$$ = new IfStmt({AdoptRef{}, $3}, {AdoptRef{}, $5}, {AdoptRef{}, $7});
+			if ( g_policy_debug )
+				$$ = new DebugIfStmt({AdoptRef{}, $3}, {AdoptRef{}, $5}, {AdoptRef{}, $7});
+			else
+				$$ = new IfStmt({AdoptRef{}, $3}, {AdoptRef{}, $5}, {AdoptRef{}, $7});
 			script_coverage_mgr.AddStmt($$);
 			}
 
@@ -1976,7 +1986,12 @@ stmt_list:
 			$1->UpdateLocationEndInfo(@2);
 			}
 	|
-			{ $$ = new StmtList(); }
+			{
+			if ( g_policy_debug )
+				$$ = new DebugStmtList();
+			else
+				$$ = new StmtList();
+			}
 	;
 
 event:


### PR DESCRIPTION
This splits some of the changes out of https://github.com/zeek/zeek/pull/4874 into a separate PR. Specifically, this moves some code that is needed by the script debugger out into specialized classes that are only used by the debugger, avoiding calling the code when the debugger isn't active.