### PR TITLE
Bump spicy-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
       exclude: '^(.typos.toml|src/SmithWaterman.cc|testing/.*|auxil/.*|scripts/base/frameworks/files/magic/.*|CHANGES|scripts/base/protocols/ssl/mozilla-ca-list.zeek|src/3rdparty/.*)$'
 
 - repo: https://github.com/bbannier/spicy-format
-  rev: v0.26.0
+  rev: v0.27.1
   hooks:
     - id: spicy-format
       exclude: '^testing/.*'

--- a/src/analyzer/protocol/ldap/ldap.spicy
+++ b/src/analyzer/protocol/ldap/ldap.spicy
@@ -247,9 +247,9 @@ type KrbWrapToken = unit {
             self.trailer_ec = self.ec;
         } else {
             if (!self.ctx_flags.sealed)
-            # If it's sealed, we'll consume until &eod anyhow
-            # and ec/rrc shouldn't apply, otherwise, bail.
-            throw "Unhandled rc %s and ec %s" % (self.ec, self.rrc);
+                # If it's sealed, we'll consume until &eod anyhow
+                # and ec/rrc shouldn't apply, otherwise, bail.
+                throw "Unhandled rc %s and ec %s" % (self.ec, self.rrc);
         }
     }
 

--- a/src/analyzer/protocol/quic/QUIC.spicy
+++ b/src/analyzer/protocol/quic/QUIC.spicy
@@ -562,9 +562,9 @@ type Packet = unit(from_client: bool, context: Context&) {
 
             : void {
                 if (self?.long_header && can_decrypt(self.long_header, context, self.crypto))
-                # If we have parsed an initial packet that we can decrypt the payload,
-                # determine the size to store into a buffer.
-                self.packet_size = self.offset();
+                    # If we have parsed an initial packet that we can decrypt the payload,
+                    # determine the size to store into a buffer.
+                    self.packet_size = self.offset();
             }
 
             # Buffer the whole packet if we determined we have a chance to decrypt.


### PR DESCRIPTION
This brings in two changes:

- proper indention for blocks starting with multiple comments
- switch the hook from `language: rust` to `language: python` to avoid nonsense due to pre-commit ignoring Rust lock files, https://github.com/pre-commit/pre-commit/issues/3162.

The second one should help avoid future instances of the hook randomly breaking as its dependencies accidentially break semver.