### PR TITLE
Logging: Add BiF to flush all logs

### DIFF
--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -47,7 +47,7 @@ public:
     explicit LogFlushWriteBufferTimer(double t) : Timer(t, zeek::detail::TIMER_LOG_FLUSH_WRITE_BUFFER) {}
 
     void Dispatch(double t, bool is_expire) override {
-        zeek::log_mgr->FlushAllWriteBuffers();
+        zeek::log_mgr->FlushAll();
 
         if ( ! is_expire )
             zeek::log_mgr->StartLogFlushTimer();
@@ -2265,7 +2265,7 @@ bool Manager::FinishedRotation(WriterFrontend* writer, const char* new_name, con
     return result;
 }
 
-void Manager::FlushAllWriteBuffers() {
+void Manager::FlushAll() {
     for ( const auto* s : zeek::log_mgr->streams ) {
         if ( ! s ) // may store nullptr
             continue;

--- a/src/logging/Manager.h
+++ b/src/logging/Manager.h
@@ -340,6 +340,11 @@ public:
     bool Flush(EnumVal* id);
 
     /**
+     * Flushes all log streams including all associated writers.
+     */
+    void FlushAll();
+
+    /**
      * Signals the manager to shutdown at Zeek's termination.
      */
     void Terminate();
@@ -390,9 +395,6 @@ protected:
     // Signals that a file has been rotated.
     bool FinishedRotation(WriterFrontend* writer, const char* new_name, const char* old_name, double open, double close,
                           bool success, bool terminating);
-
-    // Flush write buffers of all writers.
-    void FlushAllWriteBuffers();
 
     // Start the regular log flushing timer.
     void StartLogFlushTimer();

--- a/src/logging/logging.bif
+++ b/src/logging/logging.bif
@@ -99,6 +99,12 @@ namespace
 		}
 %%}
 
+function Log::flush_all%(%): any
+	%{
+	zeek::log_mgr->FlushAll();
+	return nullptr;
+	%}
+
 function Log::__delay%(id: Log::ID, rec: any, post_delay_cb: PostDelayCallback%): Log::DelayToken
         %{
         auto idptr = enum_ref(id);

--- a/src/script_opt/FuncInfo.cc
+++ b/src/script_opt/FuncInfo.cc
@@ -107,6 +107,7 @@ static std::unordered_map<std::string, unsigned int> func_attrs = {
     {"Log::__disable_stream", ATTR_NO_SCRIPT_SIDE_EFFECTS},
     {"Log::__enable_stream", ATTR_NO_SCRIPT_SIDE_EFFECTS},
     {"Log::__flush", ATTR_NO_SCRIPT_SIDE_EFFECTS},
+    {"Log::flush_all", ATTR_NO_SCRIPT_SIDE_EFFECTS},
     {"Log::__get_delay_queue_size", ATTR_NO_ZEEK_SIDE_EFFECTS},
     {"Log::__remove_filter", ATTR_NO_SCRIPT_SIDE_EFFECTS},
     {"Log::__remove_stream", ATTR_NO_SCRIPT_SIDE_EFFECTS},

--- a/testing/btest/opt/ZAM-bif-tracking.zeek
+++ b/testing/btest/opt/ZAM-bif-tracking.zeek
@@ -136,6 +136,7 @@ global known_BiFs = set(
 	"Log::__disable_stream",
 	"Log::__enable_stream",
 	"Log::__flush",
+	"Log::flush_all",
 	"Log::__get_delay_queue_size",
 	"Log::__remove_filter",
 	"Log::__remove_stream",


### PR DESCRIPTION
Let me know if you prefer going with the `Log::__func` pattern.