### PR TITLE
Logging: Consider broker buffering for flush_all

### DIFF
--- a/src/logging/logging.bif
+++ b/src/logging/logging.bif
@@ -102,6 +102,11 @@ namespace
 function Log::flush_all%(%): any
 	%{
 	zeek::log_mgr->FlushAll();
+
+	// Account for broker implementing its own buffering logic
+	if ( zeek::cluster::backend == zeek::broker_mgr )
+		zeek::broker_mgr->FlushLogBuffers();
+
 	return nullptr;
 	%}
 


### PR DESCRIPTION
As far as I understand, #4887 did not provide a drop-in solution to replace `Broker::flush_logs`, because Broker implements it's own buffering:

https://github.com/zeek/zeek/blob/ccbca1f937ddb8dfeec4d39f55ff92f529a0fb53/src/logging/WriterFrontend.cc#L182-L187

This change should support broker as well.