### PR TITLE
Send correct value for `auth` from RFB analyzer

### DIFF
--- a/scripts/base/protocols/rfb/main.zeek
+++ b/scripts/base/protocols/rfb/main.zeek
@@ -149,9 +149,9 @@ event rfb_server_parameters(c: connection, name: string, width: count, height: c
 	write_log(c);
 	}
 
-event rfb_auth_result(c: connection, result: bool) &priority=5
+event rfb_authentication_result(c: connection, result: bool) &priority=5
 	{
-	c$rfb$auth = !result;
+	c$rfb$auth = result;
 	}
 
 event rfb_share_flag(c: connection, flag: bool) &priority=5

--- a/src/analyzer/protocol/rfb/events.bif
+++ b/src/analyzer/protocol/rfb/events.bif
@@ -9,8 +9,17 @@ event rfb_authentication_type%(c: connection, authtype: count%);
 ##
 ## c: The connection record for the underlying transport-layer session/flow.
 ##
+## result: whether or not authentication was successful (false means success, true means failure)
+##
+## .. zeek:see:: rfb_authentication_result
+event rfb_auth_result%(c: connection, result: bool%) &deprecated="Remove in v9.1. Use rfb_authentication_result which has the correct value for result.";
+
+## Generated for RFB event authentication result message
+##
+## c: The connection record for the underlying transport-layer session/flow.
+##
 ## result: whether or not authentication was successful
-event rfb_auth_result%(c: connection, result: bool%);
+event rfb_authentication_result%(c: connection, result: bool%);
 
 ## Generated for RFB event share flag messages
 ##

--- a/src/analyzer/protocol/rfb/rfb-analyzer.pac
+++ b/src/analyzer/protocol/rfb/rfb-analyzer.pac
@@ -61,8 +61,12 @@ refine flow RFB_Flow += {
 
 	function proc_handle_security_result(result : uint32) : bool
 		%{
+		// Remove in v9.1: rfb_auth_result should have been removed.
 		if ( rfb_auth_result )
 			zeek::BifEvent::enqueue_rfb_auth_result(connection()->zeek_analyzer(), connection()->zeek_analyzer()->Conn(), result);
+
+		if ( rfb_authentication_result )
+			zeek::BifEvent::enqueue_rfb_authentication_result(connection()->zeek_analyzer(), connection()->zeek_analyzer()->Conn(), result == 0);
 		return true;
 		%}
 };


### PR DESCRIPTION
The RFB analyzer raises the `rfb_auth_result` event, which then sets `c$rfb$auth` to its negation. This means `c$rfb$auth` has the correct value according to [the docs](https://docs.zeek.org/en/master/scripts/base/bif/plugins/Zeek_RFB.events.bif.zeek.html#id-rfb_auth_result) while the event will always have `result` be inverted from what is claimed by the docs. This changes `proc_handle_security_result` to send the correct value to the event in the first place.