### PR TITLE
btest/broker: Use asyncio.run() in websocket tests - for 8.0

### DIFF
--- a/testing/btest/broker/web-socket-events-metadata.zeek
+++ b/testing/btest/broker/web-socket-events-metadata.zeek
@@ -9,7 +9,7 @@
 # @TEST-EXEC: btest-bg-run server "zeek -b %INPUT >output"
 # @TEST-EXEC: btest-bg-run client "python3 ../client.py >output"
 #
-# @TEST-EXEC: btest-bg-wait 5
+# @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff client/output
 # @TEST-EXEC: TEST_DIFF_CANONIFIER= btest-diff server/output
 
@@ -147,7 +147,5 @@ async def do_run():
         await ws.close()
         sys.exit()
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(do_run())
-
+asyncio.run(do_run())
 # @TEST-END-FILE

--- a/testing/btest/broker/web-socket-events.zeek
+++ b/testing/btest/broker/web-socket-events.zeek
@@ -122,7 +122,5 @@ async def do_run():
         await ws.close()
         sys.exit()
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(do_run())
-
+asyncio.run(do_run())
 # @TEST-END-FILE


### PR DESCRIPTION
Use the higher-level asyncio.run() rather than lower-level asyncio loop primitives.

Closes #4883

---

These tests aren't in `master` anymore probably due to the removal of  ``Broker::listen_websocket()``, though I'm wondering if we should've kept them around :-)