### PR TITLE
Update list of HTTP methods from IANA

### DIFF
--- a/scripts/base/protocols/http/dpd.sig
+++ b/scripts/base/protocols/http/dpd.sig
@@ -1,5 +1,12 @@
 # List of HTTP headers pulled from:
-#   https://annevankesteren.nl/2007/10/http-methods
+#   https://www.iana.org/assignments/http-methods/http-methods.xhtml
+#   https://learn.microsoft.com/en-us/previous-versions/office/developer/exchange-server-2003/aa142917(v=exchg.65)
+#   https://datatracker.ietf.org/doc/html/rfc3253 (MKWORKSPACE)
+#   Microsoft's RPC over HTTP protocol (RPC_IN_DATA / RPC_OUT_DATA)
+#
+# The headers in the signature below are ordered by the list of sources
+# above, with the exception of putting some of the more commonly-
+# encountered methods earlier in the regex.
 #
 # We match each side of the connection independently to avoid missing
 # large HTTP sessions where one side exceeds the DPD buffer size on
@@ -7,7 +14,7 @@
 
 signature dpd_http_client {
   ip-proto == tcp
-  payload /^[[:space:]]*(OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT|PROPFIND|PROPPATCH|MKCOL|COPY|MOVE|LOCK|UNLOCK|VERSION-CONTROL|REPORT|CHECKOUT|CHECKIN|UNCHECKOUT|MKWORKSPACE|UPDATE|LABEL|MERGE|BASELINE-CONTROL|MKACTIVITY|ORDERPATCH|ACL|PATCH|SEARCH|BCOPY|BDELETE|BMOVE|BPROPFIND|BPROPPATCH|NOTIFY|POLL|SUBSCRIBE|UNSUBSCRIBE|X-MS-ENUMATTS|RPC_OUT_DATA|RPC_IN_DATA)[[:space:]]*/
+  payload /^[[:space:]]*(OPTIONS|GET|HEAD|POST|PUT|DELETE|ACL|BASELINE-CONTROL|BIND|CHECKIN|CHECKOUT|CONNECT|COPY|LABEL|LINK|LOCK|MERGE|MKACTIVITY|MKCALENDAR|MKCOL|MKREDIRECTREF|MOVE|ORDERPATCH|PATCH|PROPFIND|PROPPATCH|REBIND|REPORT|SEARCH|TRACE|UNBIND|UNCHECKOUT|UNLINK|UNLOCK|UPDATE|VERSION-CONTROL|BCOPY|BDELETE|BMOVE|BPROPFIND|BPROPPATCH|NOTIFY|POLL|SUBSCRIBE|UNSUBSCRIBE|X-MS-ENUMATTS|MKWORKSPACE|RPC_IN_DATA|RPC_OUT_DATA)[[:space:]]*/
   tcp-state originator
   enable "http"
 }


### PR DESCRIPTION
I realize that sorting these made this hard to review. The changes are:

- Added methods: BIND, LINK, MKCALENDAR, MKREDIRECTREF, REBIND, UNBIND, UNLINK
- Reordered them so the non-regular-HTTP ones are at the end, such as the ones for WebDAV