### PR TITLE
Reduce nightly container builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -732,6 +732,7 @@ amd64_container_image_docker_builder:
 container_image_manifest_docker_builder:
   cpu: 1
   << : *ONLY_IF_RELEASE_TAG_NIGHTLY
+  skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   env:
     DOCKER_USERNAME: ENCRYPTED[!505b3dee552a395730a7e79e6aab280ffbe1b84ec62ae7616774dfefe104e34f896d2e20ce3ad701f338987c13c33533!]
     DOCKER_PASSWORD: ENCRYPTED[!6c4b2f6f0e5379ef1091719cc5d2d74c90cfd2665ac786942033d6d924597ffb95dbbc1df45a30cc9ddeec76c07ac620!]
@@ -811,6 +812,7 @@ container_image_manifest_docker_builder:
 public_ecr_cleanup_docker_builder:
   cpu: 1
   << : *ONLY_IF_NIGHTLY
+  skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   env:
     AWS_ACCESS_KEY_ID: ENCRYPTED[!eff52f6442e1bc78bce5b15a23546344df41bf519f6201924cb70c7af12db23f442c0e5f2b3687c2d856ceb11fcb8c49!]
     AWS_SECRET_ACCESS_KEY: ENCRYPTED[!748bc302dd196140a5fa8e89c9efd148882dc846d4e723787d2de152eb136fa98e8dea7e6d2d6779d94f72dd3c088228!]


### PR DESCRIPTION
We're currently always building/uploading new containers to the registry during the nightly jobs, even if there weren't any new changes to the branch. This adds `skip` conditions to two tasks that modify the registry to skip the task if the SHA for the last green build is the same as the current SHA.

My only concern with this is that the documentation for `CIRRUS_LAST_GREEN_CHANGE` is somewhat vague about what build it's associated with. If it's any build on the master branch, including non-nightly jobs, we potentially miss building new containers overnight if the build for the last merge to master was green. The SHAs would match and it would skip doing the build. It also means that if `master` is currently failing, the tasks would always run because the SHA would always be different.

It's unfortunate that you can't run a script as part of a `skip` condition, as we could do something fancy with GraphQL instead by looking up the last successful nightly cron build.