### PR TITLE
docker: update `websockets` dependency

### DIFF
--- a/docker/final.Dockerfile
+++ b/docker/final.Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get -q update \
      python3-minimal \
      python3-semantic-version \
      python3-websocket \
+     python3-websockets \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
use the full `python3-websockets` instead of the client only `python3-websocket` to avoid errors in `zeecktl` when using ZeroMQ Cluster backend.

This avoid the warning message:
```
Warning: zeekctl option UseWebSocket is set, but websockets non-functional: Failed to import websockets module - is it installed? (ModuleNotFoundError("No module named 'websockets'"))
```
and allows correct execution for `zeekctl` for retrieving information from the all the nodes.