### PR TITLE
af_packet: Warn for usage of loopback interface

### DIFF
--- a/src/iosource/af_packet/AF_Packet.cc
+++ b/src/iosource/af_packet/AF_Packet.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/iosource/af_packet/AF_Packet.h"
 
+#include "zeek/Reporter.h"
 #include "zeek/iosource/af_packet/RX_Ring.h"
 #include "zeek/iosource/af_packet/af_packet.bif.h"
 
@@ -58,6 +59,18 @@ void AF_PacketSource::Open() {
         close(socket_fd);
         socket_fd = -1;
         return;
+    }
+
+    if ( info.IsLoopback() ) {
+        zeek::reporter->Warning(
+            "AF_Packet: %s is a loopback interface! Using the native AF_PACKET"
+            "AF_PACKET packet source with a loopback interface is unsupported. "
+            "Zeek will receive each packet twice and detect re-transmissions and "
+            "other anomalies as well as report double the amount of packets and "
+            "bytes when compared to libpcap based tools like tcpdump or Wireshark. "
+            "Consider using Zeeks's default libpcap based packet source for "
+            "loopback monitoring instead.",
+            props.path.c_str());
     }
 
     // Create RX-ring

--- a/src/iosource/af_packet/AF_Packet.h
+++ b/src/iosource/af_packet/AF_Packet.h
@@ -69,6 +69,7 @@ private:
 
         bool Valid() { return index >= 0; }
         bool IsUp() { return flags & IFF_UP; }
+        bool IsLoopback() { return flags & IFF_LOOPBACK; }
     };
 
     InterfaceInfo GetInterfaceInfo(const std::string& path);


### PR DESCRIPTION
Reimplementation of https://github.com/zeek/zeek-af_packet-plugin/pull/59 in the Zeek repo, since the af-packet repo is archived.