### PR TITLE
Skip CI builds of automated docs updates

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -128,7 +128,7 @@ jobs:
           git status
           # git commit errors when there's nothing to commit, so guard it
           # with a check that detects whether there's anything staged.
-          git diff-index --cached --quiet HEAD || { git commit -m "Docs: Regenerated via GitHub workflow" && git push; }
+          git diff-index --cached --quiet HEAD || { git commit -m "Docs: Regenerated via GitHub workflow [nomail] [skip ci]" && git push; }
 
       - name: Send email
         # Only send notifications for scheduled runs. Runs from pull requests


### PR DESCRIPTION
Before the docs were moved in to the main repo, the commits to update the docs submodule was tagged with `[nomail] [skip ci]` since there's no reason to:

- Run a full master build on Cirrus on a docs bump
- Run a nightly job of checking the docs when the thing that made the commit was the job that checks the docs

This PR restores the flags for the docs updates.