### PR TITLE
Fixing -O gen-standalone-C++ record field / enum mappings

### DIFF
--- a/src/script_opt/CPP/Inits.cc
+++ b/src/script_opt/CPP/Inits.cc
@@ -114,7 +114,7 @@ void CPPCompile::InitializeFieldMappings() {
         if ( standalone ) {
             // We can assess whether this field is one we need to generate
             // because if it is, it will have an &optional attribute that
-            // is local to one of the cmopiled source files.
+            // is local to one of the compiled source files.
             if ( td->attrs && obj_matches_opt_files(td->attrs) == AnalyzeDecision::SHOULD ) {
                 type_arg = Fmt(TypeOffset(td->type));
                 attrs_arg = Fmt(AttributesOffset(td->attrs));


### PR DESCRIPTION
One of the (many!) tricky parts of compiling Zeek scripts to standalone C++ is that the standalone code needs to work even if used in a context where record offsets or enum values differ from those seen during the compilation due to including additional scripts that include `redef record +=` or `redef enum +=` declarations. Originally the code dealt with this by dynamically determining those mappings once all of the types had been initialized (and then tracking them in an array that maps compiled offsets to their dynamic offsets). However in some circumstances the dynamics fields or enum values are needed during the process of initializing all of the types. This PR changes the approach to instead compute the mappings for records or enums immediately after the corresponding type is built, rather than waiting until after _all_ types have been built.

BTW, the diffs are a bit bigger than the actual changes since I needed to move the declarations for the `CPP_FieldMapping` and `CPP_EnumMapping` classes to come earlier. (They also now include some new accessors.)