### PR TITLE
Enforce length for 802.3 frames. Accept truncated 802.3 frames.

### DIFF
--- a/src/packet_analysis/protocol/ethernet/Ethernet.cc
+++ b/src/packet_analysis/protocol/ethernet/Ethernet.cc
@@ -49,10 +49,13 @@ bool EthernetAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* pa
         len -= 14;
         data += 14;
 
-        if ( len < protocol ) {
+        // Need at least two bytes to check the packet types below.
+        if ( len < 2 ) {
             Weird("truncated_ethernet_frame", packet);
             return false;
         }
+        if ( len > protocol )
+            len = protocol; // use 802.3/802.2 length field and remove trailing bytes
 
         // Let specialized analyzers take over for non Ethernet II frames.
         if ( data[0] == 0xAA && data[1] == 0xAA )

--- a/src/packet_analysis/protocol/vlan/VLAN.cc
+++ b/src/packet_analysis/protocol/vlan/VLAN.cc
@@ -35,9 +35,11 @@ bool VLANAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet
 
         // Need at least two bytes to check the packet types below.
         if ( len < 2 ) {
-            Weird("truncated_vlan_frame", packet);
+            Weird("truncated_VLAN_header", packet);
             return false;
         }
+        if ( len > protocol )
+            len = protocol; // use 802.3/802.2 length field and remove trailing bytes
 
         if ( data[0] == 0xAA && data[1] == 0xAA )
             // IEEE 802.2 SNAP


### PR DESCRIPTION
Non-ethernet-2 frames provide the length in one of their fields.

This commit switches to using the provided length during parsing. This means that trailing bytes will now be ignored, whereas previously they would have been passed on to downstream protocol analyzers.

This change aligns our parsing of 802.3 packets to the parsing of other packet-types, where do enforce length fields (e.g. tcp/udp).

Furthermore, this commit now accepts trucated 802.3 frames; before they were discarded. This similarly aligns us with other protocol parsers, where this already was done; this also already was done with 802.3 frames wrapped in VLANs.

Thirdly, this commit changes the weird value `truncated_vlan_frame` to `truncated_VLAN_header`. The weird was not updated when the check was changed from a truncated frame check to a truncated header check. This aligns the weird with another weird earlier in the file, and also makes the handling the same as for normal ethernet packets in Ethernet.cc.

Addresses GH-4838