### PR TITLE
Remove pcap.h dependency from iosource/Packet.h

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -43,6 +43,11 @@ Breaking Changes
   Prometheus' checks via ``promtool``. The labels have been renamed from ``le`` to
   ``leq``, given that they technically are less-than-or-equal values.
 
+- The ``iosource/Packet.h`` header no longer depends on libpcap being installed and no
+  longer directly includes the ``pcap.h`` header. This may cause some knock-on effects
+  in building plugins that were depending on this header and others that it included
+  indirectly.
+
 New Functionality
 -----------------
 

--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -4,6 +4,7 @@
 
 #include <binpac.h>
 #include <algorithm>
+#include <cinttypes>
 
 #include "zeek/Conn.h"
 #include "zeek/Event.h"

--- a/src/analyzer/protocol/asn1/asn1.pac
+++ b/src/analyzer/protocol/asn1/asn1.pac
@@ -1,5 +1,6 @@
 %extern{
 #include <cstdlib>
+#include <cinttypes>
 %}
 
 %header{

--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -6,6 +6,7 @@
 
 #include <sys/types.h>
 #include <algorithm>
+#include <cinttypes>
 
 #include "zeek/RE.h"
 #include "zeek/analyzer/protocol/bittorrent/events.bif.h"

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -7,6 +7,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <cctype>
+#include <cinttypes>
 
 #include "zeek/Base64.h"
 #include "zeek/Event.h"

--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -2,6 +2,7 @@
 type ftp_port: record;
 
 %%{
+#include <cinttypes>
 #include "zeek/Reporter.h"
 
 static zeek::RecordValPtr parse_port(const std::string& line)

--- a/src/analyzer/protocol/http/HTTP.cc
+++ b/src/analyzer/protocol/http/HTTP.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cinttypes>
 #include <cstdlib>
 #include <string>
 

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -3,6 +3,7 @@
 #include "zeek/analyzer/protocol/mime/MIME.h"
 
 #include <openssl/evp.h>
+#include <cinttypes>
 
 #include "zeek/Base64.h"
 #include "zeek/NetVar.h"

--- a/src/analyzer/protocol/pia/PIA.cc
+++ b/src/analyzer/protocol/pia/PIA.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/analyzer/protocol/pia/PIA.h"
 
+#include <cinttypes>
+
 #include "zeek/DebugLogger.h"
 #include "zeek/Event.h"
 #include "zeek/IP.h"

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/analyzer/protocol/rpc/RPC.h"
 
+#include <cinttypes>
 #include <cstdlib>
 #include <string>
 

--- a/src/analyzer/protocol/smtp/BDAT.cc
+++ b/src/analyzer/protocol/smtp/BDAT.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/analyzer/protocol/smtp/BDAT.h"
 
+#include <cinttypes>
+
 #include "zeek/Conn.h"
 #include "zeek/DebugLogger.h"
 #include "zeek/analyzer/protocol/mime/MIME.h"

--- a/src/analyzer/protocol/smtp/SMTP.cc
+++ b/src/analyzer/protocol/smtp/SMTP.cc
@@ -2,6 +2,7 @@
 
 #include "zeek/analyzer/protocol/smtp/SMTP.h"
 
+#include <cinttypes>
 #include <cstdlib>
 #include <limits>
 

--- a/src/analyzer/protocol/ssl/dtls-analyzer.pac
+++ b/src/analyzer/protocol/ssl/dtls-analyzer.pac
@@ -1,3 +1,6 @@
+%extern{
+#include <cinttypes>
+%}
 
 refine connection SSL_Conn += {
 

--- a/src/analyzer/protocol/tcp/TCP.cc
+++ b/src/analyzer/protocol/tcp/TCP.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/analyzer/protocol/tcp/TCP.h"
 
+#include <cinttypes>
+
 #include "zeek/DebugLogger.h"
 #include "zeek/Event.h"
 #include "zeek/File.h"

--- a/src/analyzer/protocol/tcp/TCP_Reassembler.cc
+++ b/src/analyzer/protocol/tcp/TCP_Reassembler.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/analyzer/protocol/tcp/TCP_Reassembler.h"
 
+#include <cinttypes>
+
 #include "zeek/File.h"
 #include "zeek/Reporter.h"
 #include "zeek/RuleMatcher.h"

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -12,6 +12,7 @@
 #include <broker/variant.hh>
 #include <broker/zeek.hh>
 #include <unistd.h>
+#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 #include <string>

--- a/src/input/readers/raw/Raw.cc
+++ b/src/input/readers/raw/Raw.cc
@@ -11,6 +11,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <cerrno>
+#include <cinttypes>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>

--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #if defined(__OpenBSD__)
+
 #include <net/bpf.h>
 using pkt_timeval = bpf_timeval;
 #else
@@ -15,12 +16,20 @@ using pkt_timeval = struct timeval;
 #include <sys/time.h>
 #endif
 
-#include <pcap.h> // For DLT_ constants
-
 #include "zeek/IP.h"
-#include "zeek/NetVar.h" // For BifEnum::Tunnel
 #include "zeek/TunnelEncapsulation.h"
 #include "zeek/session/Session.h"
+#include "zeek/types.bif.netvar_h"
+
+// Originally from <pcap/dlt.h>, duplicated here to avoid a dependency
+// on libpcap in plugin builds.
+#ifdef __OpenBSD__
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define DLT_RAW 14 /* raw IP */
+#else
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define DLT_RAW 12 /* raw IP */
+#endif
 
 namespace zeek {
 

--- a/src/packet_analysis/Analyzer.cc
+++ b/src/packet_analysis/Analyzer.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/packet_analysis/Analyzer.h"
 
+#include <cinttypes>
+
 #include "zeek/DebugLogger.h"
 #include "zeek/Event.h"
 #include "zeek/RunState.h"

--- a/src/packet_analysis/Dispatcher.cc
+++ b/src/packet_analysis/Dispatcher.cc
@@ -3,6 +3,7 @@
 #include "zeek/packet_analysis/Dispatcher.h"
 
 #include <algorithm>
+#include <cinttypes>
 
 #include "zeek/DebugLogger.h"
 #include "zeek/Reporter.h"

--- a/src/packet_analysis/protocol/ip/IPBasedAnalyzer.cc
+++ b/src/packet_analysis/protocol/ip/IPBasedAnalyzer.cc
@@ -2,6 +2,8 @@
 
 #include "zeek/packet_analysis/protocol/ip/IPBasedAnalyzer.h"
 
+#include <cinttypes>
+
 #include "zeek/Conn.h"
 #include "zeek/RunState.h"
 #include "zeek/Val.h"


### PR DESCRIPTION
I thought to try to add `#include <net/bpf.h>` instead to Packet.h, since that should always exist, but that results in some other compiler failures due to duplicate definitions when we later include `pcap.h`. Interestingly, removing this dependency also breaks a bunch of files from building because they were depending on `inttypes.h` to have been included by it. Those are fixed in this PR also, but could possibly cause external plugins to break. I can add something in NEWS about it if that's a big enough concern.

Towards #4972 