### PR TITLE
Revert include change for bif types that was breaking Windows

### DIFF
--- a/src/iosource/Packet.h
+++ b/src/iosource/Packet.h
@@ -17,9 +17,9 @@ using pkt_timeval = struct timeval;
 #endif
 
 #include "zeek/IP.h"
+#include "zeek/NetVar.h"
 #include "zeek/TunnelEncapsulation.h"
 #include "zeek/session/Session.h"
-#include "zeek/types.bif.netvar_h"
 
 // Originally from <pcap/dlt.h>, duplicated here to avoid a dependency
 // on libpcap in plugin builds.


### PR DESCRIPTION
This reverts part of e1e5f0c706388e67343453d2180e3bdee4d97314 that broke the build on Windows