### PR TITLE
tools/systemd-generator: Add SyslogIdentifier

### DIFF
--- a/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator-defaults/normal-dir.zeek-logger@.service
+++ b/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator-defaults/normal-dir.zeek-logger@.service
@@ -9,6 +9,7 @@ PartOf=zeek.target
 StartLimitIntervalSec=0
 
 [Service]
+SyslogIdentifier=zeek-logger-%i
 Type=exec
 Nice=0
 MemoryMax=

--- a/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator-defaults/normal-dir.zeek-manager.service
+++ b/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator-defaults/normal-dir.zeek-manager.service
@@ -10,6 +10,7 @@ PartOf=zeek.target
 StartLimitIntervalSec=0
 
 [Service]
+SyslogIdentifier=zeek-manager
 Type=exec
 Nice=0
 MemoryMax=

--- a/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator-defaults/normal-dir.zeek-proxy@.service
+++ b/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator-defaults/normal-dir.zeek-proxy@.service
@@ -10,6 +10,7 @@ PartOf=zeek.target
 StartLimitIntervalSec=0
 
 [Service]
+SyslogIdentifier=zeek-proxy-%i
 Type=exec
 Nice=0
 MemoryMax=

--- a/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator-defaults/normal-dir.zeek-worker@.service
+++ b/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator-defaults/normal-dir.zeek-worker@.service
@@ -12,6 +12,7 @@ PartOf=zeek.target
 StartLimitIntervalSec=0
 
 [Service]
+SyslogIdentifier=zeek-worker-%i
 Type=exec
 Nice=0
 MemoryMax=

--- a/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator/normal-dir.zeek-logger@.service
+++ b/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator/normal-dir.zeek-logger@.service
@@ -9,6 +9,7 @@ PartOf=zeek.target
 StartLimitIntervalSec=0
 
 [Service]
+SyslogIdentifier=zeek-logger-%i
 Type=exec
 Nice=-3
 MemoryMax=2001000K

--- a/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator/normal-dir.zeek-manager.service
+++ b/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator/normal-dir.zeek-manager.service
@@ -10,6 +10,7 @@ PartOf=zeek.target
 StartLimitIntervalSec=0
 
 [Service]
+SyslogIdentifier=zeek-manager
 Type=exec
 Nice=-1
 MemoryMax=2001M

--- a/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator/normal-dir.zeek-proxy@.service
+++ b/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator/normal-dir.zeek-proxy@.service
@@ -10,6 +10,7 @@ PartOf=zeek.target
 StartLimitIntervalSec=0
 
 [Service]
+SyslogIdentifier=zeek-proxy-%i
 Type=exec
 Nice=-2
 MemoryMax=2000000000

--- a/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator/normal-dir.zeek-worker@.service
+++ b/testing/btest/Baseline/tools.systemd-generator.test-zeek-systemd-generator/normal-dir.zeek-worker@.service
@@ -12,6 +12,7 @@ PartOf=zeek.target
 StartLimitIntervalSec=0
 
 [Service]
+SyslogIdentifier=zeek-worker-%i
 Type=exec
 Nice=-19
 MemoryMax=1G

--- a/testing/btest/Baseline/tools.test-paths/..dir1.zeek-worker@.service
+++ b/testing/btest/Baseline/tools.test-paths/..dir1.zeek-worker@.service
@@ -12,6 +12,7 @@ PartOf=zeek.target
 StartLimitIntervalSec=0
 
 [Service]
+SyslogIdentifier=zeek-worker-%i
 Type=exec
 Nice=0
 MemoryMax=

--- a/testing/btest/Baseline/tools.test-paths/..dir2.zeek-worker@.service
+++ b/testing/btest/Baseline/tools.test-paths/..dir2.zeek-worker@.service
@@ -12,6 +12,7 @@ PartOf=zeek.target
 StartLimitIntervalSec=0
 
 [Service]
+SyslogIdentifier=zeek-worker-%i
 Type=exec
 Nice=0
 MemoryMax=

--- a/tools/systemd-generator/src/systemd-unit.cc
+++ b/tools/systemd-generator/src/systemd-unit.cc
@@ -44,6 +44,8 @@ std::string Unit::ToString() const {
     if ( exec_start.size() > 0 || exec_start_pre.size() > 0 ) {
         ss << "\n";
         ss << "[Service]" << "\n";
+        if ( syslog_identifier.has_value() )
+            ss << "SyslogIdentifier=" << syslog_identifier.value() << "\n";
         ss << "Type=" << service_type << "\n";
         ss << "Nice=" << nice << "\n";
         ss << "MemoryMax=" << memory_max << "\n";

--- a/tools/systemd-generator/src/systemd-unit.h
+++ b/tools/systemd-generator/src/systemd-unit.h
@@ -66,6 +66,7 @@ public:
     void SetSlice(std::string s) { slice = std::move(s); }
     void SetRemainAfterExit(bool v) { remain_after_exit = v; }
 
+    void SetSyslogIdentifier(std::string si) { syslog_identifier = std::move(si); }
     void SetServiceType(std::string st) { service_type = std::move(st); }
     void AddWantedBy(std::string wb) { wanted_by.emplace_back(std::move(wb)); }
 
@@ -112,6 +113,7 @@ private:
     std::optional<std::string> part_of;
 
     // [Service]
+    std::optional<std::string> syslog_identifier;
     std::string service_type = "exec";
     std::string user;
     std::string group;

--- a/tools/systemd-generator/src/zeek-systemd-generator.cc
+++ b/tools/systemd-generator/src/zeek-systemd-generator.cc
@@ -64,6 +64,7 @@ void ensure_symlink(const path& to, const path& new_link) {
 Unit systemd_add_node_unit(const path& file, const std::string& node, const std::string& description,
                            const ZeekClusterConfig& config) {
     auto unit = Unit(file, description, config.SourcePath(), "zeek.target");
+    unit.SetSyslogIdentifier("zeek-" + node);
     unit.SetUser(config.User());
     unit.SetGroup(config.Group());
     unit.AddRequires("zeek-setup.service");


### PR DESCRIPTION
This prefixes the log output as visible with journalctl by zeek-worker-1, zeek-logger-1, etc. etc. This allows to more easily distinguish the individual Zeek processes in the log output. By default, systemd would just show zeek[pid].

    [84397.058032] zeek-logger-1[84]: Hello World
    [84397.059265] zeek-manager[85]: Hello World
    [84397.060050] zeek-proxy-1[89]: Hello World
    [84397.116457] zeek-worker-2[86]: listening on eth0
    [84397.120385] zeek-worker-3[87]: listening on eth0