### PR TITLE
Revert "Add skip conditions for container builder tasks"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -744,7 +744,6 @@ amd64_container_image_docker_builder:
 container_image_manifest_docker_builder:
   cpu: 1
   << : *ONLY_IF_RELEASE_TAG_NIGHTLY
-  skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   env:
     DOCKER_USERNAME: ENCRYPTED[!505b3dee552a395730a7e79e6aab280ffbe1b84ec62ae7616774dfefe104e34f896d2e20ce3ad701f338987c13c33533!]
     DOCKER_PASSWORD: ENCRYPTED[!6c4b2f6f0e5379ef1091719cc5d2d74c90cfd2665ac786942033d6d924597ffb95dbbc1df45a30cc9ddeec76c07ac620!]
@@ -824,7 +823,6 @@ container_image_manifest_docker_builder:
 public_ecr_cleanup_docker_builder:
   cpu: 1
   << : *ONLY_IF_NIGHTLY
-  skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   env:
     AWS_ACCESS_KEY_ID: ENCRYPTED[!eff52f6442e1bc78bce5b15a23546344df41bf519f6201924cb70c7af12db23f442c0e5f2b3687c2d856ceb11fcb8c49!]
     AWS_SECRET_ACCESS_KEY: ENCRYPTED[!748bc302dd196140a5fa8e89c9efd148882dc846d4e723787d2de152eb136fa98e8dea7e6d2d6779d94f72dd3c088228!]


### PR DESCRIPTION
This reverts commit 016a9986a4396d4d5d2749f4bbc880542f285aeb, which is currently preventing nightly container images from being built.