### PR TITLE
Enable a couple of clang-tidy checkers without findings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,8 +6,6 @@ Checks: [-*,
          readability-container-contains,
          readability-container-size-empty,
 
-         -modernize-type-traits,
-
          # Enable a very limited number of the cppcoreguidelines checkers.
          # See the notes for some of the rest of them below.
          cppcoreguidelines-macro-usage,


### PR DESCRIPTION
- `bugprone-undefined-memory-manipulation` and `bugprone-suspicious-include` were both explicitly disabled in .clang-tidy, except neither of them report any findings when enabled. 
- `modernize-type-traits` was disabled by fc56eeaf390d31049ef8db0dd2a531d6680609dd by mistake. 
- `bugprone-empty-catch` got a better comment about why it's disabled.
- `bugprone-switch-missing-default-case` is not because of bifcl but because of binpac.