### PR TITLE
Enable clang-tidy readability-const-return-type checker, fix findings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: [-*,
          readability-isolate-declaration,
          readability-container-contains,
          readability-container-size-empty,
+         readability-const-return-type,
 
          # Enable a very limited number of the cppcoreguidelines checkers.
          # See the notes for some of the rest of them below.

--- a/src/CompHash.cc
+++ b/src/CompHash.cc
@@ -34,7 +34,7 @@ using HashkeyMapPtr = std::unique_ptr<HashkeyMap>;
 
 // Helper that produces a table from HashKeys to the ListVal indexes into the
 // table, that we can iterate over in sorted-Hashkey order.
-const HashkeyMapPtr ordered_hashkeys(const TableVal* tv) {
+static HashkeyMapPtr ordered_hashkeys(const TableVal* tv) {
     auto res = std::make_unique<HashkeyMap>();
     auto tbl = tv->AsTable();
     auto idx = 0;

--- a/src/DebugLogger.cc
+++ b/src/DebugLogger.cc
@@ -196,7 +196,7 @@ void DebugLogger::Log(const plugin::Plugin& plugin, const char* fmt, ...) {
     fflush(file);
 }
 
-const std::string DebugLogger::PluginStreamName(const std::string& plugin_name) const {
+std::string DebugLogger::PluginStreamName(const std::string& plugin_name) const {
     std::string res{util::strreplace(plugin_name, "::", "-")};
     res = util::strreplace(res, "_", "-");
     return "plugin-" + util::strtolower(res);

--- a/src/DebugLogger.h
+++ b/src/DebugLogger.h
@@ -117,7 +117,7 @@ private:
 
     // Canonical rendering of a plugin's name. This is lower-cased,
     // with "::" and "_" both becoming "-".
-    const std::string PluginStreamName(const std::string& plugin_name) const;
+    std::string PluginStreamName(const std::string& plugin_name) const;
 };
 
 extern DebugLogger debug_logger;

--- a/src/cluster/websocket/WebSocket.cc
+++ b/src/cluster/websocket/WebSocket.cc
@@ -192,7 +192,7 @@ bool WebSocketClient::AllSubscriptionsActive() const {
     return true;
 }
 
-const std::vector<std::string> WebSocketClient::GetSubscriptions() const {
+std::vector<std::string> WebSocketClient::GetSubscriptions() const {
     std::vector<std::string> subs;
     subs.reserve(subscriptions_state.size());
 

--- a/src/cluster/websocket/WebSocket.h
+++ b/src/cluster/websocket/WebSocket.h
@@ -103,7 +103,7 @@ public:
     /**
      * @return The client's subscriptions.
      */
-    const std::vector<std::string> GetSubscriptions() const;
+    std::vector<std::string> GetSubscriptions() const;
 
     /**
      * Store the client's subscriptions as "not active".

--- a/src/packet_analysis/Analyzer.cc
+++ b/src/packet_analysis/Analyzer.cc
@@ -40,7 +40,7 @@ zeek::packet_analysis::AnalyzerPtr Analyzer::LoadAnalyzer(const std::string& nam
     return packet_mgr->GetAnalyzer(analyzer_val->AsEnumVal());
 }
 
-const Tag Analyzer::GetAnalyzerTag() const {
+Tag Analyzer::GetAnalyzerTag() const {
     assert(tag);
     return tag;
 }

--- a/src/packet_analysis/Analyzer.h
+++ b/src/packet_analysis/Analyzer.h
@@ -55,7 +55,7 @@ public:
     /**
      * Returns the tag associated with the analyzer's type.
      */
-    const zeek::Tag GetAnalyzerTag() const;
+    zeek::Tag GetAnalyzerTag() const;
 
     /**
      * Returns a textual description of the analyzer's type. This is

--- a/src/plugin/Plugin.h
+++ b/src/plugin/Plugin.h
@@ -480,7 +480,7 @@ public:
      * Returns the value for a Zeek wrapped value argument.  The argument's type must
      * match accordingly.
      */
-    const std::pair<bool, Val*> AsFuncResult() const {
+    std::pair<bool, Val*> AsFuncResult() const {
         assert(type == FUNC_RESULT);
         return func_result;
     }
@@ -507,7 +507,7 @@ public:
      * Returns the value for a threading fields argument.  The argument's type must
      * match accordingly.
      */
-    const std::pair<int, const threading::Field* const*> AsThreadFields() const {
+    std::pair<int, const threading::Field* const*> AsThreadFields() const {
         assert(type == THREAD_FIELDS);
         return tfields;
     }

--- a/src/script_opt/CPP/RuntimeInits.h
+++ b/src/script_opt/CPP/RuntimeInits.h
@@ -153,7 +153,7 @@ public:
         ASSERT(strings[offset]);
         return strings[offset];
     }
-    const p_hash_type Hashes(int offset) const {
+    p_hash_type Hashes(int offset) const {
         ASSERT(offset >= 0 && offset < static_cast<int>(hashes.size()));
         return hashes[offset];
     }

--- a/src/script_opt/ZAM/Expr.cc
+++ b/src/script_opt/ZAM/Expr.cc
@@ -9,7 +9,7 @@
 
 namespace zeek::detail {
 
-const ZAMStmt ZAMCompiler::CompileExpr(const Expr* e) {
+ZAMStmt ZAMCompiler::CompileExpr(const Expr* e) {
     switch ( e->Tag() ) {
         case EXPR_INCR:
         case EXPR_DECR: return CompileIncrExpr(static_cast<const IncrExpr*>(e));
@@ -57,7 +57,7 @@ const ZAMStmt ZAMCompiler::CompileExpr(const Expr* e) {
     }
 }
 
-const ZAMStmt ZAMCompiler::CompileIncrExpr(const IncrExpr* e) {
+ZAMStmt ZAMCompiler::CompileIncrExpr(const IncrExpr* e) {
     auto target = e->Op()->AsRefExpr()->GetOp1()->AsNameExpr();
 
     if ( target->GetType()->Tag() == TYPE_INT ) {
@@ -73,7 +73,7 @@ const ZAMStmt ZAMCompiler::CompileIncrExpr(const IncrExpr* e) {
         return DecrUV(target);
 }
 
-const ZAMStmt ZAMCompiler::CompileAppendToExpr(const AppendToExpr* e) {
+ZAMStmt ZAMCompiler::CompileAppendToExpr(const AppendToExpr* e) {
     auto n1 = e->GetOp1()->AsNameExpr();
     auto op2 = e->GetOp2();
     auto n2 = op2->Tag() == EXPR_NAME ? op2->AsNameExpr() : nullptr;
@@ -85,7 +85,7 @@ const ZAMStmt ZAMCompiler::CompileAppendToExpr(const AppendToExpr* e) {
     return n2 ? AppendToVV(n1, n2) : AppendToVC(n1, cc);
 }
 
-const ZAMStmt ZAMCompiler::CompileAdd(const AggrAddExpr* e) {
+ZAMStmt ZAMCompiler::CompileAdd(const AggrAddExpr* e) {
     auto op = e->GetOp1();
     auto aggr = op->GetOp1()->AsNameExpr();
     auto index_list = op->GetOp2();
@@ -107,7 +107,7 @@ const ZAMStmt ZAMCompiler::CompileAdd(const AggrAddExpr* e) {
     return AddStmtVO(aggr, BuildVals(indices).get());
 }
 
-const ZAMStmt ZAMCompiler::CompileDel(const AggrDelExpr* e) {
+ZAMStmt ZAMCompiler::CompileDel(const AggrDelExpr* e) {
     auto op = e->GetOp1();
 
     if ( op->Tag() == EXPR_NAME ) {
@@ -135,7 +135,7 @@ const ZAMStmt ZAMCompiler::CompileDel(const AggrDelExpr* e) {
     return DelTableVO(aggr, internal_ind.get());
 }
 
-const ZAMStmt ZAMCompiler::CompileAddToExpr(const AddToExpr* e) {
+ZAMStmt ZAMCompiler::CompileAddToExpr(const AddToExpr* e) {
     auto op1 = e->GetOp1();
     auto t1 = op1->GetType()->Tag();
 
@@ -177,7 +177,7 @@ const ZAMStmt ZAMCompiler::CompileAddToExpr(const AddToExpr* e) {
     return n2 ? AddTableToTableVV(n1, n2) : AddTableToTableVC(n1, cc);
 }
 
-const ZAMStmt ZAMCompiler::CompileRemoveFromExpr(const RemoveFromExpr* e) {
+ZAMStmt ZAMCompiler::CompileRemoveFromExpr(const RemoveFromExpr* e) {
     auto n1 = e->GetOp1()->AsNameExpr();
     auto op2 = e->GetOp2();
 
@@ -187,7 +187,7 @@ const ZAMStmt ZAMCompiler::CompileRemoveFromExpr(const RemoveFromExpr* e) {
     return n2 ? RemoveTableFromTableVV(n1, n2) : RemoveTableFromTableVC(n1, cc);
 }
 
-const ZAMStmt ZAMCompiler::CompileAssignExpr(const AssignExpr* e) {
+ZAMStmt ZAMCompiler::CompileAssignExpr(const AssignExpr* e) {
     auto op1 = e->GetOp1();
     auto op2 = e->GetOp2();
 
@@ -284,7 +284,7 @@ const ZAMStmt ZAMCompiler::CompileAssignExpr(const AssignExpr* e) {
 #include "ZAM-GenExprsDefsV.h"
 }
 
-const ZAMStmt ZAMCompiler::CompileRecFieldUpdates(const RecordFieldUpdatesExpr* e) {
+ZAMStmt ZAMCompiler::CompileRecFieldUpdates(const RecordFieldUpdatesExpr* e) {
     auto rhs = e->GetOp2()->AsNameExpr();
 
     auto& rhs_map = e->RHSMap();
@@ -355,7 +355,7 @@ const ZAMStmt ZAMCompiler::CompileRecFieldUpdates(const RecordFieldUpdatesExpr* 
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::CompileZAMBuiltin(const NameExpr* lhs, const ScriptOptBuiltinExpr* zbi) {
+ZAMStmt ZAMCompiler::CompileZAMBuiltin(const NameExpr* lhs, const ScriptOptBuiltinExpr* zbi) {
     auto op1 = zbi->GetOp1();
     auto op2 = zbi->GetOp2();
 
@@ -420,7 +420,7 @@ const ZAMStmt ZAMCompiler::CompileZAMBuiltin(const NameExpr* lhs, const ScriptOp
     }
 }
 
-const ZAMStmt ZAMCompiler::CompileAssignToIndex(const NameExpr* lhs, const IndexExpr* rhs) {
+ZAMStmt ZAMCompiler::CompileAssignToIndex(const NameExpr* lhs, const IndexExpr* rhs) {
     auto aggr = rhs->GetOp1();
     auto const_aggr = aggr->Tag() == EXPR_CONST;
 
@@ -460,7 +460,7 @@ const ZAMStmt ZAMCompiler::CompileAssignToIndex(const NameExpr* lhs, const Index
         return IndexVVL(lhs, n, indexes_expr);
 }
 
-const ZAMStmt ZAMCompiler::CompileFieldLHSAssignExpr(const FieldLHSAssignExpr* e) {
+ZAMStmt ZAMCompiler::CompileFieldLHSAssignExpr(const FieldLHSAssignExpr* e) {
     auto lhs = e->Op1()->AsNameExpr();
     auto rhs = e->Op2();
     auto field = e->Field();
@@ -495,7 +495,7 @@ const ZAMStmt ZAMCompiler::CompileFieldLHSAssignExpr(const FieldLHSAssignExpr* e
 #include "ZAM-GenFieldsDefsV.h"
 }
 
-const ZAMStmt ZAMCompiler::CompileScheduleExpr(const ScheduleExpr* e) {
+ZAMStmt ZAMCompiler::CompileScheduleExpr(const ScheduleExpr* e) {
     auto event = e->Event();
     auto when = e->When();
 
@@ -510,8 +510,8 @@ const ZAMStmt ZAMCompiler::CompileScheduleExpr(const ScheduleExpr* e) {
         return ScheduleCiHL(when->AsConstExpr(), is_interval, handler.Ptr(), event_args);
 }
 
-const ZAMStmt ZAMCompiler::CompileSchedule(const NameExpr* n, const ConstExpr* c, int is_interval, EventHandler* h,
-                                           const ListExpr* l) {
+ZAMStmt ZAMCompiler::CompileSchedule(const NameExpr* n, const ConstExpr* c, int is_interval, EventHandler* h,
+                                     const ListExpr* l) {
     int len = l->Exprs().length();
     ZInstI z;
 
@@ -539,7 +539,7 @@ const ZAMStmt ZAMCompiler::CompileSchedule(const NameExpr* n, const ConstExpr* c
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::CompileEvent(EventHandler* h, const ListExpr* l) {
+ZAMStmt ZAMCompiler::CompileEvent(EventHandler* h, const ListExpr* l) {
     const auto& exprs = l->Exprs();
     unsigned int n = exprs.length();
 
@@ -614,8 +614,8 @@ const ZAMStmt ZAMCompiler::CompileEvent(EventHandler* h, const ListExpr* l) {
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::CompileInExpr(const NameExpr* n1, const NameExpr* n2, const ConstExpr* c2,
-                                         const NameExpr* n3, const ConstExpr* c3) {
+ZAMStmt ZAMCompiler::CompileInExpr(const NameExpr* n1, const NameExpr* n2, const ConstExpr* c2, const NameExpr* n3,
+                                   const ConstExpr* c3) {
     const Expr* op2 = n2;
     const Expr* op3 = n3;
 
@@ -676,8 +676,7 @@ const ZAMStmt ZAMCompiler::CompileInExpr(const NameExpr* n1, const NameExpr* n2,
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::CompileInExpr(const NameExpr* n1, const ListExpr* l, const NameExpr* n2,
-                                         const ConstExpr* c) {
+ZAMStmt ZAMCompiler::CompileInExpr(const NameExpr* n1, const ListExpr* l, const NameExpr* n2, const ConstExpr* c) {
     auto& l_e = l->Exprs();
     int n = l_e.length();
 
@@ -770,17 +769,17 @@ const ZAMStmt ZAMCompiler::CompileInExpr(const NameExpr* n1, const ListExpr* l, 
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::CompileIndex(const NameExpr* n1, const NameExpr* n2, const ListExpr* l, bool in_when) {
+ZAMStmt ZAMCompiler::CompileIndex(const NameExpr* n1, const NameExpr* n2, const ListExpr* l, bool in_when) {
     return CompileIndex(n1, FrameSlot(n2), n2->GetType(), l, in_when);
 }
 
-const ZAMStmt ZAMCompiler::CompileIndex(const NameExpr* n, const ConstExpr* c, const ListExpr* l, bool in_when) {
+ZAMStmt ZAMCompiler::CompileIndex(const NameExpr* n, const ConstExpr* c, const ListExpr* l, bool in_when) {
     auto tmp = TempForConst(c);
     return CompileIndex(n, tmp, c->GetType(), l, in_when);
 }
 
-const ZAMStmt ZAMCompiler::CompileIndex(const NameExpr* n1, int n2_slot, const TypePtr& n2t, const ListExpr* l,
-                                        bool in_when) {
+ZAMStmt ZAMCompiler::CompileIndex(const NameExpr* n1, int n2_slot, const TypePtr& n2t, const ListExpr* l,
+                                  bool in_when) {
     ZInstI z;
 
     int n = l->Exprs().length();
@@ -935,11 +934,11 @@ const ZAMStmt ZAMCompiler::CompileIndex(const NameExpr* n1, int n2_slot, const T
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::BuildLambda(const NameExpr* n, ExprPtr e) {
+ZAMStmt ZAMCompiler::BuildLambda(const NameExpr* n, ExprPtr e) {
     return BuildLambda(Frame1Slot(n, OP1_WRITE), std::move(e));
 }
 
-const ZAMStmt ZAMCompiler::BuildLambda(int n_slot, ExprPtr e) {
+ZAMStmt ZAMCompiler::BuildLambda(int n_slot, ExprPtr e) {
     auto lambda = cast_intrusive<LambdaExpr>(e);
     auto& captures = lambda->GetCaptures();
     int ncaptures = captures ? captures->size() : 0;
@@ -964,7 +963,7 @@ const ZAMStmt ZAMCompiler::BuildLambda(int n_slot, ExprPtr e) {
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::AssignVecElems(const Expr* e) {
+ZAMStmt ZAMCompiler::AssignVecElems(const Expr* e) {
     ASSERT(e->Tag() == EXPR_INDEX_ASSIGN);
     auto index_assign = static_cast<const IndexAssignExpr*>(e);
 
@@ -1055,7 +1054,7 @@ const ZAMStmt ZAMCompiler::AssignVecElems(const Expr* e) {
     return inst;
 }
 
-const ZAMStmt ZAMCompiler::AssignTableElem(const Expr* e) {
+ZAMStmt ZAMCompiler::AssignTableElem(const Expr* e) {
     ASSERT(e->Tag() == EXPR_INDEX_ASSIGN);
     auto index_assign = static_cast<const IndexAssignExpr*>(e);
 
@@ -1079,7 +1078,7 @@ const ZAMStmt ZAMCompiler::AssignTableElem(const Expr* e) {
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::Call(const ExprStmt* e) {
+ZAMStmt ZAMCompiler::Call(const ExprStmt* e) {
     auto c = cast_intrusive<CallExpr>(e->StmtExprPtr());
 
     if ( CheckForBuiltIn(c, c) )
@@ -1088,7 +1087,7 @@ const ZAMStmt ZAMCompiler::Call(const ExprStmt* e) {
     return DoCall(e->StmtExpr()->AsCallExpr(), nullptr);
 }
 
-const ZAMStmt ZAMCompiler::AssignToCall(const ExprStmt* e) {
+ZAMStmt ZAMCompiler::AssignToCall(const ExprStmt* e) {
     auto assign = e->StmtExpr()->AsAssignExpr();
     auto call = cast_intrusive<CallExpr>(assign->GetOp2());
 
@@ -1113,7 +1112,7 @@ bool ZAMCompiler::CheckForBuiltIn(const ExprPtr& e, CallExprPtr c) {
     return true;
 }
 
-const ZAMStmt ZAMCompiler::DoCall(const CallExpr* c, const NameExpr* n) {
+ZAMStmt ZAMCompiler::DoCall(const CallExpr* c, const NameExpr* n) {
     auto func = c->Func()->AsNameExpr();
     auto func_id = func->IdPtr();
     auto func_val = func_id->GetVal();
@@ -1280,7 +1279,7 @@ const ZAMStmt ZAMCompiler::DoCall(const CallExpr* c, const NameExpr* n) {
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::ConstructTable(const NameExpr* n, const Expr* e) {
+ZAMStmt ZAMCompiler::ConstructTable(const NameExpr* n, const Expr* e) {
     auto con = e->GetOp1()->AsListExpr();
     auto tt = cast_intrusive<TableType>(n->GetType());
     auto width = tt->GetIndices()->GetTypes().size();
@@ -1319,7 +1318,7 @@ const ZAMStmt ZAMCompiler::ConstructTable(const NameExpr* n, const Expr* e) {
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::ConstructSet(const NameExpr* n, const Expr* e) {
+ZAMStmt ZAMCompiler::ConstructSet(const NameExpr* n, const Expr* e) {
     auto con = e->GetOp1()->AsListExpr();
     auto tt = n->GetType()->AsTableType();
     auto width = tt->GetIndices()->GetTypes().size();
@@ -1333,7 +1332,7 @@ const ZAMStmt ZAMCompiler::ConstructSet(const NameExpr* n, const Expr* e) {
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::ConstructRecord(const NameExpr* n, const Expr* e, bool is_from_rec) {
+ZAMStmt ZAMCompiler::ConstructRecord(const NameExpr* n, const Expr* e, bool is_from_rec) {
     auto rec_e = is_from_rec ? e->GetOp1().get() : e;
     ASSERT(rec_e->Tag() == EXPR_RECORD_CONSTRUCTOR);
     auto rc = static_cast<const RecordConstructorExpr*>(rec_e);
@@ -1504,7 +1503,7 @@ const ZAMStmt ZAMCompiler::ConstructRecord(const NameExpr* n, const Expr* e, boo
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::ConstructVector(const NameExpr* n, const Expr* e) {
+ZAMStmt ZAMCompiler::ConstructVector(const NameExpr* n, const Expr* e) {
     auto con = e->GetOp1()->AsListExpr();
 
     auto z = GenInst(OP_CONSTRUCT_VECTOR_V, n);
@@ -1514,7 +1513,7 @@ const ZAMStmt ZAMCompiler::ConstructVector(const NameExpr* n, const Expr* e) {
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::ArithCoerce(const NameExpr* n, const Expr* e) {
+ZAMStmt ZAMCompiler::ArithCoerce(const NameExpr* n, const Expr* e) {
     const auto& nt = n->GetType();
     auto nt_is_vec = nt->Tag() == TYPE_VECTOR;
 
@@ -1575,7 +1574,7 @@ const ZAMStmt ZAMCompiler::ArithCoerce(const NameExpr* n, const Expr* e) {
     return AddInst(GenInst(a, n, op->AsNameExpr()));
 }
 
-const ZAMStmt ZAMCompiler::RecordCoerce(const NameExpr* n, const Expr* e) {
+ZAMStmt ZAMCompiler::RecordCoerce(const NameExpr* n, const Expr* e) {
     ASSERT(e->Tag() == EXPR_RECORD_COERCE);
     auto r = static_cast<const RecordCoerceExpr*>(e);
     auto op = r->GetOp1()->AsNameExpr();
@@ -1604,7 +1603,7 @@ const ZAMStmt ZAMCompiler::RecordCoerce(const NameExpr* n, const Expr* e) {
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::TableCoerce(const NameExpr* n, const Expr* e) {
+ZAMStmt ZAMCompiler::TableCoerce(const NameExpr* n, const Expr* e) {
     auto op = e->GetOp1()->AsNameExpr();
 
     int op_slot = FrameSlot(op);
@@ -1615,7 +1614,7 @@ const ZAMStmt ZAMCompiler::TableCoerce(const NameExpr* n, const Expr* e) {
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::VectorCoerce(const NameExpr* n, const Expr* e) {
+ZAMStmt ZAMCompiler::VectorCoerce(const NameExpr* n, const Expr* e) {
     auto op = e->GetOp1()->AsNameExpr();
     int op_slot = FrameSlot(op);
 
@@ -1626,7 +1625,7 @@ const ZAMStmt ZAMCompiler::VectorCoerce(const NameExpr* n, const Expr* e) {
     return AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::Is(const NameExpr* n, const Expr* e) {
+ZAMStmt ZAMCompiler::Is(const NameExpr* n, const Expr* e) {
     auto is = e->AsIsExpr();
     auto op = e->GetOp1()->AsNameExpr();
     int op_slot = FrameSlot(op);

--- a/src/script_opt/ZAM/Expr.h
+++ b/src/script_opt/ZAM/Expr.h
@@ -4,76 +4,75 @@
 //
 // This file is included by Compile.h to insert into the ZAMCompiler class.
 
-const ZAMStmt CompileExpr(const ExprPtr& e) { return CompileExpr(e.get()); }
-const ZAMStmt CompileExpr(const Expr* body);
+ZAMStmt CompileExpr(const ExprPtr& e) { return CompileExpr(e.get()); }
+ZAMStmt CompileExpr(const Expr* body);
 
-const ZAMStmt CompileIncrExpr(const IncrExpr* e);
-const ZAMStmt CompileAppendToExpr(const AppendToExpr* e);
-const ZAMStmt CompileAdd(const AggrAddExpr* e);
-const ZAMStmt CompileDel(const AggrDelExpr* e);
-const ZAMStmt CompileAddToExpr(const AddToExpr* e);
-const ZAMStmt CompileRemoveFromExpr(const RemoveFromExpr* e);
-const ZAMStmt CompileAssignExpr(const AssignExpr* e);
-const ZAMStmt CompileRecFieldUpdates(const RecordFieldUpdatesExpr* e);
-const ZAMStmt CompileZAMBuiltin(const NameExpr* lhs, const ScriptOptBuiltinExpr* zbi);
-const ZAMStmt CompileAssignToIndex(const NameExpr* lhs, const IndexExpr* rhs);
-const ZAMStmt CompileFieldLHSAssignExpr(const FieldLHSAssignExpr* e);
-const ZAMStmt CompileScheduleExpr(const ScheduleExpr* e);
-const ZAMStmt CompileSchedule(const NameExpr* n, const ConstExpr* c, int is_interval, EventHandler* h,
-                              const ListExpr* l);
-const ZAMStmt CompileEvent(EventHandler* h, const ListExpr* l);
+ZAMStmt CompileIncrExpr(const IncrExpr* e);
+ZAMStmt CompileAppendToExpr(const AppendToExpr* e);
+ZAMStmt CompileAdd(const AggrAddExpr* e);
+ZAMStmt CompileDel(const AggrDelExpr* e);
+ZAMStmt CompileAddToExpr(const AddToExpr* e);
+ZAMStmt CompileRemoveFromExpr(const RemoveFromExpr* e);
+ZAMStmt CompileAssignExpr(const AssignExpr* e);
+ZAMStmt CompileRecFieldUpdates(const RecordFieldUpdatesExpr* e);
+ZAMStmt CompileZAMBuiltin(const NameExpr* lhs, const ScriptOptBuiltinExpr* zbi);
+ZAMStmt CompileAssignToIndex(const NameExpr* lhs, const IndexExpr* rhs);
+ZAMStmt CompileFieldLHSAssignExpr(const FieldLHSAssignExpr* e);
+ZAMStmt CompileScheduleExpr(const ScheduleExpr* e);
+ZAMStmt CompileSchedule(const NameExpr* n, const ConstExpr* c, int is_interval, EventHandler* h, const ListExpr* l);
+ZAMStmt CompileEvent(EventHandler* h, const ListExpr* l);
 
-const ZAMStmt CompileInExpr(const NameExpr* n1, const NameExpr* n2, const NameExpr* n3) {
+ZAMStmt CompileInExpr(const NameExpr* n1, const NameExpr* n2, const NameExpr* n3) {
     return CompileInExpr(n1, n2, nullptr, n3, nullptr);
 }
 
-const ZAMStmt CompileInExpr(const NameExpr* n1, const NameExpr* n2, const ConstExpr* c) {
+ZAMStmt CompileInExpr(const NameExpr* n1, const NameExpr* n2, const ConstExpr* c) {
     return CompileInExpr(n1, n2, nullptr, nullptr, c);
 }
 
-const ZAMStmt CompileInExpr(const NameExpr* n1, const ConstExpr* c, const NameExpr* n3) {
+ZAMStmt CompileInExpr(const NameExpr* n1, const ConstExpr* c, const NameExpr* n3) {
     return CompileInExpr(n1, nullptr, c, n3, nullptr);
 }
 
 // In the following, one of n2 or c2 (likewise, n3/c3) will be nil.
-const ZAMStmt CompileInExpr(const NameExpr* n1, const NameExpr* n2, const ConstExpr* c2, const NameExpr* n3,
-                            const ConstExpr* c3);
+ZAMStmt CompileInExpr(const NameExpr* n1, const NameExpr* n2, const ConstExpr* c2, const NameExpr* n3,
+                      const ConstExpr* c3);
 
-const ZAMStmt CompileInExpr(const NameExpr* n1, const ListExpr* l, const NameExpr* n2) {
+ZAMStmt CompileInExpr(const NameExpr* n1, const ListExpr* l, const NameExpr* n2) {
     return CompileInExpr(n1, l, n2, nullptr);
 }
 
-const ZAMStmt CompileInExpr(const NameExpr* n, const ListExpr* l, const ConstExpr* c) {
+ZAMStmt CompileInExpr(const NameExpr* n, const ListExpr* l, const ConstExpr* c) {
     return CompileInExpr(n, l, nullptr, c);
 }
 
-const ZAMStmt CompileInExpr(const NameExpr* n1, const ListExpr* l, const NameExpr* n2, const ConstExpr* c);
+ZAMStmt CompileInExpr(const NameExpr* n1, const ListExpr* l, const NameExpr* n2, const ConstExpr* c);
 
-const ZAMStmt CompileIndex(const NameExpr* n1, const NameExpr* n2, const ListExpr* l, bool in_when);
-const ZAMStmt CompileIndex(const NameExpr* n1, const ConstExpr* c, const ListExpr* l, bool in_when);
-const ZAMStmt CompileIndex(const NameExpr* n1, int n2_slot, const TypePtr& n2_type, const ListExpr* l, bool in_when);
+ZAMStmt CompileIndex(const NameExpr* n1, const NameExpr* n2, const ListExpr* l, bool in_when);
+ZAMStmt CompileIndex(const NameExpr* n1, const ConstExpr* c, const ListExpr* l, bool in_when);
+ZAMStmt CompileIndex(const NameExpr* n1, int n2_slot, const TypePtr& n2_type, const ListExpr* l, bool in_when);
 
-const ZAMStmt BuildLambda(const NameExpr* n, ExprPtr le);
-const ZAMStmt BuildLambda(int n_slot, ExprPtr le);
+ZAMStmt BuildLambda(const NameExpr* n, ExprPtr le);
+ZAMStmt BuildLambda(int n_slot, ExprPtr le);
 
-const ZAMStmt AssignVecElems(const Expr* e);
-const ZAMStmt AssignTableElem(const Expr* e);
+ZAMStmt AssignVecElems(const Expr* e);
+ZAMStmt AssignTableElem(const Expr* e);
 
-const ZAMStmt Call(const ExprStmt* e);
-const ZAMStmt AssignToCall(const ExprStmt* e);
+ZAMStmt Call(const ExprStmt* e);
+ZAMStmt AssignToCall(const ExprStmt* e);
 bool CheckForBuiltIn(const ExprPtr& e, CallExprPtr c);
-const ZAMStmt DoCall(const CallExpr* c, const NameExpr* n);
+ZAMStmt DoCall(const CallExpr* c, const NameExpr* n);
 
-const ZAMStmt ConstructTable(const NameExpr* n, const Expr* e);
-const ZAMStmt ConstructSet(const NameExpr* n, const Expr* e);
-const ZAMStmt ConstructRecord(const NameExpr* n, const Expr* e) { return ConstructRecord(n, e, false); }
-const ZAMStmt ConstructRecordFromRecord(const NameExpr* n, const Expr* e) { return ConstructRecord(n, e, true); }
-const ZAMStmt ConstructRecord(const NameExpr* n, const Expr* e, bool is_from_rec);
-const ZAMStmt ConstructVector(const NameExpr* n, const Expr* e);
+ZAMStmt ConstructTable(const NameExpr* n, const Expr* e);
+ZAMStmt ConstructSet(const NameExpr* n, const Expr* e);
+ZAMStmt ConstructRecord(const NameExpr* n, const Expr* e) { return ConstructRecord(n, e, false); }
+ZAMStmt ConstructRecordFromRecord(const NameExpr* n, const Expr* e) { return ConstructRecord(n, e, true); }
+ZAMStmt ConstructRecord(const NameExpr* n, const Expr* e, bool is_from_rec);
+ZAMStmt ConstructVector(const NameExpr* n, const Expr* e);
 
-const ZAMStmt ArithCoerce(const NameExpr* n, const Expr* e);
-const ZAMStmt RecordCoerce(const NameExpr* n, const Expr* e);
-const ZAMStmt TableCoerce(const NameExpr* n, const Expr* e);
-const ZAMStmt VectorCoerce(const NameExpr* n, const Expr* e);
+ZAMStmt ArithCoerce(const NameExpr* n, const Expr* e);
+ZAMStmt RecordCoerce(const NameExpr* n, const Expr* e);
+ZAMStmt TableCoerce(const NameExpr* n, const Expr* e);
+ZAMStmt VectorCoerce(const NameExpr* n, const Expr* e);
 
-const ZAMStmt Is(const NameExpr* n, const Expr* e);
+ZAMStmt Is(const NameExpr* n, const Expr* e);

--- a/src/script_opt/ZAM/Low-Level.cc
+++ b/src/script_opt/ZAM/Low-Level.cc
@@ -8,20 +8,20 @@
 
 namespace zeek::detail {
 
-const ZAMStmt ZAMCompiler::StartingBlock() { return ZAMStmt(insts1.size()); }
+ZAMStmt ZAMCompiler::StartingBlock() { return {static_cast<int>(insts1.size())}; }
 
-const ZAMStmt ZAMCompiler::FinishBlock(const ZAMStmt /* start */) { return ZAMStmt(insts1.size() - 1); }
+ZAMStmt ZAMCompiler::FinishBlock(ZAMStmt /* start */) { return {static_cast<int>(insts1.size() - 1)}; }
 
 bool ZAMCompiler::NullStmtOK() const {
     // They're okay iff they're the entire statement body.
     return insts1.empty();
 }
 
-const ZAMStmt ZAMCompiler::EmptyStmt() { return ZAMStmt(insts1.size() - 1); }
+ZAMStmt ZAMCompiler::EmptyStmt() { return {static_cast<int>(insts1.size() - 1)}; }
 
-const ZAMStmt ZAMCompiler::ErrorStmt() { return ZAMStmt(0); }
+ZAMStmt ZAMCompiler::ErrorStmt() { return {0}; }
 
-const ZAMStmt ZAMCompiler::LastInst() { return ZAMStmt(insts1.size() - 1); }
+ZAMStmt ZAMCompiler::LastInst() { return {static_cast<int>(insts1.size() - 1)}; }
 
 void ZAMCompiler::AddCFT(ZInstI* inst, ControlFlowType cft) {
     if ( cft == CFT_NONE )
@@ -116,7 +116,7 @@ int ZAMCompiler::InternalAddVal(ZInstAux* zi, int i, Expr* e) {
     return 1;
 }
 
-const ZAMStmt ZAMCompiler::AddInst(const ZInstI& inst, bool suppress_non_local) {
+ZAMStmt ZAMCompiler::AddInst(const ZInstI& inst, bool suppress_non_local) {
     ZInstI* i;
 
     if ( pending_inst ) {
@@ -133,7 +133,7 @@ const ZAMStmt ZAMCompiler::AddInst(const ZInstI& inst, bool suppress_non_local) 
     top_main_inst = insts1.size() - 1;
 
     if ( suppress_non_local )
-        return ZAMStmt(top_main_inst);
+        return {top_main_inst};
 
     // Ensure we haven't confused ourselves about any pending stores.
     ASSERT(pending_global_store == -1 || pending_capture_store == -1);
@@ -169,7 +169,7 @@ const ZAMStmt ZAMCompiler::AddInst(const ZInstI& inst, bool suppress_non_local) 
         return AddInst(store_inst);
     }
 
-    return ZAMStmt(top_main_inst);
+    return {top_main_inst};
 }
 
 const Stmt* ZAMCompiler::LastStmt(const Stmt* s) const {

--- a/src/script_opt/ZAM/Low-Level.h
+++ b/src/script_opt/ZAM/Low-Level.h
@@ -4,14 +4,14 @@
 //
 // This file is included by Compile.h to insert into the ZAMCompiler class.
 
-const ZAMStmt StartingBlock();
-const ZAMStmt FinishBlock(const ZAMStmt start);
+ZAMStmt StartingBlock();
+ZAMStmt FinishBlock(ZAMStmt start);
 
 bool NullStmtOK() const;
 
-const ZAMStmt EmptyStmt();
-const ZAMStmt ErrorStmt();
-const ZAMStmt LastInst();
+ZAMStmt EmptyStmt();
+ZAMStmt ErrorStmt();
+ZAMStmt LastInst();
 
 // Adds control flow information to an instruction.
 void AddCFT(ZInstI* inst, ControlFlowType cft);
@@ -29,7 +29,7 @@ int InternalAddVal(ZInstAux* zi, int i, Expr* e);
 // Adds the given instruction to the ZAM program.  The second
 // argument, if true, suppresses generation of any pending
 // global/capture store for this instruction.
-const ZAMStmt AddInst(const ZInstI& inst, bool suppress_non_local = false);
+ZAMStmt AddInst(const ZInstI& inst, bool suppress_non_local = false);
 
 // Returns the last (interpreter) statement in the body.
 const Stmt* LastStmt(const Stmt* s) const;

--- a/src/script_opt/ZAM/Stmt.h
+++ b/src/script_opt/ZAM/Stmt.h
@@ -6,44 +6,44 @@
 
 // Note, we first list the AST nodes and then the helper functions, though
 // in the definitions source these are intermingled.
-const ZAMStmt CompileStmt(const StmtPtr& body) { return CompileStmt(body.get()); }
-const ZAMStmt CompileStmt(const Stmt* body);
+ZAMStmt CompileStmt(const StmtPtr& body) { return CompileStmt(body.get()); }
+ZAMStmt CompileStmt(const Stmt* body);
 
-const ZAMStmt CompilePrint(const PrintStmt* ps);
-const ZAMStmt CompileExpr(const ExprStmt* es);
-const ZAMStmt CompileIf(const IfStmt* is);
-const ZAMStmt CompileSwitch(const SwitchStmt* sw);
-const ZAMStmt CompileWhile(const WhileStmt* ws);
-const ZAMStmt CompileFor(const ForStmt* f);
-const ZAMStmt CompileReturn(const ReturnStmt* r);
-const ZAMStmt CompileCatchReturn(const CatchReturnStmt* cr);
-const ZAMStmt CompileStmts(const StmtList* sl);
-const ZAMStmt CompileInit(const InitStmt* is);
-const ZAMStmt CompileWhen(const WhenStmt* ws);
-const ZAMStmt CompileAssert(const AssertStmt* ws);
+ZAMStmt CompilePrint(const PrintStmt* ps);
+ZAMStmt CompileExpr(const ExprStmt* es);
+ZAMStmt CompileIf(const IfStmt* is);
+ZAMStmt CompileSwitch(const SwitchStmt* sw);
+ZAMStmt CompileWhile(const WhileStmt* ws);
+ZAMStmt CompileFor(const ForStmt* f);
+ZAMStmt CompileReturn(const ReturnStmt* r);
+ZAMStmt CompileCatchReturn(const CatchReturnStmt* cr);
+ZAMStmt CompileStmts(const StmtList* sl);
+ZAMStmt CompileInit(const InitStmt* is);
+ZAMStmt CompileWhen(const WhenStmt* ws);
+ZAMStmt CompileAssert(const AssertStmt* ws);
 
-const ZAMStmt CompileNext() { return GenGoTo(nexts.back()); }
-const ZAMStmt CompileBreak() { return GenGoTo(breaks.back()); }
-const ZAMStmt CompileFallThrough() { return GenGoTo(fallthroughs.back()); }
-const ZAMStmt CompileCatchReturn() { return GenGoTo(catches.back()); }
+ZAMStmt CompileNext() { return GenGoTo(nexts.back()); }
+ZAMStmt CompileBreak() { return GenGoTo(breaks.back()); }
+ZAMStmt CompileFallThrough() { return GenGoTo(fallthroughs.back()); }
+ZAMStmt CompileCatchReturn() { return GenGoTo(catches.back()); }
 
-const ZAMStmt IfElse(const Expr* e, const Stmt* s1, const Stmt* s2);
+ZAMStmt IfElse(const Expr* e, const Stmt* s1, const Stmt* s2);
 // Second argument is which instruction slot holds the branch target.
-const ZAMStmt GenCond(const Expr* e, int& branch_v);
+ZAMStmt GenCond(const Expr* e, int& branch_v);
 
-const ZAMStmt While(const Stmt* cond_stmt, const Expr* cond, const Stmt* body);
+ZAMStmt While(const Stmt* cond_stmt, const Expr* cond, const Stmt* body);
 
-const ZAMStmt ValueSwitch(const SwitchStmt* sw, const NameExpr* v, const ConstExpr* c);
-const ZAMStmt TypeSwitch(const SwitchStmt* sw, const NameExpr* v, const ConstExpr* c);
-const ZAMStmt GenSwitch(const SwitchStmt* sw, int slot, InternalTypeTag it);
+ZAMStmt ValueSwitch(const SwitchStmt* sw, const NameExpr* v, const ConstExpr* c);
+ZAMStmt TypeSwitch(const SwitchStmt* sw, const NameExpr* v, const ConstExpr* c);
+ZAMStmt GenSwitch(const SwitchStmt* sw, int slot, InternalTypeTag it);
 
-const ZAMStmt LoopOverTable(const ForStmt* f, const NameExpr* val);
-const ZAMStmt LoopOverVector(const ForStmt* f, const NameExpr* val);
-const ZAMStmt LoopOverString(const ForStmt* f, const Expr* e);
+ZAMStmt LoopOverTable(const ForStmt* f, const NameExpr* val);
+ZAMStmt LoopOverVector(const ForStmt* f, const NameExpr* val);
+ZAMStmt LoopOverString(const ForStmt* f, const Expr* e);
 
-const ZAMStmt Loop(const Stmt* body);
-const ZAMStmt FinishLoop(const ZAMStmt iter_head, ZInstI& iter_stmt, const Stmt* body, int iter_slot, bool is_table);
+ZAMStmt Loop(const Stmt* body);
+ZAMStmt FinishLoop(ZAMStmt iter_head, ZInstI& iter_stmt, const Stmt* body, int iter_slot, bool is_table);
 
-const ZAMStmt InitRecord(IDPtr id, RecordType* rt);
-const ZAMStmt InitVector(IDPtr id, VectorType* vt);
-const ZAMStmt InitTable(IDPtr id, TableType* tt, Attributes* attrs);
+ZAMStmt InitRecord(IDPtr id, RecordType* rt);
+ZAMStmt InitVector(IDPtr id, VectorType* vt);
+ZAMStmt InitTable(IDPtr id, TableType* tt, Attributes* attrs);

--- a/src/script_opt/ZAM/Vars.cc
+++ b/src/script_opt/ZAM/Vars.cc
@@ -50,7 +50,7 @@ void ZAMCompiler::LoadParam(const IDPtr& id) {
     (void)AddInst(z);
 }
 
-const ZAMStmt ZAMCompiler::LoadGlobal(const IDPtr& id) {
+ZAMStmt ZAMCompiler::LoadGlobal(const IDPtr& id) {
     ZOp op;
 
     if ( id->IsType() )
@@ -73,7 +73,7 @@ const ZAMStmt ZAMCompiler::LoadGlobal(const IDPtr& id) {
     return AddInst(z, true);
 }
 
-const ZAMStmt ZAMCompiler::LoadCapture(const IDPtr& id) {
+ZAMStmt ZAMCompiler::LoadCapture(const IDPtr& id) {
     ZOp op;
 
     if ( ZVal::IsManagedType(id->GetType()) )

--- a/src/script_opt/ZAM/Vars.h
+++ b/src/script_opt/ZAM/Vars.h
@@ -10,8 +10,8 @@ bool IsCapture(const IDPtr& id) const;
 int CaptureOffset(const IDPtr& id) const;
 
 void LoadParam(const IDPtr& id);
-const ZAMStmt LoadGlobal(const IDPtr& id);
-const ZAMStmt LoadCapture(const IDPtr& id);
+ZAMStmt LoadGlobal(const IDPtr& id);
+ZAMStmt LoadCapture(const IDPtr& id);
 
 int AddToFrame(const IDPtr&);
 

--- a/src/spicy/spicyz/config.h.in
+++ b/src/spicy/spicyz/config.h.in
@@ -35,15 +35,15 @@ static path get_env_path_or(const char* name, const char* default_) {
         return default_;
 }
 
-inline const auto InstallBinDir() { return path("${CMAKE_INSTALL_PREFIX}") / "${CMAKE_INSTALL_BINDIR}"; }
+inline auto InstallBinDir() { return path("${CMAKE_INSTALL_PREFIX}") / "${CMAKE_INSTALL_BINDIR}"; }
 
-inline const auto LibraryPath() { return get_env_path_or("ZEEK_SPICY_LIBRARY_PATH", "@ZEEK_SPICY_LIBRARY_PATH@"); }
+inline auto LibraryPath() { return get_env_path_or("ZEEK_SPICY_LIBRARY_PATH", "@ZEEK_SPICY_LIBRARY_PATH@"); }
 
-inline const auto ModulePath() { return get_env_path_or("ZEEK_SPICY_MODULE_PATH", "@ZEEK_SPICY_MODULE_PATH@"); }
+inline auto ModulePath() { return get_env_path_or("ZEEK_SPICY_MODULE_PATH", "@ZEEK_SPICY_MODULE_PATH@"); }
 
-inline const auto DataPath() { return get_env_path_or("ZEEK_SPICY_DATA_PATH", "@ZEEK_SPICY_DATA_PATH@"); }
+inline auto DataPath() { return get_env_path_or("ZEEK_SPICY_DATA_PATH", "@ZEEK_SPICY_DATA_PATH@"); }
 
-inline const auto CxxZeekIncludesDirectories() {
+inline auto CxxZeekIncludesDirectories() {
     std::string includes;
     add_path(includes, path("${CMAKE_INSTALL_PREFIX}") / "${CMAKE_INSTALL_INCLUDEDIR}");
 

--- a/tools/gen-zam/Gen-ZAM.cc
+++ b/tools/gen-zam/Gen-ZAM.cc
@@ -591,10 +591,10 @@ void ZAM_OpTemplate::InstantiateMethod(const string& m, const string& suffix, co
     auto decls = MethodDeclare(oc, zc);
 
     EmitTo(MethodDecl);
-    Emit("const ZAMStmt " + m + suffix + "(" + decls + ");");
+    Emit("ZAMStmt " + m + suffix + "(" + decls + ");");
 
     EmitTo(MethodDef);
-    Emit("const ZAMStmt ZAMCompiler::" + m + suffix + "(" + decls + ")");
+    Emit("ZAMStmt ZAMCompiler::" + m + suffix + "(" + decls + ")");
     BeginBlock();
 
     InstantiateMethodCore(oc, suffix, zc);


### PR DESCRIPTION
This enables the clang-tidy [readability-const-return-type](https://clang.llvm.org/extra/clang-tidy/checks/readability/const-return-type.html) checker and fixes the findings related to it. This checker looks for places where functions return `const` variables that don't need to be const (they're elementary types or very simple structures). It also fixes one file-local utility function to be `static` that wasn't marked as such before.