### PR TITLE
ZAM built-in for incrementing a Telemetry counter

### DIFF
--- a/src/script_opt/ZAM/BuiltIn.cc
+++ b/src/script_opt/ZAM/BuiltIn.cc
@@ -470,6 +470,13 @@ MultiZBI fsrb_ZBI{ "Files::__set_reassembly_buffer",
      {{VC}, {OP_FILES_SET_REASSEMBLY_BUFFER_VVi, OP_VVV_I3}}}
 };
 
+MultiZBI tic_ZBI{ "Telemetry::__counter_inc",
+    {{{VV}, {OP_TELEMETRY_COUNTER_INC_VV, OP_VV}},
+     {{VC}, {OP_TELEMETRY_COUNTER_INC_VC, OP_VC}}},
+    {{{VV}, {OP_TELEMETRY_COUNTER_INC_VVV, OP_VVV}},
+     {{VC}, {OP_TELEMETRY_COUNTER_INC_VVC, OP_VVC}}}
+};
+
 MultiZBI lw_ZBI{ "Log::__write",
     {{{VV}, {OP_LOG_WRITE_VV, OP_VV}},
      {{CV}, {OP_LOG_WRITE_CV, OP_V}}},

--- a/src/script_opt/ZAM/OPs/ZBI.op
+++ b/src/script_opt/ZAM/OPs/ZBI.op
@@ -490,6 +490,39 @@ op-types I S U
 side-effects OP_FILES_SET_REASSEMBLY_BUFFER_Vi OP_VV_I2
 eval	$$ = ZAM::file_mgr_set_reassembly_buffer($1, $2);
 
+macro TelemetryCounterInc(result, family, increment)
+	{
+	if ( auto ptr = dynamic_cast<CounterMetricVal*>(family) )
+		{
+		ptr->GetHandle()->Inc(increment);
+		result = 1;
+		}
+	else
+		{
+		zeek::reporter->Error("Telemetry::counter_inc: invalid handle.");
+		result = 0;
+		}
+	}
+
+internal-op Telemetry-Counter-Inc
+op1-read
+classes VV VC
+op-types O D
+eval	bool result;
+	TelemetryCounterInc(result, $1, $2)
+
+internal-op Telemetry-Counter-Inc
+class VVV
+op-types I O D
+side-effects OP_TELEMETRY_COUNTER_INC_VV OP_VV
+eval	TelemetryCounterInc($$, $1, $2)
+
+internal-op Telemetry-Counter-Inc
+class VVC
+op-types I O D
+side-effects OP_TELEMETRY_COUNTER_INC_VC OP_VC
+eval	TelemetryCounterInc($$, $1, $2)
+
 internal-op Get-Bytes-Thresh
 classes VVV VVC
 op-types U R I

--- a/src/script_opt/ZAM/Validate.cc
+++ b/src/script_opt/ZAM/Validate.cc
@@ -24,8 +24,9 @@ std::vector<std::pair<string, string>> zam_macro_desc = {
 // for now we keep this form because it provides flexibility for
 // accommodating other forms of accessors.
 static std::map<char, string> type_pats = {
-    {'A', "Addr"},    {'a', "Any"},    {'D', "Double"}, {'F', "Func"},  {'I', "Int"},  {'L', "List"},  {'N', "SubNet"},
-    {'P', "Pattern"}, {'R', "Record"}, {'S', "String"}, {'T', "Table"}, {'t', "Type"}, {'U', "Count"}, {'V', "Vector"},
+    {'A', "Addr"},   {'a', "Any"},    {'D', "Double"}, {'F', "Func"},    {'I', "Int"},
+    {'L', "List"},   {'N', "SubNet"}, {'O', "Opaque"}, {'P', "Pattern"}, {'R', "Record"},
+    {'S', "String"}, {'T', "Table"},  {'t', "Type"},   {'U', "Count"},   {'V', "Vector"},
 };
 
 static int num_valid = 0;

--- a/src/script_opt/ZAM/ZBody.cc
+++ b/src/script_opt/ZAM/ZBody.cc
@@ -16,6 +16,8 @@
 #include "zeek/script_opt/ScriptOpt.h"
 #include "zeek/script_opt/ZAM/Compile.h"
 #include "zeek/script_opt/ZAM/Support.h"
+#include "zeek/telemetry/Manager.h"
+#include "zeek/telemetry/Opaques.h"
 
 // Forward declarations from RunState.cc
 namespace zeek::run_state {


### PR DESCRIPTION
I'd like to make telemetry as cheap to use as possible. My initial use case concerns counters, so this PR adds a custom ZAM instruction for those, rather than enduring the overhead of calling the BiF. Down the road I may add others if they wind up being hot-spots too.