### PR TITLE
Avoid unnecessary `dynamic_cast` when getting metric counter values

### DIFF
--- a/src/script_opt/ZAM/OPs/ZBI.op
+++ b/src/script_opt/ZAM/OPs/ZBI.op
@@ -492,7 +492,7 @@ eval	$$ = ZAM::file_mgr_set_reassembly_buffer($1, $2);
 
 macro TelemetryCounterInc(result, family, increment)
 	{
-	if ( auto ptr = dynamic_cast<CounterMetricVal*>(family) )
+	if ( auto ptr = static_cast<CounterMetricVal*>(family) )
 		{
 		ptr->GetHandle()->Inc(increment);
 		result = 1;

--- a/src/telemetry/telemetry_functions.bif
+++ b/src/telemetry/telemetry_functions.bif
@@ -16,7 +16,7 @@ namespace {
 template <class ScriptHandle, class Fun>
 auto with(zeek::Val* val, const char* error_msg, Fun fun)
 	{
-	if ( auto ptr = dynamic_cast<ScriptHandle*>(val) )
+	if ( auto ptr = static_cast<ScriptHandle*>(val) )
 		{
 		fun(ptr->GetHandle());
 		return zeek::val_mgr->True();


### PR DESCRIPTION
This was raised by @awelzel in https://github.com/zeek/zeek/pull/5021#discussion_r2528788906.