### PR TITLE
Remove Spicy DNS from CI

### DIFF
--- a/ci/spicy-install-analyzers.sh
+++ b/ci/spicy-install-analyzers.sh
@@ -17,7 +17,6 @@ zkg --version
 
 ANALYZERS="
 https://github.com/zeek/spicy-dhcp
-https://github.com/zeek/spicy-dns
 https://github.com/zeek/spicy-http
 "
 


### PR DESCRIPTION
It probably just isn't worth it to keep up with it for now.

This caused a CI failure in master because of https://github.com/zeek/spicy-dns/issues/19