### PR TITLE
Docs: Fix reference error in the DNS analyzer docs

### DIFF
--- a/doc/script-reference/autogenerated-protocol-analyzer-index.rst
+++ b/doc/script-reference/autogenerated-protocol-analyzer-index.rst
@@ -3364,8 +3364,8 @@ Events
 
    :Type: :zeek:type:`event` (c: :zeek:type:`connection`, msg: :zeek:type:`dns_msg`, zname: :zeek:type:`string`, zclass: :zeek:type:`count`)
 
-   Generated for DNS Dynamic Update messages. See `RFC for Dynamic Updates in the Domain Name System (DNS UPDATE) <https://datatracker.ietf.org/doc/html/rfc2136`__
-   for more information about Dynamic Updates.
+   Generated for DNS Dynamic Update messages. See :rfc:`2136` for more information
+   about Dynamic Updates.
    
 
    :param c: The connection, which may be UDP or TCP depending on the type of the

--- a/doc/scripts/base/bif/plugins/Zeek_DNS.events.bif.zeek.rst
+++ b/doc/scripts/base/bif/plugins/Zeek_DNS.events.bif.zeek.rst
@@ -1008,8 +1008,8 @@ Events
 
    :Type: :zeek:type:`event` (c: :zeek:type:`connection`, msg: :zeek:type:`dns_msg`, zname: :zeek:type:`string`, zclass: :zeek:type:`count`)
 
-   Generated for DNS Dynamic Update messages. See `RFC for Dynamic Updates in the Domain Name System (DNS UPDATE) <https://datatracker.ietf.org/doc/html/rfc2136`__
-   for more information about Dynamic Updates.
+   Generated for DNS Dynamic Update messages. See :rfc:`2136` for more information
+   about Dynamic Updates.
    
 
    :param c: The connection, which may be UDP or TCP depending on the type of the

--- a/src/analyzer/protocol/dns/events.bif
+++ b/src/analyzer/protocol/dns/events.bif
@@ -837,8 +837,8 @@ event dns_HTTPS%(c: connection, msg: dns_msg, ans: dns_answer, https: dns_svcb_r
 ##    dns_skip_addl dns_skip_all_addl dns_skip_all_auth dns_skip_auth
 event dns_end%(c: connection, msg: dns_msg%);
 
-## Generated for DNS Dynamic Update messages. See `RFC for Dynamic Updates in the Domain Name System (DNS UPDATE) <https://datatracker.ietf.org/doc/html/rfc2136`__
-## for more information about Dynamic Updates.
+## Generated for DNS Dynamic Update messages. See :rfc:`2136` for more information
+## about Dynamic Updates.
 ##
 ## c: The connection, which may be UDP or TCP depending on the type of the
 ##    transport-layer session being analyzed.


### PR DESCRIPTION
This fixes the following error when building the docs:

```
/home/tim/projects/zeek/doc/script-reference/proto-analyzers.rst:: ERROR: Anonymous hyperlink mismatch: 1 references but 0 targets.
See "backrefs" attribute for IDs.
/home/tim/projects/zeek/doc/scripts/base/bif/plugins/Zeek_DNS.events.bif.zeek.rst:: ERROR: Anonymous hyperlink mismatch: 1 references but 0 targets.
See "backrefs" attribute for IDs.
```