### PR TITLE
CI: Require gcc-12 on Ubuntu 22.04 and CentOS 9

### DIFF
--- a/ci/centos-stream-9/Dockerfile
+++ b/ci/centos-stream-9/Dockerfile
@@ -25,8 +25,8 @@ RUN dnf -y --nobest install \
     cppzmq-devel \
     diffutils \
     flex \
-    gcc \
-    gcc-c++ \
+    gcc-toolset-12-gcc \
+    gcc-toolset-12-gcc-c++ \
     git \
     jq \
     libpcap-devel \
@@ -50,5 +50,9 @@ RUN dnf -y --nobest install crypto-policies-scripts && update-crypto-policies --
 # Override the default python3.9 installation paths with 3.13
 RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.13 10
 RUN alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.13 10
+
+# Override the default gcc 11 installation paths with gcc 12
+RUN alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 100
+RUN alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 100
 
 RUN pip3 install websockets junit2html

--- a/ci/ubuntu-22.04/Dockerfile
+++ b/ci/ubuntu-22.04/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get -y install \
     cmake \
     curl \
     flex \
-    g++ \
-    gcc \
+    g++-12 \
+    gcc-12 \
     git \
     jq \
     lcov \
@@ -41,3 +41,6 @@ RUN apt-get update && apt-get -y install \
 
 RUN pip3 install websockets junit2html
 RUN gem install coveralls-lcov
+
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-12 100
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 100


### PR DESCRIPTION
This updates the CI Dockerfiles for Ubuntu 22.04 and Centos Stream 9 to require gcc-12. See https://github.com/zeek/spicy/issues/2204 for details. I'll update the support matrix once this is merged.