### PR TITLE
Pass sanitizer flags to external plugin builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -829,6 +829,7 @@ if (ZEEK_SANITIZERS)
     # https://cmake.org/pipermail/cmake/2014-August/058268.html
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_sanitizer_flags}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_sanitizer_flags}")
+    set(ZEEK_SANITIZER_CXX_FLAGS ${_sanitizer_flags})
 endif ()
 
 # ##############################################################################

--- a/NEWS
+++ b/NEWS
@@ -247,6 +247,9 @@ Changed Functionality
 - The ``x509.log`` deduplication logic has been reimplemented with explicit
   ``Cluster::publish()``, rather than relying ``&backend`` tables using Broker.
 
+- Sanitizer flags passed to a Zeek build with ``configure``'s ``--santiizers`` argument are
+  now automatically passed to plugins built against that Zeek source tree.
+
 Removed Functionality
 ---------------------
 

--- a/cmake_templates/ZeekPluginBootstrap.cmake.in
+++ b/cmake_templates/ZeekPluginBootstrap.cmake.in
@@ -20,4 +20,11 @@ set(ZEEK_PLUGIN_SCRIPTS_PATH "${ZEEK_CMAKE_CONFIG_DIR}"
 
 # The CMAKE_BUILD_TYPE type to use for external plugins if not overridden.
 set(ZEEK_CMAKE_BUILD_TYPE "@CMAKE_BUILD_TYPE@"
-    CACHE PATH "Internal Zeek variable: CMAKE_BUILD_TYPE of Zeek." FORCE)
+    CACHE STRING "Internal Zeek variable: CMAKE_BUILD_TYPE of Zeek." FORCE)
+
+# Set CFLAGS/CXXFLAGS if the Zeek build was built with sanitizers.
+set(_sanitizer_flags "@ZEEK_SANITIZER_CXX_FLAGS@")
+if ( _sanitizer_flags )
+    set(CMAKE_C_FLAGS "${_sanitizer_flags} ${CMAKE_C_FLAGS}" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS "${_sanitizer_flags} ${CMAKE_CXX_FLAGS}" CACHE STRING "" FORCE)
+endif ()


### PR DESCRIPTION
This came up in some internal discussions about debugging memory issues in plugins. We realized that while we were building Zeek with ASAN turned on, those flags were not being passed down automatically to plugin builds. This might be potentially useful if you're working on a large system with lots of plugins. This sets an extra during the CMake build of Zeek and propagates it to plugins via ZeekConfig.cmake.

Note that I had to use `PARENT_SCOPE` when setting the values for the plugins. Otherwise they weren't ended up in plugin builds. I didn't investigate whether that was the case for other CMake variables being set in the same fashion.