### PR TITLE
Add flags for controlling utf8 escaping instead of bools

### DIFF
--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -250,7 +250,9 @@ void ODesc::AddBytes(const void* bytes, size_t n) {
         if ( esc_start != nullptr ) {
             if ( utf8 ) {
                 assert(esc_start >= s);
-                std::string result = util::escape_utf8({s, static_cast<size_t>(esc_start - s)}, true);
+                std::string result =
+                    util::escape_utf8({s, static_cast<size_t>(esc_start - s)},
+                                      util::ESCAPE_PRINTABLE_CONTROLS | util::ESCAPE_UNPRINTABLE_CONTROLS);
                 AddBytesRaw(result.c_str(), result.size());
             }
             else
@@ -262,7 +264,9 @@ void ODesc::AddBytes(const void* bytes, size_t n) {
         else {
             if ( utf8 ) {
                 assert(e >= s);
-                std::string result = util::escape_utf8({s, static_cast<size_t>(e - s)}, true);
+                std::string result =
+                    util::escape_utf8({s, static_cast<size_t>(e - s)},
+                                      util::ESCAPE_PRINTABLE_CONTROLS | util::ESCAPE_UNPRINTABLE_CONTROLS);
                 AddBytesRaw(result.c_str(), result.size());
             }
             else

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -432,7 +432,7 @@ static void BuildJSON(json::detail::NullDoubleWriter& writer, Val* val, bool onl
             if ( tag == TYPE_FUNC )
                 desc = util::strstrip(desc);
 
-            writer.String(util::escape_utf8(desc));
+            writer.String(util::escape_utf8(desc, util::ESCAPE_UNPRINTABLE_CONTROLS));
             break;
         }
 

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -438,9 +438,13 @@ struct scoped_reporter_location {
 #ifdef DEBUG
 namespace {
 
-std::string RenderMessage(const broker::variant& d) { return util::escape_utf8(broker::to_string(d)); }
+std::string RenderMessage(const broker::variant& d) {
+    return util::escape_utf8(broker::to_string(d), util::ESCAPE_UNPRINTABLE_CONTROLS);
+}
 
-std::string RenderMessage(const broker::variant_list& d) { return util::escape_utf8(broker::to_string(d)); }
+std::string RenderMessage(const broker::variant_list& d) {
+    return util::escape_utf8(broker::to_string(d), util::ESCAPE_UNPRINTABLE_CONTROLS);
+}
 
 std::string RenderMessage(const broker::store::response& x) {
     return util::fmt("%s [id %" PRIu64 "]", (x.answer ? broker::to_string(*x.answer).c_str() : "<no answer>"), x.id);

--- a/src/threading/formatters/JSON.cc
+++ b/src/threading/formatters/JSON.cc
@@ -145,7 +145,7 @@ void JSON::BuildJSON(zeek::json::detail::NullDoubleWriter& writer, Value* val, c
         case TYPE_FILE:
         case TYPE_FUNC: {
             writer.String(util::escape_utf8({val->val.string_val.data, static_cast<size_t>(val->val.string_val.length)},
-                                            false, false));
+                                            util::ESCAPE_NONE));
             break;
         }
 

--- a/src/util.h
+++ b/src/util.h
@@ -528,28 +528,34 @@ std::string canonify_name(const std::string& name);
  */
 void zeek_strerror_r(int zeek_errno, char* buf, size_t buflen);
 
+enum UTF8EscapingFlags : uint8_t {
+    ESCAPE_NONE = 0x00,
+    // Escape printable ASCII control characters (e.g. `\n` is converted to `\x0a`)
+    ESCAPE_PRINTABLE_CONTROLS = 0x01,
+    // Escape unprintable ASCII control characters
+    ESCAPE_UNPRINTABLE_CONTROLS = 0x02,
+};
+
 /**
  * Escapes bytes in a string that are not valid UTF8 characters with \xYY format. Used
  * by the JSON writer and BIF methods.
  * @param val the character data to be escaped. this is a string_view, but it can hold
  * null characters in the middle of the data.
- * @param escape_printable_controls flag for whether printable control characters
- * (e.g. newlines, tabs, etc) should be escaped in the output. Defaults to false.
- * @param escape_other_controls flag for whether non-printable control characters
- * (e.g. nulls, bells, etc) should be escaped in the output.
+ * @param flags a combination of the values from UTF8EscapingFlags to control special
+ * casing. Set to ESCAPE_NONE to disable all special cases.
  * @return the escaped string
  */
-std::string escape_utf8(std::string_view val, bool escape_printable_controls = false,
-                        bool escape_other_controls = true);
+std::string escape_utf8(std::string_view val, int flags);
 
 [[deprecated("Remove in v9.1. Use escape_utf8 instead.")]]
 inline std::string json_escape_utf8(const char* val, size_t val_size, bool escape_printable_controls = true) {
-    return escape_utf8(std::string_view{val, val_size}, ! escape_printable_controls);
+    return escape_utf8(std::string_view{val, val_size},
+                       escape_printable_controls ? ESCAPE_NONE : ESCAPE_PRINTABLE_CONTROLS);
 }
 
 [[deprecated("Remove in v9.1. Use escape_utf8 instead.")]]
 inline std::string json_escape_utf8(const std::string& val, bool escape_printable_controls = true) {
-    return escape_utf8(val, ! escape_printable_controls);
+    return escape_utf8(val, escape_printable_controls ? ESCAPE_NONE : ESCAPE_PRINTABLE_CONTROLS);
 }
 
 /**


### PR DESCRIPTION
This came up in the review of https://github.com/zeek/zeek/pull/5014, but I opted to push it off into a follow-up. This changes the flags for controlling what characters are escaped for UTF8 output to an `enum` of flags instead of a set of `bool`s. This should make it more explicit about what is happening.