### PR TITLE
Fix `:zeek:see:` in backtick in docs

### DIFF
--- a/scripts/base/protocols/conn/main.zeek
+++ b/scripts/base/protocols/conn/main.zeek
@@ -28,7 +28,7 @@ export {
 		## The transport layer protocol of the connection.
 		proto:        transport_proto &log;
 		## A comma-separated list of confirmed protocol(s).
-		## With :zeek:see:DPD::track_removed_services_in_connection, the list
+		## With :zeek:see:DPD::`track_removed_services_in_connection`, the list
 		## includes the same protocols prefixed with "-" to record that Zeek
 		## dropped them due to parsing violations."
 		service:      string          &log &optional;


### PR DESCRIPTION
The original change got reverted from auto-docs generation, so this fixes it in the script file itself. Co-authoring for attribution.

Original was daa0e565c04aa4355a76cd5433b81663cb09bf4f in #5054 