### PR TITLE
Use ranges versions of all_of, any_of, etc.

### DIFF
--- a/src/DNS_Mapping.cc
+++ b/src/DNS_Mapping.cc
@@ -161,8 +161,8 @@ void DNS_Mapping::Save(FILE* f) const {
 }
 
 void DNS_Mapping::Merge(const DNS_MappingPtr& other) {
-    std::copy(other->names.begin(), other->names.end(), std::back_inserter(names));
-    std::copy(other->addrs.begin(), other->addrs.end(), std::back_inserter(addrs));
+    std::ranges::copy(other->names, std::back_inserter(names));
+    std::ranges::copy(other->addrs, std::back_inserter(addrs));
 }
 
 // This value needs to be incremented if something changes in the data stored by Save(). This

--- a/src/Dict.h
+++ b/src/Dict.h
@@ -415,10 +415,10 @@ public:
             visited = new std::vector<detail::DictEntry<T>>();
 
             if ( other.inserted )
-                std::copy(other.inserted->begin(), other.inserted->end(), std::back_inserter(*inserted));
+                std::ranges::copy(*other.inserted, std::back_inserter(*inserted));
 
             if ( other.visited )
-                std::copy(other.visited->begin(), other.visited->end(), std::back_inserter(*visited));
+                std::ranges::copy(*other.visited, std::back_inserter(*visited));
 
             dict = other.dict;
             dict->IncrIters();
@@ -601,7 +601,7 @@ public:
 
                     // Check if any of the inserted elements in this iterator point at the entry
                     // being replaced. Update those too.
-                    auto it = std::find(c->inserted->begin(), c->inserted->end(), table[position]);
+                    auto it = std::ranges::find(*c->inserted, table[position]);
                     if ( it != c->inserted->end() )
                         it->value = val;
                 }
@@ -1518,7 +1518,7 @@ private:
             // Filter out visited entries.
             while ( iter->next < capacity ) {
                 ASSERT(! table[iter->next].Empty());
-                auto it = std::find(iter->visited->begin(), iter->visited->end(), table[iter->next]);
+                auto it = std::ranges::find(*iter->visited, table[iter->next]);
                 if ( it == iter->visited->end() )
                     break;
                 iter->visited->erase(it);

--- a/src/RuleAction.cc
+++ b/src/RuleAction.cc
@@ -61,8 +61,7 @@ RuleActionEvent::RuleActionEvent(const char* arg_msg, const char* event_name) {
                     continue;
 
                 std::vector<TypePtr> tplist;
-                std::for_each(p.args->Types()->begin(), p.args->Types()->end(),
-                              [&tplist](const auto* td) { tplist.push_back(td->type); });
+                std::ranges::for_each(*p.args->Types(), [&tplist](const auto* td) { tplist.push_back(td->type); });
 
                 (void)handler->GetType()->CheckArgs(tplist, true, true);
             }

--- a/src/packet_analysis/Dispatcher.cc
+++ b/src/packet_analysis/Dispatcher.cc
@@ -58,7 +58,7 @@ const AnalyzerPtr& Dispatcher::Lookup(uint64_t identifier) const {
 }
 
 size_t Dispatcher::Count() const {
-    return std::count_if(table.begin(), table.end(), [](AnalyzerPtr a) { return a != nullptr; });
+    return std::ranges::count_if(table, [](AnalyzerPtr a) { return a != nullptr; });
 }
 
 void Dispatcher::Clear() {

--- a/src/scan.l
+++ b/src/scan.l
@@ -180,8 +180,8 @@ static void do_pragma(const std::string& pragma) {
         zeek::reporter->Warning("Ignoring unknown pragma: '%s'", pragma.c_str());
 
     // Cheap: Just walk the pragma_stack now to see if we should ignore deprecations.
-    bool ignore_deprecations = std::any_of(pragma_stack.cbegin(), pragma_stack.cend(),
-                                           [](const auto& s) { return s == "ignore-deprecations"; });
+    bool ignore_deprecations = std::ranges::any_of(pragma_stack,
+                                                   [](const auto& s) { return s == "ignore-deprecations"; });
     zeek::reporter->SetIgnoreDeprecations(ignore_deprecations);
 }
 

--- a/src/telemetry/telemetry_functions.bif
+++ b/src/telemetry/telemetry_functions.bif
@@ -70,7 +70,7 @@ bool labels_valid(std::span<const zeek::telemetry::LabelView> labels,
 	{
 	auto key_in_label_names = [keys{label_names}](auto x)
 		{
-		return std::find(keys.begin(), keys.end(), x.first) != keys.end();
+		return std::ranges::find(keys, x.first) != keys.end();
 		};
 	return labels.size() == label_names.size()
 	       && std::ranges::all_of(labels, key_in_label_names);


### PR DESCRIPTION
Modernizing low-hanging fruits to use less-noisy C++20 versions. Not pulling in `<ranges>` yet, only sticking to new overloads in the `<algorithm>` header.