### PR TITLE
ZAM optimization of certain conditional branches

### DIFF
--- a/src/script_opt/ZAM/AM-Opt.h
+++ b/src/script_opt/ZAM/AM-Opt.h
@@ -15,6 +15,9 @@ void TallySwitchTargets(const CaseMapsI<T>& switches);
 // Remove code that can't be reached.  True if some removal happened.
 bool RemoveDeadCode();
 
+// Invert conditionals that branch around unconditional branches.
+bool InvertConditionalsAroundGotos();
+
 // Collapse chains of gotos.  True if some something changed.
 bool CollapseGoTos();
 
@@ -82,7 +85,7 @@ ZInstI* NextLiveInst(ZInstI* i, bool follow_gotos = false) {
         return nullptr;
     return FirstLiveInst(insts1[i->inst_num + 1], follow_gotos);
 }
-int NextLiveInst(int i, bool follow_gotos = false) { return FirstLiveInst(i + 1, follow_gotos); }
+zeek_uint_t NextLiveInst(int i, bool follow_gotos = false) { return FirstLiveInst(i + 1, follow_gotos); }
 
 // Mark an instruction as unnecessary and remove its influence on
 // other statements.  The instruction is indicated as an offset

--- a/src/script_opt/ZAM/Low-Level.cc
+++ b/src/script_opt/ZAM/Low-Level.cc
@@ -34,7 +34,7 @@ void ZAMCompiler::AddCFT(ZInstI* inst, ControlFlowType cft) {
     if ( cft_entry == inst->aux->cft.end() )
         inst->aux->cft[cft] = 1;
     else {
-        ASSERT(cft == CFT_BLOCK_END || cft == CFT_LOOP_END || cft == CFT_BREAK);
+        ASSERT(cft == CFT_BLOCK_END || cft == CFT_LOOP_END || cft == CFT_BREAK || cft == CFT_INLINED_RETURN);
         ++cft_entry->second;
     }
 }

--- a/src/script_opt/ZAM/OPs/README.txt
+++ b/src/script_opt/ZAM/OPs/README.txt
@@ -167,6 +167,14 @@
 #		such as 'b', 'f', 'g', and 's', the corresponding type to
 #		list is 'I', used for integer access.
 #
+#	inverse	For instructions that can be used in conditionals, specifies
+#		the "inverse" conditional. For example, the inverse for LE
+#		(less-than-or-equal) is GT (greater-than). This attribute
+#		isn't needed for instructions that have a "*-Not-*Cond"
+#		form (like "Val2-Is-Not-In-Table-Cond"), since for them
+#		Gen-ZAM can automatically infer that the inverse from
+#		the structure of the name (e.g., "Val2-Is-In-Table-Cond").
+#
 # 	eval	specifies a block of C++ code used to evaluation the
 # 		execution of the instruction.  The block begins with the
 # 		remainder of the "eval" line and continues until either a

--- a/src/script_opt/ZAM/OPs/non-uniform.op
+++ b/src/script_opt/ZAM/OPs/non-uniform.op
@@ -143,6 +143,7 @@ eval	EvalVal2InTablePre($1,$2,$3)
 internal-op Val2-Is-In-Table-Cond
 op1-read
 class VVVb
+inverse Val2-Is-Not-In-Table-Cond
 eval	EvalVal2InTablePre($1,$2,$3)
 	EvalVal2InTableCond($3, INDEX_LIST, $4, !)
 
@@ -153,6 +154,7 @@ macro EvalVal2InTableCond(tbl, op, BRANCH, negate)
 internal-op Val2-Is-Not-In-Table-Cond
 op1-read
 class VVVb
+inverse Val2-Is-In-Table-Cond
 eval	EvalVal2InTablePre($1,$2,$3)
 	EvalVal2InTableCond($3, INDEX_LIST, $4,)
 
@@ -169,24 +171,28 @@ eval	EvalVal2InTableCore($2.ToVal(Z_TYPE), $1.ToVal(Z_TYPE2))
 internal-op Val2-Is-In-Table-Cond
 op1-read
 class VVbC
+inverse Val2-Is-Not-In-Table-Cond
 eval	EvalVal2InTableCore($1.ToVal(Z_TYPE2), $4.ToVal(Z_TYPE))
 	EvalVal2InTableCond($2, INDEX_LIST, $3, !)
 
 internal-op Val2-Is-In-Table-Cond
 op1-read
 class VVCb
+inverse Val2-Is-Not-In-Table-Cond
 eval	EvalVal2InTableCore($3.ToVal(Z_TYPE), $1.ToVal(Z_TYPE2))
 	EvalVal2InTableCond($2, INDEX_LIST, $4, !)
 
 internal-op Val2-Is-Not-In-Table-Cond
 op1-read
 class VVbC
+inverse Val2-Is-In-Table-Cond
 eval	EvalVal2InTableCore($1.ToVal(Z_TYPE2), $4.ToVal(Z_TYPE))
 	EvalVal2InTableCond($2, INDEX_LIST, $3, )
 
 internal-op Val2-Is-Not-In-Table-Cond
 op1-read
 class VVCb
+inverse Val2-Is-In-Table-Cond
 eval	EvalVal2InTableCore($3.ToVal(Z_TYPE), $1.ToVal(Z_TYPE2))
 	EvalVal2InTableCond($2, INDEX_LIST, $4, )
 

--- a/src/script_opt/ZAM/OPs/rel-exprs.op
+++ b/src/script_opt/ZAM/OPs/rel-exprs.op
@@ -3,6 +3,7 @@
 rel-expr-op LT
 op-type I U D S T A
 vector
+inverse GE
 eval $1 < $2
 eval-type S	Bstr_cmp($1->AsString(), $2->AsString()) < 0
 eval-type T	$1->IsSubsetOf(*$2) && $1->Size() < $2->Size()
@@ -11,6 +12,7 @@ eval-type A	$1->AsAddr() < $2->AsAddr()
 rel-expr-op LE
 op-type I U D S T A
 vector
+inverse GT
 eval $1 <= $2
 eval-type S	Bstr_cmp($1->AsString(), $2->AsString()) <= 0
 eval-type T	$1->IsSubsetOf(*$2)
@@ -19,6 +21,7 @@ eval-type A	$1->AsAddr() < $2->AsAddr() || $1->AsAddr() == $2->AsAddr()
 rel-expr-op EQ
 op-type I U D S T A N F P
 vector
+inverse NE
 eval $1 == $2
 eval-type S	Bstr_cmp($1->AsString(), $2->AsString()) == 0
 eval-type T	$1->EqualTo(*$2)
@@ -31,6 +34,7 @@ eval-mixed P S	$1->MatchExactly($2->AsString())
 rel-expr-op NE
 op-type I U D S T A N F P
 vector
+inverse EQ
 eval $1 != $2
 eval-type S	Bstr_cmp($1->AsString(), $2->AsString()) != 0
 eval-type T	! $1->EqualTo(*$2)
@@ -45,6 +49,7 @@ eval-mixed P S	! $1->MatchExactly($2->AsString())
 rel-expr-op GE
 op-type I U D S A
 vector
+inverse LT
 eval $1 >= $2
 eval-type S	Bstr_cmp($1->AsString(), $2->AsString()) >= 0
 eval-type A	! ($1->AsAddr() < $2->AsAddr())
@@ -52,6 +57,7 @@ eval-type A	! ($1->AsAddr() < $2->AsAddr())
 rel-expr-op GT
 op-type I U D S A
 vector
+inverse LE
 eval $1 > $2
 eval-type S	Bstr_cmp($1->AsString(), $2->AsString()) > 0
 eval-type A	! ($1->AsAddr() < $2->AsAddr()) && $1->AsAddr() != $2->AsAddr()

--- a/src/script_opt/ZAM/ZOp.cc
+++ b/src/script_opt/ZAM/ZOp.cc
@@ -15,6 +15,15 @@ const char* ZOP_name(ZOp op) {
     return "<error>";
 }
 
+ZOp inverse_ZOP(ZOp op) {
+    switch ( op ) {
+#include "zeek/ZAM-OpInverses.h"
+        default: return OP_NOP;
+    }
+}
+
+bool ZOP_has_inverse(ZOp op) { return inverse_ZOP(op) != OP_NOP; }
+
 static const char* op_type_name(ZAMOpType ot) {
     switch ( ot ) {
         case OP_X: return "X";

--- a/src/script_opt/ZAM/ZOp.h
+++ b/src/script_opt/ZAM/ZOp.h
@@ -84,4 +84,11 @@ extern ZAMOp1Flavor op1_flavor[];
 // Maps an operand to whether it has side effects.
 extern bool op_side_effects[];
 
+// Returns the inverse of a given ZAM opcode (e.g., OP_LE -> OP_GT).
+// Returns OP_NOP if the opcode has no inverse.
+extern ZOp inverse_ZOP(ZOp op);
+
+// Returns true if the given ZAM opcode has an inverse.
+extern bool ZOP_has_inverse(ZOp op);
+
 } // namespace zeek::detail


### PR DESCRIPTION
Looking over some generated ZAM code, I noticed that there's a not-all-that-rare pattern that looks like:
```
0: on-some-condition-branch-to 2
1: goto 99
2: more-instructions
```
This can be optimized to:
```
0: on-NOT-some-condition-branch-to 99
1: more-instructions
```
providing there's a negated version of the original conditional instruction available. In addition, that optimization can then facilitate follow-on optimizations due to creating a straight-line path in the code.

This PR provides support for the optimization, divided into a few different parts:

- Extending the ZAM instruction templating language (and thus also `gen-zam`) to include a new `inverse` specifier mapping an instruction to its inverse, for use in the _...-NOT-..._ shown flipping above.
- Adding additional logic to `gen-zam` to automatically recognize certain instructions for which it can infer their inverses
- Adding an optimization step (`InvertConditionalsAroundGotos()`)  to `src/script_opt/ZAM/AM-Opt.cc` to identify opportunities for making the optimization
- Fixing the human-readable representations for some ZAM operations, which was broken a while back
- Some minor improvements to debugging output that the optimizer can generate