### PR TITLE
Add OpenContainers labels to docker images created by CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -730,7 +730,10 @@ docker_build_template: &DOCKER_BUILD_TEMPLATE
     mkdir -p ${BUILDER_IMAGE_CACHE_DIR} ${ZEEK_IMAGE_CACHE_DIR}
     if [ -f ${BUILDER_IMAGE_CACHE_DIR}/builder.zst ]; then zstd -d < ${BUILDER_IMAGE_CACHE_DIR}/builder.zst | docker load; fi
     if [ -f ${BUILDER_IMAGE_CACHE_DIR}/final.zst ]; then zstd -d < ${BUILDER_IMAGE_CACHE_DIR}/final.zst | docker load; fi
-    cd docker && docker build --cache-from zeek-builder:latest -t zeek-builder:latest -f builder.Dockerfile .
+    cd docker && docker build \
+                     --cache-from zeek-builder:latest \
+                     --build-arg GIT_COMMIT=${CIRRUS_CHANGE_IN_REPO} \
+                     -t zeek-builder:latest -f builder.Dockerfile .
     docker save zeek-builder:latest | zstd > ${BUILDER_IMAGE_CACHE_DIR}/builder.zst
   build_zeek_script: |
     set -x
@@ -746,7 +749,14 @@ docker_build_template: &DOCKER_BUILD_TEMPLATE
     docker commit zeek-builder-container zeek-build
   build_final_script: |
     set -x
-    cd docker && docker build --cache-from ${IMAGE_TAG} -t ${IMAGE_TAG} -f final.Dockerfile .
+    ZEEK_VERSION=$(cat VERSION)
+    CREATED_DATE=$(date -Iseconds)
+    cd docker && docker build \
+                     --cache-from ${IMAGE_TAG} \
+                     --build-arg ZEEK_VERSION=${ZEEK_VERSION} \
+                     --build-arg GIT_COMMIT=${CIRRUS_CHANGE_IN_REPO} \
+                     --build-arg CREATED_DATE=${CREATED_DATE} \
+                     -t ${IMAGE_TAG} -f final.Dockerfile .
     docker save ${IMAGE_TAG} | zstd > ${ZEEK_IMAGE_CACHE_DIR}/final.zst
   test_script: |
     set -x

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -46,3 +46,11 @@ RUN apt-get -q update \
 
 # Tell git all the repositories are safe.
 RUN git config --global --add safe.directory '*'
+
+# OpenContainers annotation labels. We only care about the revision label for
+# the builder image since it gets cached on Cirrus. The full set of labels is
+# set in the final image.
+# See https://github.com/opencontainers/image-spec/blob/main/annotations.md
+# for more details.
+ARG GIT_COMMIT
+LABEL org.opencontainers.image.revision=$GIT_COMMIT

--- a/docker/final.Dockerfile
+++ b/docker/final.Dockerfile
@@ -42,3 +42,24 @@ RUN apt-get -q update \
 COPY --from=zeek-build /usr/local/zeek /usr/local/zeek
 ENV PATH="/usr/local/zeek/bin:${PATH}"
 ENV PYTHONPATH="/usr/local/zeek/lib/zeek/python:${PYTHONPATH}"
+
+# OpenContainers annotation labels.
+# See https://github.com/opencontainers/image-spec/blob/main/annotations.md
+# for more details.
+ARG ZEEK_VERSION
+ARG GIT_COMMIT
+ARG CREATED_DATE
+LABEL org.opencontainers.image.created=$CREATED_DATE
+LABEL org.opencontainers.image.authors="info@zeek.org"
+LABEL org.opencontainers.image.url="https://zeek.org"
+LABEL org.opencontainers.image.documentation="https://docs.zeek.org"
+LABEL org.opencontainers.image.source="https://github.com/zeek/zeek"
+LABEL org.opencontainers.image.version=$ZEEK_VERSION
+LABEL org.opencontainers.image.revision=$GIT_COMMIT
+LABEL org.opencontainers.image.vendor="The Zeek Project"
+LABEL org.opencontainers.image.licenses="BSD-3-Clause"
+#LABEL org.opencontainers.image.ref.name=
+LABEL org.opencontainers.image.title="Zeek"
+LABEL org.opencontainers.image.description="Zeek is a powerful network analysis framework that is much different from the typical IDS you may know."
+#LABEL org.opencontainers.image.base.digest=
+#LABEL org.opencontainers.image.base.name=


### PR DESCRIPTION
This adds the annotations recommended by OCI from https://github.com/opencontainers/image-spec/blob/main/annotations.md to the docker images we generate in CI. This is a stepping stone to fixing https://github.com/zeek/zeek/issues/4794, adding the git commit hash to the image, but also adding the other labels while I was at it.

Fixes #5006 