### PR TITLE
Wait for file_state_remove to exit scripts/base/frameworks/file-analysis/logging-input-analysis btest

### DIFF
--- a/testing/btest/scripts/base/frameworks/file-analysis/logging-input-analysis.zeek
+++ b/testing/btest/scripts/base/frameworks/file-analysis/logging-input-analysis.zeek
@@ -12,7 +12,7 @@ event zeek_init()
 	Input::add_analysis([$source=source, $name=source]);
 	}
 
-event file_new(f: fa_file)
+event file_state_remove(f: fa_file)
 	{
 	terminate();
 	}


### PR DESCRIPTION
It's odd that this only happens on FreeBSD. There must be some subtle timing difference there. I do see this btest fail very randomly on my mac though, but I've never been able to reproduce it regularly like is happening on CI.

The timeout is happening because `file_analysis::Mananger::Terminate` is being called before we're done with the file, and it calls Timeout on all existing files. Instead of waiting for `file_new` in the btest, wait for `file_state_remove` so we can be sure we're done with the file.