### PR TITLE
Fix FuncInfo flag for ZAM for anonymize_addr BIF

### DIFF
--- a/src/script_opt/FuncInfo.cc
+++ b/src/script_opt/FuncInfo.cc
@@ -196,7 +196,7 @@ static std::unordered_map<std::string, unsigned int> func_attrs = {
     {"addr_to_ptr_name", ATTR_FOLDABLE},
     {"addr_to_subnet", ATTR_FOLDABLE},
     {"all_set", ATTR_FOLDABLE},
-    {"anonymize_addr", ATTR_FOLDABLE},
+    {"anonymize_addr", ATTR_IDEMPOTENT},
     {"any_set", ATTR_FOLDABLE},
     {"backtrace", ATTR_NO_SCRIPT_SIDE_EFFECTS},
     {"bare_mode", ATTR_FOLDABLE},

--- a/testing/btest/bifs/anonymize_addr.zeek
+++ b/testing/btest/bifs/anonymize_addr.zeek
@@ -1,4 +1,5 @@
 # @TEST-DOC: Test the various IP anonymizer methods
+#
 # @TEST-EXEC: zeek -b %INPUT
 # @TEST-EXEC: btest-diff .stdout
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-remove-abspath btest-diff .stderr


### PR DESCRIPTION
Running these tests under ZAM results in this error:

```
  internal error: IP anonymizer not initialized
```