### PR TITLE
Attempt to fix circular TOC dependency in docs

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _zeek-docs: https://app.readthedocs.org/projects/zeek-docs
 .. _Read the Docs: https://docs.readthedocs.com/platform/stable/index.html
 .. _Zeek repo: https://github.com/zeek/zeek

--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -1,4 +1,6 @@
 
+.. _doc_repo:  https://github.com/zeek/zeek/tree/master/doc
+
 ================
 Developer Guides
 ================
@@ -9,13 +11,15 @@ content is maintained directly in the `Zeek wiki
 the content (e.g. the author finds it to be more dynamic, informal, meta,
 transient, etc. compared to other documentation).
 
+For more information about the documentation itself, see the ``doc`` directory
+within the Zeek source tree `here <doc_repo_>`_.
+
 .. toctree::
    :maxdepth: 2
 
    plugins
    spicy/index
    websocket-api
-   Documentation Guide </README.rst>
    contributors
    maintainers
    cluster-backend-zeromq


### PR DESCRIPTION
I had a docs build that was spinning 2 processes without stopping. I went in with pyspy and found this:

```
Thread 0x204D3A200 (active+gil): "MainThread"
    <...>
    _entries_from_toctree (sphinx/environment/adapters/toctree.py:161)
    resolve (sphinx/environment/adapters/toctree.py:238)
    get_and_resolve_doctree (sphinx/environment/__init__.py:595)
    _write_parallel (sphinx/builders/__init__.py:612)
    <...>
    main (sphinx/cmd/build.py:315)
    <module> (sphinx-build:8)
```

Then, I asked Gemini to find a circular dependency in docs and it found one about 6-TOC long here. Change it in case it ever comes up again. I don't know a better way to try to find the TOC circular dependency.