### PR TITLE
Support for dynamic Config::config_files additions

### DIFF
--- a/scripts/base/frameworks/config/input.zeek
+++ b/scripts/base/frameworks/config/input.zeek
@@ -12,7 +12,11 @@ export {
 	##
 	## If the same configuration option is defined in several files with
 	## different values, behavior is unspecified.
-	const config_files: set[string] = {} &redef;
+	##
+	## If you change the variable at run-time rather than via &redef,
+	## you need to do so in a zeek_init() event handler with priority
+	## higher than 5 in order to have the change take effect.
+	global config_files: set[string] = {} &redef;
 
 	## Read specified configuration file and apply values; updates to file
 	## are not tracked.

--- a/testing/btest/Baseline/scripts.base.frameworks.config.several-files/zeek.config.log
+++ b/testing/btest/Baseline/scripts.base.frameworks.config.several-files/zeek.config.log
@@ -5,6 +5,7 @@ XXXXXXXXXX.XXXXXX	test_vector	(empty)	1,2,3,4,5,6	../configfile1
 XXXXXXXXXX.XXXXXX	testaddr	127.0.0.1	127.0.0.1	../configfile2
 XXXXXXXXXX.XXXXXX	testbool	T	F	../configfile1
 XXXXXXXXXX.XXXXXX	testcount	0	2	../configfile1
+XXXXXXXXXX.XXXXXX	testcountDyn	0	99	../configfileDyn
 XXXXXXXXXX.XXXXXX	testenum	SSH::LOG	Conn::LOG	../configfile1
 XXXXXXXXXX.XXXXXX	testint	0	-1	../configfile1
 XXXXXXXXXX.XXXXXX	testinterval	1.0 sec	1.0 min	../configfile2

--- a/testing/btest/scripts/base/frameworks/config/several-files.zeek
+++ b/testing/btest/scripts/base/frameworks/config/several-files.zeek
@@ -24,6 +24,10 @@ testinterval 60
 testtime 1507321987
 # @TEST-END-FILE
 
+# @TEST-START-FILE configfileDyn
+testcountDyn 99
+# @TEST-END-FILE
+
 @load base/protocols/ssh
 @load base/protocols/conn
 
@@ -39,7 +43,14 @@ export {
 	option teststring = "a";
 	option test_set: set[string] = {};
 	option test_vector: vector of count = {};
+
+	option testcountDyn = 0;
 }
+
+event zeek_init() &priority=10
+	{
+	Config::config_files += set("../configfileDyn");
+	}
 
 global ct = 0;
 
@@ -51,7 +62,7 @@ event Input::end_of_data(name: string, source: string)
 	++ct;
 
 	# Exit after this event has been raised for each config file.
-	if ( ct == 2 )
+	if ( ct == 3 )
 		terminate();
 
 	}


### PR DESCRIPTION
`Config::config_files` is a list of files to read to set `option`s. Currently it's a `const` variable so can't be changed dynamically. This PR changes it to `global` so that in a (high-priority) `zeek_init()` handler, a script can adjust its contents dynamically.