### PR TITLE
CI: Use docker imagetools instead of docker manifest

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -698,6 +698,7 @@ windows_task:
 docker_build_template: &DOCKER_BUILD_TEMPLATE
   cpu: *CPUS
   memory: *MEMORY
+  version_script: docker version && docker buildx version
   set_image_tag_script: echo "IMAGE_TAG=zeek/zeek-multiarch:${CIRRUS_ARCH}" >> $CIRRUS_ENV
 
   env:
@@ -822,6 +823,8 @@ container_image_manifest_docker_builder:
     DOCKER_PASSWORD: ENCRYPTED[!6c4b2f6f0e5379ef1091719cc5d2d74c90cfd2665ac786942033d6d924597ffb95dbbc1df45a30cc9ddeec76c07ac620!]
     AWS_ECR_ACCESS_KEY_ID: ENCRYPTED[!eff52f6442e1bc78bce5b15a23546344df41bf519f6201924cb70c7af12db23f442c0e5f2b3687c2d856ceb11fcb8c49!]
     AWS_ECR_SECRET_ACCESS_KEY: ENCRYPTED[!748bc302dd196140a5fa8e89c9efd148882dc846d4e723787d2de152eb136fa98e8dea7e6d2d6779d94f72dd3c088228!]
+    BUILDKIT_PROGRESS: plain
+  version_script: docker version && docker buildx version
   login_script: |
     docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
     AWS_ACCESS_KEY_ID=$AWS_ECR_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_ECR_SECRET_ACCESS_KEY aws ecr-public get-login-password --region us-east-1 | \

--- a/ci/container-images-tag-and-push.sh
+++ b/ci/container-images-tag-and-push.sh
@@ -39,11 +39,11 @@ function do_docker {
 
 function create_and_push_manifest {
     # Expects $1 to be the manifest tag, globals otherwise
-    do_docker manifest create --amend ${REGISTRY_PREFIX}${ZEEK_IMAGE_REPO}/${IMAGE_NAME}:${1} \
+    do_docker buildx imagetools create \
+        --debug \
+        --tag ${REGISTRY_PREFIX}${ZEEK_IMAGE_REPO}/${IMAGE_NAME}:${1} \
         ${REGISTRY_PREFIX}${ZEEK_IMAGE_REPO}/${IMAGE_NAME}:${IMAGE_TAG}-arm64 \
         ${REGISTRY_PREFIX}${ZEEK_IMAGE_REPO}/${IMAGE_NAME}:${IMAGE_TAG}-amd64
-
-    do_docker manifest push ${REGISTRY_PREFIX}${ZEEK_IMAGE_REPO}/$IMAGE_NAME:${1}
 }
 
 do_docker tag zeek/zeek-multiarch:arm64 ${REGISTRY_PREFIX}${ZEEK_IMAGE_REPO}/${IMAGE_NAME}:${IMAGE_TAG}-arm64


### PR DESCRIPTION
The docker manifest command was marked as experimental and newer versions of docker include a provenance manifest [1, 2]. Switch to docker imagetools create for creating the multi-platform image instead of docker manifest as suggested in some places [3].

[1] https://github.com/docker/build-push-action/issues/755
[2] https://github.com/docker/buildx/issues/1509
[3] https://stackoverflow.com/a/75742743

Fixes #5119