### PR TITLE
Fixes for -O gen-standalone-C++ working with empty Attributes

### DIFF
--- a/src/script_opt/CPP/Attrs.cc
+++ b/src/script_opt/CPP/Attrs.cc
@@ -7,7 +7,7 @@ namespace zeek::detail {
 using namespace std;
 
 shared_ptr<CPP_InitInfo> CPPCompile::RegisterAttributes(const AttributesPtr& attrs) {
-    if ( ! attrs )
+    if ( ! attrs || attrs->GetAttrs().empty() )
         return nullptr;
 
     auto a = attrs.get();

--- a/src/script_opt/CPP/Attrs.h
+++ b/src/script_opt/CPP/Attrs.h
@@ -10,8 +10,8 @@ public:
 // initialization dependencies and the generation of any
 // associated expressions.
 //
-// Returns the initialization info associated with the set of
-// attributes.
+// Returns the initialization info associated with the set of attributes.
+// Returns nil if the attributes are empty.
 std::shared_ptr<CPP_InitInfo> RegisterAttributes(const AttributesPtr& attrs);
 
 // Convenient access to the global offset associated with

--- a/src/script_opt/CPP/Inits.cc
+++ b/src/script_opt/CPP/Inits.cc
@@ -110,17 +110,18 @@ void CPPCompile::InitializeFieldMappings() {
     for ( const auto& mapping : field_decls ) {
         auto rt_arg = Fmt(mapping.first);
         auto td = mapping.second;
+        auto tda = td->attrs;
 
         string type_arg = "DO_NOT_CONSTRUCT_VALUE_MARKER";
         string attrs_arg = "DO_NOT_CONSTRUCT_VALUE_MARKER";
 
-        if ( standalone ) {
+        if ( standalone && tda && ! tda->GetAttrs().empty() ) {
             // We can assess whether this field is one we need to generate
             // because if it is, it will have an &optional attribute that
             // is local to one of the compiled source files.
-            if ( td->attrs && obj_matches_opt_files(td->attrs) == AnalyzeDecision::SHOULD ) {
+            if ( obj_matches_opt_files(tda) == AnalyzeDecision::SHOULD ) {
                 type_arg = Fmt(TypeOffset(td->type));
-                attrs_arg = Fmt(AttributesOffset(td->attrs));
+                attrs_arg = Fmt(AttributesOffset(tda));
             }
         }
 
@@ -220,7 +221,7 @@ void CPPCompile::InitializeGlobal(const IDPtr& g) {
         }
 
         const auto& attrs = g->GetAttrs();
-        if ( attrs ) {
+        if ( attrs && ! attrs->GetAttrs().empty() ) {
             auto attrs_offset = AttributesOffset(attrs);
             auto attrs_str = "CPP__Attributes__[" + Fmt(attrs_offset) + "]";
             Emit("%s->SetAttrs(%s);", globals[g->Name()], attrs_str);

--- a/src/script_opt/CPP/InitsInfo.cc
+++ b/src/script_opt/CPP/InitsInfo.cc
@@ -611,8 +611,10 @@ RecordTypeInfo::RecordTypeInfo(CPPCompile* _c, TypePtr _t, int _addl_fields)
 
         field_types.push_back(r_i->type);
 
-        if ( r_i->attrs && c->TargetingStandalone() && obj_matches_opt_files(r_i->attrs) == AnalyzeDecision::SHOULD ) {
-            gi = c->RegisterAttributes(r_i->attrs);
+        auto a = r_i->attrs;
+        if ( a && ! a->GetAttrs().empty() && c->TargetingStandalone() &&
+             obj_matches_opt_files(a) == AnalyzeDecision::SHOULD ) {
+            gi = c->RegisterAttributes(a);
             final_init_cohort = max(final_init_cohort, gi->InitCohort() + 1);
             field_attrs.push_back(gi->Offset());
         }


### PR DESCRIPTION
The compile-to-C++ compiler had some assumptions that `Attributes` objects always have at least one `Attr`. This turns out not to be the case, due to `redef` allowing the removal of an attribute. This PR fixes the compiler to always treat such instances the same as there being no attributes at all.