### PR TITLE
Add policy script to disable the opcode and opcode_name fields from dns.log

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -249,7 +249,9 @@ New Functionality
 
   This also adds new ``opcode`` and ``opcode_name`` fields to the DNS log. Previously Zeek
   was only handling opcode 0 (normal requests) so that information wasn't pertinent, but
-  with the addition of dynamic updates we're now handling a second opcode.
+  with the addition of dynamic updates we're now handling a second opcode. The new policy
+  script ``policy/protocols/dns/disable-opcode-log-fields.zeek`` can be loaded to remove
+  these fields from the log if they are not desired.
 
 - The `policy/misc/dump-events.zeek` script now features a ``DumpEvents::use_json``
   boolean toggle, false by default, to report Zeek's events in JSON format.

--- a/scripts/policy/protocols/dns/disable-opcode-log-fields.zeek
+++ b/scripts/policy/protocols/dns/disable-opcode-log-fields.zeek
@@ -1,0 +1,6 @@
+##! This script filters the opcode and opcode_name fields from dns.log.
+
+@load base/protocols/dns
+
+redef record DNS::Info$opcode -= { &log };
+redef record DNS::Info$opcode_name -= { &log };

--- a/scripts/test-all-policy.zeek
+++ b/scripts/test-all-policy.zeek
@@ -125,6 +125,7 @@
 @load protocols/dhcp/sub-opts.zeek
 @load protocols/dns/auth-addl.zeek
 @load protocols/dns/detect-external-names.zeek
+#@load protocols/dns/disable-opcode-log-fields.zeek
 @load protocols/dns/log-original-query-case.zeek
 @load protocols/ftp/detect-bruteforcing.zeek
 @load protocols/ftp/detect.zeek

--- a/scripts/zeekygen/__load__.zeek
+++ b/scripts/zeekygen/__load__.zeek
@@ -21,6 +21,7 @@
 @load policy/misc/dump-events.zeek
 @load policy/misc/systemd-generator.zeek
 @load policy/protocols/conn/speculative-service.zeek
+@load policy/protocols/dns/disable-opcode-log-fields.zeek
 
 @if ( have_spicy() )
 # Loading this messes up documentation of some elements defined elsewhere.


### PR DESCRIPTION
This needs to go into 8.1 also.