### PR TITLE
CI: Disable running tests for clang-tidy tasks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -452,6 +452,7 @@ ubuntu24_04_clang_tidy_task:
   << : *CI_TEMPLATE
   << : *ONLY_IF_PR_MASTER_RELEASE
   << : *SKIP_IF_PR_NOT_FULL_CI
+  test_script: echo "Tests disabled for clang-tidy builds"
   env:
     CC: clang-19
     CXX: clang++-19


### PR DESCRIPTION
There's no reason to run the tests for clang-tidy builds. Any failures we care about happen during the build stage. Clang-tidy being enabled isn't flowed down into the plugin btests either, so they don't count.