### PR TITLE
Remove gcc-10.2 workaround from util::strsplit

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1291,13 +1291,7 @@ string strreplace(const string& s, const string& o, const string& n) {
 std::string strstrip(std::string s) {
     auto notspace = [](unsigned char c) { return ! std::isspace(c); };
     s.erase(s.begin(), std::ranges::find_if(s, notspace));
-
-    // We require `std::reverse_iterator::base` here which in e.g., gcc-10.2.1
-    // is not implemented for the range equivalent of the code
-    // (`borrowed_iterator_t` over a `reverse_view`). Stick to the non-ranges
-    // version for now.
-    // NOLINTNEXTLINE(modernize-use-ranges)
-    s.erase(std::find_if(s.rbegin(), s.rend(), notspace).base(), s.end());
+    s.erase(std::ranges::find_if(s | std::views::reverse, notspace).base(), s.end());
 
     return s;
 }


### PR DESCRIPTION
We finally dropped Debian 11 from the support matrix. It was our last GCC 10.x platform. This means we can remove this workaround from util::strsplit and switch to `std::ranges` instead.