### PR TITLE
Topic/timw/use std format for numbers

### DIFF
--- a/src/Desc.cc
+++ b/src/Desc.cc
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <format>
 
 #include "zeek/File.h"
 #include "zeek/IPAddr.h"
@@ -89,57 +90,29 @@ void ODesc::Add(const char* s, int do_indent) {
 void ODesc::Add(int i) {
     if ( IsBinary() )
         AddBytes(&i, sizeof(i));
-    else {
-        char tmp[256];
-        auto res = std::to_chars(tmp, tmp + sizeof(tmp), i);
-        size_t len = res.ptr - tmp;
-        if ( len > 255 )
-            len = 255;
-        tmp[len] = '\0';
-        Add(tmp);
-    }
+    else
+        Add(std::format("{:d}", i).c_str());
 }
 
 void ODesc::Add(uint32_t u) {
     if ( IsBinary() )
         AddBytes(&u, sizeof(u));
-    else {
-        char tmp[256];
-        auto res = std::to_chars(tmp, tmp + sizeof(tmp), u);
-        size_t len = res.ptr - tmp;
-        if ( len > 255 )
-            len = 255;
-        tmp[len] = '\0';
-        Add(tmp);
-    }
+    else
+        Add(std::format("{:d}", u).c_str());
 }
 
 void ODesc::Add(int64_t i) {
     if ( IsBinary() )
         AddBytes(&i, sizeof(i));
-    else {
-        char tmp[256];
-        auto res = std::to_chars(tmp, tmp + sizeof(tmp), i);
-        size_t len = res.ptr - tmp;
-        if ( len > 255 )
-            len = 255;
-        tmp[len] = '\0';
-        Add(tmp);
-    }
+    else
+        Add(std::format("{:d}", i).c_str());
 }
 
 void ODesc::Add(uint64_t u) {
     if ( IsBinary() )
         AddBytes(&u, sizeof(u));
-    else {
-        char tmp[256];
-        auto res = std::to_chars(tmp, tmp + sizeof(tmp), u);
-        size_t len = res.ptr - tmp;
-        if ( len > 255 )
-            len = 255;
-        tmp[len] = '\0';
-        Add(tmp);
-    }
+    else
+        Add(std::format("{:d}", u).c_str());
 }
 
 void ODesc::Add(double d, bool no_exp) {

--- a/src/IPAddr.cc
+++ b/src/IPAddr.cc
@@ -4,6 +4,7 @@
 
 #include <charconv>
 #include <cstdlib>
+#include <format>
 #include <string>
 
 #include "zeek/3rdparty/zeek_inet_ntop.h"
@@ -222,21 +223,10 @@ IPPrefix::IPPrefix(const IPAddr& addr, uint8_t length, bool len_is_v6_relative) 
 }
 
 std::string IPPrefix::AsString() const {
-    std::string str = prefix.AsString() + "/";
-    size_t prefix_len = str.size();
-    str.reserve(prefix_len + 16);
-
-    char* start = str.data() + prefix_len;
-    std::to_chars_result res;
     if ( prefix.GetFamily() == IPv4 )
-        res = std::to_chars(start, start + 16, length - 96);
-    else
-        res = std::to_chars(start, start + 16, length);
+        return prefix.AsString() + "/" + std::format("{:d}", length - 96);
 
-    // The string comes back from to_chars without a null terminator, but res.ptr shows
-    // what character needs to be null.
-    *res.ptr = '\0';
-    return str;
+    return prefix.AsString() + "/" + std::format("{:d}", length);
 }
 
 std::unique_ptr<detail::HashKey> IPPrefix::MakeHashKey() const {

--- a/src/threading/Formatter.cc
+++ b/src/threading/Formatter.cc
@@ -4,6 +4,7 @@
 
 #include <cerrno>
 #include <charconv>
+#include <format>
 
 #include "zeek/3rdparty/zeek_inet_ntop.h"
 #include "zeek/threading/MsgThread.h"
@@ -78,17 +79,10 @@ threading::Value::addr_t Formatter::ParseAddr(const std::string& s) const {
 }
 
 std::string Formatter::Render(const threading::Value::subnet_t& subnet) {
-    char l[16];
-
-    std::to_chars_result res;
     if ( subnet.prefix.family == IPv4 )
-        res = std::to_chars(l, l + sizeof(l), subnet.length - 96);
-    else
-        res = std::to_chars(l, l + sizeof(l), subnet.length);
+        return Render(subnet.prefix) + "/" + std::format("{:d}", subnet.length - 96);
 
-    std::string s = Render(subnet.prefix) + "/" + std::string{l, static_cast<size_t>(res.ptr - l)};
-
-    return s;
+    return Render(subnet.prefix) + "/" + std::format("{:d}", subnet.length);
 }
 
 std::string Formatter::Render(double d) {


### PR DESCRIPTION
This is a follow-up to #5111, with a recommendation from @bbannier to try std::format instead of std::to_chars. This works for the integer calls, but the double calls get sticky around scientific notation and the number of digits present, etc. This is a draft PR just to see what the benchmarker thinks of it.