### PR TITLE
 Fix minor documentation issues

### DIFF
--- a/doc/cluster-setup.rst
+++ b/doc/cluster-setup.rst
@@ -338,11 +338,11 @@ a network link in a coordinated fashion.  You can operate such a setup from
 a central manager system easily using ZeekControl because it
 hides much of the complexity of the multi-machine installation.
 
-This section gives examples of how to setup common cluster configurations
+This section gives examples of how to set up common cluster configurations
 using ZeekControl.  For a full reference on ZeekControl, see the
 `ZeekControl documentation`_.
 
-Preparing to Setup a Cluster
+Preparing to Set up a Cluster
 ----------------------------
 
 We refer to the user account used to set up the cluster
@@ -377,7 +377,7 @@ instead of the manager process.
 Basic Cluster Configuration
 ---------------------------
 
-With all prerequisites in place, perform the following steps to setup
+With all prerequisites in place, perform the following steps to set up
 a Zeek cluster (do this as the Zeek user on the manager host only):
 
 - Edit the ZeekControl configuration file, ``<prefix>/etc/zeekctl.cfg``,

--- a/doc/scripting/basics.rst
+++ b/doc/scripting/basics.rst
@@ -253,7 +253,7 @@ value will be the domain queried in the malware hash registry.
 
 The rest of the script is contained within a ``when`` block.  In
 short, a ``when`` block is used when Zeek needs to perform asynchronous
-actions, such as a DNS lookup, to ensure that performance isn't effected.
+actions, such as a DNS lookup, to ensure that performance isn't affected.
 The ``when`` block performs a DNS TXT lookup and stores the result
 in the local variable ``MHR_result``.  Effectively, processing for
 this event continues and upon receipt of the values returned by
@@ -768,7 +768,7 @@ You can see the full script and its output below.
 Tables
 ~~~~~~
 
-A table in Zeek is a mapping of a key to a value or yield.  While the
+A table in Zeek is a mapping of a key to a value or field.  While the
 values don't have to be unique, each key in the table must be unique
 to preserve a one-to-one mapping of keys to values.
 

--- a/doc/scripting/event-groups.rst
+++ b/doc/scripting/event-groups.rst
@@ -50,7 +50,7 @@ the output is as follows.
 
 Such debugging functionality would generally only be enabled on demand. Extending
 the above script, we introduce an option and a change handler function from the
-:ref:`configuration framework`<framework-configuration>`
+:ref:`configuration framework`<framework-configuration>
 to enable and disable the ``http-print-debugging`` event group at runtime.
 
 .. literalinclude:: event_groups_attr_02.zeek


### PR DESCRIPTION
Addresses a small number of typos and stylistic considerations in a few documentation files.