### PR TITLE
Performance improvements for gen-standalone-C++ compilation that initializes large aggregates

### DIFF
--- a/src/script_opt/CPP/Driver.cc
+++ b/src/script_opt/CPP/Driver.cc
@@ -592,7 +592,8 @@ void CPPCompile::GenFinishInit() {
             gi->GetCohortIDs(c, init_ids);
 
             for ( auto& ii : init_ids )
-                InitializeGlobal(ii);
+                if ( ! HasFixedInit(ii) )
+                    InitializeGlobal(ii);
         }
 
     NL();

--- a/src/script_opt/CPP/Vars.h
+++ b/src/script_opt/CPP/Vars.h
@@ -33,6 +33,10 @@ bool AddGlobal(const std::string& g, const char* suffix);
 // Tracks that the body we're currently compiling refers to the given event.
 void RegisterEvent(std::string ev_name);
 
+// True if the given global has a truly constant (aggregate) initialization
+// that will not change across runs.
+bool HasFixedInit(const IDPtr& g) const;
+
 // The following match various forms of identifiers to the name used for
 // their C++ equivalent.
 const char* IDName(const IDPtr& id) { return IDNameStr(id).c_str(); }


### PR DESCRIPTION
In testing `-O gen-standalone-C++`, I ran across a Zeek script that took _2 CPU hours_ to compile. This was because it included a line that initialized a large `table` using explicit code, which GCC does very poorly on. (That was the driver behind my work on switching the initialization part of scripts-to-C++ compilation to using a table-driven approach.) This PR is an optimization for when such initializations occur in a purely constant/fixed fashion, for which we can use the existing table-driven machinery to greatly speed up compilation time. I also tweaked the descriptions inserted into the generated code to truncate after 200 characters, as these could otherwise become so big as to be a major distraction when viewing the code.