### PR TITLE
Correctly handle vector self assign-append

### DIFF
--- a/src/Val.cc
+++ b/src/Val.cc
@@ -3442,7 +3442,9 @@ bool VectorVal::AddTo(Val* val, bool /* is_first_init */) const {
 
     auto last_idx = v->Size();
 
-    for ( auto i = 0u; i < Size(); ++i )
+    const auto num_elements = Size();
+
+    for ( auto i = 0u; i < num_elements; ++i )
         if ( ! v->Assign(last_idx++, At(i)) )
             return false;
 

--- a/testing/btest/language/vector.zeek
+++ b/testing/btest/language/vector.zeek
@@ -249,3 +249,15 @@ event zeek_init()
 	test_case( fmt("pv1 == pv2 -> %s", pv_eq), (pv_eq[0] == T) && (pv_eq[1] == F) );
 	test_case( fmt("pv1 != pv2 -> %s", pv_ne), (pv_ne[0] == F) && (pv_ne[1] == T) );
 }
+
+# Assign-append of self.
+event zeek_init()
+{
+	local v1: vector of count;
+	v1 += v1;
+	assert |v1| == 0, fmt("%s", v1);
+
+	local v2 = vector(1, 2, 3);
+	v2 += v2;
+	assert all_set(v2 == vector(1, 2, 3, 1, 2, 3)), fmt("%s", v2);
+}


### PR DESCRIPTION
When iterating over the source vector during vector `+=` we previously would not cache the size which lead to an infinite loop for self assign-append. By now caching the size we only append the elements originally present.

Closes #5164.