### PR TITLE
Force building only static lightpcapng lib, fixes Windows builds

### DIFF
--- a/src/iosource/pcapng/CMakeLists.txt
+++ b/src/iosource/pcapng/CMakeLists.txt
@@ -1,7 +1,10 @@
 set(LIGHT_USE_ZSTD OFF CACHE BOOL "" FORCE)
 set(LIGHT_USE_ZLIB OFF CACHE BOOL "" FORCE)
 
+set(_build_shared ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(auxil/LightPcapNg)
+set(BUILD_SHARED_LIBS ${_build_shared})
 
 zeek_add_plugin(
     Zeek Pcapng


### PR DESCRIPTION
The shared library isn't necessary, since we don't want to have to install it anyways.