### PR TITLE
Docs: render the version on the index page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,6 +2,9 @@
 .. image:: /images/zeek-logo-text.png
    :align: center
 
+.. centered::
+   Version |release|
+
 ==================
 Zeek Documentation
 ==================


### PR DESCRIPTION
With the switch to showing the `current`-tagged docs by default we noticed that it's hard to identify which version one's looking at. It's already in the page title, but that's quite tucked away. This adds the version, already accessible from our VERSION parsing in conf.py, to the index page.

We should backport this into `release/8.1`, since that branch will receive the next `current` release.

<img src="https://github.com/user-attachments/assets/f9c3bb56-4a5d-4bea-bd7a-131e36480f23" />
