### PR TITLE
Fix clang-tidy findings from recent merge

### DIFF
--- a/src/script_opt/CPP/Vars.cc
+++ b/src/script_opt/CPP/Vars.cc
@@ -125,11 +125,11 @@ void CPPCompile::RegisterEvent(string ev_name) { body_events[body_name].emplace_
 
 class FixedInitChecker : public TraversalCallback {
 public:
-    FixedInitChecker() {}
+    FixedInitChecker() = default;
 
     bool IsFixed() const { return is_fixed; }
 
-    TraversalCode PreExpr(const Expr* e);
+    TraversalCode PreExpr(const Expr* e) override;
 
 private:
     TraversalCode NotFixed() {


### PR DESCRIPTION
https://github.com/zeek/zeek/pull/5165 caused a couple of clang-tidy findings that are resulting in nightly CI failures.