### PR TITLE
misc: downgrade mkdir() failure from error to warning

### DIFF
--- a/testing/btest/scripts/misc-mkdir-warning.zeek
+++ b/testing/btest/scripts/misc-mkdir-warning.zeek
@@ -1,0 +1,8 @@
+# @TEST-EXEC: zeek
+
+event zeek_init()
+    {
+    local ok = mkdir("/root/should_fail");
+    print ok;
+    }
+


### PR DESCRIPTION
## Summary
Downgrades mkdir() failure reporting from error to warning, since directory
creation failures are non-fatal for most scripts.

## Changes
- Replaced error reporting with warning in mkdir() BiF
- Added btest coverage

Fixes #3595
