### PR TITLE
Disable LeakSanitizer on macOS by default

### DIFF
--- a/cmake_templates/zeek-config.h.in
+++ b/cmake_templates/zeek-config.h.in
@@ -274,7 +274,7 @@
 	#endif
 #endif
 
-#if defined(ZEEK_ASAN) && !defined(__FreeBSD__)
+#if defined(ZEEK_ASAN) && ! defined(__FreeBSD__) && ! defined(__APPLE__)
     #include <sanitizer/lsan_interface.h>
     #define ZEEK_LSAN_CHECK(...) __lsan_do_leak_check(__VA_ARGS__)
     #define ZEEK_LSAN_ENABLE(...) __lsan_enable(__VA_ARGS__)

--- a/tools/bifcl/builtin-func.l
+++ b/tools/bifcl/builtin-func.l
@@ -307,8 +307,8 @@ void finish_alternative_mode() {
 #endif
 #endif
 
-// FreeBSD doesn't support LeakSanitizer
-#if defined(USING_ASAN) && ! defined(__FreeBSD__)
+// FreeBSD and macOS don't support LeakSanitizer
+#if defined(USING_ASAN) && ! defined(__FreeBSD__) && ! defined(__APPLE__)
 #include <sanitizer/lsan_interface.h>
 #define BIFCL_LSAN_DISABLE() __lsan_disable()
 #else

--- a/tools/binpac/src/pac_main.cc
+++ b/tools/binpac/src/pac_main.cc
@@ -199,8 +199,8 @@ void usage() {
 #endif
 #endif
 
-// FreeBSD doesn't support LeakSanitizer
-#if defined(USING_ASAN) && ! defined(__FreeBSD__)
+// FreeBSD and macOS don't support LeakSanitizer
+#if defined(USING_ASAN) && ! defined(__FreeBSD__) && ! defined(__APPLE__)
 #include <sanitizer/lsan_interface.h>
 #define BINPAC_LSAN_DISABLE() __lsan_disable()
 #else


### PR DESCRIPTION
This is part of the discussion in #3347. It extends the existing disabling of LeakSanitizer on FreeBSD to include macOS by default, since LSan isn't implemented there and we're required to add `detect_leaks=0` to `ASAN_OPTIONS`. Instead of requiring that, just disable it entirely.