### PR TITLE
docs: use HTTPS for try.zeek.org link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ And run it:
 `zeek hello.zeek`
 
 For learning more about the Zeek scripting
-language, [try.zeek.org](http://try.zeek.org) is a great resource.
+language, [try.zeek.org](https://try.zeek.org) is a great resource.
 
 Development
 -----------


### PR DESCRIPTION
## Summary
Updates the try.zeek.org link in README.md to use HTTPS instead of HTTP.

## Changes
- Changed `http://try.zeek.org` to `https://try.zeek.org` on line 89

## Motivation
The try.zeek.org site fully supports HTTPS. Using HTTPS:
- Provides encrypted connections for users
- Follows modern security best practices
- Prevents potential MITM attacks
- Aligns with other links in the README (which already use HTTPS)

## Testing
Verified that https://try.zeek.org responds successfully with HTTP/2 200.

## Type
- [x] Documentation
- [ ] Bug fix  
- [ ] New feature
- [ ] Breaking change