### PR TITLE
Restore ZAM custom instruction for Files::__add_analyzer

### DIFF
--- a/src/script_opt/ZAM/BuiltIn.cc
+++ b/src/script_opt/ZAM/BuiltIn.cc
@@ -455,6 +455,14 @@ OptAssignZBI bfl_ZBI{ "Broker::__flush_logs",
     0
 };
 
+MultiZBI faa_ZBI{ "Files::__add_analyzer",
+    {{{VVV}, {OP_FILES_ADD_ANALYZER_VVV, OP_VVV}},
+     {{VCV}, {OP_FILES_ADD_ANALYZER_VCV, OP_VVC}}},
+    {{{VVV}, {OP_FILES_ADD_ANALYZER_VVVV, OP_VVVV}},
+     {{VCV}, {OP_FILES_ADD_ANALYZER_VVCV, OP_VVVC}}},
+    1
+};
+
 MultiZBI fra_ZBI{ "Files::__remove_analyzer",
     {{{VVV}, {OP_FILES_REMOVE_ANALYZER_VVV, OP_VVV}},
      {{VCV}, {OP_FILES_REMOVE_ANALYZER_VCV, OP_VVC}}},


### PR DESCRIPTION
https://github.com/zeek/zeek/pull/3967 accidentally removed recognition of the `Files::__add_analyzer` BiF for replacement by ZAM with a custom instruction. This PR reverts that change.