### PR TITLE
Fix clang-tidy warning about needless parameter copies

### DIFF
--- a/src/Func.cc
+++ b/src/Func.cc
@@ -141,7 +141,7 @@ void Func::AddBody(std::function<void(const zeek::Args&, detail::StmtFlowType&)>
     AddBody({.stmts = std::move(stmt), .priority = priority}, {}, 0);
 }
 
-void Func::AddBody(Func::Body new_body, const std::vector<detail::IDPtr>& new_inits, size_t new_frame_size) {
+void Func::AddBody(Func::Body&& new_body, const std::vector<detail::IDPtr>& new_inits, size_t new_frame_size) {
     Internal("Func::AddBody called");
 }
 
@@ -539,7 +539,7 @@ void ScriptFunc::SetCaptures(Frame* f) {
     }
 }
 
-void ScriptFunc::AddBody(Func::Body new_body, const std::vector<IDPtr>& new_inits, size_t new_frame_size) {
+void ScriptFunc::AddBody(Func::Body&& new_body, const std::vector<IDPtr>& new_inits, size_t new_frame_size) {
     auto num_args = static_cast<size_t>(GetType()->Params()->NumFields());
     frame_size = std::max({frame_size, new_frame_size, num_args});
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -119,7 +119,7 @@ public:
 
     // A richer interface for controlling priority, event groups,
     // initializations, and frame size.
-    virtual void AddBody(Func::Body new_body, const std::vector<detail::IDPtr>& new_inits, size_t new_frame_size);
+    virtual void AddBody(Func::Body&& new_body, const std::vector<detail::IDPtr>& new_inits, size_t new_frame_size);
 
     // Deprecated interfaces.
     [[deprecated("Remove in v9.1. Use AddBody(Func::Body...) interface instead.")]]
@@ -261,7 +261,7 @@ public:
 
     using Func::AddBody;
 
-    void AddBody(Func::Body new_body, const std::vector<detail::IDPtr>& new_inits, size_t new_frame_size) override;
+    void AddBody(Func::Body&& new_body, const std::vector<detail::IDPtr>& new_inits, size_t new_frame_size) override;
 
     // Deprecated interface.
     void AddBody(detail::StmtPtr new_body, const std::vector<detail::IDPtr>& new_inits, size_t new_frame_size,


### PR DESCRIPTION
Since not all overloads of the function might consume the passed parameter clang-tidy correctly warns that the copy might be needless (it is for the default implementation). Rewrite the code to a version which performs no copy.