### PR TITLE
Restore running pre-commit during 'Generate Docs' workflow

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -110,6 +110,9 @@ jobs:
 
           cd doc
 
+          echo "*** Running pre-commit ***"
+          pre-commit run -a --show-diff-on-failure --color=always
+
           echo "*** Generating Sphinx Docs ***"
           make > make.out 2>&1
           make_status=$?


### PR DESCRIPTION
https://github.com/zeek/zeek/commit/bcede2a1351d8e448eb91a23d3ea9fe0e3be68df removed running pre-commit as part of the "Generate Docs" workflow. I'm not entirely sure why I did that. The workflow is now complaining about not being able to cache the pre-commit setup because it never actually gets initialized. Restore running pre-commit so that the typos job gets run as part of the workflow at least.