### PR TITLE
Remove install/caching of pre-commit in docs generation workflow

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -64,7 +64,6 @@ jobs:
           python3 -m venv ci-docs-venv
           source ci-docs-venv/bin/activate
           pip3 install -r doc/requirements.txt
-          pip3 install pre-commit
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -92,12 +91,6 @@ jobs:
 
       - name: Check Spicy docs
         run: cd doc && make check-spicy-docs
-
-      # Cache pre-commit environment for reuse.
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: doc-pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('doc/.pre-commit-config.yaml') }}
 
       - name: Generate Docs
         run: |


### PR DESCRIPTION
When the docs moved over into the main repo, we removed calling pre-commit on the docs as part of the docs generation workflow. This makes sense because any commits to the main repo already call pre-commit, and anything that would end up in the docs generation would be caught. There's no reason to keep the other references in the docs generation workflow.