### PR TITLE
Remove trivial uses for unistd.h

### DIFF
--- a/src/Anon.cc
+++ b/src/Anon.cc
@@ -3,7 +3,6 @@
 #include "zeek/Anon.h"
 
 #include <sys/time.h>
-#include <unistd.h>
 #include <cassert>
 #include <cstdlib>
 

--- a/src/DNS_Mgr.cc
+++ b/src/DNS_Mgr.cc
@@ -10,10 +10,11 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cstdlib>
+#include <thread>
 #include <vector>
 
 #ifdef TIME_WITH_SYS_TIME
@@ -45,6 +46,8 @@ using ztd::out_ptr::out_ptr;
 #include "zeek/telemetry/Manager.h"
 
 #include "zeek/3rdparty/doctest.h"
+
+using namespace std::literals;
 
 // Number of seconds we'll wait for a reply.
 constexpr int DNS_TIMEOUT = 5;
@@ -1538,7 +1541,7 @@ TEST_CASE("dns_mgr async host" * doctest::skip(true)) {
     int count = 0;
     while ( ! cb.done && (count < DNS_TIMEOUT + 1) ) {
         mgr.Process();
-        sleep(1);
+        std::this_thread::sleep_for(1s);
         if ( ! cb.timeout )
             count++;
     }
@@ -1566,7 +1569,7 @@ TEST_CASE("dns_mgr async addr" * doctest::skip(true)) {
     int count = 0;
     while ( ! cb.done && (count < DNS_TIMEOUT + 1) ) {
         mgr.Process();
-        sleep(1);
+        std::this_thread::sleep_for(1s);
         if ( ! cb.timeout )
             count++;
     }
@@ -1590,7 +1593,7 @@ TEST_CASE("dns_mgr async text" * doctest::skip(true)) {
     int count = 0;
     while ( ! cb.done && (count < DNS_TIMEOUT + 1) ) {
         mgr.Process();
-        sleep(1);
+        std::this_thread::sleep_for(1s);
         if ( ! cb.timeout )
             count++;
     }
@@ -1645,7 +1648,7 @@ TEST_CASE("dns_mgr async timeouts" * doctest::skip(true)) {
     int count = 0;
     while ( ! cb.done && (count < DNS_TIMEOUT + 1) ) {
         mgr.Process();
-        sleep(1);
+        std::this_thread::sleep_for(1s);
         if ( ! cb.timeout )
             count++;
     }

--- a/src/DebugLogger.cc
+++ b/src/DebugLogger.cc
@@ -2,7 +2,6 @@
 
 #include "zeek/DebugLogger.h"
 
-#include <unistd.h>
 #include <algorithm>
 #include <cstdlib>
 

--- a/src/File.cc
+++ b/src/File.cc
@@ -30,7 +30,11 @@
 
 namespace zeek {
 
-std::list<std::pair<std::string, File*>> File::open_files;
+namespace {
+
+std::list<std::pair<std::string, File*>> open_files;
+
+} // namespace
 
 // Maximizes the number of open file descriptors.
 static void maximize_num_fds() {

--- a/src/File.h
+++ b/src/File.h
@@ -112,9 +112,6 @@ protected:
     bool raw_output = false;
 
     static constexpr int MIN_BUFFER_SIZE = 1024;
-
-private:
-    static std::list<std::pair<std::string, File*>> open_files;
 };
 
 } // namespace zeek

--- a/src/Func.cc
+++ b/src/Func.cc
@@ -9,7 +9,6 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sys/param.h>
-#include <unistd.h>
 #include <algorithm>
 #include <cctype>
 #include <cerrno>

--- a/src/Hash.h
+++ b/src/Hash.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include <unistd.h>
 #include <cstdlib>
 
 #include "zeek/util-types.h" // for zeek_int_t

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <sstream>
 
 #include "zeek/3rdparty/bsd-getopt-long.h"
@@ -641,14 +642,14 @@ Options parse_cmdline(int argc, char** argv) {
         }
 
         // Need to translate relative path to absolute.
-        char cwd[PATH_MAX];
-
-        if ( ! getcwd(cwd, sizeof(cwd)) ) {
-            fprintf(stderr, "failed to get current directory: %s\n", strerror(errno));
+        std::error_code ec;
+        auto cwd = std::filesystem::current_path(ec);
+        if ( ec ) {
+            fprintf(stderr, "failed to get current directory: %s\n", ec.message().c_str());
             exit(1);
         }
 
-        *path = std::string(cwd) + "/" + *path;
+        *path = (cwd / *path).string();
     };
 
     if ( rval.supervisor_mode ) {

--- a/src/Reporter.cc
+++ b/src/Reporter.cc
@@ -5,7 +5,6 @@
 #include "zeek/Reporter.h"
 
 #include <syslog.h>
-#include <unistd.h>
 
 #include "zeek/Conn.h"
 #include "zeek/Desc.h"

--- a/src/RunState.cc
+++ b/src/RunState.cc
@@ -16,7 +16,6 @@
 #endif
 #endif
 
-#include <unistd.h>
 #include <csignal>
 #include <cstdlib>
 

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -12,7 +12,6 @@
 #include <rapidjson/error/en.h>
 #include <sys/param.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>

--- a/src/broker/Manager.cc
+++ b/src/broker/Manager.cc
@@ -11,7 +11,6 @@
 #include <broker/time.hh>
 #include <broker/variant.hh>
 #include <broker/zeek.hh>
-#include <unistd.h>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>

--- a/src/input/readers/ascii/Ascii.cc
+++ b/src/input/readers/ascii/Ascii.cc
@@ -4,7 +4,6 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <algorithm>
 #include <cerrno>
 

--- a/src/input/readers/benchmark/Benchmark.cc
+++ b/src/input/readers/benchmark/Benchmark.cc
@@ -4,8 +4,9 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <cerrno>
+#include <chrono>
+#include <thread>
 
 #include "zeek/input/readers/benchmark/benchmark.bif.h"
 #include "zeek/threading/SerialTypes.h"
@@ -75,6 +76,8 @@ double Benchmark::CurrTime() {
 
 // read the entire file and send appropriate thingies back to InputMgr
 bool Benchmark::DoUpdate() {
+    using std::chrono::microseconds;
+
     int linestosend = num_lines * heartbeat_interval;
     for ( int i = 0; i < linestosend; i++ ) {
         threading::Value** field = new threading::Value*[NumFields()];
@@ -89,10 +92,10 @@ bool Benchmark::DoUpdate() {
 
         if ( stopspreadat == 0 || num_lines < stopspreadat ) {
             if ( spread != 0 )
-                usleep(spread);
+                std::this_thread::sleep_for(microseconds{spread});
 
             if ( autospread_time != 0 )
-                usleep(autospread_time);
+                std::this_thread::sleep_for(microseconds{autospread_time});
         }
 
         if ( timedspread != 0.0 ) {

--- a/src/input/readers/config/Config.cc
+++ b/src/input/readers/config/Config.cc
@@ -9,7 +9,6 @@
 #endif
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <cerrno>
 #include <unordered_set>
 

--- a/src/input/readers/raw/Raw.h
+++ b/src/input/readers/raw/Raw.h
@@ -76,7 +76,7 @@ private:
     int64_t offset;
 
     int pipes[6] = {-1};
-    pid_t childpid;
+    int childpid;
 
     enum IoChannels : uint8_t {
         stdout_in = 0,

--- a/src/input/readers/sqlite/SQLite.cc
+++ b/src/input/readers/sqlite/SQLite.cc
@@ -4,7 +4,6 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 #include "zeek/input/readers/sqlite/sqlite.bif.h"
 #include "zeek/logging/writers/ascii/ascii.bif.h"

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <cerrno>
 #include <cstdio>
 #include <ctime>

--- a/src/scan.l
+++ b/src/scan.l
@@ -19,7 +19,6 @@
 #include <string>
 #include <algorithm>
 #include <sys/stat.h>
-#include <sys/param.h>
 #include <unistd.h>
 #include <libgen.h>
 
@@ -423,12 +422,12 @@ when	return TOK_WHEN;
 	std::string rval = zeek::util::SafeDirname(::filename).result;
 
 	if ( ! rval.empty() && rval[0] == '.' ) {
-		char path[MAXPATHLEN];
-
-		if ( ! getcwd(path, MAXPATHLEN) )
-			zeek::reporter->InternalError("getcwd failed: %s", strerror(errno));
+		std::error_code ec;
+		auto cwd = std::filesystem::current_path(ec);
+		if ( ec )
+			zeek::reporter->InternalError("current_path failed: %s", ec.message().c_str());
 		else
-			rval = std::string(path) + "/" + rval;
+			rval = (std::filesystem::path(cwd) / rval).string();
 	}
 
 	RET_CONST(new zeek::StringVal(rval.c_str()));

--- a/src/script_opt/CPP/Driver.cc
+++ b/src/script_opt/CPP/Driver.cc
@@ -1,8 +1,8 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
 #include <sys/stat.h>
-#include <unistd.h>
 #include <cerrno>
+#include <filesystem>
 
 #include "zeek/script_opt/CPP/Compile.h"
 #include "zeek/script_opt/IDOptInfo.h"
@@ -325,12 +325,14 @@ void CPPCompile::GenProlog() {
 
     // Get the working directory for annotating the output to help
     // with debugging.
-    char working_dir[8192];
-    if ( ! getcwd(working_dir, sizeof working_dir) )
-        reporter->FatalError("getcwd failed: %s", strerror(errno));
+    std::error_code ec;
+    auto cwd = std::filesystem::current_path(ec);
+    if ( ec )
+        reporter->FatalError("current_path failed: %s", ec.message().c_str());
+    std::string working_dir = cwd.string();
 
     Emit("namespace zeek::detail { //\n");
-    Emit("namespace CPP_%s { // %s\n", Fmt(total_hash), string(working_dir));
+    Emit("namespace CPP_%s { // %s\n", Fmt(total_hash), working_dir.c_str());
 
     // The following might-or-might-not wind up being populated/used.
     Emit("std::vector<zeek_int_t> field_mapping;");

--- a/src/script_opt/CPP/Util.cc
+++ b/src/script_opt/CPP/Util.cc
@@ -3,7 +3,6 @@
 #include "zeek/script_opt/CPP/Util.h"
 
 #include <sys/file.h>
-#include <unistd.h>
 #include <cerrno>
 
 #include "zeek/script_opt/StmtOptInfo.h"

--- a/src/script_opt/ProfileFunc.cc
+++ b/src/script_opt/ProfileFunc.cc
@@ -2,7 +2,6 @@
 
 #include "zeek/script_opt/ProfileFunc.h"
 
-#include <unistd.h>
 #include <cerrno>
 
 #include "zeek/Desc.h"

--- a/src/session/Manager.cc
+++ b/src/session/Manager.cc
@@ -5,8 +5,8 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <pcap.h>
-#include <unistd.h>
 #include <algorithm>
+#include <cstddef>
 #include <cstdlib>
 
 #include "zeek/Conn.h"
@@ -34,7 +34,7 @@ public:
     struct Protocol {
         std::shared_ptr<telemetry::Gauge> active;
         std::shared_ptr<telemetry::Counter> total;
-        ssize_t max = 0;
+        ptrdiff_t max = 0;
 
         Protocol(const std::shared_ptr<telemetry::GaugeFamily>& active_family,
                  const std::shared_ptr<telemetry::CounterFamily>& total_family, std::string protocol)

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -12,6 +12,7 @@
 #include <csignal>
 #include <cstdarg>
 #include <cstdio>
+#include <filesystem>
 #include <sstream>
 #include <utility>
 #include <variant>
@@ -1400,9 +1401,11 @@ void SupervisedNode::Init(Options* options) const {
     const auto& node_name = config.name;
 
     if ( config.directory ) {
-        if ( chdir(config.directory->data()) ) {
-            fprintf(stderr, "node '%s' failed to chdir to %s: %s\n", node_name.data(), config.directory->data(),
-                    strerror(errno));
+        std::error_code ec;
+        std::filesystem::current_path(config.directory->data(), ec);
+        if ( ec ) {
+            fprintf(stderr, "node '%s' failed to set working directory to %s: %s\n", node_name.data(),
+                    config.directory->data(), ec.message().c_str());
             exit(1);
         }
     }

--- a/src/supervisor/Supervisor.h
+++ b/src/supervisor/Supervisor.h
@@ -253,7 +253,7 @@ public:
     /**
      * @return the process ID of the Stem.
      */
-    pid_t StemPID() const { return stem_pid; }
+    int StemPID() const { return stem_pid; }
 
     /**
      * @return the state of currently supervised processes.  The map uses
@@ -323,7 +323,7 @@ private:
     static std::optional<detail::SupervisedNode> supervised_node;
 
     Config config;
-    pid_t stem_pid;
+    int stem_pid;
     std::atomic<int> last_signal = -1;
     std::unique_ptr<detail::PipePair> stem_pipe;
     detail::LineBufferedPipe stem_stdout;
@@ -356,7 +356,7 @@ struct SupervisorStemHandle {
     /**
      * The Stem's process ID.
      */
-    pid_t pid = 0;
+    int pid = 0;
 };
 
 /**
@@ -378,7 +378,7 @@ struct SupervisedNode {
      * The process ID of the supervised node's parent process (i.e. the PID
      * of the Stem process).
      */
-    pid_t parent_pid;
+    int parent_pid;
 };
 
 /**
@@ -409,7 +409,7 @@ struct SupervisorNode {
     /**
      * Process ID of the node (positive/non-zero are valid/live PIDs).
      */
-    pid_t pid = 0;
+    int pid = 0;
     /**
      * Whether the node is voluntarily marked for termination by the
      * Supervisor.

--- a/src/telemetry/Gauge.h
+++ b/src/telemetry/Gauge.h
@@ -4,7 +4,6 @@
 
 #include <prometheus/family.h>
 #include <prometheus/gauge.h>
-#include <unistd.h>
 #include <initializer_list>
 #include <memory>
 #include <span>

--- a/src/threading/BasicThread.h
+++ b/src/threading/BasicThread.h
@@ -4,7 +4,7 @@
 
 #include "zeek/zeek-config.h"
 
-#include <unistd.h>
+#include <unistd.h> // for __attribute__ on Windows
 #include <atomic>
 #include <cstdint>
 #include <thread>

--- a/src/threading/Manager.cc
+++ b/src/threading/Manager.cc
@@ -3,7 +3,6 @@
 #include "zeek/threading/Manager.h"
 
 #include <sys/socket.h>
-#include <unistd.h>
 #include <cstdint>
 #include <limits>
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -643,14 +643,13 @@ std::string get_exe_path(const std::string& invocation) {
 
     if ( invocation_path.is_relative() && invocation_path.has_parent_path() ) {
         // Relative path
-        char cwd[PATH_MAX];
-
-        if ( ! getcwd(cwd, sizeof(cwd)) ) {
-            fprintf(stderr, "failed to get current directory: %s\n", strerror(errno));
+        std::error_code ec;
+        auto cwd = std::filesystem::current_path(ec);
+        if ( ec ) {
+            fprintf(stderr, "failed to get current directory: %s\n", ec.message().c_str());
             exit(1);
         }
-
-        return (std::filesystem::path(cwd) / invocation_path).string();
+        return (cwd / invocation_path).string();
     }
 
     auto path = getenv("PATH");

--- a/src/zeekygen/Target.cc
+++ b/src/zeekygen/Target.cc
@@ -5,7 +5,6 @@
 #include <fts.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <regex>
 
 #include "zeek/Reporter.h"


### PR DESCRIPTION
The only potentially controversial change, I think, is in `File::Size`: using `fseek` / `ftell` instead of `fstat` to get the file size. Those two may give different results.

- Replace `sleep` and `usleep` with `sleep_for`
- Replace `ssize_t` with `ptrdiff_t`
- Replace `pid_t` with `int`
- Replace uses of `cwd` & co with `std::filesystem`
- Remove `unistd.h` includes where they aren't actually needed