### PR TITLE
Avoid integer overflow

### DIFF
--- a/src/IPAddr.cc
+++ b/src/IPAddr.cc
@@ -26,7 +26,7 @@ static inline uint32_t bit_mask32(int bottom_bits) {
     if ( bottom_bits >= 32 )
         return 0xffffffff;
 
-    return static_cast<uint32_t>((1 << bottom_bits) - 1);
+    return ((static_cast<uint32_t>(1)) << bottom_bits) - 1;
 }
 
 void IPAddr::Mask(int top_bits_to_keep) {


### PR DESCRIPTION
In 76044ce860 we replaced many C-style casts with proper ones. In the review I suggested to rewrite one expression "for readability" so more of a computation would be performed in `int` and only casted to `uint32_t` later. I missed that that would introduce a potential bug since signed integer overflow is UB while unsigned overflow (liked used previously) is well-defined.

This patch reverts the expression to the previous types, but now using proper casts.