### PR TITLE
cmake: use absolute source paths in flex_target() calls to fix DWARF debug info

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,8 +55,8 @@ replace_yy_prefix_target(${CMAKE_CURRENT_BINARY_DIR}/rup.cc
                          ${CMAKE_CURRENT_BINARY_DIR}/rule-parse.cc rules_ rules_)
 replace_yy_prefix_target(${CMAKE_CURRENT_BINARY_DIR}/rup.h ${CMAKE_CURRENT_BINARY_DIR}/rule-parse.h
                          rules_ rules_)
-flex_target(RuleScanner rule-scan.l ${CMAKE_CURRENT_BINARY_DIR}/rule-scan.cc
-            COMPILE_FLAGS "-Prules_")
+flex_target(RuleScanner ${CMAKE_CURRENT_SOURCE_DIR}/rule-scan.l
+            ${CMAKE_CURRENT_BINARY_DIR}/rule-scan.cc COMPILE_FLAGS "-Prules_")
 set_property(SOURCE rule-scan.cc APPEND_STRING PROPERTY COMPILE_FLAGS "${SIGN_COMPARE_FLAG}")
 
 # RE parser/scanner
@@ -67,7 +67,8 @@ bison_target(
     COMPILE_FLAGS "${BISON_FLAGS}")
 replace_yy_prefix_target(${CMAKE_CURRENT_BINARY_DIR}/rep.cc ${CMAKE_CURRENT_BINARY_DIR}/re-parse.cc
                          re_ RE_)
-flex_target(REScanner re-scan.l ${CMAKE_CURRENT_BINARY_DIR}/re-scan.cc COMPILE_FLAGS "-Pre_")
+flex_target(REScanner ${CMAKE_CURRENT_SOURCE_DIR}/re-scan.l ${CMAKE_CURRENT_BINARY_DIR}/re-scan.cc
+            COMPILE_FLAGS "-Pre_")
 add_flex_bison_dependency(REScanner REParser)
 set_property(SOURCE re-scan.cc APPEND_STRING PROPERTY COMPILE_FLAGS "${SIGN_COMPARE_FLAG}")
 
@@ -79,7 +80,8 @@ bison_target(
     COMPILE_FLAGS "${BISON_FLAGS}")
 replace_yy_prefix_target(${CMAKE_CURRENT_BINARY_DIR}/p.cc ${CMAKE_CURRENT_BINARY_DIR}/parse.cc zeek
                          yy)
-flex_target(Scanner scan.l ${CMAKE_CURRENT_BINARY_DIR}/scan.cc COMPILE_FLAGS "-Pzeek")
+flex_target(Scanner ${CMAKE_CURRENT_SOURCE_DIR}/scan.l ${CMAKE_CURRENT_BINARY_DIR}/scan.cc
+            COMPILE_FLAGS "-Pzeek")
 set_property(SOURCE scan.cc APPEND_STRING PROPERTY COMPILE_FLAGS "${SIGN_COMPARE_FLAG}")
 
 set(zeek_bison_generated_files

--- a/tools/bifcl/CMakeLists.txt
+++ b/tools/bifcl/CMakeLists.txt
@@ -6,7 +6,8 @@ set(BISON_FLAGS "--debug")
 # BIF parser/scanner
 bison_target(BIFParser builtin-func.y ${CMAKE_CURRENT_BINARY_DIR}/bif_parse.cc
              DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/bif_parse.h COMPILE_FLAGS "${BISON_FLAGS}")
-flex_target(BIFScanner builtin-func.l ${CMAKE_CURRENT_BINARY_DIR}/bif_lex.cc)
+flex_target(BIFScanner ${CMAKE_CURRENT_SOURCE_DIR}/builtin-func.l
+            ${CMAKE_CURRENT_BINARY_DIR}/bif_lex.cc)
 add_flex_bison_dependency(BIFScanner BIFParser)
 
 set(bifcl_SRCS ${BISON_BIFParser_INPUT} ${FLEX_BIFScanner_INPUT} ${BISON_BIFParser_OUTPUTS}

--- a/tools/binpac/src/CMakeLists.txt
+++ b/tools/binpac/src/CMakeLists.txt
@@ -3,7 +3,8 @@ find_package(BISON REQUIRED)
 
 bison_target(PACParser pac_parse.yy ${CMAKE_CURRENT_BINARY_DIR}/pac_parse.cc
              DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/pac_parse.h COMPILE_FLAGS "--debug")
-flex_target(PACScanner pac_scan.ll ${CMAKE_CURRENT_BINARY_DIR}/pac_scan.cc)
+flex_target(PACScanner ${CMAKE_CURRENT_SOURCE_DIR}/pac_scan.ll
+            ${CMAKE_CURRENT_BINARY_DIR}/pac_scan.cc)
 add_flex_bison_dependency(PACScanner PACParser)
 if (MSVC)
     set_property(SOURCE pac_scan.cc APPEND_STRING PROPERTY COMPILE_FLAGS "/wd4018")


### PR DESCRIPTION
The five flex_target() calls in `src/CMakeLists.txt`, `tools/bifcl/CMakeLists.txt`, and `tools/binpac/src/CMakeLists.txt` previously passed the `.l/.ll` input file as a bare filename. When CMake invokes flex from an out-of-source build directory, flex writes `#line 1 "rule-scan.l"` (a relative path) into the generated C++ output. GCC records this as `<build-dir>/rule-scan.l` in DWARF debug information, a path that does not exist in the source tree.

This silently breaks the zeek-debugsource RPM on Fedora/RHEL (and equivalent dbgsym packages on Debian-based distributions): cpio cannot stat the non-existent paths and omits the .l grammar files from the debugsource package, making source-level debugging of scanner code impossible.

Changing the input to `${CMAKE_CURRENT_SOURCE_DIR}/rule-scan.l` (absolute path) causes flex to emit the full path in #line directives. GCC records the correct source path in DWARF, debugedit can rewrite it, and the debugsource package is complete.

This change has no effect on the generated scanner logic, the Zeek API, or build performance. It only affects the string written into #line directives and the resulting DWARF debug info.