### PR TITLE
Update basics.rst to include 'string' data type

### DIFF
--- a/doc/scripting/basics.rst
+++ b/doc/scripting/basics.rst
@@ -683,6 +683,9 @@ reinventing the wheel.
   * - :zeek:see:`pattern`
     - regular expression
 
+  * - :zeek:see:`string`
+    - text or binary data
+
 Sets
 ~~~~
 


### PR DESCRIPTION
Add 'string' to the list of data types in the basics documentation.