### PR TITLE
Redirect maintenance to reflect tutorial merge (#4928)

### DIFF
--- a/doc/redirects.yml
+++ b/doc/redirects.yml
@@ -152,3 +152,5 @@
   to_url: /reference/zeekscript/event-semantics.html#tracing-events
 - from_url: /scripting/usage.html
   to_url: /advanced/scripting/usage.html
+- from_url: /troubleshooting.html
+  to_url: /advanced/troubleshooting.html


### PR DESCRIPTION
This is based on the attached output from `doc-redirects scan`, plus a few additional cleanups.

A good way to test these in the future would be to set up a duplicate of the docs project in RTD.

[new-redirects.yml.txt](https://github.com/user-attachments/files/25924152/new-redirects.yml.txt)
