### PR TITLE
GH-5273: Pass the payload length from IP analyzer if available

### DIFF
--- a/src/packet_analysis/protocol/ip/IP.cc
+++ b/src/packet_analysis/protocol/ip/IP.cc
@@ -3,6 +3,7 @@
 #include "zeek/packet_analysis/protocol/ip/IP.h"
 
 #include <netinet/in.h>
+#include <algorithm>
 
 #include "zeek/Discard.h"
 #include "zeek/Event.h"
@@ -222,6 +223,9 @@ bool IPAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet) 
     // pointing at the reassembled data for a fragmented packet.
     data = packet->ip_hdr->Payload();
     len -= ip_hdr_len;
+
+    if ( packet->ip_hdr->PayloadLen() != 0 )
+        len = std::min(len, static_cast<size_t>(packet->ip_hdr->PayloadLen()));
 
     // Session analysis assumes that the header size stored in the packet does not include the IP
     // header size. There are two reasons for this: 1) Packet::ToRawPktHdrVal() wants to look at the

--- a/testing/btest/Baseline/core.truncation/output
+++ b/testing/btest/Baseline/core.truncation/output
@@ -78,5 +78,5 @@ XXXXXXXXXX.XXXXXX	-	-	-	-	-	internally_truncated_header	-	F	zeek	IP
 #open XXXX-XX-XX-XX-XX-XX
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	name	addl	notice	peer	source
 #types	time	string	addr	port	addr	port	string	string	bool	string	string
-XXXXXXXXXX.XXXXXX	-	-	-	-	-	invalid_IP_header_size_in_tunnel	-	F	zeek	IP
+XXXXXXXXXX.XXXXXX	-	b100:7265::6904:2aff	0	3bbf:ff00:40:21:ffff:ffff:fffd:f7ff	0	truncated_inner_IP	-	F	zeek	IPTUNNEL
 #close XXXX-XX-XX-XX-XX-XX

--- a/testing/btest/Baseline/core.tunnels.ip-in-ip-version/output
+++ b/testing/btest/Baseline/core.tunnels.ip-in-ip-version/output
@@ -7,7 +7,7 @@
 #open XXXX-XX-XX-XX-XX-XX
 #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	name	addl	notice	peer	source
 #types	time	string	addr	port	addr	port	string	string	bool	string	string
-XXXXXXXXXX.XXXXXX	-	ff00:0:6929::6904:ff:3bbf	0	ffff:0:69:2900:0:69:400:ff3b	0	invalid_inner_IP_version_in_tunnel	-	F	zeek	IPTUNNEL
+XXXXXXXXXX.XXXXXX	-	b100:7265::6904:2aff	0	3bbf:ff00:40:21:ffff:ffff:fffd:f7ff	0	truncated_inner_IP	-	F	zeek	IPTUNNEL
 #close XXXX-XX-XX-XX-XX-XX
 #separator \x09
 #set_separator	,


### PR DESCRIPTION
Payload length in an IP packet can be shorter than the actual packet, if one of the earlier protocols (e.g. Ethernet) has trailing data after the IP parts. The payload length in the header can also be zero, so this makes sure to check for that. The two tests that change are because of truncated data. For example, the outer packet in core.tunnels.ip-in-ip-version reports a payload length of 44, but next inner packet is only 40 bytes. Instead of reporting that the outer packet is wrong, we report a truncation of the inner packet instead.

Fixes #5273 