### PR TITLE
generate-docs: Fix git add for new structure

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -117,7 +117,8 @@ jobs:
         if: github.event_name == 'schedule'
         run: |
           cd doc
-          git add scripts/ script-reference/
+          # Stage any changes to auto-generated files.
+          git add scripts/ reference/zeekscript/
           git status
           # git commit errors when there's nothing to commit, so guard it
           # with a check that detects whether there's anything staged.


### PR DESCRIPTION
Fixup generate-docs job after 5055195bc8d0f4b60c0d7820182ad0ccc6e35303 moved script-reference to reference/zeekscript.