### PR TITLE
fix: pin 5 unpinned action(s)

### DIFF
--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -11,7 +11,7 @@ jobs:
         run: cat "$GITHUB_EVENT_PATH" || true
 
       - name: Send CI Email Notification
-        uses: zeek/ci-email-action@master
+        uses: zeek/ci-email-action@ddb018559b0b814d005d72590afd83d9384f7c9d # master
         env:
           CI_APP_NAME: "Cirrus CI"
           BRANCH_REGEX: "master|release/.*"

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -45,7 +45,7 @@ jobs:
         # Only send notifications for scheduled runs. Runs from pull requests
         # show failures in the GitHub UI.
         if: failure()
-        uses: dawidd6/action-send-mail@v6
+        uses: dawidd6/action-send-mail@6d98ae34d733f9a723a9e04e94f2f24ba05e1402 # v6
         with:
           server_address: ${{secrets.SMTP_HOST}}
           server_port: ${{secrets.SMTP_PORT}}

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -66,7 +66,7 @@ jobs:
           pip3 install -r doc/requirements.txt
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: 'docs-gen-${{ github.job }}'
           max-size: '2000M'
@@ -128,7 +128,7 @@ jobs:
         # Only send notifications for scheduled runs. Runs from pull requests
         # show failures in the GitHub UI.
         if: failure() && github.event_name == 'schedule'
-        uses: dawidd6/action-send-mail@v6
+        uses: dawidd6/action-send-mail@6d98ae34d733f9a723a9e04e94f2f24ba05e1402 # v6
         with:
           server_address: ${{secrets.SMTP_HOST}}
           server_port: ${{secrets.SMTP_PORT}}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v6
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
## Security Scan Results

Runner Guard identified the following CI/CD security findings in your GitHub Actions workflows:

### Fixes Applied

| Rule | Severity | File | Fix |
|------|----------|------|-----|
| RGS-007 | medium | ci-notification.yml | Pinned zeek/ci-email-action to commit SHA |
| RGS-007 | medium | docs-link-check.yml | Pinned dawidd6/action-send-mail to commit SHA |
| RGS-007 | medium | generate-docs.yml | Pinned hendrikmuhs/ccache-action to commit SHA |
| RGS-007 | medium | generate-docs.yml | Pinned dawidd6/action-send-mail to commit SHA |
| RGS-007 | medium | pre-commit.yml | Pinned pre-commit/action to commit SHA |

### Remaining Advisory Findings

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-012 | high | coverity-scan.yml | Secret Exfiltration via Outbound HTTP Request |
| RGS-012 | high | coverity-scan.yml | Secret Exfiltration via Outbound HTTP Request |

### Why This Matters

Actions referenced by mutable tag (e.g., `@v4`, `@master`) can be silently replaced if the upstream repository is compromised. Pinning to a full commit SHA ensures immutability — the exact code you audit today is the code that runs tomorrow.

This vulnerability class was actively exploited in the [March 2026 supply chain attacks](https://www.vigilantdefense.com/research/github-top-50k-repos-cicd-security-scan) against litellm, trivy, and other major open-source projects.

---

Scanned by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | [Vigilant](https://vigilantnow.com)