### PR TITLE
Ignore checksums by default

### DIFF
--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -1684,7 +1684,7 @@ const UDP_ACTIVE = 1;	##< Endpoint has sent something.
 ## feature is enabled.
 ## Note that the ``-C`` command-line option overrides the setting of this
 ## variable.
-const ignore_checksums = F &redef;
+const ignore_checksums = T &redef;
 
 ## Checksums are ignored for all packets with a src address within this set of
 ## networks. Useful for cases where a host might be seeing packets collected

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -507,7 +507,7 @@ Options parse_cmdline(int argc, char** argv) {
 #endif
                 break;
 
-            case 'C': rval.ignore_checksums = true; break;
+            case 'C': rval.ignore_checksums = false; break;
             case 'D': rval.deterministic_mode = true; break;
             case 'E': rval.event_trace_file = optarg; break;
             case 'F':

--- a/src/Options.h
+++ b/src/Options.h
@@ -44,7 +44,7 @@ struct Options {
     std::vector<std::string> script_prefixes = {""}; // "" = "no prefix"
 
     int signature_re_level = 4;
-    bool ignore_checksums = false;
+    bool ignore_checksums = true;
     bool use_watchdog = false;
     double pseudo_realtime = 0;
     detail::DNS_MgrMode dns_mode = detail::DNS_DEFAULT;


### PR DESCRIPTION
This swaps Zeek's behavior to ignore checksums by default. The only thing here that I have qualms about is that I swapped the semantics of `-C` to enable checksumming instead of disabling it. If that's a problem to someone, I can move enabling it to a different argument and sunset the `-C` argument.