### PR TITLE
fix: pin 5 unpinned action(s) to commit SHA

### DIFF
--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -11,7 +11,7 @@ jobs:
         run: cat "$GITHUB_EVENT_PATH" || true
 
       - name: Send CI Email Notification
-        uses: zeek/ci-email-action@master
+        uses: zeek/ci-email-action@ddb018559b0b814d005d72590afd83d9384f7c9d # master
         env:
           CI_APP_NAME: "Cirrus CI"
           BRANCH_REGEX: "master|release/.*"

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -45,7 +45,7 @@ jobs:
         # Only send notifications for scheduled runs. Runs from pull requests
         # show failures in the GitHub UI.
         if: failure()
-        uses: dawidd6/action-send-mail@v6
+        uses: dawidd6/action-send-mail@6d98ae34d733f9a723a9e04e94f2f24ba05e1402 # v6
         with:
           server_address: ${{secrets.SMTP_HOST}}
           server_port: ${{secrets.SMTP_PORT}}

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -66,7 +66,7 @@ jobs:
           pip3 install -r doc/requirements.txt
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: 'docs-gen-${{ github.job }}'
           max-size: '2000M'
@@ -128,7 +128,7 @@ jobs:
         # Only send notifications for scheduled runs. Runs from pull requests
         # show failures in the GitHub UI.
         if: failure() && github.event_name == 'schedule'
-        uses: dawidd6/action-send-mail@v6
+        uses: dawidd6/action-send-mail@6d98ae34d733f9a723a9e04e94f2f24ba05e1402 # v6
         with:
           server_address: ${{secrets.SMTP_HOST}}
           server_port: ${{secrets.SMTP_PORT}}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v6
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, my name is Chris. I'm a security researcher and I built [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), a CI/CD security scanner that detects GitHub Actions vulnerabilities. Over the last three weeks, I've been scanning public repositories for the same vulnerability classes that were exploited in the tj-actions/changed-files supply chain attack. Your repo came up in that scan as affected, and I'm working to get fixes out to maintainers.

I'm a real person, not a bot. This PR fixes what I could automatically, and flags anything else that needs a manual look. If you have any questions or concerns, just drop a comment here and I'll respond.

### Fixes applied

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | medium | `ci-notification.yml` | Pinned zeek/ci-email-action@master to commit SHA |
| RGS-007 | medium | `docs-link-check.yml` | Pinned dawidd6/action-send-mail@v6 to commit SHA |
| RGS-007 | medium | `generate-docs.yml` | Pinned hendrikmuhs/ccache-action@v1.2 and dawidd6/action-send-mail@v6 to commit SHA |
| RGS-007 | medium | `pre-commit.yml` | Pinned pre-commit/action@v3.0.1 to commit SHA |

### Additional findings (manual review recommended)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-012 | high | `coverity-scan.yml` | Secrets and outbound HTTP requests in the same job. If this workflow is compromised, secrets could be exfiltrated via the outbound HTTP call to Coverity. |

### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose secrets inline, or use unpinned third-party actions are vulnerable to code injection, credential theft, and supply chain attacks. These are the same vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-attack-and-its-impact) which compromised CI secrets across thousands of repositories.

### How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: Pins third-party actions to immutable commit SHAs (original version tag preserved as comment)

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant](https://www.vigilantnow.com)

If this PR is not welcome, just close it and I won't send another.