### PR TITLE
telemetry/ProcessStats: Fix missing procstat_freefiles()

### DIFF
--- a/src/telemetry/ProcessStats.cc
+++ b/src/telemetry/ProcessStats.cc
@@ -209,6 +209,7 @@ process_stats get_process_stats() {
         STAILQ_FOREACH(file, files, next)
         result.fds++;
 
+        procstat_freefiles(procstat, files);
         procstat_freeprocs(procstat, kp);
         procstat_close(procstat);
     }


### PR DESCRIPTION
Found and reported by @anthonyalayo, thanks!

Closes #5301

---

This was tested with a simple `while true ; do curl http://localhost:9991/metrics; done` with a Zeek process started as `zeek -i vtnet0 Telemetry::metrics_port=9991/tcp`.