### PR TITLE
Fix a few deprecated c_msg usages in btests

### DIFF
--- a/testing/btest/plugins/binpac-flowbuffer-frame-length-plugin/src/FOO.cc
+++ b/testing/btest/plugins/binpac-flowbuffer-frame-length-plugin/src/FOO.cc
@@ -41,8 +41,8 @@ void FOO_Analyzer::DeliverStream(int len, const u_char* data, bool orig) {
     try {
         interp->NewData(orig, data, data + len);
     } catch ( const binpac::Exception& e ) {
-        printf("Exception: %s\n", e.c_msg());
-        AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
+        printf("Exception: %s\n", e.what());
+        AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.what()));
     }
 }
 

--- a/testing/btest/plugins/protocol-plugin/src/Foo.cc
+++ b/testing/btest/plugins/protocol-plugin/src/Foo.cc
@@ -51,7 +51,7 @@ void Foo::DeliverStream(int len, const u_char* data, bool orig) {
     try {
         interp->NewData(orig, data, data + len);
     } catch ( const binpac::Exception& e ) {
-        AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
+        AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.what()));
     }
 }
 

--- a/testing/builtin-plugins/Files/protocol-plugin/src/Foo.cc
+++ b/testing/builtin-plugins/Files/protocol-plugin/src/Foo.cc
@@ -35,7 +35,7 @@ void Foo::DeliverStream(int len, const u_char* data, bool orig) {
     try {
         interp->NewData(orig, data, data + len);
     } catch ( const binpac::Exception& e ) {
-        AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
+        AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.what()));
     }
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/zeek/zeek/pull/5315