### PR TITLE
Fix up pattern matching in ZAM's `table[pattern]` logic

### DIFF
--- a/src/script_opt/ZAM/OPs/non-uniform.op
+++ b/src/script_opt/ZAM/OPs/non-uniform.op
@@ -120,7 +120,7 @@ eval	$2->Find($1.ToVal(Z_TYPE)) != nullptr
 predicate-op Val-Is-In-Pattern-Table
 class VV
 op-types X T
-eval	$2->LookupPattern(cast_intrusive<StringVal>($1.ToVal(Z_TYPE))) != nullptr
+eval	$2->MatchPattern(cast_intrusive<StringVal>($1.ToVal(Z_TYPE)))
 
 # Variants for indexing two values, one of which might be a constant.
 # We set the instructions's *second* type to be that of the first variable
@@ -210,7 +210,7 @@ eval	$1->Find($2.ToVal(Z_TYPE)) != nullptr
 predicate-op Const-Is-In-Pattern-Table
 class VC
 op-types T X
-eval	$1->LookupPattern(cast_intrusive<StringVal>($2.ToVal(Z_TYPE))) != nullptr
+eval	$1->MatchPattern(cast_intrusive<StringVal>($2.ToVal(Z_TYPE)))
 
 internal-op List-Is-In-Table
 classes VV VC

--- a/testing/btest/opt/regress-pat-table-cond.zeek
+++ b/testing/btest/opt/regress-pat-table-cond.zeek
@@ -7,22 +7,33 @@ global prefixes: table[pattern] of string;
 
 event zeek_init()
 	{
-	local pat = string_to_pattern(convert_for_pattern("z/t/") + ".*", F);
+	local pat = string_to_pattern(convert_for_pattern("z/t/foo/") + ".*", F);
 	prefixes[pat] = "working OK";
 
 	# We test two paths, one where it's a variable we're checking/accessing,
 	# the other a constant.
-	local var = "z/t/morestuff";
+	local var = "z/t/foo/stuff";
+	local var2 = "z/t/bar/stuff";
 
 	# The following fakes out ZAM (since it refers to a global) into not
 	# optimizing "var" into constant propagation.
 	if ( |prefixes| == 0 )
+		{
 		var = "nope";
+		var2 = "nope";
+		}
 
 	if ( var in prefixes )
 		print prefixes[var];
 
 	# Now test the same but with a constant.
-	if ( "z/t/morestuff" in prefixes )
-		print prefixes["z/t/morestuff"];
+	if ( "z/t/foo/stuff" in prefixes )
+		print prefixes["z/t/foo/stuff"];
+
+	# Also test the negative case:
+	if ( var2 in prefixes )
+		print prefixes[var2];
+
+	if ( "z/t/bar/stuff" in prefixes )
+		print prefixes["z/t/bar/stuff"];
 	}


### PR DESCRIPTION
Follow-up to #5331. This fixes the `cluster.publish-on-change.broker-set-element-new-worker-only` test, and expands the regression test to cover the negative case.

(@vpax, fyi)