### PR TITLE
Update documentation of ssl_extension_signature_algorithm for TLS 1.3

### DIFF
--- a/src/analyzer/protocol/ssl/events.bif
+++ b/src/analyzer/protocol/ssl/events.bif
@@ -157,10 +157,18 @@ event ssl_extension_elliptic_curves%(c: connection, is_client: bool, curves: ind
 ##    ssl_extension_connection_id
 event ssl_extension_ec_point_formats%(c: connection, is_client: bool, point_formats: index_vec%);
 
-## Generated for an Signature Algorithms extension. This TLS extension
-## is defined in :rfc:`5246` and sent by the client in the initial
-## handshake. It gives the list of signature and hash algorithms supported by the
-## client.
+## Generated for an Signature Algorithms extension.
+##
+## This TLS extension is defined in :rfc:`5246` (TLS 1.2) and :rfc:`8446` (TLS 1.3)
+## and sent by the client in the initial handshake.
+##
+## For TLS 1.2 and lower, it gives the list of signature and hash algorithms supported
+## by the client. Possible values for SignatureAlgorithm and HashAlgorithm are available in
+## the list of Transport Layer Security (TLS) Parameters by IANA.
+##
+## For TLS 1.3, the definition of the event changed. SignatureAlgorithms and HashAlgorithms
+## are now linked. If using TLS 1.3 or above, use the SignatureScheme list of
+## Transport Layer Security (TLS) Parameters by IANA.
 ##
 ## c: The connection.
 ##
@@ -168,7 +176,8 @@ event ssl_extension_ec_point_formats%(c: connection, is_client: bool, point_form
 ##            (the side that sends the client hello). This is typically equivalent
 ##            with the originator, but does not have to be in all circumstances.
 ##
-## signature_algorithms: List of supported signature and hash algorithm pairs.
+## signature_algorithms: List of supported signature and hash algorithm pairs (TLS 1.2),
+##                       or SignatureSchemes (TLS 1.3).
 ##
 ## .. zeek:see:: ssl_alert ssl_client_hello ssl_established ssl_server_hello
 ##    ssl_session_ticket_handshake ssl_extension


### PR DESCRIPTION
TLS 1.2 and TLS 1.3 use different interpretations of the data available in the event. This PR adds documentation pointing out this difference.

Related to #5320

As noted in #5320, we could also choose to deprecate the hash_algorithms and signature_algorithms tables in ssl consts. I did not do this in this PR, as this is a bit more invasive - but I would be happy to add it :)
