### PR TITLE
CI/opensuse-leap: Fix ZeroMQ missing CURVE support

### DIFF
--- a/ci/opensuse-leap-15.6/Dockerfile
+++ b/ci/opensuse-leap-15.6/Dockerfile
@@ -20,6 +20,7 @@ RUN zypper addrepo https://download.opensuse.org/repositories/openSUSE:Leap:15.6
     jq \
     libopenssl-devel \
     libpcap-devel \
+    libsodium-devel \
     make \
     openssh \
     procps \
@@ -48,5 +49,5 @@ RUN cd /opt \
     && curl -L https://github.com/zeromq/libzmq/releases/download/v${ZEROMQ_VERSION}/zeromq-${ZEROMQ_VERSION}.tar.gz -o zeromq-${ZEROMQ_VERSION}.tar.gz \
     && echo "${ZEROMQ_SHA1} zeromq-${ZEROMQ_VERSION}.tar.gz" | sha1sum -c \
     && tar xf zeromq-${ZEROMQ_VERSION}.tar.gz \
-    && (cd ./zeromq-${ZEROMQ_VERSION} && ./configure --prefix=/usr/local && make -j && make install) \
+    && (cd ./zeromq-${ZEROMQ_VERSION} && ./configure --with-libsodium --prefix=/usr/local && make -j && make install) \
     && rm -rf zeromq-${ZEROMQ_VERSION}*

--- a/ci/opensuse-leap-16.0/Dockerfile
+++ b/ci/opensuse-leap-16.0/Dockerfile
@@ -28,19 +28,8 @@ RUN zypper refresh \
     swig \
     tar \
     which \
+    zeromq-devel \
     zlib-devel \
   && rm -rf /var/cache/zypp
-
-# There isn't any version of cppzmq in the repos for Leap 16.0, and the version of libzmq
-# doesn't have a devel package that includes the headers. Install both of them manually.
-RUN git clone --depth 1 --branch v4.3.5 https://github.com/zeromq/libzmq.git \
- && cmake -B libzmq/build libzmq \
- && cmake --build libzmq/build \
- && cmake --install libzmq/build
-
-RUN git clone --depth 1 --branch v4.11.0 https://github.com/zeromq/cppzmq.git \
- && cmake -B cppzmq/build cppzmq \
- && cmake --build cppzmq/build \
- && cmake --install cppzmq/build
 
 RUN pip3 install websockets junit2html


### PR DESCRIPTION
On OpenSuSE Leap 15.6, we need to build ZeroMQ by hand because the included version is too old. Make sure we do so using ``--with-libsodium`` to enable CURVE support.

For OpenSuSE Leap 16.0, remove the manual installation and use zeromq-devel from the repo. The cppzmq parts are already vendored via src/cluster/backends/zeromq/auxil.