### PR TITLE
Document `zeek` invocation behavior without args

### DIFF
--- a/doc/tutorial/invoking-zeek.rst
+++ b/doc/tutorial/invoking-zeek.rst
@@ -54,7 +54,7 @@ any packets with checksum errors---due to checksum offloading, this may
 be all packets in a particular direction!
 
 .. _providing_script_values:
- 
+
 *************************
  Providing Script Values
 *************************
@@ -90,6 +90,14 @@ segments:
    # zeek -e "print \"hello\"; print\"there\";"
    hello
    there
+
+Similarly, executing ``zeek`` without arguments causes it to read
+script code from standard input:
+
+.. code:: console
+
+   # echo "print \"Hello, world\!\";" | zeek
+   Hello, world!
 
 As you begin to make more complex adjustments, it quickly becomes
 easier to write your own Zeek scripts. More on this shortly!

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -80,7 +80,7 @@ void usage(const char* prog) {
 
     printf("usage: %s [options] [file ...]\n", prog);
     printf("usage: %s --test [doctest-options] -- [options] [file ...]\n", prog);
-    printf("    <file>                          | Zeek script file, or read stdin\n");
+    printf("    <file>                          | Zeek script file, or read stdin (-)\n");
     printf("    -a|--parse-only                 | exit immediately after parsing scripts\n");
     printf("    -b|--bare-mode                  | don't load scripts from the base/ directory\n");
     printf("    -c|--capture-unprocessed <file> | write unprocessed packets to a tcpdump file\n");


### PR DESCRIPTION
@ckreibich mentioned this when we were talking

Zeek would read from stdin without arguments, but that behavior is unintuitive, especially because this is stated exactly no where (to my knowledge). So, this documents it.
