### PR TITLE
Add warning to SSL::hash_algorithms and signature_algorithms.

### DIFF
--- a/scripts/base/protocols/ssl/consts.zeek
+++ b/scripts/base/protocols/ssl/consts.zeek
@@ -78,6 +78,11 @@ export {
 
 	## Mapping between numeric codes and human readable strings for hash
 	## algorithms.
+	##
+	## Use only for TLS 1.2 and below; starting with TLS 1.3
+	## the interpretation of these values changed; use
+	## `TLS SignatureScheme <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme>`_
+	## for TLS 1.3.
 	const hash_algorithms: table[count] of string = {
 		[0] = "none",
 		[1] = "md5",
@@ -91,6 +96,11 @@ export {
 
 	## Mapping between numeric codes and human readable strings for signature
 	## algorithms.
+	##
+	## Use only for TLS 1.2 and below; starting with TLS 1.3
+	## the interpretation of these values changed; use
+	## `TLS SignatureScheme <https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme>`_
+	## for TLS 1.3.
 	const signature_algorithms: table[count] of string = {
 		[0] = "anonymous",
 		[1] = "rsa",


### PR DESCRIPTION
These should only be used for TLS 1.2 and below.

Relates to GH-5320. I still plan to deprecate them after 8.2 - but it seems nice to already add a warning to our dcumentation.