### PR TITLE
X509 certificate type parsing: fix build failure on Rocky Linux 8

### DIFF
--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -223,6 +223,8 @@ RecordValPtr X509::ParseCertificate(X509Val* cert_val, file_analysis::File* f) {
             pX509Cert->Assign(9, "ecdsa");
             pX509Cert->Assign(12, KeyCurve(pkey));
         }
+#endif
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
         else {
             auto* type_name = EVP_PKEY_get0_type_name(pkey);
             if ( type_name ) // nullptr if no name found


### PR DESCRIPTION
Guard new API use behing OpenSSL 3.0 feature flag, and also fix small logic error with OPENSSL_NO_EC #ifdef.

For old OpenSSL versions, unknown key information will just not be filled out.