### PR TITLE
bifs/to_port: Fix calling streq() past input string

### DIFF
--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -3555,7 +3555,7 @@ function to_port%(s: string%): port
         char* slash;
         errno = 0;
         port = strtol(s->CheckString(), &slash, 10);
-        if ( ! errno )
+        if ( ! errno && *slash )
             {
             ++slash;
             if ( zeek::util::streq(slash, "tcp") )


### PR DESCRIPTION
Commit eb34c9e984889013e5ce15f3a94c3570c582246d exposed a buffer overread in to_port(). If strtol() stopped on the final NUL character of the input string, we'd previously compare some bytes behind it against the proto.