### PR TITLE
Switch script_opt/ to having its own CMake config info

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,6 +200,7 @@ add_subdirectory(input)
 add_subdirectory(iosource)
 add_subdirectory(logging)
 add_subdirectory(probabilistic)
+add_subdirectory(script_opt)
 add_subdirectory(session)
 add_subdirectory(storage)
 
@@ -407,56 +408,7 @@ set(MAIN_SRCS
     plugin/ComponentManager.h
     plugin/Manager.cc
     plugin/Plugin.cc
-    script_opt/CPP/Attrs.cc
-    script_opt/CPP/Consts.cc
-    script_opt/CPP/DeclFunc.cc
-    script_opt/CPP/Driver.cc
-    script_opt/CPP/Emit.cc
-    script_opt/CPP/Exprs.cc
-    script_opt/CPP/Func.cc
-    script_opt/CPP/GenFunc.cc
-    script_opt/CPP/Inits.cc
-    script_opt/CPP/InitsInfo.cc
-    script_opt/CPP/RuntimeInits.cc
-    script_opt/CPP/RuntimeInitSupport.cc
-    script_opt/CPP/RuntimeOps.cc
-    script_opt/CPP/RuntimeVec.cc
-    script_opt/CPP/Stmts.cc
-    script_opt/CPP/Tracker.cc
-    script_opt/CPP/Types.cc
-    script_opt/CPP/Util.cc
-    script_opt/CPP/Vars.cc
     ${_gen_zeek_script_cpp}
-    script_opt/CSE.cc
-    script_opt/Expr.cc
-    script_opt/FuncInfo.cc
-    script_opt/GenIDDefs.cc
-    script_opt/IDOptInfo.cc
-    script_opt/Inline.cc
-    script_opt/ProfileFunc.cc
-    script_opt/Reduce.cc
-    script_opt/ScriptOpt.cc
-    script_opt/Stmt.cc
-    script_opt/TempVar.cc
-    script_opt/UsageAnalyzer.cc
-    script_opt/UseDefs.cc
-    script_opt/ZAM/AM-Opt.cc
-    script_opt/ZAM/Branches.cc
-    script_opt/ZAM/BuiltIn.cc
-    script_opt/ZAM/BuiltInSupport.cc
-    script_opt/ZAM/Driver.cc
-    script_opt/ZAM/Expr.cc
-    script_opt/ZAM/Inst-Gen.cc
-    script_opt/ZAM/Low-Level.cc
-    script_opt/ZAM/Profile.cc
-    script_opt/ZAM/Stmt.cc
-    script_opt/ZAM/Support.cc
-    script_opt/ZAM/Validate.cc
-    script_opt/ZAM/Vars.cc
-    script_opt/ZAM/ZBody.cc
-    script_opt/ZAM/ZInst.cc
-    script_opt/ZAM/ZInstAux.cc
-    script_opt/ZAM/ZOp.cc
     digest.h)
 
 set(THIRD_PARTY_SRCS

--- a/src/script_opt/CMakeLists.txt
+++ b/src/script_opt/CMakeLists.txt
@@ -1,0 +1,19 @@
+zeek_add_subdir_library(
+    script_opt
+    SOURCES
+    CSE.cc
+    Expr.cc
+    FuncInfo.cc
+    GenIDDefs.cc
+    IDOptInfo.cc
+    Inline.cc
+    ProfileFunc.cc
+    Reduce.cc
+    ScriptOpt.cc
+    Stmt.cc
+    TempVar.cc
+    UsageAnalyzer.cc
+    UseDefs.cc)
+
+add_subdirectory(CPP)
+add_subdirectory(ZAM)

--- a/src/script_opt/CPP/CMakeLists.txt
+++ b/src/script_opt/CPP/CMakeLists.txt
@@ -1,0 +1,22 @@
+zeek_add_subdir_library(
+    CPP
+    SOURCES
+    Attrs.cc
+    Consts.cc
+    DeclFunc.cc
+    Driver.cc
+    Emit.cc
+    Exprs.cc
+    Func.cc
+    GenFunc.cc
+    Inits.cc
+    InitsInfo.cc
+    RuntimeInitSupport.cc
+    RuntimeInits.cc
+    RuntimeOps.cc
+    RuntimeVec.cc
+    Stmts.cc
+    Tracker.cc
+    Types.cc
+    Util.cc
+    Vars.cc)

--- a/src/script_opt/ZAM/CMakeLists.txt
+++ b/src/script_opt/ZAM/CMakeLists.txt
@@ -1,0 +1,20 @@
+zeek_add_subdir_library(
+    ZAM
+    SOURCES
+    AM-Opt.cc
+    Branches.cc
+    BuiltIn.cc
+    BuiltInSupport.cc
+    Driver.cc
+    Expr.cc
+    Inst-Gen.cc
+    Low-Level.cc
+    Profile.cc
+    Stmt.cc
+    Support.cc
+    Validate.cc
+    Vars.cc
+    ZBody.cc
+    ZInst.cc
+    ZInstAux.cc
+    ZOp.cc)

--- a/src/script_opt/ZAM/ZBody.cc
+++ b/src/script_opt/ZAM/ZBody.cc
@@ -265,18 +265,6 @@ ZBody::~ZBody() {
     delete[] insts;
 }
 
-void ZBody::SetInsts(vector<ZInst*>& _insts) {
-    end_pc = _insts.size();
-    auto insts_copy = new ZInst[end_pc];
-
-    for ( auto i = 0U; i < end_pc; ++i )
-        insts_copy[i] = *_insts[i];
-
-    insts = insts_copy;
-
-    InitProfile();
-}
-
 void ZBody::SetInsts(vector<ZInstI*>& instsI) {
     end_pc = instsI.size();
     auto insts_copy = new ZInst[end_pc];

--- a/src/script_opt/ZAM/ZBody.h
+++ b/src/script_opt/ZAM/ZBody.h
@@ -42,10 +42,8 @@ public:
 
     ~ZBody() override;
 
-    // These are split out from the constructor to allow construction
-    // of a ZBody from either save-file full instructions (first method,
-    // not currently supported) or intermediary instructions (second method).
-    void SetInsts(std::vector<ZInst*>& insts);
+    // This is split out from the constructor to allow construction of
+    // a ZBody from save-file instructions (not currently supported).
     void SetInsts(std::vector<ZInstI*>& instsI);
 
     ValPtr Exec(Frame* f, StmtFlowType& flow) override;


### PR DESCRIPTION
I'm looking to add some ZAM-associated BiFs and the natural way to do so is homing them in `script_opt/ZAM/` rather than at the top level. To do so cleanly requires moving CMake configuration information into `script_opt/` and its children.

The PR also incidentally picked up a very minor change I had made prior to the config work. It simply removes an unused method, so hopefully it's okay to bundle with this, but let me know if not.