### PR TITLE
CI: Request 16GB of RAM for Windows builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -659,7 +659,7 @@ windows_task:
     os_version: 2019
     cpu: 8
     # Not allowed to request less than 8GB for an 8 CPU Windows VM.
-    memory: 8GB
+    memory: 16GB
   sync_submodules_script: git submodule update --recursive --init
   prepare_script: ci/windows/prepare.cmd
   build_script: ci/windows/build.cmd


### PR DESCRIPTION
I'm hoping this speeds up Windows builds a little. There was a reason we only used 8GB back when we added Windows builds, but I don't remember why it was.