### PR TITLE
Include zeek-packet-source-udp as builtin plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -67,3 +67,6 @@
 [submodule "src/iosource/pcapng/auxil/LightPcapNg"]
 	path = src/iosource/pcapng/auxil/LightPcapNg
 	url = https://github.com/Technica-Engineering/LightPcapNg
+[submodule "auxil/zeek-packet-source-udp"]
+	path = auxil/zeek-packet-source-udp
+	url = https://github.com/zeek/zeek-packet-source-udp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1256,6 +1256,19 @@ if (NOT DISABLE_JAVASCRIPT)
     endif ()
 endif ()
 
+# Enable the UDP packet source on FreeBSD and Linux.
+set(_packet_source_udp_default ((${CMAKE_SYSTEM_NAME} MATCHES "Linux") OR (${CMAKE_SYSTEM_NAME}
+                                                                           MATCHES "FreeBSD")))
+set(ENABLE_PACKET_SOURCE_UDP ${_packet_source_udp_default} CACHE INTERNAL
+                                                                 "Enable UDP packet source support")
+set(ZEEK_HAVE_PACKET_SOURCE_UDP no)
+
+if (ENABLE_PACKET_SOURCE_UDP)
+    set(ZEEK_PACKET_SOURCE_UDP_PLUGIN_PATH ${CMAKE_SOURCE_DIR}/auxil/zeek-packet-source-udp)
+    list(APPEND ZEEK_INCLUDE_PLUGINS ${ZEEK_PACKET_SOURCE_UDP_PLUGIN_PATH})
+    set(ZEEK_HAVE_PACKET_SOURCE_UDP yes)
+endif ()
+
 set(ZEEK_HAVE_AF_PACKET no CACHE INTERNAL "Zeek has AF_PACKET support")
 set(ZEEK_HAVE_JAVASCRIPT ${ZEEK_HAVE_JAVASCRIPT} CACHE INTERNAL "Zeek has JavaScript support")
 

--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,28 @@ Breaking Changes
 New Functionality
 -----------------
 
+- The zeek-packet-source-udp (https://github.com/zeek/zeek-packet-source-udp)
+  plugin is now included and enabled by default on Linux and FreeBSD.
+
+  Instead of reading raw packets from a network interface, this packet source turns
+  Zeek into a UDP server to process UDP-based VXLAN or GENEVE mirror traffic directly:
+
+	zeek -i udp::0.0.0.0:4789:vxlan
+
+  The listening UDP socket is opened using the SO_REUSEPORT socket option. When
+  scaling the number of Zeek workers, the kernel will balance packets among the
+  individual UDP sockets based on the hash of the outermost UDP headers.
+
+  This packet source comes with a few ConnKey implementations to make connection
+  tracking aware of VXLAN VNI and GENEVE VNI. This feature needs to be explicitly
+  enabled by loading one of the corresponding policy scripts, for example:
+
+	zeek -i udp::0.0.0.0:4789:vxlan policy/frameworks/conn_key/packet_source/udp/vxlan_vni
+
+  To disable building the packet source, use:
+
+	./configure -D ENABLE_PACKET_SOURCE_UDP=no
+
 Changed Functionality
 ---------------------
 

--- a/testing/btest/coverage/bare-load-baseline.test
+++ b/testing/btest/coverage/bare-load-baseline.test
@@ -16,5 +16,5 @@
 # @TEST-EXEC: cat loaded_scripts.log | grep -E -v '#' | awk 'NR>0{print $1}' | sed -e ':a' -e '$!N' -e 's/^\(.*\).*\n\1.*/\1/' -e 'ta' >prefix
 # @TEST-EXEC: (cd $BUILD && pwd) | sed "s#^$(cd $DIST && pwd)/##" >buildprefix
 # @TEST-EXEC: cat loaded_scripts.log | sed "s#`cat buildprefix`#build#g" | sed "s#`cat prefix`##g" >prefix_canonified_loaded_scripts.log
-# @TEST-EXEC: grep -E -v 'Zeek_(AF_Packet|JavaScript)' prefix_canonified_loaded_scripts.log > canonified_loaded_scripts.log
+# @TEST-EXEC: grep -E -v 'Zeek_(AF_Packet|JavaScript|PacketSourceUDP)' prefix_canonified_loaded_scripts.log > canonified_loaded_scripts.log
 # @TEST-EXEC: btest-diff canonified_loaded_scripts.log

--- a/testing/btest/coverage/default-load-baseline.test
+++ b/testing/btest/coverage/default-load-baseline.test
@@ -15,5 +15,5 @@
 # @TEST-EXEC: cat loaded_scripts.log | grep -E -v '#' | sed 's/ //g' | sed -e ':a' -e '$!N' -e 's/^\(.*\).*\n\1.*/\1/' -e 'ta' >prefix
 # @TEST-EXEC: (cd $BUILD && pwd) | sed "s#^$(cd $DIST && pwd)/##" >buildprefix
 # @TEST-EXEC: cat loaded_scripts.log | sed "s#`cat buildprefix`#build#g" | sed "s#`cat prefix`##g" >prefix_canonified_loaded_scripts.log
-# @TEST-EXEC: grep -E -v 'Zeek_(AF_Packet|JavaScript)' prefix_canonified_loaded_scripts.log > canonified_loaded_scripts.log
+# @TEST-EXEC: grep -E -v 'Zeek_(AF_Packet|JavaScript|PacketSourceUDP)' prefix_canonified_loaded_scripts.log > canonified_loaded_scripts.log
 # @TEST-EXEC: btest-diff canonified_loaded_scripts.log

--- a/testing/btest/plugins/hooks-plugin/src/Plugin.cc
+++ b/testing/btest/plugins/hooks-plugin/src/Plugin.cc
@@ -37,6 +37,7 @@ static std::set<std::string> sanitized_functions = {
 static std::set<std::string> load_file_filter = {
     "Zeek_AF_Packet",
     "Zeek_JavaScript",
+    "Zeek_PacketSourceUDP",
 };
 
 static bool skip_load_file_logging_for(const std::string& s) {


### PR DESCRIPTION
I chatted with Christian a while ago and he wasn't completely opposed. The integration is straightforward and IMO this is a nice feature for the cloudier environments.

---

@ckreibich or others - what do you think?