### PR TITLE
CI: Remove usage of FreeBSD latest ports tree

### DIFF
--- a/ci/freebsd/prepare.sh
+++ b/ci/freebsd/prepare.sh
@@ -7,12 +7,6 @@ set -x
 
 env ASSUME_ALWAYS_YES=YES pkg bootstrap
 
-# Switch from "quarterly" to "latest" ABI builds. In early March 2026, the quarterly ABI
-# does not contain dnsmasq builds for amd64 (https://www.freshports.org/dns/dnsmasq/),
-# while "latest" does.
-sed -i .bak 's/quarterly/latest/g' /etc/pkg/FreeBSD.conf
-pkg update -f
-
 pkg install -y bash cppzmq git cmake-core swig bison python3 base64 flex ccache jq dnsmasq krb5
 pkg upgrade -y curl
 pyver=$(python3 -c 'import sys; print(f"py{sys.version_info[0]}{sys.version_info[1]}")')


### PR DESCRIPTION
As of April 2026, the version of dnsmasq in both quarterly and latest are the same again. On top of this, using latest is causing CI failures on FreeBSD's side

```
[20:14:42.638] pkg: Repository FreeBSD-ports has a wrong packagesite, need to re-create database
[20:14:42.740] Fetching meta.conf: . done
[20:14:42.846] Fetching data: .......... done
[20:14:43.316] pkg: truncated reply for signature_fingerprintsoutput, wanted 0 bytes
```