### PR TITLE
Bump version of GitPython used by docs builds

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,4 +4,4 @@ sphinx-rtd-theme==3.0.2
 # This version is the last version that supports Python 3.9.
 # 8.1.x is the last version series that supports Python 3.10.
 Sphinx==7.4.7
-GitPython==3.1.45
+GitPython==3.1.47


### PR DESCRIPTION
This fixes the two dependabot warnings. I'm opening a PR so that the workflow can test it.