### PR TITLE
Fix assignment typo in `zeek::threading::Value`'s move constructor

### DIFF
--- a/src/threading/SerialTypes.cc
+++ b/src/threading/SerialTypes.cc
@@ -124,7 +124,7 @@ Value::Value(const Value& other) {
 Value::Value(Value&& other) noexcept {
     present = other.present;
     type = other.type;
-    subtype = other.type;
+    subtype = other.subtype;
     line_number = other.line_number;
 
     val = other.val; // take ownership.


### PR DESCRIPTION
This is a minor Claude-provided finding reported by Martin Arlitt. This originally came via #3893, a perf improvement.