### PR TITLE
Make Zeek compile against OpenSSL 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1243,6 +1243,10 @@ if ((OPENSSL_VERSION VERSION_EQUAL "3.0.0") OR (OPENSSL_VERSION VERSION_GREATER 
     set(ZEEK_HAVE_OPENSSL_3_0 true CACHE INTERNAL "" FORCE)
 endif ()
 
+# Keep track of OpenSSL version to prevent allow checking if plugins use the same version
+# when compiling
+string(REGEX REPLACE "^([0-9]+)\\..*" "\\1" ZEEK_OPENSSL_VERSION_MAJOR "${OPENSSL_VERSION}")
+
 # Tell the plugin code that we're building as part of the main tree.
 set(ZEEK_PLUGIN_INTERNAL_BUILD true CACHE INTERNAL "" FORCE)
 

--- a/cmake_templates/zeek-config.h.in
+++ b/cmake_templates/zeek-config.h.in
@@ -94,6 +94,9 @@
 /* d2i_x509 uses const char** */
 #cmakedefine OPENSSL_D2I_X509_USES_CONST_CHAR
 
+/* OpenSSL major version number detected at CMake configure time */
+#define ZEEK_OPENSSL_VERSION_MAJOR @ZEEK_OPENSSL_VERSION_MAJOR@
+
 /* Define as the return type of signal handlers (`int' or `void'). */
 #define RETSIGTYPE @RETSIGTYPE@
 

--- a/src/file_analysis/analyzer/x509/OCSP.cc
+++ b/src/file_analysis/analyzer/x509/OCSP.cc
@@ -499,7 +499,7 @@ void OCSP::ParseResponse(OCSP_RESPONSE* resp) {
 
         num_ext = OCSP_SINGLERESP_get_ext_count(single_resp);
         for ( int k = 0; k < num_ext; ++k ) {
-            X509_EXTENSION* ex = OCSP_SINGLERESP_get_ext(single_resp, k);
+            auto* ex = OCSP_SINGLERESP_get_ext(single_resp, k);
             if ( ! ex )
                 continue;
 
@@ -537,7 +537,7 @@ void OCSP::ParseResponse(OCSP_RESPONSE* resp) {
     // ok, now that we are done with the actual certificate - let's parse extensions :)
     num_ext = OCSP_BASICRESP_get_ext_count(basic_resp);
     for ( int k = 0; k < num_ext; ++k ) {
-        X509_EXTENSION* ex = OCSP_BASICRESP_get_ext(basic_resp, k);
+        auto* ex = OCSP_BASICRESP_get_ext(basic_resp, k);
         if ( ! ex )
             continue;
 
@@ -550,7 +550,7 @@ clean_up:
     BIO_free(bio);
 }
 
-void OCSP::ParseExtensionsSpecific(X509_EXTENSION* ex, bool global, ASN1_OBJECT* ext_asn, const char* oid) {
+void OCSP::ParseExtensionsSpecific(openssl_x509_ext_t* ex, bool global, openssl_asn1_obj_t* ext_asn, const char* oid) {
     // In OpenSSL 1.0.2+, we can get the extension by using NID_ct_cert_scts.
     // In OpenSSL <= 1.0.1, this is not yet defined yet, so we have to manually
     // look it up by performing a string comparison on the oid.

--- a/src/file_analysis/analyzer/x509/OCSP.h
+++ b/src/file_analysis/analyzer/x509/OCSP.h
@@ -28,7 +28,7 @@ protected:
 private:
     void ParseResponse(OCSP_RESPONSE*);
     void ParseRequest(OCSP_REQUEST*);
-    void ParseExtensionsSpecific(X509_EXTENSION* ex, bool, ASN1_OBJECT*, const char*) override;
+    void ParseExtensionsSpecific(openssl_x509_ext_t* ex, bool, openssl_asn1_obj_t*, const char*) override;
 
     std::string ocsp_data;
     bool request = false; // true if ocsp request, false if reply

--- a/src/file_analysis/analyzer/x509/X509.cc
+++ b/src/file_analysis/analyzer/x509/X509.cc
@@ -84,7 +84,7 @@ bool X509::EndOfFile() {
 
     int num_ext = X509_get_ext_count(ssl_cert);
     for ( int k = 0; k < num_ext; ++k ) {
-        X509_EXTENSION* ex = X509_get_ext(ssl_cert, k);
+        auto* ex = X509_get_ext(ssl_cert, k);
         if ( ! ex )
             continue;
 
@@ -124,7 +124,7 @@ RecordValPtr X509::ParseCertificate(X509Val* cert_val, file_analysis::File* f) {
     pX509Cert->Assign(2, make_intrusive<StringVal>(len, buf));
     BIO_reset(bio);
 
-    X509_NAME* subject_name = X509_get_subject_name(ssl_cert);
+    auto* subject_name = X509_get_subject_name(ssl_cert);
     // extract the most specific (last) common name from the subject
     int namepos = -1;
     for ( ;; ) {
@@ -273,7 +273,7 @@ void X509::FreeRootStore() {
         X509_STORE_free(e.second);
 }
 
-void X509::ParseBasicConstraints(X509_EXTENSION* ex) {
+void X509::ParseBasicConstraints(openssl_x509_ext_t* ex) {
     assert(OBJ_obj2nid(X509_EXTENSION_get_object(ex)) == NID_basic_constraints);
 
     BASIC_CONSTRAINTS* constr = reinterpret_cast<BASIC_CONSTRAINTS*>(X509V3_EXT_d2i(ex));
@@ -296,7 +296,7 @@ void X509::ParseBasicConstraints(X509_EXTENSION* ex) {
         reporter->Weird(GetFile(), "x509_invalid_basic_constraint");
 }
 
-void X509::ParseExtensionsSpecific(X509_EXTENSION* ex, bool global, ASN1_OBJECT* ext_asn, const char* oid) {
+void X509::ParseExtensionsSpecific(openssl_x509_ext_t* ex, bool global, openssl_asn1_obj_t* ext_asn, const char* oid) {
     // look if we have a specialized handler for this event...
     if ( OBJ_obj2nid(ext_asn) == NID_basic_constraints )
         ParseBasicConstraints(ex);
@@ -315,7 +315,7 @@ void X509::ParseExtensionsSpecific(X509_EXTENSION* ex, bool global, ASN1_OBJECT*
         ParseSignedCertificateTimestamps(ex);
 }
 
-void X509::ParseSAN(X509_EXTENSION* ext) {
+void X509::ParseSAN(openssl_x509_ext_t* ext) {
     assert(OBJ_obj2nid(X509_EXTENSION_get_object(ext)) == NID_subject_alt_name);
 
     GENERAL_NAMES* altname = reinterpret_cast<GENERAL_NAMES*>(X509V3_EXT_d2i(ext));
@@ -375,16 +375,17 @@ void X509::ParseSAN(X509_EXTENSION* ext) {
             if ( ips == nullptr )
                 ips = make_intrusive<VectorVal>(id::find_type<VectorType>("addr_vec"));
 
-            uint32_t* addr = reinterpret_cast<uint32_t*>(gen->d.ip->data);
+            const uint32_t* addr = reinterpret_cast<const uint32_t*>(ASN1_STRING_get0_data(gen->d.ip));
+            int ip_len = ASN1_STRING_length(gen->d.ip);
 
-            if ( gen->d.ip->length == 4 )
+            if ( ip_len == 4 )
                 ips->Assign(ips->Size(), make_intrusive<AddrVal>(*addr));
 
-            else if ( gen->d.ip->length == 16 )
+            else if ( ip_len == 16 )
                 ips->Assign(ips->Size(), make_intrusive<AddrVal>(addr));
 
             else {
-                reporter->Weird(GetFile(), "x509_san_ip_length", util::fmt("%d", gen->d.ip->length));
+                reporter->Weird(GetFile(), "x509_san_ip_length", util::fmt("%d", ip_len));
                 continue;
             }
         }

--- a/src/file_analysis/analyzer/x509/X509.h
+++ b/src/file_analysis/analyzer/x509/X509.h
@@ -74,9 +74,9 @@ protected:
     X509(RecordValPtr args, file_analysis::File* file);
 
 private:
-    void ParseBasicConstraints(X509_EXTENSION* ex);
-    void ParseSAN(X509_EXTENSION* ex);
-    void ParseExtensionsSpecific(X509_EXTENSION* ex, bool, ASN1_OBJECT*, const char*) override;
+    void ParseBasicConstraints(openssl_x509_ext_t* ex);
+    void ParseSAN(openssl_x509_ext_t* ex);
+    void ParseExtensionsSpecific(openssl_x509_ext_t* ex, bool, openssl_asn1_obj_t*, const char*) override;
 
     std::string cert_data;
 

--- a/src/file_analysis/analyzer/x509/X509Common.cc
+++ b/src/file_analysis/analyzer/x509/X509Common.cc
@@ -31,10 +31,10 @@ double X509Common::GetTimeFromAsn1(const ASN1_TIME* atime, file_analysis::File* 
     char lBuffer[26];
     char* pBuffer = lBuffer;
 
-    const char* pString = reinterpret_cast<const char*>(atime->data);
-    unsigned int remaining = atime->length;
+    const char* pString = reinterpret_cast<const char*>(ASN1_STRING_get0_data(atime));
+    unsigned int remaining = ASN1_STRING_length(atime);
 
-    if ( atime->type == V_ASN1_UTCTIME ) {
+    if ( ASN1_STRING_type(atime) == V_ASN1_UTCTIME ) {
         if ( remaining < 11 || remaining > 17 ) {
             EmitWeird("x509_utc_length", f);
             return 0;
@@ -62,7 +62,7 @@ double X509Common::GetTimeFromAsn1(const ASN1_TIME* atime, file_analysis::File* 
         pString += 10;
         remaining -= 10;
     }
-    else if ( atime->type == V_ASN1_GENERALIZEDTIME ) {
+    else if ( ASN1_STRING_type(atime) == V_ASN1_GENERALIZEDTIME ) {
         // generalized time. We apparently ignore the YYYYMMDDHH case
         // for now and assume we always have minutes and seconds.
         // This should be ok because it is specified as a requirement in RFC 2459 4.1.2.5.2
@@ -166,22 +166,23 @@ double X509Common::GetTimeFromAsn1(const ASN1_TIME* atime, file_analysis::File* 
     return lResult;
 }
 
-void X509Common::ParseSignedCertificateTimestamps(X509_EXTENSION* ext) {
+void X509Common::ParseSignedCertificateTimestamps(openssl_x509_ext_t* ext) {
     // Ok, signed certificate timestamps are a bit of an odd case out; we don't
     // want to use the (basically nonexistent) OpenSSL functionality to parse them.
     // Instead we have our own, self-written binpac parser to parse just them,
     // which we will initialize here and tear down immediately again.
 
-    ASN1_OCTET_STRING* ext_val = X509_EXTENSION_get_data(ext);
+    auto* ext_val = X509_EXTENSION_get_data(ext);
     // the octet string of the extension contains the octet string which in turn
     // contains the SCT. Obviously.
 
-    unsigned char* ext_val_copy = reinterpret_cast<unsigned char*>(OPENSSL_malloc(ext_val->length));
+    int ext_val_len = ASN1_STRING_length(ext_val);
+    unsigned char* ext_val_copy = reinterpret_cast<unsigned char*>(OPENSSL_malloc(ext_val_len));
     unsigned char* ext_val_second_pointer = ext_val_copy;
-    memcpy(ext_val_copy, ext_val->data, ext_val->length);
+    memcpy(ext_val_copy, ASN1_STRING_get0_data(ext_val), ext_val_len);
 
     ASN1_OCTET_STRING* inner =
-        d2i_ASN1_OCTET_STRING(nullptr, const_cast<const unsigned char**>(&ext_val_copy), ext_val->length);
+        d2i_ASN1_OCTET_STRING(nullptr, const_cast<const unsigned char**>(&ext_val_copy), ext_val_len);
     if ( ! inner ) {
         OPENSSL_free(ext_val_second_pointer);
         reporter->Error("X509::ParseSignedCertificateTimestamps could not parse inner octet string");
@@ -192,7 +193,8 @@ void X509Common::ParseSignedCertificateTimestamps(X509_EXTENSION* ext) {
     binpac::X509Extension::SignedCertTimestampExt* interp = new binpac::X509Extension::SignedCertTimestampExt(conn);
 
     try {
-        interp->NewData(inner->data, inner->data + inner->length);
+        const unsigned char* inner_data = ASN1_STRING_get0_data(inner);
+        interp->NewData(inner_data, inner_data + ASN1_STRING_length(inner));
     } catch ( const binpac::Exception& e ) {
         // throw a warning or sth
         reporter->Error("X509::ParseSignedCertificateTimestamps could not parse SCT");
@@ -207,11 +209,11 @@ void X509Common::ParseSignedCertificateTimestamps(X509_EXTENSION* ext) {
     delete conn;
 }
 
-void X509Common::ParseExtension(X509_EXTENSION* ex, const EventHandlerPtr& h, bool global) {
+void X509Common::ParseExtension(openssl_x509_ext_t* ex, const EventHandlerPtr& h, bool global) {
     char name[256];
     char oid[256];
 
-    ASN1_OBJECT* ext_asn = X509_EXTENSION_get_object(ex);
+    auto* ext_asn = X509_EXTENSION_get_object(ex);
     const char* short_name = OBJ_nid2sn(OBJ_obj2nid(ext_asn));
 
     OBJ_obj2txt(name, 255, ext_asn, 0);

--- a/src/file_analysis/analyzer/x509/X509Common.h
+++ b/src/file_analysis/analyzer/x509/X509Common.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <openssl/asn1.h>
+#include <openssl/opensslv.h>
 #include <openssl/x509.h>
 
 #include "zeek/file_analysis/Analyzer.h"
@@ -24,6 +25,19 @@ namespace file_analysis {
 class File;
 
 namespace detail {
+
+// X509_get_ext(), X509_EXTENSION_get_object() and related functions return const
+// pointers in OpenSSL 4.0+, but non-const in earlier versions. This is awkward, as
+// we have the signatures in some functions. We use type aliases in these cases now,
+// and adjust them to be the same as the OpenSSL API. Not pretty, but I don't have a
+// better idea.
+#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+using openssl_x509_ext_t = const X509_EXTENSION;
+using openssl_asn1_obj_t = const ASN1_OBJECT;
+#else
+using openssl_x509_ext_t = X509_EXTENSION;
+using openssl_asn1_obj_t = ASN1_OBJECT;
+#endif
 
 class X509Common : public file_analysis::Analyzer {
 public:
@@ -45,9 +59,9 @@ public:
 protected:
     X509Common(const zeek::Tag& arg_tag, RecordValPtr arg_args, file_analysis::File* arg_file);
 
-    void ParseExtension(X509_EXTENSION* ex, const EventHandlerPtr& h, bool global);
-    void ParseSignedCertificateTimestamps(X509_EXTENSION* ext);
-    virtual void ParseExtensionsSpecific(X509_EXTENSION* ex, bool, ASN1_OBJECT*, const char*) = 0;
+    void ParseExtension(openssl_x509_ext_t* ex, const EventHandlerPtr& h, bool global);
+    void ParseSignedCertificateTimestamps(openssl_x509_ext_t* ext);
+    virtual void ParseExtensionsSpecific(openssl_x509_ext_t* ex, bool, openssl_asn1_obj_t*, const char*) = 0;
 };
 
 } // namespace detail

--- a/src/file_analysis/analyzer/x509/X509Common.h
+++ b/src/file_analysis/analyzer/x509/X509Common.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "zeek/zeek-config.h"
+
 #include <openssl/asn1.h>
 #include <openssl/opensslv.h>
 #include <openssl/x509.h>
@@ -26,12 +28,16 @@ class File;
 
 namespace detail {
 
+static_assert(ZEEK_OPENSSL_VERSION_MAJOR == OPENSSL_VERSION_MAJOR,
+              "OpenSSL major version mismatch: Zeek was configured with a different "
+              "OpenSSL major version than the headers being compiled against.");
+
 // X509_get_ext(), X509_EXTENSION_get_object() and related functions return const
 // pointers in OpenSSL 4.0+, but non-const in earlier versions. This is awkward, as
 // we have the signatures in some functions. We use type aliases in these cases now,
 // and adjust them to be the same as the OpenSSL API. Not pretty, but I don't have a
 // better idea.
-#if OPENSSL_VERSION_NUMBER >= 0x40000000L
+#if ZEEK_OPENSSL_VERSION_MAJOR >= 4
 using openssl_x509_ext_t = const X509_EXTENSION;
 using openssl_asn1_obj_t = const ASN1_OBJECT;
 #else

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -73,10 +73,10 @@ X509* x509_get_ocsp_signer(const STACK_OF(X509)* certs,
 									const_cast<X509_NAME*>(name));
 
 	// Just like OpenSSL, we just support SHA-1 lookups and bail out otherwise.
-	if ( key->length != SHA_DIGEST_LENGTH )
+	if ( ASN1_STRING_length(key) != SHA_DIGEST_LENGTH )
 		return nullptr;
 
-	unsigned char* key_hash = key->data;
+	const unsigned char* key_hash = ASN1_STRING_get0_data(key);
 
 	for ( int i = 0; i < sk_X509_num(certs); ++i )
 		{
@@ -481,9 +481,13 @@ function x509_ocsp_verify%(certs: x509_opaque_vector, ocsp_reply: string, root_c
 	// Well, we will do it manually.
 
 
-	if ( X509_cmp_time(thisUpdate, &vtime) > 0 )
+	if ( ASN1_TIME_cmp_time_t(thisUpdate, vtime) == -2 )
+		rval = x509_result_record(-1, "OCSP reply has invalid thisUpdate time");
+	else if ( ASN1_TIME_cmp_time_t(thisUpdate, vtime) > 0 )
 		rval = x509_result_record(-1, "OCSP reply specifies time in future");
-	else if ( X509_cmp_time(nextUpdate, &vtime) < 0 )
+	else if ( ASN1_TIME_cmp_time_t(nextUpdate, vtime) == -2 )
+		rval = x509_result_record(-1, "OCSP reply has invalid nextUpdate time");
+	else if ( ASN1_TIME_cmp_time_t(nextUpdate, vtime) < 0 )
 		rval = x509_result_record(-1, "OCSP reply expired");
 	else if ( type != V_OCSP_CERTSTATUS_GOOD )
 		rval = x509_result_record(-1, OCSP_cert_status_str(type));
@@ -813,8 +817,8 @@ zeek::StringValPtr x509_entity_hash(zeek::file_analysis::detail::X509Val *cert_h
 		return nullptr;
 		}
 
-	X509_NAME *subject_name = X509_get_subject_name(cert_x509);
-	X509_NAME *issuer_name = X509_get_issuer_name(cert_x509);
+	auto* subject_name = X509_get_subject_name(cert_x509);
+	auto* issuer_name = X509_get_issuer_name(cert_x509);
 	if ( subject_name == nullptr || issuer_name == nullptr )
 		{
 		zeek::emit_builtin_error("fail to get subject/issuer name from certificate");


### PR DESCRIPTION
The bulk of the changes are function signature changes that move to more const-ness. This is slightly annoying as we use these in our function signatures too.

We also move away from the deprecated asn1 time comparison function.

I used typedefs to keep the changes contained. If anyone has a better idea, please let me know.

This commit is based on top of the commit for #5422 and has to be rebased when/if that commit is accepted.

This commit was partially authored by Claude Sonnet 4.6. I reviewed and fully understand all changes that I did not author myself.