### PR TITLE
Gracefully handle when tables cannot grow anymore

### DIFF
--- a/src/Dict.h
+++ b/src/Dict.h
@@ -13,6 +13,7 @@
 #include "zeek/Hash.h"
 #include "zeek/Obj.h"
 #include "zeek/Reporter.h"
+#include "zeek/util.h"
 
 // Type for function to be called when deleting elements.
 using dict_delete_func = void (*)(void*);
@@ -1415,7 +1416,7 @@ private:
         SetLog2Buckets(log2_buckets + 1);
 
         int capacity = Capacity();
-        table = static_cast<detail::DictEntry<T>*>(realloc(table, capacity * sizeof(detail::DictEntry<T>)));
+        table = static_cast<detail::DictEntry<T>*>(util::safe_realloc(table, capacity * sizeof(detail::DictEntry<T>)));
         for ( int i = prev_capacity; i < capacity; i++ )
             table[i].SetEmpty();
 


### PR DESCRIPTION
In the current implementation tables hold all data in a single memory allocation, and to add more entries it might need to `realloc` the allocation. If the `realloc` call fails e.g., due to out of memory, a nullptr is returned which we previously did not check for; instead we would have dereferenced the the nullptr which ideally would have led to a SEGFAULT.

This patch changes the call to instead use our safe wrapper around `realloc` which makes sure that we do not keep running if the realloc failed.