### PR TITLE
Require sqlite3 binary for scripts.base.frameworks.storage.sqlite.multi-backend btest

### DIFF
--- a/testing/btest/scripts/base/frameworks/storage/sqlite/multi-backend.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite/multi-backend.zeek
@@ -1,5 +1,6 @@
 # @TEST-DOC: Opens multiple separate sqlite backends simultaneously to ensure data is written into the correct tables
 #
+# @TEST-REQUIRES: which sqlite3
 # @TEST-EXEC: zeek -b %INPUT > out
 # @TEST-EXEC: sqlite3 test1.sqlite "select * from testing" > test1-testing.out
 # @TEST-EXEC: sqlite3 test2.sqlite "select * from testing1" > test2-testing1.out


### PR DESCRIPTION
This is a follow-up to https://github.com/zeek/zeek/pull/5419 that requires the `sqlite3` binary to run the added btest. This would have been caught before (after?) I merged it back then, but our CI was down at the time.