### PR TITLE
Simplification of script optimization profiling of records

### DIFF
--- a/src/script_opt/CPP/RuntimeOps.h
+++ b/src/script_opt/CPP/RuntimeOps.h
@@ -202,7 +202,7 @@ inline TableValPtr table_remove_from__CPP(const TableValPtr& t1, const TableValP
     return t1;
 }
 
-// The same, for an empty record.
+// The same, for an empty vector.
 inline VectorValPtr vector_coerce__CPP(const ValPtr& v, const TypePtr& t) {
     VectorVal* vv = v->AsVectorVal();
 

--- a/src/script_opt/Inline.cc
+++ b/src/script_opt/Inline.cc
@@ -309,7 +309,7 @@ void Inliner::CoalesceEventHandlers(ScriptFuncPtr func, const std::vector<Func::
     Func::Body body{.stmts = merged_body};
     funcs.emplace_back(inlined_func, new_scope, std::move(body));
 
-    auto pf = std::make_shared<ProfileFunc>(inlined_func.get(), merged_body, true);
+    auto pf = std::make_shared<ProfileFunc>(inlined_func.get(), merged_body);
     funcs.back().SetProfile(std::move(pf));
 }
 

--- a/src/script_opt/ProfileFunc.cc
+++ b/src/script_opt/ProfileFunc.cc
@@ -21,11 +21,10 @@ p_hash_type p_hash(const Obj* o) {
     return p_hash(d.Description());
 }
 
-ProfileFunc::ProfileFunc(const Func* func, const StmtPtr& body, bool _abs_rec_fields) {
+ProfileFunc::ProfileFunc(const Func* func, const StmtPtr& body) {
     profiled_func = func;
     profiled_scope = profiled_func->GetScope();
     profiled_body = body.get();
-    abs_rec_fields = _abs_rec_fields;
 
     profiled_func_t = cast_intrusive<FuncType>(func->GetType());
     auto& fcaps = profiled_func_t->GetCaptures();
@@ -56,16 +55,13 @@ ProfileFunc::ProfileFunc(const Func* func, const StmtPtr& body, bool _abs_rec_fi
     }
 }
 
-ProfileFunc::ProfileFunc(const Stmt* s, bool _abs_rec_fields) {
+ProfileFunc::ProfileFunc(const Stmt* s) {
     profiled_body = s;
-    abs_rec_fields = _abs_rec_fields;
     s->Traverse(this);
 }
 
-ProfileFunc::ProfileFunc(const Expr* e, bool _abs_rec_fields) {
+ProfileFunc::ProfileFunc(const Expr* e) {
     profiled_expr = e;
-
-    abs_rec_fields = _abs_rec_fields;
 
     if ( e->Tag() == EXPR_LAMBDA ) {
         auto func = e->AsLambdaExpr();
@@ -212,27 +208,17 @@ TraversalCode ProfileFunc::PreExpr(const Expr* e) {
             break;
         }
 
-        case EXPR_FIELD:
-            if ( abs_rec_fields ) {
-                auto f = e->AsFieldExpr()->Field();
-                addl_hashes.push_back(p_hash(f));
-            }
-            else {
-                auto fn = e->AsFieldExpr()->FieldName();
-                addl_hashes.push_back(p_hash(fn));
-            }
+        case EXPR_FIELD: {
+            auto f = e->AsFieldExpr()->Field();
+            addl_hashes.push_back(p_hash(f));
             break;
+        }
 
-        case EXPR_HAS_FIELD:
-            if ( abs_rec_fields ) {
-                auto f = e->AsHasFieldExpr()->Field();
-                addl_hashes.push_back(std::hash<int>{}(f));
-            }
-            else {
-                auto fn = e->AsHasFieldExpr()->FieldName();
-                addl_hashes.push_back(std::hash<std::string>{}(fn));
-            }
+        case EXPR_HAS_FIELD: {
+            auto f = e->AsHasFieldExpr()->Field();
+            addl_hashes.push_back(std::hash<int>{}(f));
             break;
+        }
 
         case EXPR_INDEX: {
             auto lhs_t = e->GetOp1()->GetType();
@@ -440,7 +426,7 @@ TraversalCode ProfileFunc::PreExpr(const Expr* e) {
             // In general, we don't want to recurse into the body.
             // However, we still want to *profile* it so we can
             // identify calls within it.
-            auto pf = std::make_shared<ProfileFunc>(l->Ingredients()->Body().get(), false);
+            auto pf = std::make_shared<ProfileFunc>(l->Ingredients()->Body().get());
             script_calls.insert(pf->ScriptCalls().begin(), pf->ScriptCalls().end());
 
             return TC_ABORTSTMT;
@@ -576,13 +562,11 @@ void ProfileFunc::CheckRecordConstructor(TypePtr t) {
     }
 }
 
-ProfileFuncs::ProfileFuncs(std::vector<FuncInfo>& funcs, is_compilable_pred pred, bool _compute_func_hashes,
-                           bool _full_record_hashes) {
+ProfileFuncs::ProfileFuncs(std::vector<FuncInfo>& funcs, is_compilable_pred pred, bool _compute_func_hashes) {
     compute_func_hashes = _compute_func_hashes;
-    full_record_hashes = _full_record_hashes;
 
     for ( auto& f : funcs ) {
-        auto pf = std::make_shared<ProfileFunc>(f.Func(), f.Body(), full_record_hashes);
+        auto pf = std::make_shared<ProfileFunc>(f.Func(), f.Body());
 
         if ( ! pred || (*pred)(pf.get(), nullptr) )
             MergeInProfile(pf.get());
@@ -850,7 +834,7 @@ void ProfileFuncs::DrainPendingExprs() {
         pending_exprs.clear();
 
         for ( auto e : pe ) {
-            auto pf = std::make_shared<ProfileFunc>(e, full_record_hashes);
+            auto pf = std::make_shared<ProfileFunc>(e);
 
             expr_profs[e] = pf;
             MergeInProfile(pf.get());
@@ -908,10 +892,7 @@ void ProfileFuncs::ComputeProfileHash(const std::shared_ptr<ProfileFunc>& pf) {
     // (such as Stmt's or Expr's that are only represented by
     // the hash of their tag).
     h = merge_p_hashes(h, p_hash("params"));
-    auto& ov = pf->ProfiledScope()->OrderedVars();
-    int n = pf->NumParams();
-    for ( int i = 0; i < n; ++i )
-        h = merge_p_hashes(h, p_hash(ov[i]->Name()));
+    h = merge_p_hashes(h, HashType(pf->ProfiledFuncType()));
 
     h = merge_p_hashes(h, p_hash("stmts"));
     for ( auto& i : pf->Stmts() )
@@ -1008,34 +989,20 @@ p_hash_type ProfileFuncs::HashType(const Type* t) {
             auto orig_n = ft->NumOrigFields();
 
             h = merge_p_hashes(h, p_hash("record"));
+            h = merge_p_hashes(h, p_hash(orig_n));
 
-            if ( full_record_hashes )
-                h = merge_p_hashes(h, p_hash(n));
-            else
-                h = merge_p_hashes(h, p_hash(orig_n));
-
-            for ( auto i = 0; i < n; ++i ) {
-                bool do_hash = full_record_hashes;
-                if ( ! do_hash )
-                    do_hash = (i < orig_n);
-
+            for ( auto i = 0; i < orig_n; ++i ) {
                 const auto& f = ft->FieldDecl(i);
                 auto type_h = HashType(f->type);
 
-                if ( do_hash ) {
-                    h = merge_p_hashes(h, p_hash(f->id));
-                    h = merge_p_hashes(h, type_h);
-                }
-
                 h = merge_p_hashes(h, p_hash(f->id));
-                h = merge_p_hashes(h, HashType(f->type));
+                h = merge_p_hashes(h, type_h);
 
                 // We don't hash the field name, as in some contexts
                 // those are ignored.
 
                 if ( f->attrs ) {
-                    if ( do_hash )
-                        h = merge_p_hashes(h, HashAttrs(f->attrs));
+                    h = merge_p_hashes(h, HashAttrs(f->attrs));
                     AnalyzeAttrs(f->attrs.get(), ft);
                 }
             }

--- a/src/script_opt/ProfileFunc.h
+++ b/src/script_opt/ProfileFunc.h
@@ -73,18 +73,19 @@ class ProfileFunc : public TraversalCallback {
 public:
     // Constructor used for the usual case of profiling a script
     // function and one of its bodies.
-    ProfileFunc(const Func* func, const StmtPtr& body, bool abs_rec_fields);
+    ProfileFunc(const Func* func, const StmtPtr& body);
 
     // Constructors for profiling an AST statement expression.  These exist
     // to support (1) profiling lambda expressions and loop bodies, and
     // (2) traversing attribute expressions (such as &default=expr)
     // to discover what components they include.
-    ProfileFunc(const Stmt* body, bool abs_rec_fields = false);
-    ProfileFunc(const Expr* func, bool abs_rec_fields = false);
+    ProfileFunc(const Stmt* body);
+    ProfileFunc(const Expr* func);
 
     // Returns the function, body, or expression profiled.  Each can be
     // null depending on the constructor used.
     const Func* ProfiledFunc() const { return profiled_func; }
+    const FuncTypePtr& ProfiledFuncType() const { return profiled_func_t; }
     const ScopePtr& ProfiledScope() const { return profiled_scope; }
     const Stmt* ProfiledBody() const { return profiled_body; }
     const Expr* ProfiledExpr() const { return profiled_expr; }
@@ -165,8 +166,8 @@ protected:
     // The function, body, or expression profiled.  Can be null
     // depending on which constructor was used.
     const Func* profiled_func = nullptr;
-    ScopePtr profiled_scope;     // null when not in a full function context
-    FuncTypePtr profiled_func_t; // null when not in a full function context
+    ScopePtr profiled_scope;     // null when not in a function/lambda context
+    FuncTypePtr profiled_func_t; // null when not in a function/lambda context
     const Stmt* profiled_body = nullptr;
     const Expr* profiled_expr = nullptr;
 
@@ -301,10 +302,6 @@ protected:
     // track these individually, but to date all that's mattered is
     // whether a given body contains any.
     int num_when_stmts = 0;
-
-    // Whether we should treat record field accesses as absolute
-    // (integer offset) or relative (name-based).
-    bool abs_rec_fields;
 };
 
 // Describes an operation for which some forms of access can lead to state
@@ -364,11 +361,8 @@ public:
     // then it is called for each profile to see whether it's compilable,
     // and, if not, the FuncInfo is marked as ShouldSkip().
     // "compute_func_hashes" governs whether we compute hashes for the
-    // FuncInfo entries, or keep their existing ones.  "full_record_hashes"
-    // controls whether the hashes for extended records covers their final,
-    // full form, or should only their original fields.
-    ProfileFuncs(std::vector<FuncInfo>& funcs, is_compilable_pred pred, bool compute_func_hashes,
-                 bool full_record_hashes);
+    // FuncInfo entries, or keep their existing ones.
+    ProfileFuncs(std::vector<FuncInfo>& funcs, is_compilable_pred pred, bool compute_func_hashes);
 
     // Used to profile additional lambdas that (potentially) weren't part
     // of the overall function profiling.
@@ -643,10 +637,6 @@ protected:
     // Whether to compute new hashes for the FuncInfo entries. If the FuncInfo
     // doesn't have a hash, it will always be computed.
     bool compute_func_hashes;
-
-    // Whether the hashes for extended records should cover their final,
-    // full form, or only their original fields.
-    bool full_record_hashes;
 };
 
 // Updates the line numbers associated with an AST node to reflect its

--- a/src/script_opt/ScriptOpt.cc
+++ b/src/script_opt/ScriptOpt.cc
@@ -199,7 +199,7 @@ AnalyzeDecision obj_matches_opt_files(const Obj* obj) {
 
 static bool optimize_AST(ScriptFuncPtr f, std::shared_ptr<ProfileFunc>& pf, std::shared_ptr<Reducer>& rc,
                          ScopePtr scope, StmtPtr& body) {
-    pf = std::make_shared<ProfileFunc>(f.get(), body, true);
+    pf = std::make_shared<ProfileFunc>(f.get(), body);
 
     GenIDDefs ID_defs(pf, f, scope, body);
 
@@ -276,7 +276,7 @@ static void optimize_func(ScriptFuncPtr f, std::shared_ptr<ProfileFunc> pf, cons
     }
 
     // Profile the new body.
-    pf = std::make_shared<ProfileFunc>(f.get(), body, true);
+    pf = std::make_shared<ProfileFunc>(f.get(), body);
 
     // Compute its reaching definitions.
     GenIDDefs ID_defs(pf, f, scope, body);
@@ -491,7 +491,7 @@ static void use_CPP() {
 
     int num_used = 0;
 
-    auto pfs = std::make_unique<ProfileFuncs>(funcs, is_CPP_compilable, true, false);
+    auto pfs = std::make_unique<ProfileFuncs>(funcs, is_CPP_compilable, true);
 
     for ( auto& f : funcs ) {
         if ( f.ShouldSkip() )
@@ -710,7 +710,7 @@ void analyze_scripts(bool no_unused_warnings) {
     }
 
     if ( analysis_options.report_CPP ) {
-        auto pfs = std::make_unique<ProfileFuncs>(funcs, is_CPP_compilable, true, false);
+        auto pfs = std::make_unique<ProfileFuncs>(funcs, is_CPP_compilable, true);
         report_CPP();
         exit(0);
     }
@@ -722,12 +722,12 @@ void analyze_scripts(bool no_unused_warnings) {
         if ( analysis_options.gen_ZAM )
             reporter->FatalError("-O ZAM and -O gen-C++ conflict");
 
-        auto pfs = std::make_shared<ProfileFuncs>(funcs, is_CPP_compilable, true, false);
+        auto pfs = std::make_shared<ProfileFuncs>(funcs, is_CPP_compilable, true);
         generate_CPP(std::move(pfs));
         exit(0);
     }
 
-    auto pfs = std::make_shared<ProfileFuncs>(funcs, nullptr, true, true);
+    auto pfs = std::make_shared<ProfileFuncs>(funcs, nullptr, true);
     analyze_scripts_for_ZAM(pfs);
 
     if ( reporter->Errors() > 0 )


### PR DESCRIPTION
This is that rare-but-happy PR that pretty much only removes code, and the result is performance gains.

**Background:** when compiling scripts to C++ via `-O gen-C++`, there needs to be a way to associate scripts seen in the future with their compiled versions. This is done by hashing each function body's AST, and then using the hash to associate the AST with a previously compiled version of the body. Among (many) other things, the hashing includes hashing each type that the body uses. For record types, this presents an issue of which fields to hash over, given that scripts can extend records with additional fields. For compiled code that wires in field offsets, those offsets can be potentially incorrect if the compiled body is loaded after a new script (that wasn't present during the original compilation) that adds fields and hence changes those offsets. Because of this, the hashing methods could optionally include all fields in the hash, with the idea being that if such a new script is added, the hashes will change, and the compiled code with the wrong wired-in field offsets wouldn't be used.

**However:** a while ago I added logic to the compilation to use an intermediate, dynamically generated mapping to go from abstract field offsets to concrete ones. This means that compiled bodies will work correctly regardless of whether new scripts are introduced that alter the original offsets. Because of that change, we can now remove the hashing of extension fields. Doing so means that we can now use compiled code where we often couldn't before (such as for `connection_established` handlers, given that scripts often `redef` the `connection` record, changing field offsets), resulting for those instances in significant performance gains.