### PR TITLE
Warn when expiration interval is a dynamic value (e.g. function argument)Warn when expiration interval is a dynamic value

### DIFF
--- a/src/Attr.cc
+++ b/src/Attr.cc
@@ -390,6 +390,18 @@ bool Attributes::CheckAttr(Attr* a, const TypePtr& attrs_t) {
                 return AttrError(
                     "set/table can only have one of &read_expire, &write_expire, "
                     "&create_expire");
+
+            // Warn if the expiration expression is not a constant or global
+            // variable. Dynamic values such as function arguments are evaluated
+            // in isolation and will not reflect the intended runtime value,
+            // leading to silently incorrect expiration behavior.
+            if ( a->GetExpr() &&
+                 a->GetExpr()->Tag() != EXPR_CONST &&
+                 a->GetExpr()->Tag() != EXPR_NAME )
+                reporter->Warning(
+                    "expiration interval is not a constant or global variable; "
+                    "dynamic values such as function arguments will not have "
+                    "the intended effect");
         }
 
 #if 0


### PR DESCRIPTION
Fixes #5207

## Problem
When &create_expire, &read_expire, or &write_expire is given a dynamic 
value such as a function argument, Zeek silently ignores it and no 
expiration takes effect. Only literals and globals work correctly.

## Fix
Added a warning in Attr.cc when the expiration expression is not a 
constant (EXPR_CONST) or global variable (EXPR_NAME), so users are 
informed instead of experiencing silent incorrect behavior.