### PR TITLE
Mark SSL::hash_algorithms and SSL::signature_algorithms as deprecated

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -69,6 +69,11 @@ Changed Functionality
 Deprecated Functionality
 ------------------------
 
+- The ``SSL::hash_algorithms`` and ``SSL::signature_algorithms`` tables have been deprecated.
+  They are outdated with TLS 1.3, and not used in Zeek. If you currently use these tables,
+  you should switch to your own copy of the IANA tables and consider also using the
+  TLS SignatureScheme IANA table.
+
 Zeek 8.2.0
 ==========
 

--- a/scripts/base/protocols/ssl/consts.zeek
+++ b/scripts/base/protocols/ssl/consts.zeek
@@ -92,7 +92,7 @@ export {
 		[5] = "sha384",
 		[6] = "sha512",
 		[8] = "Intrinsic",
-	} &default=function(i: count):string { return fmt("unknown-%d", i); };
+	} &default=function(i: count):string { return fmt("unknown-%d", i); } &deprecated="Remove in 9.1: The SSL::hash_algorithms table is not used by Zeek itself and outdated with TLS 1.3.";
 
 	## Mapping between numeric codes and human readable strings for signature
 	## algorithms.
@@ -116,7 +116,7 @@ export {
 		[11] = "rsa_pss_sha512",
 		[64] = "gostr34102012_256",
 		[65] = "gostr34102012_256",
-	} &default=function(i: count):string { return fmt("unknown-%d", i); };
+	} &default=function(i: count):string { return fmt("unknown-%d", i); } &deprecated="Remove in 9.1: The SSL::signature_algorithms table is not used by Zeek itself and outdated with TLS 1.3.";
 
 	## Mapping between numeric codes and human readable strings for alert
 	## descriptions.

--- a/testing/btest/scripts/base/protocols/ssl/tls-extension-events.test
+++ b/testing/btest/scripts/base/protocols/ssl/tls-extension-events.test
@@ -5,6 +5,34 @@
 
 @load base/protocols/ssl
 
+const hash_algorithms: table[count] of string = {
+	[0] = "none",
+	[1] = "md5",
+	[2] = "sha1",
+	[3] = "sha224",
+	[4] = "sha256",
+	[5] = "sha384",
+	[6] = "sha512",
+	[8] = "Intrinsic",
+} &default=function(i: count):string { return fmt("unknown-%d", i); };
+
+const signature_algorithms: table[count] of string = {
+	[0] = "anonymous",
+	[1] = "rsa",
+	[2] = "dsa",
+	[3] = "ecdsa",
+	[4] = "rsa_pss_sha256",
+	[5] = "rsa_pss_sha384",
+	[6] = "rsa_pss_sha512",
+	[7] = "ed25519",
+	[8] = "ed448",
+	[9] = "rsa_pss_sha256",
+	[10] = "rsa_pss_sha384",
+	[11] = "rsa_pss_sha512",
+	[64] = "gostr34102012_256",
+	[65] = "gostr34102012_256",
+} &default=function(i: count):string { return fmt("unknown-%d", i); };
+
 event ssl_extension_elliptic_curves(c: connection, is_client: bool, curves: index_vec)
 	{
 	print "Curves", c$id$orig_h, c$id$resp_h;
@@ -29,12 +57,12 @@ event ssl_extension_server_name(c: connection, is_client: bool, names: string_ve
 	print "server_name", c$id$orig_h, c$id$resp_h, names;
 	}
 
-event ssl_extension_signature_algorithm(c: connection, is_client: bool, signature_algorithms: vector of SSL::SignatureAndHashAlgorithm)
+event ssl_extension_signature_algorithm(c: connection, is_client: bool, sigalgs: vector of SSL::SignatureAndHashAlgorithm)
 	{
 	print "signature_algorithm", c$id$orig_h, c$id$resp_h;
-	for ( i in signature_algorithms)
+	for ( i in sigalgs)
 		{
-		print SSL::hash_algorithms[signature_algorithms[i]$HashAlgorithm], SSL::signature_algorithms[signature_algorithms[i]$SignatureAlgorithm];
+		print hash_algorithms[sigalgs[i]$HashAlgorithm], signature_algorithms[sigalgs[i]$SignatureAlgorithm];
 		}
 	}
 


### PR DESCRIPTION
We don't use those tables in Zeek ourselves, and they are (kind of) outdated with TLS 1.3. Users that need these values are probably better served by creating their own tables and keeping them up to date.

Closes GH-5320