### PR TITLE
Tune ZeroMQ drop tests to overflow the XPUB watermark more easily

### DIFF
--- a/testing/btest/cluster/zeromq/overload-drop.zeek
+++ b/testing/btest/cluster/zeromq/overload-drop.zeek
@@ -48,8 +48,8 @@ const batch = 1000;
 # seems to reliably pass with an ASAN build, nothing more. They
 # interact with the number of publishes and chosen batch. If this
 # becomes unmaintainalbe going forward, easier to skip on ASAN IMO.
-redef Cluster::Backend::ZeroMQ::xpub_sndhwm = batch / 5;
-redef Cluster::Backend::ZeroMQ::onloop_queue_hwm = batch / 6;
+redef Cluster::Backend::ZeroMQ::xpub_sndhwm = batch / 100;
+redef Cluster::Backend::ZeroMQ::onloop_queue_hwm = batch / 20;
 
 global test_nodes = set( "proxy", "worker-1", "worker-2" ) &ordered;
 # @TEST-END-FILE

--- a/testing/btest/cluster/zeromq/overload-worker-proxy-topic-drop.zeek
+++ b/testing/btest/cluster/zeromq/overload-worker-proxy-topic-drop.zeek
@@ -119,7 +119,7 @@ event zeek_done()
 # seems to reliably pass with an ASAN build, nothing more. They
 # interact with the number of publishes and chosen batch. If this
 # becomes unmaintainalbe going forward, easier to skip on ASAN IMO.
-redef Cluster::Backend::ZeroMQ::xpub_sndhwm = batch / 5;
+redef Cluster::Backend::ZeroMQ::xpub_sndhwm = batch / 100;
 redef Cluster::Backend::ZeroMQ::onloop_queue_hwm = batch / 6;
 
 # last_c tracks the last publish offset from other nodes.


### PR DESCRIPTION
These two tests consistently fail on my machines at the previous XPUB high watermark. Even with a fraction of 50 they're still unreliable. With 100, and me keeping the machines otherwise idle, it passes hundreds of times without error. Since the threshold shouldn't matter as much as us verifying that the overflow is detected relibly, I think this is okay.

I experimented with making the ping event consume additional buffer space by adding large strings to its argument. This prolongs the tests considerably (for example, a 10K buffer makes the overload-drop test take nearly twice as long), but has no impact on reaching the high water mark, so (perhaps unsurprisingly) the overhead all seems to be in per-message processing.