### PR TITLE
CI: Rework Windows Dockerfile to use newer version of Windows

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -647,7 +647,7 @@ windows_task:
   timeout_in: 120m
   windows_container:
     dockerfile: ci/windows/Dockerfile
-    os_version: 2019
+    os_version: 2025
     cpu: 8
     # Not allowed to request less than 8GB for an 8 CPU Windows VM.
     memory: 16GB

--- a/ci/windows/Dockerfile
+++ b/ci/windows/Dockerfile
@@ -1,11 +1,13 @@
 # escape=`
-FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
-
-SHELL [ "powershell" ]
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8.1-windowsservercore-ltsc2025
 
 # A version field to invalidatea Cirrus's build cache when needed, as suggested in
 # https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
-ENV DOCKERFILE_VERSION=20260420
+ENV DOCKERFILE_VERSION=20260520
+
+# Set the shell to powershell so that we can install Chocolatey with the right
+# permissions.
+SHELL [ "powershell" ]
 
 RUN Set-ExecutionPolicy Unrestricted -Force
 
@@ -13,22 +15,39 @@ RUN Set-ExecutionPolicy Unrestricted -Force
 RUN [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; `
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
-# Install prerequisites
-RUN choco install -y --no-progress visualstudio2022buildtools --version=117.14.29
-RUN choco install -y --no-progress visualstudio2022-workload-vctools --version=1.0.0 --package-parameters '--add Microsoft.VisualStudio.Component.VC.ATLMFC'
-RUN choco install -y --no-progress sed
-RUN choco install -y --no-progress winflexbison3
-RUN choco install -y --no-progress msysgit
-RUN choco install -y --no-progress python
+# Install prerequisites via Chocolatey
+RUN choco install -y --no-progress sed winflexbison3 msysgit python ccache
 RUN choco install -y --no-progress openssl --version=3.1.1
-RUN choco install -y --no-progress ccache
+
+# Restore the default Windows shell for correct batch processing.
+SHELL ["cmd", "/S", "/C"]
+
+# Install the Visual Studio environment
+RUN `
+    # Download the Build Tools bootstrapper.
+    curl -SL --output vs_buildtools.exe https://aka.ms/vs/stable/vs_buildtools.exe `
+    `
+    # Install Build Tools with the Microsoft.VisualStudio.Workload.AzureBuildTools workload, excluding workloads and components with known issues.
+    && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
+        --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\BuildTools" `
+        --add Microsoft.VisualStudio.Workload.AzureBuildTools `
+        --add Microsoft.VisualStudio.Workload.VCTools `
+        --add Microsoft.VisualStudio.Component.VC.CMake.Project `
+        --add Microsoft.VisualStudio.Component.Windows11SDK.26100 `
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
+        --remove Microsoft.VisualStudio.Component.Windows81SDK `
+        || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
+    `
+    # Cleanup
+    && del /q vs_buildtools.exe
 
 # Set working environment.
 SHELL [ "cmd", "/c" ]
 RUN setx /M PATH "%PATH%;C:\\Program Files\\Git\\bin"
-RUN setx /M CONAN_SKIP_BROKEN_SYMLINKS_CHECK 1
 RUN mkdir C:\build
 WORKDIR C:\build
 
 # This entry point starts the developer command prompt and launches the PowerShell shell.
-ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "-arch=x64", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Unrestricted"]
+ENTRYPOINT ["C:\\Program Files (x86)\\Microsoft Visual Studio\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "-arch=amd64", "&&", "powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]


### PR DESCRIPTION
This updates the Dockerfile used for Windows CI builds to the lstc2025 image, which is much newer than the old 2019 image. It also updates to Visual Studio 2026 (or "latest", since they don't offer versioned installers anymore past 2022).

This requires merging https://github.com/zeek/libunistd/pull/15 as well.