### PR TITLE
docs: clarify note about package manager versions in Quickstart Guide

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -17,10 +17,6 @@ numbers, please refer to our `Release Cadence
 
 .. _docker-images:
 
-Note: Some Linux distributions may provide older versions of Zeek. For the latest
-official Zeek binary packages, see https://docs.zeek.org/en/master/install.html#binary-packages.
-
-
 Docker Images
 =============
 
@@ -105,6 +101,11 @@ on which version you’re using), and includes a complete Zeek environment with
 
 See our `Binary Packages wiki page <https://github.com/zeek/zeek/wiki/Binary-Packages>`_
 for the latest updates on binary releases.
+
+.. note::
+
+   Some Linux distributions may provide older versions of Zeek. Check the version
+   packaged for your distribution before installing.
 
 macOS
 -----

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -17,6 +17,10 @@ numbers, please refer to our `Release Cadence
 
 .. _docker-images:
 
+Note: Some Linux distributions may provide older versions of Zeek. For the latest
+official Zeek binary packages, see https://docs.zeek.org/en/master/install.html#binary-packages.
+
+
 Docker Images
 =============
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -15,7 +15,6 @@ systems and does not require custom hardware. See :doc:`install` in order to
 install from pre-built binary packages, or :doc:`building-from-source` in order
 to build Zeek from source.
 
-
 We will first analyze previously captured network traffic from a ``pcap`` file -
 :download:`quickstart.pcap <traces/quickstart.pcap>`. Later, we will use Zeek to
 monitor live traffic. Each section builds on the previous section.

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -12,7 +12,7 @@ Quick Start Guide
 
 Zeek is a network traffic analyzer. Zeek works on most modern Unix-based
 systems and does not require custom hardware. See :doc:`install` in order to
-install from pre-built binary packages (note that some distributions may provide older versions),  or :doc:`building-from-source` in order
+install from official Zeek binary packages (see https://docs.zeek.org/en/master/install.html#binary-packages),  or :doc:`building-from-source` in order
 to build Zeek from source.
 
 We will first analyze previously captured network traffic from a ``pcap`` file -

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -12,7 +12,7 @@ Quick Start Guide
 
 Zeek is a network traffic analyzer. Zeek works on most modern Unix-based
 systems and does not require custom hardware. See :doc:`install` in order to
-install from pre-built binary packages, or :doc:`building-from-source` in order
+install from pre-built binary packages (note that some distributions may provide older versions),  or :doc:`building-from-source` in order
 to build Zeek from source.
 
 We will first analyze previously captured network traffic from a ``pcap`` file -

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -12,8 +12,9 @@ Quick Start Guide
 
 Zeek is a network traffic analyzer. Zeek works on most modern Unix-based
 systems and does not require custom hardware. See :doc:`install` in order to
-install from official Zeek binary packages (see https://docs.zeek.org/en/master/install.html#binary-packages),  or :doc:`building-from-source` in order
+install from pre-built binary packages, or :doc:`building-from-source` in order
 to build Zeek from source.
+
 
 We will first analyze previously captured network traffic from a ``pcap`` file -
 :download:`quickstart.pcap <traces/quickstart.pcap>`. Later, we will use Zeek to


### PR DESCRIPTION
This update adds a brief clarification to the Quickstart Guide noting that some Linux distributions may provide older versions of Zeek through their system package managers. This helps new users understand why their installed version may not match the documentation or available features, and encourages them to consider building from source when they need the latest release.


The change improves accuracy and reduces potential confusion for first‑time users following the installation instructions.