### PR TITLE
netbios: fix out-of-bounds read in NetbiosSSN_Interpreter::ConvertName

### DIFF
--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -184,7 +184,10 @@ int NetbiosSSN_Interpreter::ConvertName(const u_char* name, int name_len, u_char
     int len = (*name++) / 2;
     xlen = len;
 
-    if ( len > 30 || len < 1 || name_len < len )
+    // The loop below reads two bytes per encoded name character, on top
+    // of the one length byte already consumed above, so the input must
+    // hold at least 2 * len + 1 bytes total.
+    if ( len > 30 || len < 1 || name_len < 2 * len + 1 )
         return 0;
 
     u_char* convert_name = new u_char[len + 1];


### PR DESCRIPTION
### What

`NetbiosSSN_Interpreter::ConvertName()` in `src/analyzer/protocol/netbios/NetbiosSSN.cc` validates the encoded NetBIOS name length with:

```cpp
int len = (*name++) / 2;          // 1 length byte consumed
xlen = len;
if ( len > 30 || len < 1 || name_len < len )
    return 0;
```

The check only guarantees that `name_len >= len`, but the conversion loop below it consumes **two** bytes per character on top of the length byte already read at the top of the function:

```cpp
while ( len-- ) {
    if ( name[0] < 'A' || name[0] > 'P' ||
         name[1] < 'A' || name[1] > 'P' ) {
        *convert_name = 0;
        return 0;
    }
    *convert_name = ((name[0] - 'A') << 4) + (name[1] - 'A');
    name += 2;
    ++convert_name;
}
```

So the actual requirement is `name_len >= 2 * len + 1`. With a length byte of `0x3c` (`len == 30`) and a 30-byte NetBIOS session request body delivered to `ParseSessionReq()` → `ConvertName()`, the guard passes and the loop walks up to 30 bytes past the end of the input buffer.

### Reproduction

Feeding an isolated copy of the function with a 30-byte buffer whose first byte is `0x3c` and the remaining 29 bytes are `'A'` is enough — AddressSanitizer reports a clean heap-buffer-overflow read:

```
==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x...
READ of size 1 at 0x... thread T0
    #0 ConvertName_buggy(unsigned char const*, int, unsigned char*&, int&) NetbiosSSN.cc:22
...
0x... is located 0 bytes after 30-byte region
```

In the live analyzer the input comes from the TCP stream via `Contents_NetbiosSSN::ProcessChunk()` → `interp->ParseMessage(NETBIOS_SSN_REQ, …)` → `ParseSessionReq()` → `ConvertName(data, len, …)`, so the bug is reachable from a crafted peer on a TCP session that the NetBIOS SSN analyzer is bound to.

### Fix

The fix is local to the callee: tighten the length check so the buffer is known to hold the length byte plus two bytes per encoded character.

```diff
-    if ( len > 30 || len < 1 || name_len < len )
+    if ( len > 30 || len < 1 || name_len < 2 * len + 1 )
         return 0;
```

A short comment is added next to the guard so the `2 * len + 1` arithmetic is not lost on future readers.

Re-running the reproducer with the patched check produces `rv=0` (the malformed name is rejected) and no ASan report; a well-formed 33-byte body still parses successfully (`rv=1, xlen=16`).

### Notes

- No behavioural change for well-formed NetBIOS session requests — valid encodings already satisfy `name_len == 2 * len + 1`.
- The change is confined to `ConvertName()` and does not touch its callers or any header.