### PR TITLE
Ignore -Wmaybe-uninitialized for GCC when building with --enable-werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,15 @@ else ()
         if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0)
             list(APPEND WERROR_FLAG "-Wno-error=restrict")
         endif ()
+
+        # When optimizing GCC often reports false positives around maybe uninitialized
+        # values, e.g., in its string implementation. These are extremely tedious to
+        # silence, so just disable the warning altogether. See
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105616.
+        if (CMAKE_COMPILER_IS_GNUCXX)
+            list(APPEND WERROR_FLAG "-Wno-maybe-uninitialized")
+        endif ()
+
     endif ()
 endif ()
 


### PR DESCRIPTION
This is happening on my CircleCi builds when building the asan-sanitizer-zam job (but strangely, not the asan-sanitizer one). There's a similar work-around in Spicy's CMake setup, so I'm port it over. This fixes warnings/errors when including `<functional>` due to a known false-positive in some versions of GCC.