### PR TITLE
login: fix out-of-bounds read in TelnetEnvironmentOption::ExtractEnv

### DIFF
--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -258,6 +258,9 @@ void TelnetEnvironmentOption::RecvSubOption(u_char* data, int len) {
 }
 
 char* TelnetEnvironmentOption::ExtractEnv(u_char*& data, int& len, int& code) {
+    if ( len <= 0 )
+        return nullptr;
+
     code = data[0];
 
     if ( code != ENVIRON_VAR && code != ENVIRON_VAL && code != ENVIRON_USERVAR )


### PR DESCRIPTION
### What

`TelnetEnvironmentOption::ExtractEnv()` in `src/analyzer/protocol/login/NVT.cc` reads `data[0]` before checking that the caller-supplied length is positive:

```cpp
char* TelnetEnvironmentOption::ExtractEnv(u_char*& data, int& len, int& code) {
    code = data[0];   // <-- read with no len > 0 check

    if ( code != ENVIRON_VAR && code != ENVIRON_VAL && code != ENVIRON_USERVAR )
        return nullptr;

    --len;
    ++data;
    ...
```

`RecvSubOption()` calls `ExtractEnv()` twice per loop iteration:

```cpp
while ( len > 0 ) {
    int code1;
    int code2;
    char* var_name = ExtractEnv(data, len, code1);
    char* var_val  = ExtractEnv(data, len, code2);
    ...
}
```

The `while (len > 0)` gate only protects the first call. When the first `ExtractEnv()` consumes the last byte of the sub-option payload, the second call is entered with `len == 0` but still reads `data[0]`, which is one byte past the end of the suboption buffer.

### How to reproduce

A Telnet `IAC SB ENVIRON ENVIRON_IS ENVIRON_VAR IAC SE` sub-option, two bytes after `SawSubOption` strips the option code (`ENVIRON`), is just `[ENVIRON_IS, ENVIRON_VAR]`. `RecvSubOption()` consumes the leading `ENVIRON_IS` byte and enters the loop with `len == 1` pointing at `ENVIRON_VAR`.

A standalone reproducer that mirrors the function bodies confirms the trace:

```
after first ExtractEnv:  code1=0 len=0 data offset=2 var_name=''
after second ExtractEnv: code2=170 len=0 data offset=2 var_val='(null)'
observed_second_code = 0xaa (sentinel value placed one byte past the suboption)
```

The second `ExtractEnv()` read the sentinel byte we placed past the end of the 2-byte sub-option payload.

### Fix

Add an early `len <= 0` check at the top of `ExtractEnv()` so the `data[0]` access is gated by the same length precondition as the rest of the function. This keeps the fix local to the callee and does not require any changes in `RecvSubOption()`.