### PR TITLE
bittorrent: fix out-of-bounds read in ResponseBenc peers parser

### DIFF
--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -414,7 +414,10 @@ void BitTorrentTracker_Analyzer::ParseHeader(char* name, char* value, bool is_re
 void BitTorrentTracker_Analyzer::ResponseBenc(int name_len, char* name, detail::BTT_BencTypes type, int value_len,
                                               char* value) {
     if ( name_len == 5 && ! strncmp(name, "peers", 5) ) {
-        for ( char* end = value + value_len; value < end; value += 6 ) {
+        // The "peers" value is a compact list of 6-byte <IPv4,port>
+        // tuples. Require at least six bytes remaining to avoid an
+        // out-of-bounds read when value_len is not a multiple of six.
+        for ( char* end = value + value_len; end - value >= 6; value += 6 ) {
             // Note, weirdly/unfortunately AddrVal's take
             // addresses in network order but PortVal's
             // take ports in host order.  BitTorrent specifies


### PR DESCRIPTION
## Bug

`BitTorrentTracker_Analyzer::ResponseBenc()` in `src/analyzer/protocol/bittorrent/BitTorrentTracker.cc` parses the compact `peers` value from a bencoded tracker response as a list of 6-byte `<IPv4, port>` tuples. The loop that walks this list reads six bytes per iteration but only checks that the cursor has not yet reached the buffer end:

```cpp
for ( char* end = value + value_len; value < end; value += 6 ) {
    uint32_t ad = extract_uint32(reinterpret_cast<u_char*>(value));
    uint16_t pt = ntohs((value[4] << 8) | value[5]);
    ...
}
```

When the server-supplied `value_len` is not a multiple of six, the final iteration still passes `value < end` even though fewer than six bytes remain, and the body reads up to five bytes past the end of the buffer.

`value_len` is the bencoded string length parsed directly from the tracker response (see the `BENC_STATE_STR1` / `BENC_STATE_STR2` handling and the `ResponseBenc(..., BENC_TYPE_STR, benc_str_len, benc_str)` call around line 681), so an attacker controlling a BitTorrent tracker response can pick any length.

## Reproducer

Mapping a buffer of `value_len == 7` such that the page immediately after it is `PROT_NONE` and then running the original loop body reliably produces a SIGBUS on the second iteration:

```
Parsed 0 peers (should not get here for value_len=7)
exit: 138   # 128 + SIGBUS(10)
```

With the patched loop condition the same test prints `Parsed 1 peers (should be 1, no crash)` and exits cleanly.

## Fix

Require six bytes of remaining input before reading another `<IPv4, port>` tuple:

```cpp
for ( char* end = value + value_len; end - value >= 6; value += 6 ) {
```

The fix is local to the callee (`ResponseBenc`); no caller changes are required. Trailing bytes that do not make up a full peer entry are silently ignored, matching what callers receive today on a well-formed response.