### PR TITLE
Bump zeekjs to v0.23.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,7 @@ spicy_ssl_config: &SPICY_SSL_CONFIG --build-type=release --disable-broker-tests 
 asan_sanitizer_config: &ASAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=address --enable-fuzzers --enable-coverage --ccache --enable-werror
 ubsan_sanitizer_config: &UBSAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=undefined --enable-fuzzers --ccache --enable-werror
 tsan_sanitizer_config: &TSAN_SANITIZER_CONFIG --build-type=debug --disable-broker-tests --sanitizers=thread --enable-fuzzers --ccache --enable-werror
-macos_config: &MACOS_CONFIG --build-type=release --disable-broker-tests --prefix=$CIRRUS_WORKING_DIR/install --ccache --enable-werror --with-krb5=/opt/homebrew/opt/krb5 -D NODEJS_ROOT_DIR=/opt/homebrew/opt/node@24
+macos_config: &MACOS_CONFIG --build-type=release --disable-broker-tests --prefix=$CIRRUS_WORKING_DIR/install --ccache --enable-werror --with-krb5=/opt/homebrew/opt/krb5
 clang_tidy_config: &CLANG_TIDY_CONFIG --build-type=debug --disable-broker-tests --prefix=$CIRRUS_WORKING_DIR/install --ccache --enable-werror --enable-clang-tidy
 
 resources_template: &RESOURCES_TEMPLATE

--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -7,7 +7,7 @@ set -x
 
 brew update
 brew upgrade cmake
-brew install cppzmq openssl@3 python@3 swig bison flex ccache libmaxminddb dnsmasq krb5 node@24
+brew install cppzmq openssl@3 python@3 swig bison flex ccache libmaxminddb dnsmasq krb5 node
 
 which python3
 python3 --version


### PR DESCRIPTION
    3be2225 version: 0.23.0
    b929f82 Update CI to Fedora 44 and Ubuntu 26.04
    b00825a Call AddMessageListener() only after locking isolate
    0fafc23 Rework This() / HolderV2() change
    087e9fd Make {Get,Set}AlignedPointerFromInternalField() calls v26 compatible
    101f7fc Replace uses of v8::PropertyCallbackInfo::This() with v8::PropertyCallbackInfo::HolderV2() for Node v26
    d7618e1 Replace use of v8::Message::GetIsolate() with v8::Isolate::GetCurrent() for Node v26