### PR TITLE
netbios: fix MAKE_INT16 high-byte left shift

### DIFF
--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -12,7 +12,7 @@
 
 static constexpr void MAKE_INT16(uint16_t& dest, const u_char*& src) {
     dest = *src;
-    dest <= 8;
+    dest <<= 8;
     src++;
     dest |= *src;
     src++;


### PR DESCRIPTION
MAKE_INT16 in NetbiosSSN.cc has `dest <= 8;` (a discarded comparison) where `dest <<= 8;` was intended, so the four uint16_t fields parsed via this helper in NetbiosDGM_RawMsgHdr (id, srcport, length, offset) end up as `byte0 | byte1` rather than `(byte0 << 8) | byte1`. clang flags the line under -Wunused-comparison. The neighbouring NetbiosSSN_RawMsgHdr does the equivalent shift inline and is unaffected.