### PR TITLE
netbios: reject short UDP datagrams in ParseMessageUDP

### DIFF
--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -136,6 +136,13 @@ void NetbiosSSN_Interpreter::ParseMessageTCP(const u_char* data, int len, bool i
 }
 
 void NetbiosSSN_Interpreter::ParseMessageUDP(const u_char* data, int len, bool is_query) {
+    // The NetBIOS Datagram Service header consumed by NetbiosDGM_RawMsgHdr
+    // is 14 bytes (type, flags, id, srcip, srcport, length, offset). Reject
+    // short datagrams here so the header constructor does not read past the
+    // end of the caller-supplied UDP payload.
+    if ( len < 14 )
+        return;
+
     NetbiosDGM_RawMsgHdr hdr(data, len);
 
     if ( static_cast<unsigned>(hdr.length - 14) > static_cast<unsigned>(len) )

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -8,6 +8,7 @@
 #include "zeek/RunState.h"
 #include "zeek/ZeekString.h"
 #include "zeek/analyzer/protocol/netbios/events.bif.h"
+#include "zeek/net_util.h"
 #include "zeek/session/Manager.h"
 
 static constexpr void MAKE_INT16(uint16_t& dest, const u_char*& src) {
@@ -43,10 +44,8 @@ NetbiosDGM_RawMsgHdr::NetbiosDGM_RawMsgHdr(const u_char*& data, int& len) {
     MAKE_INT16(id, data);
     len -= 2;
 
-    srcip = *data++ << 24;
-    srcip |= *data++ << 16;
-    srcip |= *data++ << 8;
-    srcip |= *data++;
+    srcip = extract_uint32(data);
+    data += 4;
     len -= 4;
 
     MAKE_INT16(srcport, data);
@@ -140,8 +139,11 @@ void NetbiosSSN_Interpreter::ParseMessageUDP(const u_char* data, int len, bool i
     // is 14 bytes (type, flags, id, srcip, srcport, length, offset). Reject
     // short datagrams here so the header constructor does not read past the
     // end of the caller-supplied UDP payload.
-    if ( len < 14 )
+    if ( len < 14 ) {
+        analyzer->AnalyzerViolation("NetBIOS datagram too short for header", reinterpret_cast<const char*>(data),
+                                    len);
         return;
+    }
 
     NetbiosDGM_RawMsgHdr hdr(data, len);
 


### PR DESCRIPTION
NetbiosSSN_Interpreter::ParseMessageUDP() in src/analyzer/protocol/netbios/NetbiosSSN.cc hands the analyzer-supplied UDP payload straight to the NetbiosDGM_RawMsgHdr constructor, which reads 14 bytes (type, flags, id, srcip, srcport, length, offset) without checking len. Any NetBIOS Datagram Service packet (UDP/138) shorter than 14 bytes therefore drives a read past the end of the caller-supplied buffer; placing a 4-byte payload directly before a PROT_NONE page reliably faults during the header parse. Gate the constructor with a 14-byte minimum check at the top of ParseMessageUDP.