### PR TITLE
ident: fix signed overflow in ParsePort

### DIFF
--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -191,7 +191,12 @@ const char* Ident_Analyzer::ParsePort(const char* line, const char* end_of_line,
     do {
         n = n * 10 + (*line - '0');
         ++line;
-    } while ( line < end_of_line && isdigit(*line) );
+    } while ( line < end_of_line && isdigit(*line) && n <= 65535 );
+
+    // Skip any leftover digits past the port-number range so the
+    // caller sees the same line position regardless of overflow.
+    while ( line < end_of_line && isdigit(*line) )
+        ++line;
 
     line = util::skip_whitespace(line, end_of_line);
 

--- a/src/analyzer/protocol/ident/Ident.cc
+++ b/src/analyzer/protocol/ident/Ident.cc
@@ -189,14 +189,12 @@ const char* Ident_Analyzer::ParsePort(const char* line, const char* end_of_line,
     const char* l = line;
 
     do {
-        n = n * 10 + (*line - '0');
+        // Stop accumulating once the value is out of range to avoid
+        // signed overflow; the check below still flags it as bad.
+        if ( n <= 65535 )
+            n = n * 10 + (*line - '0');
         ++line;
-    } while ( line < end_of_line && isdigit(*line) && n <= 65535 );
-
-    // Skip any leftover digits past the port-number range so the
-    // caller sees the same line position regardless of overflow.
-    while ( line < end_of_line && isdigit(*line) )
-        ++line;
+    } while ( line < end_of_line && isdigit(*line) );
 
     line = util::skip_whitespace(line, end_of_line);
 


### PR DESCRIPTION
ParsePort accumulates digits into a signed int with no overflow
guard, so an ident line of more than ~10 digits triggers
undefined behavior before the post-loop range check can fire.
Cap n in the loop and consume any leftover digits.