### PR TITLE
null: cast to uint32_t to avoid signed-shift UB

### DIFF
--- a/src/packet_analysis/protocol/null/Null.cc
+++ b/src/packet_analysis/protocol/null/Null.cc
@@ -12,7 +12,8 @@ bool NullAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet
         return false;
     }
 
-    uint32_t protocol = (static_cast<uint32_t>(data[3]) << 24) + (data[2] << 16) + (data[1] << 8) + data[0];
+    uint32_t protocol = (static_cast<uint32_t>(data[3]) << 24) + (static_cast<uint32_t>(data[2]) << 16) +
+                        (static_cast<uint32_t>(data[1]) << 8) + data[0];
     // skip link header
     return ForwardPacket(len - 4, data + 4, packet, protocol);
 }

--- a/src/packet_analysis/protocol/null/Null.cc
+++ b/src/packet_analysis/protocol/null/Null.cc
@@ -12,7 +12,7 @@ bool NullAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet
         return false;
     }
 
-    uint32_t protocol = (data[3] << 24) + (data[2] << 16) + (data[1] << 8) + data[0];
+    uint32_t protocol = (static_cast<uint32_t>(data[3]) << 24) + (data[2] << 16) + (data[1] << 8) + data[0];
     // skip link header
     return ForwardPacket(len - 4, data + 4, packet, protocol);
 }


### PR DESCRIPTION
data[3] << 24 promotes uint8_t to int and overflows when bit 7 is set; cast to uint32_t to keep the shift unsigned.