### PR TITLE
krb: fix out-of-bounds read in GetStringFromPrincipalName

### DIFF
--- a/src/analyzer/protocol/krb/krb-types.pac
+++ b/src/analyzer/protocol/krb/krb-types.pac
@@ -20,9 +20,9 @@ zeek::ValPtr GetStringFromPrincipalName(const KRB_Principal_Name* pname)
 	if ( pname->data()->size() == 1 )
 		return to_stringval(pname->data()[0][0]->encoding()->content());
 	if ( pname->data()->size() == 2 )
-		return zeek::make_intrusive<zeek::StringVal>(zeek::util::fmt("%s/%s", reinterpret_cast<const char *> (pname->data()[0][0]->encoding()->content().begin()), reinterpret_cast<const char *>(pname->data()[0][1]->encoding()->content().begin())));
+		return zeek::make_intrusive<zeek::StringVal>(zeek::util::fmt("%.*s/%.*s", pname->data()[0][0]->encoding()->content().length(), reinterpret_cast<const char *> (pname->data()[0][0]->encoding()->content().begin()), pname->data()[0][1]->encoding()->content().length(), reinterpret_cast<const char *>(pname->data()[0][1]->encoding()->content().begin())));
 	if ( pname->data()->size() == 3 ) // if the name-string has a third value, this will just append it, else this will return unknown as the principal name
-		return zeek::make_intrusive<zeek::StringVal>(zeek::util::fmt("%s/%s/%s", reinterpret_cast<const char *>(pname->data()[0][0]->encoding()->content().begin()), reinterpret_cast<const char *>(pname->data()[0][1]->encoding()->content().begin()), reinterpret_cast<const char *>(pname->data()[0][2]->encoding()->content().begin())));
+		return zeek::make_intrusive<zeek::StringVal>(zeek::util::fmt("%.*s/%.*s/%.*s", pname->data()[0][0]->encoding()->content().length(), reinterpret_cast<const char *>(pname->data()[0][0]->encoding()->content().begin()), pname->data()[0][1]->encoding()->content().length(), reinterpret_cast<const char *>(pname->data()[0][1]->encoding()->content().begin()), pname->data()[0][2]->encoding()->content().length(), reinterpret_cast<const char *>(pname->data()[0][2]->encoding()->content().begin())));
 
 	return zeek::make_intrusive<zeek::StringVal>("unknown");
 }


### PR DESCRIPTION
Noticed GetStringFromPrincipalName formats 2- and 3-component names with %s on encoding()->content().begin(). content() is a bytestring with no NUL terminator, so %s reads past its length into adjacent heap for any KRB principal name with more than one component. Switch to %.*s bounded by content().length(); the single-component branch already uses the length-aware to_stringval().