### PR TITLE
rfb: fix null deref in proc_handle_server_params on empty name

### DIFF
--- a/src/analyzer/protocol/rfb/rfb-analyzer.pac
+++ b/src/analyzer/protocol/rfb/rfb-analyzer.pac
@@ -49,7 +49,7 @@ refine flow RFB_Flow += {
 		if ( rfb_server_parameters )
 			{
 			auto vec_ptr = ${msg.name};
-			auto name_ptr = vec_ptr->empty() ? "" : reinterpret_cast<const char*>(vec_ptr->data());
+			auto name_ptr = reinterpret_cast<const char*>(vec_ptr->data());
 			zeek::BifEvent::enqueue_rfb_server_parameters(
 			    connection()->zeek_analyzer(), connection()->zeek_analyzer()->Conn(),
 			    zeek::make_intrusive<zeek::StringVal>(${msg.name}->size(), name_ptr),

--- a/src/analyzer/protocol/rfb/rfb-analyzer.pac
+++ b/src/analyzer/protocol/rfb/rfb-analyzer.pac
@@ -49,10 +49,10 @@ refine flow RFB_Flow += {
 		if ( rfb_server_parameters )
 			{
 			auto vec_ptr = ${msg.name};
-			auto name_ptr = &((*vec_ptr)[0]);
+			auto name_ptr = vec_ptr->empty() ? "" : reinterpret_cast<const char*>(vec_ptr->data());
 			zeek::BifEvent::enqueue_rfb_server_parameters(
 			    connection()->zeek_analyzer(), connection()->zeek_analyzer()->Conn(),
-			    zeek::make_intrusive<zeek::StringVal>(${msg.name}->size(), reinterpret_cast<const char*>(name_ptr)),
+			    zeek::make_intrusive<zeek::StringVal>(${msg.name}->size(), name_ptr),
 			    ${msg.width},
 			    ${msg.height});
 			}


### PR DESCRIPTION
Noticed `proc_handle_server_params` takes the address of `(*msg.name)[0]`, but `name` is empty when a server sends a zero-length desktop name in the ServerInit, so that binds a reference to a null pointer (UBSan: `reference binding to null pointer of type 'unsigned char'`). Switched to `data()` with an empty-name guard so the StringVal is built from a valid pointer.