### PR TITLE
gssapi: fix out-of-bounds read in is_first_byte on empty token

### DIFF
--- a/src/analyzer/protocol/gssapi/gssapi-protocol.pac
+++ b/src/analyzer/protocol/gssapi/gssapi-protocol.pac
@@ -76,6 +76,6 @@ type KRB_OID_BLOB = record {
 refine connection GSSAPI_Conn += {
 	function is_first_byte(token: bytestring, byte: uint8): bool
 		%{
-		return token[0] == byte;
+		return token.length() > 0 && token[0] == byte;
 		%}
 };


### PR DESCRIPTION
is_first_byte() dispatches the SPNEGO mech_token on token[0], but an ASN.1 element of length 0 (the two bytes 04 00) leaves token empty, so begin()[0] reads one byte past the GSSAPI blob when the token ends at the captured boundary. Gate the read on length() > 0 so an empty token returns false.