### PR TITLE
Fix typo in operator

### DIFF
--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -12,7 +12,7 @@
 
 static constexpr void MAKE_INT16(uint16_t& dest, const u_char*& src) {
     dest = *src;
-    dest <= 8;
+    dest <<= 8;
     src++;
     dest |= *src;
     src++;


### PR DESCRIPTION
This got broken accidentially in
460fe24a9a42ee0f24d46353019d89fad9bd868a.