### PR TITLE
gtpv1: fix out-of-bounds read in BuildEndUserAddr

### DIFF
--- a/src/packet_analysis/protocol/gtpv1/gtpv1-analyzer.pac
+++ b/src/packet_analysis/protocol/gtpv1/gtpv1-analyzer.pac
@@ -97,10 +97,14 @@ zeek::RecordValPtr BuildEndUserAddr(const InformationElement* ie)
 
 		switch ( ie->end_user_addr()->pdp_type_num() ) {
 		case 0x21:
+			if ( len < 4 )
+				break;
 			ev->Assign(2, zeek::make_intrusive<zeek::AddrVal>(
 			  zeek::IPAddr(IPv4, reinterpret_cast<const uint32*>(d), zeek::IPAddr::Network)));
 			break;
 		case 0x57:
+			if ( len < 16 )
+				break;
 			ev->Assign(2, zeek::make_intrusive<zeek::AddrVal>(
 			  zeek::IPAddr(IPv6, reinterpret_cast<const uint32*>(d), zeek::IPAddr::Network)));
 			break;


### PR DESCRIPTION
BuildEndUserAddr in src/packet_analysis/protocol/gtpv1/gtpv1-analyzer.pac casts the pdp_addr bytestring data to uint32* and constructs an IPv4 or IPv6 IPAddr based on pdp_type_num, but never checks that pdp_addr.length() is at least 4 (0x21/IPv4) or 16 (0x57/IPv6). The IE field is parsed as bytestring &length=(n-2) from the wire-supplied TLV length, so a TLV with length 3-5 for an IPv4 PDP type (or 3-17 for IPv6) leaves pdp_addr shorter than the IPAddr constructor's memcpy, reading past the captured GTPv1 packet. Add the length gate before the IPAddr construction; pdp_ip/pdp_other_addr are already optional, so a short malformed IE just leaves them unset.