### PR TITLE
dns: cast to uint32_t in ExtractLong to avoid signed-shift overflow

### DIFF
--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -636,8 +636,8 @@ uint32_t DNS_Interpreter::ExtractLong(const u_char*& data, int& len) {
     uint32_t val;
 
     val = static_cast<uint32_t>(data[0]) << 24;
-    val |= data[1] << 16;
-    val |= data[2] << 8;
+    val |= static_cast<uint32_t>(data[1]) << 16;
+    val |= static_cast<uint32_t>(data[2]) << 8;
     val |= data[3];
 
     data += sizeof(val);

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -635,7 +635,7 @@ uint32_t DNS_Interpreter::ExtractLong(const u_char*& data, int& len) {
 
     uint32_t val;
 
-    val = data[0] << 24;
+    val = static_cast<uint32_t>(data[0]) << 24;
     val |= data[1] << 16;
     val |= data[2] << 8;
     val |= data[3];


### PR DESCRIPTION
DNS_Interpreter::ExtractLong in src/analyzer/protocol/dns/DNS.cc builds the 4-byte field with `val = data[0] << 24`. data[0] is u_char, integer-promoted to int, so when the high bit is set the result of the shift exceeds INT_MAX, which is signed-integer overflow. The field is used for TTL on every DNS RR (line 312) as well as SOA serial/refresh/retry/expire/minimum, RRSIG inception/expiration and TSIG sign_time_sec, all reached from any DNS response on the default-enabled analyzer. Cast data[0] to uint32_t before the shift, matching the well-defined-behavior idiom from `938fd42d Avoid integer overflow`. The remaining `data[N] << 16` and `data[N] << 8` shifts fit in int and are unchanged.