### PR TITLE
net_util: cast to uint32_t in extract_uint32 to avoid signed-shift overflow

### DIFF
--- a/src/net_util.cc
+++ b/src/net_util.cc
@@ -229,8 +229,8 @@ uint32_t extract_uint32(const u_char* data) {
     uint32_t val;
 
     val = static_cast<uint32_t>(data[0]) << 24;
-    val |= data[1] << 16;
-    val |= data[2] << 8;
+    val |= static_cast<uint32_t>(data[1]) << 16;
+    val |= static_cast<uint32_t>(data[2]) << 8;
     val |= data[3];
 
     return val;

--- a/src/net_util.cc
+++ b/src/net_util.cc
@@ -228,7 +228,7 @@ std::pair<std::unique_ptr<uint8_t[]>, int> fmt_mac_bytes(const unsigned char* m,
 uint32_t extract_uint32(const u_char* data) {
     uint32_t val;
 
-    val = data[0] << 24;
+    val = static_cast<uint32_t>(data[0]) << 24;
     val |= data[1] << 16;
     val |= data[2] << 8;
     val |= data[3];


### PR DESCRIPTION
zeek::extract_uint32 in src/net_util.cc builds the 4-byte network-order field with `val = data[0] << 24`. data[0] is u_char, integer-promoted to int, so when the high bit is set the result of the shift exceeds INT_MAX, which is signed-integer overflow. The function is called on the IPv4 octets of every APP_IPADDRESS_TAG (network-address) ASN.1 value in SNMP via network_address_to_val(), reached from any SNMP packet on the default-enabled UDP/161 analyzer, and on the wire-order bytes of every <IPv4,port> tuple in a BitTorrent tracker peers list. Cast data[0] to uint32_t before the shift, matching the well-defined-behavior idiom from `938fd42d Avoid integer overflow`. The remaining data[N] << 16 and data[N] << 8 shifts fit in int and are unchanged.