### PR TITLE
irc: guard empty params before indexing nick in DeliverStream

### DIFF
--- a/src/analyzer/protocol/irc/IRC.cc
+++ b/src/analyzer/protocol/irc/IRC.cc
@@ -838,7 +838,7 @@ void IRC_Analyzer::DeliverStream(int length, const u_char* line, bool orig) {
 
     else if ( irc_nick_message && command == "NICK" ) {
         string_view nick{params};
-        if ( nick[0] == ':' )
+        if ( nick.starts_with(':') )
             nick = nick.substr(1);
 
         EnqueueConnEvent(irc_nick_message, ConnVal(), val_mgr->Bool(orig), make_intrusive<StringVal>(prefix.c_str()),


### PR DESCRIPTION
A NICK command with no parameters ("NICK\r\n", or only trailing whitespace) reaches the handler with an empty params string. `string_view nick{params}; nick[0]` then indexes a zero-length view, which is UB under [string.view.access] and aborts under hardened libstdc++/libc++. Guard on non-empty before the index, matching the WHO and INVITE branches just below.