### PR TITLE
Fix potential null-dereference in pcapng packet source

### DIFF
--- a/src/iosource/pcapng/Source.cc
+++ b/src/iosource/pcapng/Source.cc
@@ -174,7 +174,7 @@ void Source::ParseInterfaceBlock(light_block block) {
     intf.snaplen = lidb->snapshot_length;
 
     light_option opt = light_find_option(block, LIGHT_OPTION_IF_TSRESOL);
-    if ( opt ) {
+    if ( opt && opt->length > 0 ) {
         if ( (opt->data[0] & 0x80) == 0x80 )
             intf.ts_resolution = 2 << (opt->data[0] & 0x7F);
         else


### PR DESCRIPTION
This fixes a potential null dereference/crash in the pcapng packet source. Option blocks can have multiple entries, including zero entries, even if the option structure is valid. If we get an option with a zero length, we were trying to get the first data element anyways.

This was discovered by gpt-5.5.