### PR TITLE
[release/8.2] backport two OSS-Fuzz OOB-read fixes (BitTorrent tracker + NetBIOS name decode)

### DIFF
--- a/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
+++ b/src/analyzer/protocol/bittorrent/BitTorrentTracker.cc
@@ -414,7 +414,10 @@ void BitTorrentTracker_Analyzer::ParseHeader(char* name, char* value, bool is_re
 void BitTorrentTracker_Analyzer::ResponseBenc(int name_len, char* name, detail::BTT_BencTypes type, int value_len,
                                               char* value) {
     if ( name_len == 5 && ! strncmp(name, "peers", 5) ) {
-        for ( char* end = value + value_len; value < end; value += 6 ) {
+        // The "peers" value is a compact list of 6-byte <IPv4,port>
+        // tuples. Require at least six bytes remaining to avoid an
+        // out-of-bounds read when value_len is not a multiple of six.
+        for ( char* end = value + value_len; end - value >= 6; value += 6 ) {
             // Note, weirdly/unfortunately AddrVal's take
             // addresses in network order but PortVal's
             // take ports in host order.  BitTorrent specifies

--- a/src/analyzer/protocol/netbios/NetbiosSSN.cc
+++ b/src/analyzer/protocol/netbios/NetbiosSSN.cc
@@ -184,7 +184,10 @@ int NetbiosSSN_Interpreter::ConvertName(const u_char* name, int name_len, u_char
     int len = (*name++) / 2;
     xlen = len;
 
-    if ( len > 30 || len < 1 || name_len < len )
+    // The loop below reads two bytes per encoded name character, on top
+    // of the one length byte already consumed above, so the input must
+    // hold at least 2 * len + 1 bytes total.
+    if ( len > 30 || len < 1 || name_len < 2 * len + 1 )
         return 0;
 
     u_char* convert_name = new u_char[len + 1];


### PR DESCRIPTION
release/8.2 is missing two OOB-read fixes that are on master, both originally OSS-Fuzz finds in protocol analyzers. Figured they're worth pulling onto 8.2 together since they're the same shape (read past the end of a parsed buffer) and one-line-ish guards.

1. BitTorrent tracker (BitTorrentTracker.cc) — the ResponseBenc peers parser walks the compact peer list in 6-byte steps with `value < end; value += 6` but doesn't check the last step has a full 6 bytes, so extract_uint32 reads past the buffer. master fix f4d7e72a6 adds the bound.

2. NetBIOS (NetbiosSSN.cc) — NetbiosSSN_Interpreter::ConvertName trusts the on-wire name length and the decode loop over-reads; master fix 636705676 caps it.

checked both actually over-read on release/8.2 (not just a missing line): built the two parse paths with -fsanitize=address on ubuntu:22.04 and fed crafted tracker/NetBIOS inputs. Pre-fix each gives an ASan heap-buffer-overflow READ just past the buffer; with the master fixes cherry-picked, both run clean. A malicious tracker / crafted NetBIOS session reaches these.

Both cherry-picked clean with `-x` (no conflicts), original authors preserved (jmestwa-coder, dxbjavid). Happy to split into two PRs if you'd rather take them separately.

upstream: https://github.com/zeek/zeek/commit/f4d7e72a6392e5e77c2daa608f12a9a206f43c85
upstream: https://github.com/zeek/zeek/commit/636705676d37e7fdfcef6e2d925bbadd2638ff10