### PR TITLE
ftp: cast to uint32_t in parse_port to avoid signed-shift overflow

### DIFF
--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -30,7 +30,7 @@ static zeek::RecordValPtr parse_port(const std::string& line)
 
 		if ( good )
 			{
-			addr = (bytes[0] << 24) | (bytes[1] << 16) |
+			addr = (static_cast<uint32_t>(bytes[0]) << 24) | (bytes[1] << 16) |
 					(bytes[2] << 8) | bytes[3];
 			port = (bytes[4] << 8) | bytes[5];
 			}

--- a/src/analyzer/protocol/ftp/functions.bif
+++ b/src/analyzer/protocol/ftp/functions.bif
@@ -30,9 +30,9 @@ static zeek::RecordValPtr parse_port(const std::string& line)
 
 		if ( good )
 			{
-			addr = (static_cast<uint32_t>(bytes[0]) << 24) | (bytes[1] << 16) |
-					(bytes[2] << 8) | bytes[3];
-			port = (bytes[4] << 8) | bytes[5];
+			addr = (static_cast<uint32_t>(bytes[0]) << 24) | (static_cast<uint32_t>(bytes[1]) << 16) |
+					(static_cast<uint32_t>(bytes[2]) << 8) | bytes[3];
+			port = (static_cast<uint32_t>(bytes[4]) << 8) | bytes[5];
 			}
 		}
 


### PR DESCRIPTION
A PORT command like `200,0,0,1,4,31` makes parse_port evaluate `bytes[0] << 24` with bytes[0] in 128..255, which shifts a set bit into the sign of int (signed overflow). The value comes straight off the wire through parse_ftp_port, so it is reachable on the default FTP path. Cast bytes[0] to uint32_t before the shift, matching the data[0] casts already used in the dns and null analyzers.