### PR TITLE
ipaddr: cast first octet to uint32_t in ConvertString

### DIFF
--- a/src/IPAddr.cc
+++ b/src/IPAddr.cc
@@ -95,7 +95,7 @@ bool IPAddr::ConvertString(const char* s, in6_addr* result) {
         if ( num < 0 || num > 255 )
             return false;
 
-    uint32_t addr = (a[0] << 24) | (a[1] << 16) | (a[2] << 8) | a[3];
+    uint32_t addr = (static_cast<uint32_t>(a[0]) << 24) | (a[1] << 16) | (a[2] << 8) | a[3];
     addr = htonl(addr);
     memcpy(result->s6_addr, v4_mapped_prefix, sizeof(v4_mapped_prefix));
     memcpy(&result->s6_addr[12], &addr, sizeof(uint32_t));

--- a/src/IPAddr.cc
+++ b/src/IPAddr.cc
@@ -95,7 +95,8 @@ bool IPAddr::ConvertString(const char* s, in6_addr* result) {
         if ( num < 0 || num > 255 )
             return false;
 
-    uint32_t addr = (static_cast<uint32_t>(a[0]) << 24) | (a[1] << 16) | (a[2] << 8) | a[3];
+    uint32_t addr = (static_cast<uint32_t>(a[0]) << 24) | (static_cast<uint32_t>(a[1]) << 16) |
+                    (static_cast<uint32_t>(a[2]) << 8) | a[3];
     addr = htonl(addr);
     memcpy(result->s6_addr, v4_mapped_prefix, sizeof(v4_mapped_prefix));
     memcpy(&result->s6_addr[12], &addr, sizeof(uint32_t));


### PR DESCRIPTION
Noticed the IPv4 path in `IPAddr::ConvertString` builds the address with `a[0] << 24`. `a[0]` is an int validated to 0-255, so for any first octet >= 128 the shift pushes a set bit into the sign bit of int, which is signed overflow. Reached from `to_addr()` on a dotted-quad with a high first octet, e.g. `to_addr("200.0.0.1")`. Cast it to uint32_t so the shift runs on an unsigned type, matching the idiom in the recent DNS/null/net_util fixes.