### PR TITLE
Move `Log::flush_all` and pcapng source NEWS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -262,6 +262,12 @@ New Functionality
   engineering team at Microsoft. The btest suite now runs on CI builds. The great majority
   of btests pass, with a small number skipped for various documented reasons.
 
+- A new packet source was added that supports reading pcapng files. This supports packet
+  captures with multiple interfaces, packet metadata, and capture file metadata. It will
+  be automatically used when the magic number in the file header is detected, or if
+  ``pcapng::`` is passed as a prefix to the filename with Zeek's ``-r`` argument. It does
+  not currently support BPF filtering via Zeek's ``-f`` argument.
+
 Changed Functionality
 ---------------------
 
@@ -565,11 +571,8 @@ New Functionality
   https://github.com/opencontainers/image-spec/blob/main/annotations.md for more details
   about the labels.
 
-- A new packet source was added that supports reading pcapng files. This supports packet
-  captures with multiple interfaces, packet metadata, and capture file metadata. It will
-  be automatically used when the magic number in the file header is detected, or if
-  ``pcapng::`` is passed as a prefix to the filename with Zeek's ``-r`` argument. It does
-  not currently support BPF filtering via Zeek's ``-f`` argument.
+- A new BIF ``Log::flush_all`` was added that causes all logs to be written to disk
+  immediately.
 
 Changed Functionality
 ---------------------
@@ -1592,9 +1595,6 @@ New Functionality
 
 - A new weird ``DNS_unknown_opcode`` was added to the DNS analyzer to report
   when it receives opcodes that it cannot process.
-
-- A new BIF ``Log::flush_all`` was added that causes all logs to be written to disk
-  immediately.
 
 Changed Functionality
 ---------------------


### PR DESCRIPTION
Reported by @J-Gras in Slack

They were in the wrong versions.

`Log::flush_all` introduced by:

ccab1a91bf8168eb54d0dda8b1de62c4939cbcaa

pcapng source introduced by:

3c966a37ebb6abf8327c002f8447f38d53fbf06a