### PR TITLE
github/workflows: Switch cifuzz to run nightly

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,7 +1,8 @@
 name: CIFuzz
 
 on:
-  pull_request:
+  schedule:
+    - cron: "13 2 * * *"
 
 permissions: {}
 


### PR DESCRIPTION
This was added originally to ensure we don't break fuzzers unknowingly. It doesn't need to run on every PR push or merge. Every night should be fine.