### PR TITLE
ssl: validate record length before reading AEAD nonce during decryption

### DIFF
--- a/src/analyzer/protocol/ssl/SSL.cc
+++ b/src/analyzer/protocol/ssl/SSL.cc
@@ -243,6 +243,13 @@ bool SSL_Analyzer::TryDecryptApplicationData(int len, const u_char* data, bool i
         else
             s_seq++;
 
+        // The record must be large enough to hold the 8-byte explicit nonce
+        // and the 16-byte GCM authentication tag.
+        if ( encrypted_len <= (16 + 8) ) {
+            DBG_LOG(DBG_ANALYZER, "Invalid encrypted length encountered during TLS decryption");
+            return false;
+        }
+
         // AEAD nonce, length 12
         byte_buffer s_aead_nonce;
         s_aead_nonce.reserve(12);
@@ -260,12 +267,7 @@ bool SSL_Analyzer::TryDecryptApplicationData(int len, const u_char* data, bool i
         EVP_CipherInit(ctx, EVP_aes_256_gcm(), nullptr, nullptr, 0);
 
         encrypted += 8;
-        // FIXME: is this because of nonce and aead tag?
-        if ( encrypted_len <= (16 + 8) ) {
-            DBG_LOG(DBG_ANALYZER, "Invalid encrypted length encountered during TLS decryption");
-            EVP_CIPHER_CTX_free(ctx);
-            return false;
-        }
+        // Subtract the explicit nonce (8 bytes) and the GCM tag (16 bytes);
         encrypted_len -= 8;
         encrypted_len -= 16;
 


### PR DESCRIPTION
While digging through the TLS decryption path I noticed SSL_Analyzer::TryDecryptApplicationData pulls the 8-byte explicit nonce out of the record before it ever checks how long the record actually is. The length check is there, but it sits a few lines too low — it only runs after we've already copied those 8 bytes into the nonce buffer. So if an application_data record comes in shorter than 8 bytes, we end up reading past the end of the record.

It's not something you'd hit in normal traffic, but since this only kicks in once decryption is turned on (keys/secret supplied and the 0xC030 cipher negotiated), a peer on a monitored TLS connection could send a tiny record on purpose and trip the out-of-bounds read.

The fix is basically just reordering: I moved the existing encrypted_len <= (16 + 8) check up so it runs before we touch any bytes from the record, and dropped the duplicate check that used to live further down. The threshold is exactly the same, so anything we accepted/rejected before behaves the same way now — the only difference is we bail out early instead of after the read. Bonus: since we now return before allocating the cipher context, the old EVP_CIPHER_CTX_free on that path isn't needed anymore, so there's one less alloc/free to worry about. Sequence counters still increment in the same spot as before.

No API or call-site changes, contained entirely to this one function.