### PR TITLE
dce-rpc: fix off-by-one read when trimming trailing null from sec_addr

### DIFF
--- a/src/analyzer/protocol/dce-rpc/dce_rpc-analyzer.pac
+++ b/src/analyzer/protocol/dce-rpc/dce_rpc-analyzer.pac
@@ -87,7 +87,7 @@ refine connection DCE_RPC_Conn += {
 
 			// Remove the null from the end of the string if it's there.
 			if ( ${bind.sec_addr}.length() > 0 &&
-			     *(${bind.sec_addr}.begin() + ${bind.sec_addr}.length()) == 0 )
+			     *(${bind.sec_addr}.begin() + ${bind.sec_addr}.length() - 1) == 0 )
 				sec_addr = zeek::make_intrusive<zeek::StringVal>(${bind.sec_addr}.length()-1, reinterpret_cast<const char*>(${bind.sec_addr}.begin()));
 			else
 				sec_addr = zeek::make_intrusive<zeek::StringVal>(${bind.sec_addr}.length(), reinterpret_cast<const char*>(${bind.sec_addr}.begin()));


### PR DESCRIPTION
Came across this one while reading through the DCE-RPC bind-ack handler. The code wants to strip a trailing null byte off the sec_addr string before handing it to the event, and the comment even says as much — "Remove the null from the end of the string if it's there." Problem is, it checks begin() + length() to find that last byte, but that's actually one position past the end of the field, not the last character. To look at the final byte you want begin() + length() - 1.

In practice this mostly slips by unnoticed because a bind-ack usually has a pad field right after sec_addr, so the byte it accidentally reads is still inside the buffer — it just happens to be the wrong byte. That also means the null-trimming logic was keyed off a byte that isn't part of the string at all, so it wasn't really doing what it was supposed to. The nastier case is when sec_addr runs right up to the end of the reassembled data with nothing after it; then that read goes one byte past the allocation.

Fix is a one-character change: subtract one so we look at the real last byte. The length() > 0 guard that's already there keeps us from underflowing, and the length() - 1 trim on the next line now lines up with what we're actually checking. No signature or call-site changes, just this single expression.

