### PR TITLE
testing/btest: Skip large-cluster under ASAN, bump some timeouts

### DIFF
--- a/testing/btest/cluster/websocket/bad-url.zeek
+++ b/testing/btest/cluster/websocket/bad-url.zeek
@@ -19,7 +19,7 @@
 # @TEST-EXEC: btest-bg-run manager "ZEEKPATH=$ZEEKPATH:.. && CLUSTER_NODE=manager zeek -b ../manager.zeek >out"
 # @TEST-EXEC: btest-bg-run client "python3 ../client.py >out"
 #
-# @TEST-EXEC: btest-bg-wait 5
+# @TEST-EXEC: btest-bg-wait 30
 # @TEST-EXEC: btest-diff ./manager/out
 # @TEST-EXEC: btest-diff ./manager/.stderr
 # @TEST-EXEC: btest-diff ./client/out

--- a/testing/btest/scripts/base/frameworks/notice/suppression-batching-cluster.zeek
+++ b/testing/btest/scripts/base/frameworks/notice/suppression-batching-cluster.zeek
@@ -19,7 +19,7 @@
 # @TEST-EXEC: btest-bg-run worker-2  ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b %INPUT
 # @TEST-EXEC: btest-bg-run worker-3  ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-3 zeek -b %INPUT
 # @TEST-EXEC: btest-bg-run worker-4  ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-4 zeek -b %INPUT
-# @TEST-EXEC: btest-bg-wait 10
+# @TEST-EXEC: btest-bg-wait 30
 # @TEST-EXEC: btest-diff manager/.stdout
 # @TEST-EXEC: btest-diff proxy-2/.stdout
 # @TEST-EXEC: btest-diff proxy-1/.stdout

--- a/testing/btest/supervisor/large-cluster.zeek
+++ b/testing/btest/supervisor/large-cluster.zeek
@@ -6,6 +6,8 @@
 # On Windows, spawning 32 concurrent processes with Broker peering
 # exceeds the reliable process/handle limits in CI and hangs.
 # @TEST-REQUIRES: ! is-windows
+# Very slow with ASAN, skip it there.
+# @TEST-REQUIRES: ! have-asan
 # @TEST-PORT: BROKER_PORT
 # @TEST-REQUIRES: test "${ZEEK_USE_CPP}" != "1"
 # @TEST-EXEC: btest-bg-run zeek zeek -j -b %INPUT


### PR DESCRIPTION
Saw these failing on Circle CI in the ASAN build and figured 5 and 10 seconds might be a bit too short and the large-cluster test seems fine to just skip under ASAN.