### PR TITLE
Netcontrol acld - fix command

### DIFF
--- a/scripts/base/frameworks/netcontrol/plugins/acld.zeek
+++ b/scripts/base/frameworks/netcontrol/plugins/acld.zeek
@@ -183,9 +183,9 @@ function rule_to_acl_rule(p: PluginState, r: Rule) : AclRule
 			else if ( is_tcp_port(f$dst_p) && r$ty == WHITELIST )
 				command = "permittcpdsthostport";
 			else if ( is_udp_port(f$dst_p) && r$ty == DROP)
-				command = "dropucpdsthostport";
+				command = "dropudpdsthostport";
 			else if ( is_udp_port(f$dst_p) && r$ty == WHITELIST)
-				command = "permitucpdsthostport";
+				command = "permitudpdsthostport";
 
 			arg = fmt("%s %d", f$dst_h as addr, f$dst_p);
 			}


### PR DESCRIPTION
This fixes a typo in the conversion of a netcontrol rule to an acld.rule. This bug, in principle, would cause an invalid acld command to be sent, which would probably cause the rule to just not be executed.

We never noticed that, because the people using netcontrol+acld don't use it for flow rules - so this code is not really exercised. This also makes this a rather low importance bugfix - but it still seems not nice to have it broken like this.

Found with the help of Claude Opus 4.7. I fixed the typos myself.