### PR TITLE
Management framework: fix regression in metrics-port collision avoidance

### DIFF
--- a/scripts/policy/frameworks/management/controller/main.zeek
+++ b/scripts/policy/frameworks/management/controller/main.zeek
@@ -418,8 +418,8 @@ function config_assign_metrics_ports(config: Management::Configuration)
 	# Pre-populate nodes with pre-defined metrics ports, as well
 	# as their Broker ports:
 	for ( node in config$nodes )
-		node_addr = instance_addr_lookup[node$instance];
 		{
+		node_addr = instance_addr_lookup[node$instance];
 		if ( node?$p )
 			add instance_ports_set[node_addr][node$p as count];
 		if ( node?$metrics_port )


### PR DESCRIPTION
A bug was introduced in 0c0769b1b2, which added a statement before the opening braces of the for loop.

This means that most of the ports were never recorded in instance_ports_set, which can lead to collisions.

Found with the help of Claude Opus 4.7.