### PR TITLE
Fix off-by-one error in base/utils/thresholds

### DIFF
--- a/scripts/base/utils/thresholds.zeek
+++ b/scripts/base/utils/thresholds.zeek
@@ -48,7 +48,7 @@ function new_track_count(): TrackCount
 
 function check_threshold(v: vector of count, tracker: TrackCount): bool
 	{
-	if ( tracker$index <= |v| && tracker$n >= v[tracker$index] )
+	if ( tracker$index < |v| && tracker$n >= v[tracker$index] )
 		{
 		++tracker$index;
 		return T;

--- a/testing/btest/Baseline/scripts.base.utils.thresholds/output
+++ b/testing/btest/Baseline/scripts.base.utils.thresholds/output
@@ -21,6 +21,10 @@ Iteration: 9, threshold check: F
 [n=9, index=4]
 Iteration: 10, threshold check: T
 [n=10, index=5]
+Iteration: 11, threshold check: F
+[n=11, index=5]
+Iteration: 12, threshold check: F
+[n=12, index=5]
 ====================================
 Iteration: 0, threshold check: F
 [n=0, index=0]
@@ -44,3 +48,7 @@ Iteration: 9, threshold check: F
 [n=9, index=4]
 Iteration: 10, threshold check: T
 [n=10, index=5]
+Iteration: 11, threshold check: F
+[n=11, index=5]
+Iteration: 12, threshold check: F
+[n=12, index=5]

--- a/testing/btest/scripts/base/utils/thresholds.test
+++ b/testing/btest/scripts/base/utils/thresholds.test
@@ -5,7 +5,7 @@
 
 redef default_notice_thresholds = { 2, 4, 6, 8, 10 };
 const my_thresholds: vector of count = { 2, 4, 6, 8, 10 };
-const loop_v: vector of count = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+const loop_v: vector of count = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
 global track_count: TrackCount;
 
 for ( i in loop_v )


### PR DESCRIPTION
Base-utils-thresholds will try to read a non-existing entry from the thresholds vector, when crossing the last threshold.

As far as I can tell this error has been present since the original SVN import.

This problem was found using Claude Opus 4.7.