### PR TITLE
conn_key: allow factories to customize fragment reassembly keys

### DIFF
--- a/src/Frag.cc
+++ b/src/Frag.cc
@@ -6,6 +6,7 @@
 #include "zeek/NetVar.h"
 #include "zeek/Reporter.h"
 #include "zeek/RunState.h"
+#include "zeek/conn_key/Manager.h"
 #include "zeek/session/Manager.h"
 
 constexpr uint32_t MIN_ACCEPTABLE_FRAG_SIZE = 64;
@@ -26,10 +27,9 @@ void FragTimer::Dispatch(double t, bool /* is_expire */) {
 }
 
 FragReassembler::FragReassembler(session::Manager* arg_s, const std::shared_ptr<IP_Hdr>& ip, const u_char* pkt,
-                                 const FragReassemblerKey& k, double t)
-    : Reassembler(0, REASSEM_FRAG) {
+                                 FragReassemblerKey k, double t)
+    : Reassembler(0, REASSEM_FRAG), key(std::move(k)) {
     s = arg_s;
-    key = k;
 
     const struct ip* ip4 = ip->IP4_Hdr();
     if ( ip4 ) {
@@ -298,18 +298,20 @@ void FragReassembler::DeleteTimer() {
 
 FragmentManager::~FragmentManager() { Clear(); }
 
-FragReassembler* FragmentManager::NextFragment(double t, const std::shared_ptr<IP_Hdr>& ip, const u_char* pkt) {
-    uint32_t frag_id = ip->ID();
-    FragReassemblerKey key = std::make_tuple(ip->SrcAddr(), ip->DstAddr(), frag_id);
+FragReassembler* FragmentManager::NextFragment(double t, const Packet& packet, const std::shared_ptr<IP_Hdr>& ip,
+                                               const u_char* pkt) {
+    auto lookup_key = conn_key_mgr->GetFactory().FragmentKey(packet, *ip);
 
     FragReassembler* f = nullptr;
-    auto it = fragments.find(key);
+    auto it = fragments.find(lookup_key);
     if ( it != fragments.end() )
         f = it->second;
 
     if ( ! f ) {
-        f = new FragReassembler(session_mgr, ip, pkt, key, t);
-        fragments[key] = f;
+        auto owned_key = conn_key_mgr->GetFactory().FragmentKey(packet, *ip);
+        auto map_key = conn_key_mgr->GetFactory().FragmentKey(packet, *ip);
+        f = new FragReassembler(session_mgr, ip, pkt, std::move(owned_key), t);
+        fragments.emplace(std::move(map_key), f);
         if ( fragments.size() > max_fragments )
             max_fragments = fragments.size();
         return f;

--- a/src/Frag.h
+++ b/src/Frag.h
@@ -10,11 +10,13 @@
 #include "zeek/IPAddr.h"
 #include "zeek/Reassem.h"
 #include "zeek/Timer.h"
+#include "zeek/session/Key.h"
 #include "zeek/util-types.h"
 
 namespace zeek {
 
 class IP_Hdr;
+class Packet;
 
 namespace session {
 class Manager;
@@ -25,12 +27,12 @@ namespace detail {
 class FragReassembler;
 class FragTimer;
 
-using FragReassemblerKey = std::tuple<IPAddr, IPAddr, zeek_uint_t>;
+using FragReassemblerKey = zeek::session::detail::Key;
 
 class FragReassembler : public Reassembler {
 public:
     FragReassembler(session::Manager* s, const std::shared_ptr<IP_Hdr>& ip, const u_char* pkt,
-                    const FragReassemblerKey& k, double t);
+                    FragReassemblerKey k, double t);
     ~FragReassembler() override;
 
     void AddFragment(double t, const std::shared_ptr<IP_Hdr>& ip, const u_char* pkt);
@@ -77,7 +79,7 @@ public:
     FragmentManager() = default;
     ~FragmentManager();
 
-    FragReassembler* NextFragment(double t, const std::shared_ptr<IP_Hdr>& ip, const u_char* pkt);
+    FragReassembler* NextFragment(double t, const Packet& packet, const std::shared_ptr<IP_Hdr>& ip, const u_char* pkt);
     void Clear();
     void Remove(detail::FragReassembler* f);
 

--- a/src/conn_key/CMakeLists.txt
+++ b/src/conn_key/CMakeLists.txt
@@ -1,1 +1,1 @@
-zeek_add_subdir_library(connkey SOURCES Factory.h Component.cc Manager.cc)
+zeek_add_subdir_library(connkey SOURCES Factory.h Factory.cc Component.cc Manager.cc)

--- a/src/conn_key/Factory.cc
+++ b/src/conn_key/Factory.cc
@@ -1,0 +1,31 @@
+// See the file "COPYING" in the main distribution directory for copyright.
+
+#include "zeek/conn_key/Factory.h"
+
+#include <netinet/in.h>
+
+#include "zeek/IP.h"
+#include "zeek/iosource/Packet.h"
+
+namespace zeek::conn_key {
+
+namespace {
+
+struct FragmentKeyData {
+    in6_addr src;
+    in6_addr dst;
+    uint32_t id = 0;
+} __attribute__((packed, aligned));
+
+} // namespace
+
+session::detail::Key Factory::DoFragmentKey(const Packet& /* pkt */, const IP_Hdr& ip) const {
+    FragmentKeyData key;
+    ip.SrcAddr().CopyIPv6(&key.src);
+    ip.DstAddr().CopyIPv6(&key.dst);
+    key.id = ip.ID();
+
+    return {&key, sizeof(key), session::detail::Key::FRAGMENT_KEY_TYPE, true};
+}
+
+} // namespace zeek::conn_key

--- a/src/conn_key/Factory.h
+++ b/src/conn_key/Factory.h
@@ -2,11 +2,13 @@
 #pragma once
 
 #include "zeek/ConnKey.h"
+#include "zeek/session/Key.h"
 #include "zeek/util-types.h"
 
 namespace zeek {
 
 class Packet;
+class IP_Hdr;
 class RecordVal;
 using RecordValPtr = IntrusivePtr<RecordVal>;
 
@@ -42,6 +44,14 @@ public:
         return DoConnKeyFromVal(v);
     }
 
+    /**
+     * Creates a fragment-reassembly key for the current IP fragment.
+     *
+     * ConnKey factories may override this to keep fragment reassembly aligned
+     * with their connection-key semantics, e.g. by including VLAN metadata.
+     */
+    zeek::session::detail::Key FragmentKey(const Packet& pkt, const IP_Hdr& ip) const { return DoFragmentKey(pkt, ip); }
+
 protected:
     /**
      * Hook for Factory::NewConnKey.
@@ -56,6 +66,11 @@ protected:
      * @return A unique pointer to the ConnKey instance, or an error message.
      */
     virtual zeek::expected<zeek::ConnKeyPtr, std::string> DoConnKeyFromVal(const zeek::Val& v) const = 0;
+
+    /**
+     * Hook for Factory::FragmentKey.
+     */
+    virtual zeek::session::detail::Key DoFragmentKey(const Packet& pkt, const IP_Hdr& ip) const;
 };
 
 } // namespace conn_key

--- a/src/packet_analysis/protocol/ip/IP.cc
+++ b/src/packet_analysis/protocol/ip/IP.cc
@@ -156,7 +156,7 @@ bool IPAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet) 
                 return false;
         }
         else {
-            f = zeek::detail::fragment_mgr->NextFragment(run_state::processing_start_time, packet->ip_hdr,
+            f = zeek::detail::fragment_mgr->NextFragment(run_state::processing_start_time, *packet, packet->ip_hdr,
                                                          packet->data + hdr_size);
             std::shared_ptr<IP_Hdr> ih = f->ReassembledPkt();
 

--- a/src/packet_analysis/protocol/ip/conn_key/vlan_fivetuple/Factory.cc
+++ b/src/packet_analysis/protocol/ip/conn_key/vlan_fivetuple/Factory.cc
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "zeek/Desc.h"
+#include "zeek/IP.h"
 #include "zeek/ID.h"
 #include "zeek/Val.h"
 #include "zeek/iosource/Packet.h"
@@ -125,6 +126,29 @@ zeek::expected<zeek::ConnKeyPtr, std::string> Factory::DoConnKeyFromVal(const ze
         k->key.inner_vlan = vlan_unset_val;
 
     return ck;
+}
+
+zeek::session::detail::Key Factory::DoFragmentKey(const zeek::Packet& pkt, const zeek::IP_Hdr& ip) const {
+    struct FragmentKeyData {
+        in6_addr src;
+        in6_addr dst;
+        uint32_t id = 0;
+        uint32_t vlan = vlan_unset_val;
+        uint32_t inner_vlan = vlan_unset_val;
+    } __attribute__((packed, aligned));
+
+    FragmentKeyData key;
+    ip.SrcAddr().CopyIPv6(&key.src);
+    ip.DstAddr().CopyIPv6(&key.dst);
+    key.id = ip.ID();
+
+    if ( pkt.vlan )
+        key.vlan = pkt.vlan->id;
+
+    if ( pkt.inner_vlan )
+        key.inner_vlan = pkt.inner_vlan->id;
+
+    return {&key, sizeof(key), zeek::session::detail::Key::FRAGMENT_KEY_TYPE, true};
 }
 
 } // namespace zeek::conn_key::vlan_fivetuple

--- a/src/packet_analysis/protocol/ip/conn_key/vlan_fivetuple/Factory.h
+++ b/src/packet_analysis/protocol/ip/conn_key/vlan_fivetuple/Factory.h
@@ -28,6 +28,8 @@ private:
      * @return A unique pointer to the ConnKey instance, or an error message.
      */
     zeek::expected<zeek::ConnKeyPtr, std::string> DoConnKeyFromVal(const zeek::Val& v) const override;
+
+    zeek::session::detail::Key DoFragmentKey(const zeek::Packet& pkt, const zeek::IP_Hdr& ip) const override;
 };
 
 } // namespace zeek::conn_key::vlan_fivetuple

--- a/src/session/Key.h
+++ b/src/session/Key.h
@@ -24,6 +24,7 @@ struct KeyHash;
 class Key final {
 public:
     const static size_t CONNECTION_KEY_TYPE = 0;
+    const static size_t FRAGMENT_KEY_TYPE = 1;
 
     /**
      * Create a new session key from a data pointer.

--- a/testing/btest/plugins/connkey-fragment.zeek
+++ b/testing/btest/plugins/connkey-fragment.zeek
@@ -1,0 +1,12 @@
+# @TEST-EXEC: ${DIST}/auxil/zeek-aux/plugin-support/init-plugin -u . Demo Foo
+# @TEST-EXEC: cp -r %DIR/connkey-plugin/* .
+# @TEST-EXEC: ./configure --zeek-dist=${DIST} && make
+# @TEST-EXEC: ZEEK_PLUGIN_PATH=`pwd` zeek -C -r $TRACES/ipv4/fragmented-1.pcap %INPUT >>output
+# @TEST-EXEC: btest-diff output
+
+redef ConnKey::factory = ConnKey::CONNKEY_FOO;
+
+event zeek_done()
+	{
+	print "done";
+	}

--- a/testing/btest/plugins/connkey-plugin/src/Foo.cc
+++ b/testing/btest/plugins/connkey-plugin/src/Foo.cc
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "zeek/Desc.h"
+#include "zeek/IP.h"
 #include "zeek/Val.h"
 #include "zeek/iosource/Packet.h"
 #include "zeek/packet_analysis/protocol/ip/conn_key/IPBasedConnKey.h"
@@ -46,5 +47,9 @@ zeek::ConnKeyPtr FooFactory::DoNewConnKey() const {
 zeek::expected<zeek::ConnKeyPtr, std::string> FooFactory::DoConnKeyFromVal(const zeek::Val& v) const {
     std::printf("DoConnKeyFromVal for %s\n", zeek::obj_desc_short(&v).c_str());
     return zeek::conn_key::fivetuple::Factory::DoConnKeyFromVal(v);
+}
+zeek::session::detail::Key FooFactory::DoFragmentKey(const zeek::Packet& pkt, const zeek::IP_Hdr& ip) const {
+    std::printf("DoFragmentKey (%u)\n", ip.ID());
+    return zeek::conn_key::fivetuple::Factory::DoFragmentKey(pkt, ip);
 }
 zeek::conn_key::FactoryPtr FooFactory::Instantiate() { return std::make_unique<FooFactory>(); }

--- a/testing/btest/plugins/connkey-plugin/src/Foo.h
+++ b/testing/btest/plugins/connkey-plugin/src/Foo.h
@@ -18,6 +18,7 @@ public:
 protected:
     zeek::ConnKeyPtr DoNewConnKey() const override;
     zeek::expected<zeek::ConnKeyPtr, std::string> DoConnKeyFromVal(const zeek::Val& v) const override;
+    zeek::session::detail::Key DoFragmentKey(const zeek::Packet& pkt, const zeek::IP_Hdr& ip) const override;
 
 private:
 };


### PR DESCRIPTION
## Summary

  This adds fragment-key customization to conn-key factories so custom connection-key schemes can also
  control fragment reassembly keys.

  ## Changes

  - add a fragment-key factory API
  - use factory-provided keys in fragment reassembly lookup
  - add VLAN-aware fragment-key handling for the VLAN five-tuple factory
  - add a regression test plugin/btest for fragment-key customization

  Fixes #4871.
