### PR TITLE
serialization: reject negative string lengths in binary format

### DIFF
--- a/src/SerializationFormat.cc
+++ b/src/SerializationFormat.cc
@@ -163,6 +163,19 @@ bool BinarySerializationFormat::Read(char** str, int* len, const char* tag) {
         return false;
 
     l = ntohl(l);
+
+    // A negative length is invalid and only arises from corrupt or malicious
+    // input. Reject it before it is used to size an allocation or as a byte
+    // count: "new char[l + 1]" would either allocate a zero-byte buffer (l ==
+    // -1) or throw std::bad_array_new_length, and passing a negative "l" to
+    // ReadData() widens it to a huge size_t, bypassing the bounds check and
+    // causing an out-of-bounds read/write.
+    if ( l < 0 ) {
+        reporter->Error("negative string length in binary format");
+        *str = nullptr;
+        return false;
+    }
+
     char* s = new char[l + 1];
 
     if ( ! ReadData(s, l) ) {


### PR DESCRIPTION
While reading a string in BinarySerializationFormat::Read(), the length
field is taken straight off the wire as a signed int and used without any
sanity check. A negative value causes problems:

  - l == -1 makes `new char[l + 1]` allocate a zero-byte buffer, and then
    ReadData(s, l) passes -1 as the size_t count, which becomes SIZE_MAX.
    The bounds check in ReadData is `input_pos + count > input_len`, and
    that addition wraps around, so the check passes and we memcpy way past
    the end of the buffer.
  - other negative values throw bad_array_new_length out of the allocation.

This path is reachable from the cluster log-write deserializer, so a
malformed message can corrupt memory on the receiving node.

Fix is to bail out early if the decoded length is negative. Valid data is
never affected since lengths are always written as non-negative string
sizes, and the function already returns false on read errors so callers
handle it the same way they always have.
