### PR TITLE
serialization: don't abort() on short read in binary format

### DIFF
--- a/src/SerializationFormat.cc
+++ b/src/SerializationFormat.cc
@@ -50,9 +50,11 @@ size_t SerializationFormat::EndWrite(char** data) {
 }
 
 bool SerializationFormat::ReadData(void* b, size_t count) {
-    if ( input_pos + count > input_len ) {
+    // Note the subtraction rather than "input_pos + count > input_len": the
+    // latter can wrap around for a large "count" and pass the check. The
+    // invariant input_pos <= input_len always holds, so this cannot underflow.
+    if ( count > input_len - input_pos ) {
         reporter->Error("data underflow during read in binary format");
-        abort();
         return false;
     }
 


### PR DESCRIPTION
ReadData() calls abort() when there aren't enough bytes left to satisfy a
read. The function is already written to return false on that condition and
all callers handle it, so the abort() just turns a recoverable parse error
into a hard process exit. Since the binary format is fed by cluster
log-write messages, a single malformed message can take a node down.

Drop the abort() and let the existing `return false` do its job. While here,
rewrite the bounds check as `count > input_len - input_pos` instead of
`input_pos + count > input_len`, which can wrap for a large count and let an
oversized read slip through.
