### PR TITLE
threading: validate set/vector sizes when reading binary values

### DIFF
--- a/src/threading/SerialTypes.cc
+++ b/src/threading/SerialTypes.cc
@@ -295,7 +295,22 @@ bool Value::Read(detail::SerializationFormat* fmt) {
             if ( ! fmt->Read(&val.set_val.size, "set_size") )
                 return false;
 
-            val.set_val.vals = new Value*[val.set_val.size];
+            // A negative size is invalid input. Reject it before it reaches
+            // new[], where it is converted to a huge size_t and throws
+            // std::bad_array_new_length. Reset to 0 so the destructor does not
+            // walk a bogus length.
+            if ( val.set_val.size < 0 ) {
+                reporter->Error("negative set size in binary format");
+                val.set_val.size = 0;
+                return false;
+            }
+
+            // Value-initialize the array so every element pointer starts null.
+            // If a later element fails to read and we bail out below, the
+            // destructor's "delete val.set_val.vals[i]" over the full size is a
+            // safe no-op on the not-yet-populated slots rather than a free of
+            // an indeterminate pointer.
+            val.set_val.vals = new Value*[val.set_val.size]();
 
             for ( zeek_int_t i = 0; i < val.set_val.size; ++i ) {
                 val.set_val.vals[i] = new Value;
@@ -311,7 +326,14 @@ bool Value::Read(detail::SerializationFormat* fmt) {
             if ( ! fmt->Read(&val.vector_val.size, "vector_size") )
                 return false;
 
-            val.vector_val.vals = new Value*[val.vector_val.size];
+            // See the TYPE_TABLE case above for why these two guards exist.
+            if ( val.vector_val.size < 0 ) {
+                reporter->Error("negative vector size in binary format");
+                val.vector_val.size = 0;
+                return false;
+            }
+
+            val.vector_val.vals = new Value*[val.vector_val.size]();
 
             for ( zeek_int_t i = 0; i < val.vector_val.size; ++i ) {
                 val.vector_val.vals[i] = new Value;


### PR DESCRIPTION
Value::Read() reads the element count for sets and vectors as a signed 64-bit
value straight off the wire and hands it to new Value*[size] with no checks.

Two problems with that:
  - a negative count becomes a huge size_t in new[], which throws
    bad_array_new_length and takes the process down.
  - new Value*[size] leaves the pointers uninitialized. We fill them in a
    loop, but if one of the element reads fails partway through we return with
    size still set to the full count. The destructor then deletes every entry
    up to size, including the slots we never populated, so it frees garbage
    pointers.

Reject a negative size up front, and value-initialize the array so the unused
slots are null and safe to delete. Valid input is unaffected since the loop
overwrites every slot anyway.

These values are reachable from the cluster log-write path, where the value
type and count come from a remote peer.
