### PR TITLE
RDP: Cap certain protocol fields to 1000 entries or 256 KB in length

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -124,6 +124,10 @@ Changed Functionality
   for log streams. Previously, it would result in scheduling a new timer that
   would immediately expire, something that isn't very useful.
 
+- Certain protocol fields in the RDP parser are capped to maximum values to
+  prevent unbounded buffering. This also prevents signed integer overflow
+  reports from the BinPAC-generated code when running under UBSAN.
+
 Deprecated Functionality
 ------------------------
 

--- a/src/analyzer/protocol/rdp/rdp-protocol.pac
+++ b/src/analyzer/protocol/rdp/rdp-protocol.pac
@@ -1,5 +1,11 @@
 %include ../asn1/asn1.pac
 
+
+# The protocol specifies some 32-bit variable-length data fields for the
+# key and cert material. This value caps the size of these to help prevent
+# excessive buffering and integer overflows in BinPAC. This is 256 KB.
+let MAX_DATA_LENGTH: uint32 = 262144;
+
 type TPKT(is_orig: bool) = record {
 	version:  uint8;
 	reserved: uint8;
@@ -235,7 +241,7 @@ type Client_Security_Data = record {
 } &byteorder=littleendian;
 
 type Client_Network_Data = record {
-	channel_count: uint32;
+	channel_count: uint32 &enforce(channel_count <= 1000);
 	channel_def_array: Client_Channel_Def[channel_count];
 } &byteorder=littleendian;
 
@@ -325,7 +331,7 @@ type Server_Security_Data = record {
 	encryption_method:      uint32;
 	encryption_level:       uint32;
 	server_random_length:   uint32 &enforce((encryption_level == 0 && encryption_method == 0 && server_random_length == 0) || (server_random_length == 0x20));
-	server_cert_length:     uint32;
+	server_cert_length:     uint32 &enforce(server_random_length <= MAX_DATA_LENGTH);
 	server_random:          bytestring &length=server_random_length;
 	server_certificate:     Server_Certificate &length=server_cert_length;
 } &let {
@@ -359,19 +365,19 @@ type Server_Proprietary_Cert(cert: Server_Certificate) = record {
 
 type Public_Key_Blob = record {
 	magic:           bytestring &length=4;
-	key_length:      uint32;
+	key_length:      uint32 &enforce(key_length <= MAX_DATA_LENGTH);
 	bit_length:      uint32;
 	public_exponent: uint32;
 	modulus:         bytestring &length=key_length;
 } &byteorder=littleendian;
 
 type X509 = record {
-	num_of_certs: uint32;
+	num_of_certs: uint32 &enforce(num_of_certs <= 1000);
 	certs: X509_Cert_Data[num_of_certs];
 } &byteorder=littleendian;
 
 type X509_Cert_Data = record {
-	cert_len: uint32;
+	cert_len: uint32 &enforce(cert_len <= MAX_DATA_LENGTH);
 	cert: bytestring &length=cert_len;
 } &byteorder=littleendian;
 


### PR DESCRIPTION
When fuzzing RDP with UBSAN, the fuzzer would produce lengths for key or cert data close to INT_MAX which then leads to signed integer overflows in error messages from BinPAC. Prevent this by capping key and cert blobs to 256 KB similar to what's done in RFB. This should be sufficient and also prevent unreasonable buffering.  Also cap channels and num_of_certs in X509 to 1000.

---

```
$ ../../fuzz-build/src/fuzzers/zeek-rdp-fuzzer ./clusterfuzz-testcase-minimized-zeek-rdp-fuzzer-5515910667632640 2>&1 | ../../testing/scripts/diff-remove-abspath 
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 419702088
INFO: Loaded 6 modules   (1811238 inline 8-bit counters): 684 [0x7f5e2a4c42e0, 0x7f5e2a4c458c), 293741 [0x7f5e19897648, 0x7f5e198df1b5), 459454 [0x7f5e209f3c38, 0x7f5e20a63ef6), 188703 [0x7f5e23a0c718, 0x7f5e23a3a837), 867817 [0x7f5e29268270, 0x7f5e2933c059), 839 [0x55d281e90108, 0x55d281e9044f), 
INFO: Loaded 6 PC tables (1811238 PCs): 684 [0x7f5e2a4c4590,0x7f5e2a4c7050), 293741 [0x7f5e198df1b8,0x7f5e19d5a888), 459454 [0x7f5e20a63ef8,0x7f5e21166ad8), 188703 [0x7f5e23a3a838,0x7f5e23d1ba28), 867817 [0x7f5e2933c060,0x7f5e2a079ef0), 839 [0x55d281e90450,0x55d281e938c0), 
..<...>/zeek-rdp-fuzzer: Running 1 inputs 1 time(s) each.
Running: ./clusterfuzz-testcase-minimized-zeek-rdp-fuzzer-5515910667632640
<...>/rdp_pac.cc:3422:14: runtime error: signed integer overflow: 4 + 2147483647 cannot be represented in type 'int'
    #0 0x7f5e27055e4b in binpac::RDP::X509_Cert_Data::Parse(unsigned char const*, unsigned char const*, binpac::RDP::ContextRDP*) <...>/rdp_pac.cc:3422:14
    #1 0x7f5e27054aeb in binpac::RDP::X509::Parse(unsigned char const*, unsigned char const*, binpac::RDP::ContextRDP*) <...>/rdp_pac.cc:3373:45
    #2 0x7f5e2705390b in binpac::RDP::Server_Certificate::Parse(unsigned char const*, unsigned char const*, binpac::RDP::ContextRDP*) <...>/rdp_pac.cc:3115:39
```