### PR TITLE
General CircleCI fixups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,7 +488,7 @@ _filter_if_pr_not_full_or_zeekctl: &FILTER_IF_PR_NOT_FULL_OR_ZEEKCTL
              and not pipeline.parameters.pr_label_zeekctl))
 
 workflows:
-  circleci-config-testing:
+  zeek_builds:
     jobs:
       - fetch-test-traces
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,14 +35,20 @@ parameters:
 commands:
   clone_repo:
     parameters:
+      include_submodules:
+        type: boolean
+        default: true
       include_external_tests:
         type: boolean
         default: true
     steps:
       - checkout
-      - run:
-          name: Update submodules
-          command: git submodule update --recursive --init
+      - when:
+          condition: << parameters.include_submodules >>
+          steps:
+            - run:
+                name: Update submodules
+                command: git submodule update --recursive --init --recommend-shallow -j ${ZEEK_CI_CPUS}
       - when:
           condition: << parameters.include_external_tests >>
           steps:

--- a/.circleci/setup.yml
+++ b/.circleci/setup.yml
@@ -27,7 +27,12 @@ workflows:
     when:
       or:
         - equal: [ "pull_request", << pipeline.event.name >> ]
-        - equal: [ master, << pipeline.git.branch >> ]
+        - and:
+          # The check for the trigger here prevents us from doing double builds on pushes
+          # to master. If the all-pushes trigger is deleted or recreated from the project
+          # this needs to be fixed. See below for more docs on how to get this ID.
+          - equal: [ master, << pipeline.git.branch >> ]
+          - equal: [ f5314bc7-fc82-4458-bd27-fc73c71e5a73, << pipeline.trigger.id >> ]
         - matches:
             pattern: "^release/.*"
             value: << pipeline.git.branch >>
@@ -38,3 +43,21 @@ workflows:
         - equal: [ "weekly", << pipeline.schedule.name >> ]
     jobs:
       - setup_job
+
+
+# To get the ID for the trigger above, you must go through the CircleCI API. It doesn't
+# show up anywhere on the UI that I have found. This requires a bit of gymnastics. You'll
+# need the following:
+# - A personal access token on your CircleCI account
+# - The project ID, available from the "Overview" page for the project on the site
+# - The pipeline ID, available from the "Project Setup" page for the project on the site.
+#   The ID is right under the title of the pipeline.
+#
+# Make a request to the API like such:
+#   curl --request GET \
+#     --url https://circleci.com/api/v2/projects/<project id>/pipeline-definitions/<pipeline id>/trigger \
+#     --header "Circle-Token: $CIRCLE_TOKEN"
+#
+# Find the ID for the "all-pushes" trigger in the output. Alternatively, you can use the
+# "only-build-prs" trigger. It doesn't really matter, because we're just using one of the
+# IDs to avoid doing builds for master from both triggers.

--- a/testing/btest/spicy/tcp-eod-behavior-on-destroy.zeek
+++ b/testing/btest/spicy/tcp-eod-behavior-on-destroy.zeek
@@ -1,4 +1,5 @@
 # @TEST-REQUIRES: have-spicy
+# @TEST-REQUIRES: ! have-asan
 #
 # @TEST-EXEC: spicyz -d foo.spicy foo.evt -o foo.hlto
 # @TEST-EXEC: zeek -r ${TRACES}/http/206_example_b.pcap foo.hlto "Spicy::enable_print=T" >output 2>&1


### PR DESCRIPTION
This is a collection of fixups for various CircleCI things, mostly pulled out of https://github.com/zeek/zeek/pull/5534 to make that PR more targeted on the docker changes alone.

- Add a trigger ID check for the master branch during setup to avoid master being built from more than one trigger. This keeps us from doing two full builds for every merge to master.
- Rename the default builds workflow from the one that I gave it when I was doing the original work.
- Rework clone_repos a little bit to allow skipping submodules, plus making submodule updates a bit faster.