### PR TITLE
Some signed bitshift fixes

### DIFF
--- a/src/Base64.cc
+++ b/src/Base64.cc
@@ -35,14 +35,19 @@ void Base64Converter::Encode(int len, const unsigned char* data, int* pblen, cha
     }
 
     for ( int i = 0, j = 0; (i < len) && (j < blen); ) {
-        uint32_t bit32 = data[i++] << 16;
-        bit32 += (i++ < len ? data[i - 1] : 0) << 8;
-        bit32 += i++ < len ? data[i - 1] : 0;
+        int remaining = len - i;
+        uint32_t bit32 = 0;
 
-        buf[j++] = alphabet[(bit32 >> 18) & 0x3f];
-        buf[j++] = alphabet[(bit32 >> 12) & 0x3f];
-        buf[j++] = (i == (len + 2)) ? '=' : alphabet[(bit32 >> 6) & 0x3f];
-        buf[j++] = (i >= (len + 1)) ? '=' : alphabet[bit32 & 0x3f];
+        bit32 |= (static_cast<uint32_t>(data[i++]) << 16u);
+        if ( remaining > 1 )
+            bit32 |= (static_cast<uint32_t>(data[i++]) << 8u);
+        if ( remaining > 2 )
+            bit32 |= data[i++];
+
+        buf[j++] = alphabet[(bit32 >> 18u) & 0x3fu];
+        buf[j++] = alphabet[(bit32 >> 12u) & 0x3fu];
+        buf[j++] = (remaining < 2) ? '=' : alphabet[(bit32 >> 6u) & 0x3fu];
+        buf[j++] = (remaining < 3) ? '=' : alphabet[bit32 & 0x3fu];
     }
 }
 

--- a/src/packet_analysis/protocol/geneve/Geneve.cc
+++ b/src/packet_analysis/protocol/geneve/Geneve.cc
@@ -95,10 +95,10 @@ bool GeneveAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* pack
 
     // Get the next header. This will probably be Ethernet (0x6558), but get it
     // anyways so that the forwarding can do its thing.
-    auto next_header = (data[2] << 8) + data[3];
+    auto next_header = (static_cast<uint32_t>(data[2]) << 8u) | data[3];
 
     // Grab the VNI out of the data before advancing the data pointer
-    auto vni = (data[4] << 16) + (data[5] << 8) + data[6];
+    auto vni = (static_cast<uint32_t>(data[4]) << 16u) | (static_cast<uint32_t>(data[5]) << 8u) | data[6];
 
     len -= hdr_size;
     data += hdr_size;

--- a/src/packet_analysis/protocol/snap/SNAP.cc
+++ b/src/packet_analysis/protocol/snap/SNAP.cc
@@ -30,8 +30,8 @@ bool SNAPAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet
     data += llc_header_len;
     len -= llc_header_len;
 
-    int oui = (data[0] << 16) | (data[1] << 8) | data[2];
-    int protocol = (data[3] << 8) | data[4];
+    int oui = (static_cast<uint32_t>(data[0]) << 16u) | (static_cast<uint32_t>(data[1]) << 8u) | data[2];
+    int protocol = (static_cast<uint32_t>(data[3]) << 8u) | data[4];
 
     data += 5;
     len -= 5;

--- a/src/packet_analysis/protocol/vxlan/VXLAN.cc
+++ b/src/packet_analysis/protocol/vxlan/VXLAN.cc
@@ -38,7 +38,7 @@ bool VXLAN_Analyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* pack
         return false;
     }
 
-    int vni = (data[4] << 16) + (data[5] << 8) + (data[6] << 0);
+    uint32_t vni = (static_cast<uint32_t>(data[4]) << 16u) | (static_cast<uint32_t>(data[5]) << 8u) | data[6];
 
     len -= hdr_size;
     data += hdr_size;


### PR DESCRIPTION
This just has a few bitshift fixes that I found just from grepping through the codebase, not using clang tidy. We can find more with clang-tidy but it might be a bit noisy. Figured I'd just get a few in at once.

Added benefit of switching `+` to `|`, mainly because I think it's clearer to read.

The base64 one was a little funky and I used Gemini to help understand the code there. I don't think we should keep that math around, it made me really nervous with the `i++` and ternaries then later relying on `i` going beyond the buffer... just odd stuff to my eyes.