### PR TITLE
Tune the `testing/external/scripts/testing-setup.zeek` script

### DIFF
--- a/testing/external/scripts/testing-setup.zeek
+++ b/testing/external/scripts/testing-setup.zeek
@@ -17,6 +17,16 @@ redef DPD::track_removed_services_in_connection=T;
 	redef LogAscii::use_json = F;
 @endif
 
+@ifdef ( Telemetry::log_interval )
+	# We're reading pcaps, so the frequency of metrics collection is not
+	# significant. Frequent collection can dominate the runtime of a test,
+	# so dial this down considerably.
+	redef Telemetry::log_interval = 24hr;
+@endif
+
+# Similar to the above, dial down the profiling frequency.
+redef profiling_interval = 24hr;
+
 # The tests don't load intel data and so all Intel event groups are disabled
 # due to intel/seen/manage-event-groups being loaded by default. Disable that
 # functionality by default to cover execution in the intel/seen scripts.

--- a/testing/external/scripts/testing-setup.zeek
+++ b/testing/external/scripts/testing-setup.zeek
@@ -1,7 +1,7 @@
 # Sets some testing specific options.
 
-@load external-ca-list
-@load external-ct-list
+@load ./external-ca-list
+@load ./external-ct-list
 
 @load protocols/conn/failed-service-logging
 redef DPD::track_removed_services_in_connection=T;

--- a/testing/external/scripts/testing-setup.zeek
+++ b/testing/external/scripts/testing-setup.zeek
@@ -44,6 +44,3 @@ redef Analyzer::DebugLogging::include_disabling = F;
 # in order to skip initialization of cluster backend. Cluster backends may keep
 # the IO loop alive once registered due to registering IO sources.
 redef Cluster::backend = Cluster::CLUSTER_BACKEND_NONE;
-
-# Register the ZIP analyzer to handle application/zip
-@load policy/files/zip/register


### PR DESCRIPTION
I was looking into where all the time goes when processing the CTU pcap in the `zeek-testing` testsuite (as part of #5512). I found that since that pcap is relatively sparse but spans a week, we spend almost half of our time collecting telemetry (via `policy/frameworks/telemetry/log.zeek`, which collects once per minute). We don't actually baseline telemetry.log, so the number of times we collect doesn't matter for the test.

<img width="3840" height="278" alt="Screenshot_20260610_141219" src="https://github.com/user-attachments/assets/b01c5edb-f4ba-4565-828b-f839aa6598ae" />

Dialing this way down provides a healthy speedup for all pcaps, for example (with a debug build):
```
$ time btest ./tests/m57-long.zeek
all 1 tests successful

real    0m42.132s
user    0m51.141s
sys     0m3.900s
```
... vs after:
```
$ time btest ./tests/m57-long.zeek
all 1 tests successful

real    0m26.908s
user    0m30.361s
sys     0m3.881s
```

We may still want to look into whether there's anything obvious to improve in the collection — 60 * 24 * 7 is still "only" 10K metrics collections.

I'm also dialing down the profiling frequency since it likewise doesn't contribute to the baselines. It mainly saves on generated log volume, not overhead.

The other changes are just minor local tweaks.

