### PR TITLE
Upgrade AndreKurait/docker-cache action to 0.7.0 (fixes node20 warning)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -373,8 +373,7 @@ jobs:
         persist-credentials: false
 
     - name: Cache Docker image
-      # uses: ScribeMD/docker-cache@0.5.0
-      uses: AndreKurait/docker-cache@0fe76702a40db986d9663c24954fc14c6a6031b7 # 0.6.0
+      uses: AndreKurait/docker-cache@7a3887908bdb97935395833df69b060cfcca0f7f # 0.7.0
       id: docker-cache
       with:
         key: docker-${{ matrix.id }}-${{ hashFiles(matrix.file) }}


### PR DESCRIPTION
This fixes the warning that gets printed with every workflow job:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: AndreKurait/docker-cache@0fe76702a40db986d9663c24954fc14c6a6031b7. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/