### PR TITLE
github/workflows: Run CIFuzz only on zeek/zeek

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -12,6 +12,7 @@ permissions: {}
 
 jobs:
   Fuzzing:
+    if: github.repository == 'zeek/zeek'
     runs-on: ubuntu-latest
     permissions:
       security-events: write


### PR DESCRIPTION
The job clones from github.com/zeek/zeek, so it doesn't make a lot of sense to run that in forks as it'll always fail.