### PR TITLE
utils/atoi_n: Prevent overflows and fix digit parsing for base < 10

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -25,6 +25,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 
 #if defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)
 #include <malloc.h>
@@ -1138,8 +1139,10 @@ char* strcasestr(const char* s, const char* find) {
 
 template<std::integral T>
 int atoi_n(int len, const char* s, const char** end, int base, T& result) {
-    T n = 0;
     int neg = 0;
+
+    if ( base < 2 || base > 36 )
+        return 0;
 
     if ( len > 0 && *s == '-' ) {
         neg = 1;
@@ -1147,11 +1150,20 @@ int atoi_n(int len, const char* s, const char** end, int base, T& result) {
         ++s;
     }
 
+    using Unsigned = std::make_unsigned_t<T>;
+    constexpr T min = std::numeric_limits<T>::min();
+    constexpr T max = std::numeric_limits<T>::max();
+    constexpr auto max_value = std::is_signed_v<T> ? static_cast<Unsigned>(min) : static_cast<Unsigned>(max);
+    static_assert(max_value <= std::numeric_limits<uint64_t>::max());
+
+    const auto base_u = static_cast<Unsigned>(base); // base unsigned
+    uint64_t n = 0;
+
     int i;
     for ( i = 0; i < len; ++i ) {
         unsigned int d;
 
-        if ( isdigit(s[i]) )
+        if ( s[i] >= '0' && s[i] < '0' + base )
             d = s[i] - '0';
 
         else if ( s[i] >= 'a' && s[i] < 'a' - 10 + base )
@@ -1164,6 +1176,11 @@ int atoi_n(int len, const char* s, const char** end, int base, T& result) {
             break;
 
         else
+            return 0;
+
+        // Can we multiply n without overflowing? And then
+        // also add the digit just parsed? Else, fail.
+        if ( n > (max_value / base_u) || d > (max_value - n * base_u) )
             return 0;
 
         n = n * base + d;
@@ -2300,6 +2317,15 @@ TEST_SUITE("util") {
 
 #endif
 
+    TEST_CASE("atoi_n bad base") {
+        const char* dec = "123";
+        int val;
+
+        // base starts at two and max is 36, like for Spicy.
+        CHECK(atoi_n(strlen(dec), dec, nullptr, 1, val) == 0);
+        CHECK(atoi_n(strlen(dec), dec, nullptr, 37, val) == 0);
+    }
+
     TEST_CASE("atoi_n") {
         const char* dec = "12345";
         int val;
@@ -2313,6 +2339,149 @@ TEST_SUITE("util") {
 
         const char* fail = "XYZ";
         CHECK(atoi_n(strlen(fail), fail, nullptr, 10, val) == 0);
+    }
+
+    // Test that parsing -1 into an uint8_t produces 255 and uint64_t produces
+    // uint64_t::max(). Also check that 255 is parsed for uint8_t as 255, but
+    // rejected for int8_t.
+    TEST_CASE("atoi_n underflows") {
+        std::string minus_one = "-1";
+        std::string minus_two = "-2";
+        std::string two_fifty_five = "255";
+
+        uint8_t result;
+        uint64_t result64;
+        int r;
+
+        r = atoi_n<uint8_t>(minus_one.size(), minus_one.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, 255);
+
+        r = atoi_n<uint64_t>(minus_one.size(), minus_one.c_str(), nullptr, 10, result64);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result64, std::numeric_limits<uint64_t>::max());
+
+        r = atoi_n<uint8_t>(minus_two.size(), minus_two.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, 254);
+
+        r = atoi_n<uint8_t>(two_fifty_five.size(), two_fifty_five.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, 255);
+
+        // 255 does not fit into int8_t, so this fails.
+        int8_t signed_result;
+        r = atoi_n<int8_t>(two_fifty_five.size(), two_fifty_five.c_str(), nullptr, 10, signed_result);
+        CHECK_EQ(r, 0);
+    }
+
+    TEST_CASE("atoi_n int32_t") {
+        std::string int32t_min = std::to_string(std::numeric_limits<int32_t>::min());
+        std::string int32t_max = std::to_string(std::numeric_limits<int32_t>::max());
+
+        int32_t result;
+        int r;
+
+        r = atoi_n(int32t_min.size(), int32t_min.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, std::numeric_limits<int32_t>::min());
+
+        r = atoi_n(int32t_max.size(), int32t_max.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, std::numeric_limits<int32_t>::max());
+
+        std::string int32t_min_overflow = int32t_min + "9";
+        std::string int32t_max_overflow = int32t_max + "9";
+        r = atoi_n(int32t_min_overflow.size(), int32t_min_overflow.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 0);
+        r = atoi_n(int32t_max_overflow.size(), int32t_max_overflow.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 0);
+    }
+
+    TEST_CASE("atoi_n uint32_t") {
+        std::string uint32t_min = std::to_string(std::numeric_limits<uint32_t>::min());
+        std::string uint32t_max = std::to_string(std::numeric_limits<uint32_t>::max());
+
+        uint32_t result;
+        int r;
+
+        r = atoi_n(uint32t_min.size(), uint32t_min.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, std::numeric_limits<uint32_t>::min());
+
+        r = atoi_n(uint32t_max.size(), uint32t_max.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, std::numeric_limits<uint32_t>::max());
+
+        std::string uint32t_max_overflow = uint32t_max + "9";
+        r = atoi_n(uint32t_max_overflow.size(), uint32t_max_overflow.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 0);
+    }
+
+    TEST_CASE("atoi_n int64_t") {
+        std::string int64t_min = std::to_string(std::numeric_limits<int64_t>::min());
+        std::string int64t_max = std::to_string(std::numeric_limits<int64_t>::max());
+
+        int64_t result;
+        int r;
+
+        r = atoi_n(int64t_min.size(), int64t_min.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, std::numeric_limits<int64_t>::min());
+
+        r = atoi_n(int64t_max.size(), int64t_max.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, std::numeric_limits<int64_t>::max());
+
+        std::string int64t_min_overflow = int64t_min + "9";
+        std::string int64t_max_overflow = int64t_max + "9";
+        r = atoi_n(int64t_min_overflow.size(), int64t_min_overflow.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 0);
+        r = atoi_n(int64t_max_overflow.size(), int64t_max_overflow.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 0);
+    }
+
+    TEST_CASE("atoi_n uint64_t") {
+        std::string uint64t_min = std::to_string(std::numeric_limits<uint64_t>::min());
+        std::string uint64t_max = std::to_string(std::numeric_limits<uint64_t>::max());
+
+        uint64_t result;
+        int r;
+
+        r = atoi_n(uint64t_min.size(), uint64t_min.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, 0ULL);
+
+        r = atoi_n(uint64t_max.size(), uint64t_max.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(result, std::numeric_limits<uint64_t>::max());
+
+        std::string int64t_max_overflow = uint64t_max + "9";
+        r = atoi_n(int64t_max_overflow.size(), int64t_max_overflow.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 0);
+    }
+
+    TEST_CASE("atoi_n base 2") {
+        const char* dec = "0101"; // 5
+        int val;
+
+        CHECK(atoi_n(strlen(dec), dec, nullptr, 2, val) == 1);
+        CHECK(val == 5);
+    }
+
+    TEST_CASE("atoi_n base 2 wrong") {
+        const char* dec = "4234";
+        int val;
+
+        CHECK(atoi_n(strlen(dec), dec, nullptr, 2, val) == 0);
+    }
+
+    TEST_CASE("atoi_n base 2 wrong end") {
+        const char* dec = "010177"; // 5
+        int val;
+
+        CHECK(atoi_n(strlen(dec), dec, nullptr, 2, val) == 1);
+        CHECK(val == 5);
     }
 
     TEST_CASE("uitoa_n") {

--- a/src/util.cc
+++ b/src/util.cc
@@ -1144,61 +1144,18 @@ int atoi_n(int len, const char* s, const char** end, int base, T& result) {
     if ( base < 2 || base > 36 )
         return 0;
 
-    if ( len > 0 && *s == '-' ) {
-        neg = 1;
-        --len;
-        ++s;
-    }
+    const char* last = s + len;
 
-    // Reject negative numbers for unsigned result type.
-    if ( neg && std::is_unsigned_v<T> )
+    auto r = std::from_chars(s, last, result, base);
+
+    if ( r.ec == std::errc::invalid_argument )
         return 0;
 
-    using Unsigned = std::make_unsigned_t<T>;
-    constexpr T min = std::numeric_limits<T>::min();
-    constexpr T max = std::numeric_limits<T>::max();
-    const auto base_u = static_cast<Unsigned>(base); // base unsigned
-
-    // int8_t: range -128..127
-    // If neg and signed, parse to 128 ((uint8_t(-128)), otherwise 127.
-    // For uint8_t, 255 (uint8_t max) is used. If neg, rejected above.
-    const auto max_value = (neg && std::is_signed_v<T>) ? static_cast<Unsigned>(min) : static_cast<Unsigned>(max);
-    uint64_t n = 0;
-
-    int i;
-    for ( i = 0; i < len; ++i ) {
-        unsigned int d;
-
-        if ( s[i] >= '0' && s[i] < '0' + base )
-            d = s[i] - '0';
-
-        else if ( s[i] >= 'a' && s[i] < 'a' - 10 + base )
-            d = s[i] - 'a' + 10;
-
-        else if ( s[i] >= 'A' && s[i] < 'A' - 10 + base )
-            d = s[i] - 'A' + 10;
-
-        else if ( i > 0 )
-            break;
-
-        else
-            return 0;
-
-        // Can we multiply n without overflowing? And then
-        // also add the digit just parsed? Else, fail.
-        if ( n > (max_value / base_u) || d > (max_value - n * base_u) )
-            return 0;
-
-        n = n * base + d;
-    }
-
-    if ( neg )
-        result = -n;
-    else
-        result = n;
+    if ( r.ec == std::errc::result_out_of_range )
+        return 0;
 
     if ( end )
-        *end = s + i;
+        *end = r.ptr;
 
     return 1;
 }
@@ -2332,6 +2289,20 @@ TEST_SUITE("util") {
         CHECK(atoi_n(strlen(dec), dec, nullptr, 37, val) == 0);
     }
 
+    // This succeeded previously and returned 0, with std::from_chars
+    // it fails, which seems very reasonable.
+    TEST_CASE("atoi_n empty string fails") {
+        int val;
+        CHECK(atoi_n(0, "", nullptr, 10, val) == 0);
+    }
+
+    // This succeeded previously and returned 0, with std::from_chars
+    // it fails, which seems very reasonable.
+    TEST_CASE("atoi_n solitary minus fails") {
+        int val;
+        CHECK(atoi_n(1, "-", nullptr, 10, val) == 0);
+    }
+
     TEST_CASE("atoi_n") {
         const char* dec = "12345";
         int val;
@@ -2339,9 +2310,18 @@ TEST_SUITE("util") {
         CHECK(atoi_n(strlen(dec), dec, nullptr, 10, val) == 1);
         CHECK(val == 12345);
 
+        const char* dec0 = "012345";
+
+        CHECK(atoi_n(strlen(dec0), dec0, nullptr, 10, val) == 1);
+        CHECK(val == 12345);
+
         const char* hex = "12AB";
         CHECK(atoi_n(strlen(hex), hex, nullptr, 16, val) == 1);
         CHECK(val == 0x12AB);
+
+        const char* hex0 = "00ff";
+        CHECK(atoi_n(strlen(hex0), hex0, nullptr, 16, val) == 1);
+        CHECK(val == 0xff);
 
         const char* fail = "XYZ";
         CHECK(atoi_n(strlen(fail), fail, nullptr, 10, val) == 0);

--- a/src/util.cc
+++ b/src/util.cc
@@ -1150,13 +1150,19 @@ int atoi_n(int len, const char* s, const char** end, int base, T& result) {
         ++s;
     }
 
+    // Reject negative numbers for unsigned result type.
+    if ( neg && std::is_unsigned_v<T> )
+        return 0;
+
     using Unsigned = std::make_unsigned_t<T>;
     constexpr T min = std::numeric_limits<T>::min();
     constexpr T max = std::numeric_limits<T>::max();
-    constexpr auto max_value = std::is_signed_v<T> ? static_cast<Unsigned>(min) : static_cast<Unsigned>(max);
-    static_assert(max_value <= std::numeric_limits<uint64_t>::max());
-
     const auto base_u = static_cast<Unsigned>(base); // base unsigned
+
+    // int8_t: range -128..127
+    // If neg and signed, parse to 128 ((uint8_t(-128)), otherwise 127.
+    // For uint8_t, 255 (uint8_t max) is used. If neg, rejected above.
+    const auto max_value = (neg && std::is_signed_v<T>) ? static_cast<Unsigned>(min) : static_cast<Unsigned>(max);
     uint64_t n = 0;
 
     int i;
@@ -2341,37 +2347,58 @@ TEST_SUITE("util") {
         CHECK(atoi_n(strlen(fail), fail, nullptr, 10, val) == 0);
     }
 
-    // Test that parsing -1 into an uint8_t produces 255 and uint64_t produces
-    // uint64_t::max(). Also check that 255 is parsed for uint8_t as 255, but
-    // rejected for int8_t.
-    TEST_CASE("atoi_n underflows") {
+    TEST_CASE("atoi_n overflows") {
         std::string minus_one = "-1";
-        std::string minus_two = "-2";
+        std::string one_twenty_seven = "127";
+        std::string one_twenty_eight = "128";
+        std::string minus_one_twenty_eight = "-128";
+        std::string minus_one_twenty_nine = "-129";
         std::string two_fifty_five = "255";
+        std::string two_fifty_six = "256";
 
         uint8_t result;
+        int8_t signed_result;
         uint64_t result64;
         int r;
 
         r = atoi_n<uint8_t>(minus_one.size(), minus_one.c_str(), nullptr, 10, result);
-        CHECK_EQ(r, 1);
-        CHECK_EQ(result, 255);
+        CHECK_EQ(r, 0);
 
         r = atoi_n<uint64_t>(minus_one.size(), minus_one.c_str(), nullptr, 10, result64);
-        CHECK_EQ(r, 1);
-        CHECK_EQ(result64, std::numeric_limits<uint64_t>::max());
+        CHECK_EQ(r, 0);
 
-        r = atoi_n<uint8_t>(minus_two.size(), minus_two.c_str(), nullptr, 10, result);
+        r = atoi_n<int8_t>(minus_one.size(), minus_one.c_str(), nullptr, 10, signed_result);
         CHECK_EQ(r, 1);
-        CHECK_EQ(result, 254);
+        CHECK_EQ(signed_result, -1);
 
         r = atoi_n<uint8_t>(two_fifty_five.size(), two_fifty_five.c_str(), nullptr, 10, result);
         CHECK_EQ(r, 1);
         CHECK_EQ(result, 255);
 
+        // 256 does not fit uint8_t
+        r = atoi_n<uint8_t>(two_fifty_six.size(), two_fifty_six.c_str(), nullptr, 10, result);
+        CHECK_EQ(r, 0);
+
         // 255 does not fit into int8_t, so this fails.
-        int8_t signed_result;
         r = atoi_n<int8_t>(two_fifty_five.size(), two_fifty_five.c_str(), nullptr, 10, signed_result);
+        CHECK_EQ(r, 0);
+
+        // 127 does fit into int8_t, this passes
+        r = atoi_n<int8_t>(one_twenty_seven.size(), one_twenty_seven.c_str(), nullptr, 10, signed_result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(signed_result, 127);
+
+        // -128 does fit into int8_t, this passes
+        r = atoi_n<int8_t>(minus_one_twenty_eight.size(), minus_one_twenty_eight.c_str(), nullptr, 10, signed_result);
+        CHECK_EQ(r, 1);
+        CHECK_EQ(signed_result, -128);
+
+        // 128 does not fit into int8_t, so this fails.
+        r = atoi_n<int8_t>(one_twenty_eight.size(), one_twenty_eight.c_str(), nullptr, 10, signed_result);
+        CHECK_EQ(r, 0);
+
+        // -129 does fit into int8_t, this passes
+        r = atoi_n<int8_t>(minus_one_twenty_nine.size(), minus_one_twenty_nine.c_str(), nullptr, 10, signed_result);
         CHECK_EQ(r, 0);
     }
 
@@ -2479,9 +2506,19 @@ TEST_SUITE("util") {
     TEST_CASE("atoi_n base 2 wrong end") {
         const char* dec = "010177"; // 5
         int val;
+        const char* endp;
 
-        CHECK(atoi_n(strlen(dec), dec, nullptr, 2, val) == 1);
+        CHECK(atoi_n(strlen(dec), dec, &endp, 2, val) == 1);
         CHECK(val == 5);
+        CHECK(*endp == '7');
+        CHECK(endp == (dec + 4));
+    }
+
+    TEST_CASE("atoi_n fronting space fails") {
+        const char* dec = " 40";
+        int val;
+
+        CHECK(atoi_n(strlen(dec), dec, nullptr, 10, val) == 0);
     }
 
     TEST_CASE("uitoa_n") {


### PR DESCRIPTION
Fuzzing with UBSAN triggered the n = n * base + d line as overflowing, incorporate the atoi_n changes ~to~ from Spicy also in the Zeek code and add some tests for the edge cases.

Reference zeek/spicy#2382 zeek/spicy#2397