### PR TITLE
Fix some -pedantic warnings

### DIFF
--- a/src/Debug.h
+++ b/src/Debug.h
@@ -65,7 +65,6 @@ public:
     void TraceOff();
 
     int LogTrace(const char* fmt, ...) __attribute__((format(printf, 2, 3)));
-    ;
 
 protected:
     bool dbgtrace; // print an execution trace

--- a/src/Reporter.h
+++ b/src/Reporter.h
@@ -157,7 +157,6 @@ public:
     // Report an analyzer error. That analyzer will be set to not process
     // any further input, but Zeek otherwise continues normally.
     void AnalyzerError(analyzer::Analyzer* a, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
-    ;
 
     // Toggle whether non-fatal messages should be reported through the
     // scripting layer rather on standard output. Fatal errors are always
@@ -293,7 +292,6 @@ private:
     // and that takes va_list anyway.
     void WeirdHelper(EventHandlerPtr event, ValPList vl, const char* fmt_name, ...)
         __attribute__((format(printf, 4, 5)));
-    ;
     void UpdateWeirdStats(const char* name);
     inline bool WeirdOnSamplingWhiteList(const char* name) { return weird_sampling_whitelist.contains(name); }
     inline bool WeirdOnGlobalList(const char* name) { return weird_sampling_global_list.contains(name); }

--- a/src/Type.cc
+++ b/src/Type.cc
@@ -267,7 +267,8 @@ bool TypeList::AllMatch(const Type* t, bool is_init) const {
 void TypeList::Append(TypePtr t) {
     if ( pure_type && ! same_type(t, pure_type) )
         reporter->InternalError("pure type-list violation t=%s (%p) pure_type=%s (%p)", obj_desc_short(t).c_str(),
-                                t.get(), obj_desc_short(pure_type).c_str(), pure_type.get());
+                                static_cast<void*>(t.get()), obj_desc_short(pure_type).c_str(),
+                                static_cast<void*>(pure_type.get()));
 
     types.emplace_back(std::move(t));
 }

--- a/src/cluster/backend/zeromq/ZeroMQ.cc
+++ b/src/cluster/backend/zeromq/ZeroMQ.cc
@@ -925,9 +925,9 @@ void ZeroMQBackend::HandleMonitoringMessages(const std::vector<MultipartMessage>
 
 void ZeroMQBackend::Run() {
     char name[4 + 2 + 16 + 1]{}; // zmq-0x<8byte pointer in hex><nul>
-    snprintf(name, sizeof(name), "zmq-%p", this);
+    snprintf(name, sizeof(name), "zmq-%p", static_cast<void*>(this));
     util::detail::set_thread_name(name);
-    ZEROMQ_DEBUG_THREAD_PRINTF(DebugFlag::THREAD, "Thread starting (%p)\n", this);
+    ZEROMQ_DEBUG_THREAD_PRINTF(DebugFlag::THREAD, "Thread starting (%p)\n", static_cast<void*>(this));
 
     struct SocketInfo {
         zmq::socket_ref socket;
@@ -960,7 +960,7 @@ void ZeroMQBackend::Run() {
         for ( auto& s : monitoring_sockets )
             s.close();
 
-        ZEROMQ_DEBUG_THREAD_PRINTF(DebugFlag::THREAD, "Thread sockets closed (%p)\n", this);
+        ZEROMQ_DEBUG_THREAD_PRINTF(DebugFlag::THREAD, "Thread sockets closed (%p)\n", static_cast<void*>(this));
     });
 
     std::vector<zmq::pollitem_t> poll_items(sockets.size());
@@ -1054,7 +1054,7 @@ void ZeroMQBackend::Run() {
                 throw;
 
             // Shutdown.
-            ZEROMQ_DEBUG_THREAD_PRINTF(DebugFlag::THREAD, "Thread terminating (%p)\n", this);
+            ZEROMQ_DEBUG_THREAD_PRINTF(DebugFlag::THREAD, "Thread terminating (%p)\n", static_cast<void*>(this));
             break;
         }
 

--- a/src/cluster/publish_on_change.bif
+++ b/src/cluster/publish_on_change.bif
@@ -42,7 +42,7 @@ function apply_table_change_infos%(tcheader: TableChangeHeader, table_change_inf
 	zeek::detail::PublishOnChangeState* poc_state = tval->GetPublishOnChangeState();
 	if ( ! poc_state ) {
 		zeek::reporter->Warning("apply_table_change_infos: %s (%p) has no PublishOnChange state!",
-		                        idstr->ToStdString().c_str(), tval.get());
+		                        idstr->ToStdString().c_str(), static_cast<void*>(tval.get()));
 		return zeek::val_mgr->False();
 	}
 

--- a/src/file_analysis/AnalyzerSet.h
+++ b/src/file_analysis/AnalyzerSet.h
@@ -88,7 +88,6 @@ public:
 
     // Iterator support
     using iterator = zeek::DictIterator<file_analysis::Analyzer>;
-    ;
     using const_iterator = const iterator;
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;

--- a/src/logging/Manager.cc
+++ b/src/logging/Manager.cc
@@ -1290,14 +1290,15 @@ bool Manager::DelayFinish(const EnumValPtr& id, const RecordValPtr& record, cons
     const auto& it = stream->delay_tokens.find(token);
 
     if ( it == stream->delay_tokens.end() ) {
-        reporter->Error("non-existing log record for token=%" PRIu64 " %p", token, record.get());
+        reporter->Error("non-existing log record for token=%" PRIu64 " %p", token, static_cast<void*>(record.get()));
         return false;
     }
 
     auto& delay_info = it->second;
 
     if ( delay_info->Record() != record ) {
-        reporter->Error("record mismatch token=%" PRIu64 " %p and %p", token, record.get(), delay_info->Record().get());
+        reporter->Error("record mismatch token=%" PRIu64 " %p and %p", token, static_cast<void*>(record.get()),
+                        static_cast<void*>(delay_info->Record().get()));
         return false;
     }
 

--- a/src/telemetry/ProcessStats.cc
+++ b/src/telemetry/ProcessStats.cc
@@ -151,7 +151,7 @@ process_stats get_process_stats() {
                          "%*d " // 21. Obsolete since 2.6
                          "%*u " // 22. Time the process started after system boot
                          "%lu " // 23. Virtual memory size in bytes
-                         "%ld", // 24. Resident set size in pages
+                         "%lu", // 24. Resident set size in pages
                          &utime_ticks, &stime_ticks, &vmsize_bytes, &rss_pages);
         fclose(f);
 

--- a/src/threading/BasicThread.h
+++ b/src/threading/BasicThread.h
@@ -126,7 +126,6 @@ public:
      * other thread than the current one.
      */
     const char* Fmt(const char* format, ...) __attribute__((format(printf, 2, 3)));
-    ;
 
     /**
      * A version of strerror() that the thread can safely use. This is

--- a/src/zeek.bif
+++ b/src/zeek.bif
@@ -3849,7 +3849,7 @@ function hexstr_to_bytestring%(hexstr: string%): string
 
 	const char* bytes = hexstr->AsString()->CheckString();
 	size_t outlen = (len/2);
-	auto bytestring_buf = std::make_unique<char[]>(outlen);
+	auto bytestring_buf = std::make_unique<unsigned char[]>(outlen);
 	auto bytestring = bytestring_buf.get();
 	memset(bytestring, 0, outlen);
 
@@ -3871,7 +3871,7 @@ function hexstr_to_bytestring%(hexstr: string%): string
 
 		}
 
-	return zeek::make_intrusive<zeek::StringVal>(outlen, bytestring);
+	return zeek::make_intrusive<zeek::StringVal>(outlen, reinterpret_cast<char*>(bytestring));
 	%}
 
 ## Encodes a Base64-encoded string.

--- a/tools/binpac/src/pac_cstr.cc
+++ b/tools/binpac/src/pac_cstr.cc
@@ -56,11 +56,12 @@ int expand_escape(const char*& s) {
             for ( int len = 0; len < 3 && isascii(*s) && isdigit(*s); ++s, ++len )
                 ;
 
-            int result;
+            unsigned int result;
             if ( sscanf(start, "%3o", &result) != 1 )
                 throw EscapeException(strfmt("bad octal escape: \"%s", start));
 
-            return result;
+            // Capped at 777, safe to cast.
+            return static_cast<int>(result);
         }
 
         case 'x': { /* \x<hex> */
@@ -70,11 +71,12 @@ int expand_escape(const char*& s) {
             for ( int len = 0; len < 2 && isascii(*s) && isxdigit(*s); ++s, ++len )
                 ;
 
-            int result;
+            unsigned int result;
             if ( sscanf(start, "%2x", &result) != 1 )
                 throw EscapeException(strfmt("bad hexadecimal escape: \"%s", start));
 
-            return result;
+            // Capped at 255, safe to cast.
+            return static_cast<int>(result);
         }
 
         default: return s[-1];

--- a/tools/binpac/src/pac_scan.ll
+++ b/tools/binpac/src/pac_scan.ll
@@ -241,7 +241,7 @@ ESCSEQ	(\\([^\n]|[0-7]{3}|x[[:xdigit:]]{2}))
 <INITIAL>&until			return TOK_ATTR_UNTIL;
 
 <INITIAL,PP>"0x"{HEX}		{
-				int n;
+				unsigned int n;
 				sscanf(yytext + 2, "%x", &n);
 				yylval.num = new Number(yytext, n);
 				return TOK_NUMBER;

--- a/tools/binpac/src/pac_type.cc
+++ b/tools/binpac/src/pac_type.cc
@@ -661,7 +661,7 @@ bool Type::AddSizeVar(Output* out_cc, Env* env) {
 
     ID* size_var_id = new ID(strfmt("%s__size", value_var() ? value_var()->Name() : decl_id()->Name()));
 
-    DEBUG_MSG("adding size var `%s' to env %p\n", size_var_id->Name(), env);
+    DEBUG_MSG("adding size var `%s' to env %p\n", size_var_id->Name(), static_cast<void*>(env));
 
     size_var_field_ = new TempVarField(size_var_id, extern_type_int->Clone());
     size_var_field_->Prepare(env);


### PR DESCRIPTION
Mostly just tried `-pedantic` in the compile flags and seeing the stray `;` was annoying. Then did the remaining warnings within Zeek/binpac.

libkqueue and LightPcapNG light up a lot with `-pedantic` and I'm not sure it's generally useful to compile that way, so this is mostly a fly-by.