### PR TITLE
Ignore build-time-generated libkqueue headers for clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -83,7 +83,7 @@ Checks: [-*,
 ]
 
 HeaderFilterRegex: '.h'
-ExcludeHeaderFilterRegex: '.*(auxil|3rdparty)/.*'
+ExcludeHeaderFilterRegex: '.*(auxil|3rdparty|build/libkqueue-build)/.*'
 SystemHeaders: false
 CheckOptions:
     - key: modernize-use-default-member-init.UseAssignment


### PR DESCRIPTION
This popped after merging https://github.com/zeek/zeek/pull/5437