### PR TITLE
Disable default buildx attestations when building docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,6 +530,9 @@ jobs:
       # These duplicate the default parameter values from the other jobs
       CCACHE_MAXSIZE: 1000M
       CCACHE_MAXFILES: 20000
+      # Fixes an issue with the ubuntu-2404 image not having the latest buildx and the
+      # manifest getting deleted mid-build, which causes errors.
+      BUILDX_NO_DEFAULT_ATTESTATIONS: 1
     machine:
       image: ubuntu-2404:current
       docker_layer_caching: true


### PR DESCRIPTION
Nick @ CircleCI says that the ubuntu-24.04 VM we use to build the Docker images doesn't have the latest `buildx` on it, so we might need this flag in order to fix this error:

```
#10 ERROR: failed to extract layer sha256:f4f8b983b714f130e2cff99176baa26352db6a55d3622e10ada40f2b4720a4eb: failed to get reader from content store: content digest sha256:72c03230f1363a3fb61d2f98504cf168bad3fe22f511ad2005dc021515d7ce97: not found
------
 > exporting to image:
------
ERROR: failed to build: failed to solve: failed to extract layer sha256:f4f8b983b714f130e2cff99176baa26352db6a55d3622e10ada40f2b4720a4eb: failed to get reader from content store: content digest sha256:72c03230f1363a3fb61d2f98504cf168bad3fe22f511ad2005dc021515d7ce97: not found
```