### PR TITLE
smb/smb1_writex_and_response: Fix written_high int overflow by using <<

### DIFF
--- a/src/analyzer/protocol/smb/smb1-com-write-andx.pac
+++ b/src/analyzer/protocol/smb/smb1-com-write-andx.pac
@@ -80,6 +80,6 @@ type SMB1_write_andx_response(header: SMB_Header, offset: uint16) = record {
 
 	andx_command    : SMB_andx_command(header, false, offset+offsetof(andx_command), andx.command);
 } &let {
-	written_bytes : uint32 = (written_high * 0x10000) + written_low;
+	written_bytes : uint32 = (written_high << 16) + written_low;
 	proc          : bool   = $context.connection.proc_smb1_write_andx_response(header, this);
 };


### PR DESCRIPTION
The uint16 written_high is promoted to int before the multiplication and potentially causes the sign-bit of the int be set, causing UBSAN to report an overflow:

    /src/zeek/build/src/analyzer/protocol/smb/smb_pac.cc:8456:40: runtime error: signed integer overflow: 56387 * 65536 cannot be represented in type 'int'

Bit-shifting with 16 has the same effect, but is not undefined with C++20 anymore, so use this. Alternative would be to create a written_high32 intermediary in the &let section, but the data_len of the write_andx_request uses shifting, too.