### PR TITLE
Extend timeouts for some cluster-based jobs for CI ASAN ZAM testing

### DIFF
--- a/testing/btest/cluster/zeromq/overload-worker-proxy-topic-no-drop.zeek
+++ b/testing/btest/cluster/zeromq/overload-worker-proxy-topic-no-drop.zeek
@@ -21,7 +21,7 @@
 # @TEST-EXEC: btest-bg-run worker-1 "ZEEKPATH=$ZEEKPATH:.. && CLUSTER_NODE=worker-1 zeek -b ../other.zeek >out"
 # @TEST-EXEC: btest-bg-run worker-2 "ZEEKPATH=$ZEEKPATH:.. && CLUSTER_NODE=worker-2 zeek -b ../other.zeek >out"
 #
-# @TEST-EXEC: btest-bg-wait 30
+# @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff manager/out
 # @TEST-EXEC: btest-diff proxy/out
 # @TEST-EXEC: btest-diff worker-1/out

--- a/testing/btest/scripts/base/files/x509/log-caching-disabled-cluster.test
+++ b/testing/btest/scripts/base/files/x509/log-caching-disabled-cluster.test
@@ -17,7 +17,7 @@
 # @TEST-EXEC: $SCRIPTS/wait-for-file manager/lost 15 || (btest-bg-wait -k 1 && false)
 
 # @TEST-EXEC: btest-bg-run worker-2  "cp ../cluster-layout.zeek . && CLUSTER_NODE=worker-2 zeek -b --pseudo-realtime -C -r $TRACES/tls/ecdhe.pcap %INPUT"
-# @TEST-EXEC: btest-bg-wait 30
+# @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff manager/x509.log
 
 @load base/protocols/ssl

--- a/testing/btest/scripts/base/frameworks/openflow/log-cluster.zeek
+++ b/testing/btest/scripts/base/frameworks/openflow/log-cluster.zeek
@@ -6,7 +6,7 @@
 #
 # @TEST-EXEC: btest-bg-run manager  "cp ../cluster-layout.zeek . && CLUSTER_NODE=manager  zeek %INPUT"
 # @TEST-EXEC: btest-bg-run worker-1 "cp ../cluster-layout.zeek . && CLUSTER_NODE=worker-1 zeek --pseudo-realtime -C -r $TRACES/smtp.pcap %INPUT"
-# @TEST-EXEC: btest-bg-wait 45
+# @TEST-EXEC: btest-bg-wait 60
 # @TEST-EXEC: btest-diff manager/openflow.log
 
 redef Log::default_rotation_interval = 0secs;
@@ -70,4 +70,3 @@ event Broker::peer_lost(endpoint: Broker::EndpointInfo, msg: string)
 	{
 	schedule 2sec { terminate_me() };
 	}
-

--- a/testing/btest/scripts/base/frameworks/storage/redis/cluster.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis/cluster.zeek
@@ -9,10 +9,12 @@
 # @TEST-EXEC: cp $FILES/broker/cluster-layout.zeek .
 
 # @TEST-EXEC: btest-bg-run redis-server run-redis-server ${REDIS_PORT%/tcp}
+# Wait a few seconds for the redis server to come up
+# @TEST-EXEC: sleep 5
 # @TEST-EXEC: btest-bg-run manager  ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=manager  zeek -b %INPUT
 # @TEST-EXEC: btest-bg-run worker-1 ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b %INPUT
 # @TEST-EXEC: btest-bg-run worker-2 ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b %INPUT
-# @TEST-EXEC: btest-bg-wait -k 5
+# @TEST-EXEC: btest-bg-wait -k 30
 # @TEST-EXEC: btest-diff worker-1/.stdout
 # @TEST-EXEC: btest-diff worker-2/.stdout
 # @TEST-EXEC:

--- a/testing/btest/scripts/base/frameworks/storage/sqlite/cluster.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite/cluster.zeek
@@ -10,7 +10,7 @@
 # @TEST-EXEC: btest-bg-run manager ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=manager zeek -b %INPUT
 # @TEST-EXEC: btest-bg-run worker-1  ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b %INPUT
 # @TEST-EXEC: btest-bg-run worker-2  ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b %INPUT
-# @TEST-EXEC: btest-bg-wait -k 10
+# @TEST-EXEC: btest-bg-wait -k 30
 # @TEST-EXEC: btest-diff worker-1/.stdout
 # @TEST-EXEC: btest-diff worker-2/.stdout
 # @TEST-EXEC:

--- a/testing/btest/scripts/base/frameworks/sumstats/sample-cluster.zeek
+++ b/testing/btest/scripts/base/frameworks/sumstats/sample-cluster.zeek
@@ -8,7 +8,7 @@
 # @TEST-EXEC: btest-bg-run worker-1  ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-1 zeek -b %INPUT
 # @TEST-EXEC: btest-bg-run worker-2  ZEEKPATH=$ZEEKPATH:.. CLUSTER_NODE=worker-2 zeek -b %INPUT
 # This timeout needs to be large to accommodate ZAM compilation delays.
-# @TEST-EXEC: btest-bg-wait 45
+# @TEST-EXEC: btest-bg-wait 60
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-sort btest-diff manager/.stdout
 
 @load base/frameworks/sumstats
@@ -29,7 +29,7 @@ event zeek_init() &priority=5
 	                  	local r = result["test"];
 	                  	print fmt("Host: %s  Sampled observations: %d", key$host, r$sample_elements);
 	                  	local sample_nums: vector of count = vector();
-	                  	for ( sample in r$samples ) 
+	                  	for ( sample in r$samples )
 	                  		sample_nums += r$samples[sample]$num;
 
 	                  	print fmt("    %s", sort(sample_nums));

--- a/testing/btest/scripts/policy/frameworks/cluster/cluster_started_restart_manager.zeek
+++ b/testing/btest/scripts/policy/frameworks/cluster/cluster_started_restart_manager.zeek
@@ -7,7 +7,7 @@
 # @TEST-PORT: WORKER1_PORT
 # @TEST-PORT: WORKER2_PORT
 # @TEST-EXEC: btest-bg-run zeek zeek -j -b %INPUT
-# @TEST-EXEC: btest-bg-wait 25
+# @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff zeek/supervisor.out
 # @TEST-EXEC: btest-diff zeek/manager/stdout
 # @TEST-EXEC: btest-diff zeek/worker-1/stdout

--- a/testing/btest/scripts/policy/frameworks/management/controller/agent-checkin.zeek
+++ b/testing/btest/scripts/policy/frameworks/management/controller/agent-checkin.zeek
@@ -8,7 +8,7 @@
 # @TEST-PORT: BROKER_PORT
 
 # @TEST-EXEC: ZEEK_MANAGEMENT_TESTING=1 btest-bg-run zeek zeek -j %INPUT
-# @TEST-EXEC: btest-bg-wait 10
+# @TEST-EXEC: btest-bg-wait 30
 # @TEST-EXEC: btest-diff zeek/nodes/controller/stdout
 
 @load policy/frameworks/cluster/backend/broker

--- a/testing/btest/supervisor/config-bare-mode.zeek
+++ b/testing/btest/supervisor/config-bare-mode.zeek
@@ -6,7 +6,7 @@
 # @TEST-REQUIRES: test "${ZEEK_USE_CPP}" != "1"
 # @TEST-REQUIRES: ! is-windows-ci
 # @TEST-EXEC: btest-bg-run zeek zeek -j -b %INPUT
-# @TEST-EXEC: btest-bg-wait 30
+# @TEST-EXEC: btest-bg-wait 45
 # @TEST-EXEC: btest-diff zeek/inherit/node.out
 # @TEST-EXEC: btest-diff zeek/bare/node.out
 # @TEST-EXEC: btest-diff zeek/default/node.out

--- a/testing/btest/supervisor/config-cluster-pcap.zeek
+++ b/testing/btest/supervisor/config-cluster-pcap.zeek
@@ -4,7 +4,7 @@
 # @TEST-PORT: MANAGER_PORT
 # @TEST-PORT: WORKER_PORT
 # @TEST-EXEC: btest-bg-run zeek zeek -j %INPUT
-# @TEST-EXEC: btest-bg-wait 45
+# @TEST-EXEC: btest-bg-wait 60
 # @TEST-EXEC: mv zeek/worker/conn.log zeek/worker/conn.log.orig
 # @TEST-EXEC: zeek-cut ts uid id.orig_h id.resp_h history service < zeek/worker/conn.log.orig > zeek/worker/conn.log
 # @TEST-EXEC: TEST_DIFF_CANONIFIER= btest-diff zeek/worker/conn.log


### PR DESCRIPTION
A bunch of cluster-related btests are failing on the asan ZAM builds. This is a PR to test whether extending the timeouts on those tests resolves the problems, or if it's something deeper than that.