### PR TITLE
Add sqlite3.rc to enforce certain sqlite3 options to ensure baseline determinism across versions

### DIFF
--- a/testing/btest/Files/sqlite3.rc
+++ b/testing/btest/Files/sqlite3.rc
@@ -1,0 +1,10 @@
+-- Silence any output for these commands. This prevents breaking baselines.
+.output /dev/null
+
+-- Sqlite 3.52.0 and up return 17 digits for floating point values by default,
+-- which breaks some baselines. Enforce the old 15 digit version for btest
+-- baselines.
+.dbconfig fp_digits 15
+
+-- Restore output to stdout
+.output stdout

--- a/testing/btest/scripts/base/frameworks/logging/sqlite/wikipedia.zeek
+++ b/testing/btest/scripts/base/frameworks/logging/sqlite/wikipedia.zeek
@@ -4,8 +4,8 @@
 # @TEST-GROUP: sqlite
 #
 # @TEST-EXEC: zeek -b -r $TRACES/wikipedia.pcap %INPUT Log::default_writer=Log::WRITER_SQLITE
-# @TEST-EXEC: sqlite3 conn.sqlite 'select * from conn order by ts' | sort -n > conn.select
-# @TEST-EXEC: sqlite3 http.sqlite 'select * from http order by ts' | sort -n > http.select
+# @TEST-EXEC: sqlite3 conn.sqlite -init $FILES/sqlite3.rc 'select * from conn order by ts;' | sort -n > conn.select
+# @TEST-EXEC: sqlite3 http.sqlite -init $FILES/sqlite3.rc 'select * from http order by ts' | sort -n > http.select
 # @TEST-EXEC: btest-diff conn.select
 # @TEST-EXEC: btest-diff http.select
 


### PR DESCRIPTION
SQLite 3.52.0 changed out they output floating point numbers to default to 17 digits. See section 1.3.1 of https://sqlite.org/floatingpoint.html for more details about that. Unfortunately, this broke one of our btest baselines because we're outputting a very long FP number. This PR adds an sqlite3 rc file that gets run before the commands for that btest that enforces the old 15 digit output.

The option is per-session here and only for output. It doesn't change anything for how the data is stored in the database. This means we can't just do something simple like call `sqlite3_db_config` on the database when we create it in the log writer, since that only applies to the writer and not to the `sqlite3` commands we run in the btest. @ckreibich and I discussed also wrapping the `sqlite3` commands in a script that checked for a version number and prepended the command, but decided this seemed simpler. I tested with both SQLite 3.51.0 and 3.53.2, and the test passes for both.