### PR TITLE
Allow unsigned constants in binpac code

### DIFF
--- a/src/analyzer/protocol/ntp/ntp-protocol.pac
+++ b/src/analyzer/protocol/ntp/ntp-protocol.pac
@@ -118,9 +118,9 @@ type Extension_Field = record {
 	association_id: uint16;
 	timestamp:      uint32;
 	filestamp:      uint32;
-	value_len:      uint32 &enforce(value_len <= (len - 18));
+	value_len:      uint32 &enforce(value_len <= (len - 18u));
 	value:          bytestring &length=value_len;
-	sig_len:        uint32 &enforce(value_len <= (len - 22));
+	sig_len:        uint32 &enforce(value_len <= (len - 22u));
 	signature:      bytestring &length=sig_len;
 	pad:            padding to (len - offsetof(first_byte_ext));
 } &let {

--- a/tools/binpac/src/pac_expr.cc
+++ b/tools/binpac/src/pac_expr.cc
@@ -75,7 +75,10 @@ Expr::Expr(Number* arg_num) : DataDepElement(EXPR) {
     init();
     expr_type_ = EXPR_NUM;
     num_ = arg_num;
-    orig_ = strfmt("((int) %s)", num_->Str());
+    if ( num_->IsUnsigned() )
+        orig_ = strfmt("((unsigned int) %s)", num_->Str());
+    else
+        orig_ = strfmt("((int) %s)", num_->Str());
 }
 
 Expr::Expr(Nullptr* arg_nullp) : DataDepElement(EXPR) {

--- a/tools/binpac/src/pac_number.h
+++ b/tools/binpac/src/pac_number.h
@@ -4,17 +4,33 @@
 #define pac_number_h
 
 #include "pac_common.h"
+#include "pac_exception.h"
 
 class Number : public Object {
 public:
     Number(int arg_n) : s(strfmt("%d", arg_n)), n(arg_n) {}
+    Number(unsigned int arg_u) : s(strfmt("%uu", arg_u)), is_unsigned(true), u(arg_u) {}
     Number(const char* arg_s, int arg_n) : s(arg_s), n(arg_n) {}
     const char* Str() const { return s.c_str(); }
-    int Num() const { return n; }
+    int Num() const {
+        if ( is_unsigned )
+            throw Exception(this, "Num() called for unsigned number");
+        return n;
+    }
+    unsigned int Unsigned() const {
+        if ( ! is_unsigned )
+            throw Exception(this, "Unsigned() called for signed number");
+        return u;
+    }
+    bool IsUnsigned() const { return is_unsigned; }
 
 protected:
     const string s;
-    const int n;
+    bool is_unsigned = false;
+    union {
+        const int n;
+        const unsigned int u;
+    };
 };
 
 #endif // pac_number_h

--- a/tools/binpac/src/pac_scan.ll
+++ b/tools/binpac/src/pac_scan.ll
@@ -254,6 +254,13 @@ ESCSEQ	(\\([^\n]|[0-7]{3}|x[[:xdigit:]]{2}))
 				return TOK_NUMBER;
 				}
 
+<INITIAL,PP>{D}u		{
+				unsigned int n;
+				sscanf(yytext, "%uu", &n);
+				yylval.num = new Number(n);
+				return TOK_NUMBER;
+				}
+
 <INITIAL,PP>{ID}(::{ID})*	{
 				yylval.id = new ID(yytext);
 				return TOK_ID;


### PR DESCRIPTION
https://github.com/zeek/zeek/pull/5584 added some additional checks to the NTP analyzer. Unfortunately, on newer compilers, the math operations cause the type to be converted from unsigned to signed, and results in the following warnings:

```
/root/project/build/src/analyzer/protocol/ntp/ntp_pac.cc: In member function 'int binpac::NTP::Extension_Field::Parse(binpac::const_byteptr, binpac::const_byteptr, int)':
/root/project/build/src/analyzer/protocol/ntp/ntp_pac.cc:957:25: error: comparison of integer expressions of different signedness: 'binpac::uint32' {aka 'unsigned int'} and 'int' [-Werror=sign-compare]
  957 |     if (! ( value_len() <=  ( len() - 18 )  ) ) {
      |             ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/root/project/build/src/analyzer/protocol/ntp/ntp_pac.cc:994:25: error: comparison of integer expressions of different signedness: 'binpac::uint32' {aka 'unsigned int'} and 'int' [-Werror=sign-compare]
  994 |     if (! ( value_len() <=  ( len() - 22 )  ) ) {
      |             ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
```

This PR adds support for the `u` suffix on integer constants in binpac code, allowing the codegen to pass along that these are unsigned values. It results in the correct output in the generated code and the warnings are resolved.