### PR TITLE
Add better error handling to the release image builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,7 +601,10 @@ jobs:
       - restore_cache:
           name: Restore ccache
           keys:
-            - cache-v1-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+            - ccache-v1-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+            - ccache-v1-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-
+            - ccache-v1-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-
+            - ccache-v1-{{ .Environment.CIRCLE_JOB }}-
       - run:
           name: Build zeek in new image
           command: |
@@ -640,14 +643,14 @@ jobs:
             make -C docker/btest
       - save_cache:
           name: Save ccache
-          key: cache-v1-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+          key: ccache-v1-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
           paths:
             - /tmp/ccache
       - persist_to_workspace:
           name: Persist saved image to workspace
           root: /tmp/zeek_images
           paths:
-            - ${IMAGE_ARCH}
+            - .
 
   container-image-manifest-build:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,15 +558,32 @@ jobs:
       - run:
           name: Create builder image
           command: |
-            set -x
+            set -euxo pipefail
+
+            build_builder() {
+              (cd docker && docker build \
+                               --build-arg GIT_COMMIT=${CIRCLE_SHA1} \
+                               -t zeek-builder:latest \
+                               -f builder.Dockerfile .)
+            }
 
             LAST_BUILDER_IMAGE_ID=$(docker inspect -f "{{ .Id }}" zeek-builder:latest 2>/dev/null || true)
             LAST_BUILDER_SHA=$(docker inspect -f "{{ index .Config.Labels "org.opencontainers.image.revision" }}" zeek-builder:latest 2>/dev/null || true)
 
-            (cd docker && docker build \
-                             --build-arg GIT_COMMIT=${CIRCLE_SHA1} \
-                             -t zeek-builder:latest \
-                             -f builder.Dockerfile .)
+            # DLC can restore BuildKit cache without the tagged image or blobs.
+            if [ -z "${LAST_BUILDER_IMAGE_ID}" ]; then
+              docker builder prune -af || true
+            fi
+
+            # Attempt to build the image once. If it fails, do it again without the cache.
+            if ! build_builder; then
+              echo "Builder build failed; clearing build cache and retrying once with --no-cache..."
+              docker builder prune -af || true
+              (cd docker && docker build --no-cache \
+                --build-arg GIT_COMMIT=${CIRCLE_SHA1} \
+                -t zeek-builder:latest \
+                -f builder.Dockerfile .)
+            fi
 
             NEW_BUILDER_IMAGE_ID=$(docker inspect -f "{{ .Id }}" zeek-builder:latest)
 


### PR DESCRIPTION
This includes improvements to our release image building as recommended by support at CircleCi:

> Thanks for contacting CircleCI support, sorry to hear that you're getting a failure in your build. I've had a look at your config and I think I can see why it's failing. The failure is caused by an inconsistent Docker layer cache state when using the machine executor with DLC enabled.
> These changes will do 3 things:
> 1. Stricter error handling — The step fails clearly if the build fails, instead of continuing with a broken state.
> 2. Cache cleanup when the image is missing — If zeek-builder:latest isn’t on the runner but BuildKit still has cached layers, we run docker builder prune first so we don’t hit “cached layers but missing blobs.”
> 3. One automatic retry — If the build still fails (e.g. digest not found during export), we clear the build cache and rerun once with --no-cache so the job can succeed without a manual re-run.
