### PR TITLE
Drop `zkg` from distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,6 +372,12 @@ jobs:
                 name: Install spicy analyzers
                 command: |
                   set +e
+
+                  # `./ci/spicy-install-analyzers.sh` requires zkg.
+                  pipx ensurepath
+                  source ~/.bashrc
+                  pipx install zkg
+
                   ci/spicy-install-analyzers.sh
       - when:
           condition: << parameters.enable_benchmarks >>

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -233,6 +233,11 @@ jobs:
             git submodule update --init --recursive;
             )
 
+            # `./ci/spicy-install-analyzers.sh` requires zkg.
+            pipx ensurepath
+            source ~/.bashrc
+            pipx install zkg
+
             ./ci/pre-build.sh
             ./ci/build.sh
             ./ci/test.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,6 @@
 [submodule "auxil/highwayhash"]
 	path = auxil/highwayhash
 	url = https://github.com/google/highwayhash
-[submodule "auxil/package-manager"]
-	path = auxil/package-manager
-	url = https://github.com/zeek/package-manager
 [submodule "auxil/zeek-client"]
 	path = auxil/zeek-client
 	url = https://github.com/zeek/zeek-client

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,6 @@ option(INSTALL_BTEST "Install btest alongside Zeek." ${ZEEK_INSTALL_TOOLS_DEFAUL
 option(INSTALL_BTEST_PCAPS "Install pcap files for testing." ${ZEEK_INSTALL_TOOLS_DEFAULT})
 option(INSTALL_ZEEKCTL "Install zeekctl." ${ZEEK_INSTALL_TOOLS_DEFAULT})
 option(INSTALL_ZEEK_CLIENT "Install the zeek-client." ${ZEEK_INSTALL_TOOLS_DEFAULT})
-option(INSTALL_ZKG "Install zkg." ${ZEEK_INSTALL_TOOLS_DEFAULT})
 option(PREALLOCATE_PORT_ARRAY "Pre-allocate all ports for zeek::Val." ON)
 option(ZEEK_STANDALONE "Build Zeek as stand-alone binary." ON)
 option(ZEEK_ENABLE_FUZZERS "Build Zeek fuzzing targets." OFF)
@@ -1341,23 +1340,6 @@ if (NOT MSVC)
 endif ()
 
 # ##############################################################################
-# zkg configuration
-
-if (INSTALL_ZKG)
-    # An etc/zkg directory for zkg's config file simplifies zkg's config file
-    # code.
-    set(ZEEK_ZKG_CONFIG_DIR "${ZEEK_ETC_INSTALL_DIR}/zkg")
-    set(ZEEK_ZKG_STATE_DIR "${ZEEK_STATE_DIR}/zkg")
-
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake_templates/zkg-config.in
-                   ${CMAKE_CURRENT_BINARY_DIR}/zkg-config @ONLY)
-
-    install(DIRECTORY DESTINATION var/lib/zkg)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zkg-config DESTINATION ${ZEEK_ZKG_CONFIG_DIR}
-            RENAME config)
-endif ()
-
-# ##############################################################################
 # Look for external plugins to build in
 
 string(REPLACE "," " " _build_in_plugins "${ZEEK_INCLUDE_PLUGINS}")
@@ -1432,7 +1414,6 @@ endif ()
 include(CheckOptionalBuildSources)
 
 checkoptionalbuildsources(auxil/btest BTest INSTALL_BTEST)
-checkoptionalbuildsources(auxil/package-manager ZKG INSTALL_ZKG)
 checkoptionalbuildsources(auxil/zeekctl ZeekControl INSTALL_ZEEKCTL)
 checkoptionalbuildsources(auxil/zeek-aux Zeek-Aux INSTALL_AUX_TOOLS)
 checkoptionalbuildsources(auxil/zeek-client ZeekClient INSTALL_ZEEK_CLIENT)
@@ -1464,7 +1445,7 @@ zeek_finalize_bif_autogen_stubs(src/__all__.bif.cc src/__all__.bif.init.cc
 # ##############################################################################
 # Packaging Setup
 
-if (INSTALL_ZEEKCTL OR INSTALL_ZKG OR INSTALL_ZEEK_CLIENT)
+if (INSTALL_ZEEKCTL OR INSTALL_ZEEK_CLIENT)
     # CPack RPM Generator may not automatically detect this
     set(CPACK_RPM_PACKAGE_REQUIRES "python >= ${ZEEK_PYTHON_MIN}")
 endif ()
@@ -1630,7 +1611,6 @@ output_summary_bool("Spicy analyzers" ${USE_SPICY_ANALYZERS})
 output_summary_bool("zeek-client" ${INSTALL_ZEEK_CLIENT})
 output_summary_bool("zeek-systemd-generator" ${ENABLE_ZEEK_SYSTEMD_GENERATOR})
 output_summary_bool("ZeekControl" ${INSTALL_ZEEKCTL})
-output_summary_bool("zkg" ${INSTALL_ZKG})
 message("")
 
 output_summary_bool("libmaxminddb" ${USE_GEOIP})

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get -y install \
     libpcap-dev \
     libssl-dev \
     make \
+    pipx \
     python3 \
     python3-dev \
     python3-git \

--- a/cmake_templates/zkg-config.in
+++ b/cmake_templates/zkg-config.in
@@ -1,9 +1,0 @@
-# Zeek-generated zkg config file.
-[sources]
-zeek = https://github.com/zeek/packages
-
-[paths]
-state_dir = @ZEEK_ZKG_STATE_DIR@
-script_dir = @ZEEK_SCRIPT_INSTALL_PATH@/site
-plugin_dir = @ZEEK_PLUGIN_DIR@
-bin_dir = @CMAKE_INSTALL_PREFIX@/bin

--- a/configure
+++ b/configure
@@ -86,7 +86,6 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --disable-spicy        don't include Spicy
     --disable-zeek-client  don't install Zeek cluster management client
     --disable-zeekctl      don't install ZeekControl
-    --disable-zkg          don't install zkg
 
   Required Packages in Non-Standard Locations:
     --with-bison=PATH      path to bison executable
@@ -351,9 +350,6 @@ while [ $# -ne 0 ]; do
             ;;
         --disable-zeekctl)
             append_cache_entry INSTALL_ZEEKCTL BOOL false
-            ;;
-        --disable-zkg)
-            append_cache_entry INSTALL_ZKG BOOL false
             ;;
         --with-bind=*)
             append_cache_entry BIND_ROOT_DIR PATH $optarg


### PR DESCRIPTION
Shipping `zkg` with Zeek was always slightly unusual, and e.g., required installing dependencies out of band. Including it in Zeek on Zeek's release schedule on the other hand made it much harder to e.g., make fixes available quickly.

Since `zkg` is a proper Python project which can be installed from PyPi or source just fine with e.g., `pipx`, and there is nothing in Zeek truely requiring it, drop it from the distribution.