### PR TITLE
base: protocols: make DHCPv6 analyzer cluster-aware and add logging

### DIFF
--- a/scripts/base/protocols/dhcpv6/__load__.zeek
+++ b/scripts/base/protocols/dhcpv6/__load__.zeek
@@ -1,0 +1,1 @@
+@load ./main

--- a/scripts/base/protocols/dhcpv6/main.zeek
+++ b/scripts/base/protocols/dhcpv6/main.zeek
@@ -1,0 +1,66 @@
+@load base/frameworks/cluster
+@load base/frameworks/logging 
+
+module DHCPv6;
+
+export {
+	redef enum Log::ID += { LOG };
+
+	type Info: record {
+		ts:             time      &log;
+		uid:            string    &log;
+		id:             conn_id   &log;
+		transaction_id: count     &log;
+		msg_type_req:   count     &log &optional;
+		msg_type_rep:   count     &log &optional;
+	};
+
+	global relay_dhcpv6_event: event(msg_type: count, transaction_id: count, is_orig: bool, uid: string, id: conn_id, ts: time);
+	global tx_table: table[count] of Info &create_expire=1 mins;
+}
+
+event zeek_init()
+	{
+	Analyzer::register_for_port(Analyzer::ANALYZER_DHCPV6, 546/udp);
+	Analyzer::register_for_port(Analyzer::ANALYZER_DHCPV6, 547/udp);
+
+	Log::create_stream(DHCPv6::LOG, [$columns=Info, $path="dhcpv6"]);
+	}
+
+event dhcpv6_message(c: connection, is_orig: bool, msg_type: count, transaction_id: count)
+	{
+	if ( ! Cluster::is_enabled() )
+		{
+		event DHCPv6::relay_dhcpv6_event(msg_type, transaction_id, is_orig, c$uid, c$id, network_time());
+		return;
+		}
+	Cluster::publish_hrw(Cluster::WORKER, transaction_id, relay_dhcpv6_event, msg_type, transaction_id, is_orig, c$uid, c$id, network_time());
+	}
+
+event relay_dhcpv6_event(msg_type: count, transaction_id: count, is_orig: bool, uid: string, id: conn_id, ts: time)
+	{
+	if ( transaction_id !in tx_table )
+		{
+		local info: Info = [$ts=ts, $uid=uid, $id=id, $transaction_id=transaction_id];
+		
+		if ( id$orig_p == 546/udp )
+			info$msg_type_req = msg_type;
+		else
+			info$msg_type_rep = msg_type;
+
+		tx_table[transaction_id] = info;
+		}
+	else
+		{
+		local current_info = tx_table[transaction_id];
+		
+		if ( id$orig_p == 546/udp )
+			current_info$msg_type_req = msg_type;
+		else
+			current_info$msg_type_rep = msg_type;
+
+		Log::write(DHCPv6::LOG, current_info);
+		
+		delete tx_table[transaction_id];
+		}
+	}


### PR DESCRIPTION
## Description

This PR addresses the missing cluster-aware log implementation for the DHCPv6 analyzer. Previously, DHCPv6 events were parsed but lacked an integrated logging infrastructure capable of correctly merging distributed network state across multi-worker environments. 

### Key Changes:
* **Cluster Support (HRW Hashing):** Integrated the `Cluster` framework using `Cluster::publish_hrw` to shard and route events uniformly across Zeek workers using the DHCPv6 `transaction_id` as the hashing key. This prevents state fragmentation caused by asymmetric routing.
* **Transaction Tracking & State Merging:** Implemented a standardized internal state table (`tx_table`) that stores incomplete DHCPv6 transaction blocks (`Info` records) with a strict 1-minute expiration timer to guard against memory exhaustion.
* **Accurate Message Categorization:** Refactored the logging event logic to analyze the originating ports (`id$orig_p == 546/udp`). This accurately maps client requests (`Solicit`, `Request`, `Release`) and server replies (`Advertise`, `Reply`) into unified, single-row log entries instead of isolated, fragmented columns.
* **Standard-Compliant Stream Registration:** Added standard initialization via `Log::create_stream` to output full connection details (`ts`, `uid`, `id`, `transaction_id`) along with correlated request/reply message types to `dhcpv6.log`.

## Related Issues

Closes #5606