### PR TITLE
Disable cluster.zeromq.overload-drop btest on CI under asan and ubsan

### DIFF
--- a/testing/btest/cluster/zeromq/overload-drop.zeek
+++ b/testing/btest/cluster/zeromq/overload-drop.zeek
@@ -2,6 +2,8 @@
 #
 # @TEST-REQUIRES: have-zeromq
 # @TEST-REQUIRES: ! is-windows-ci
+# @TEST-REQUIRES: ! ( have-asan && test -n "${CI}" )
+# @TEST-REQUIRES: ! ( have-ubsan && test -n "${CI}" )
 #
 # @TEST-GROUP: cluster-zeromq
 #

--- a/testing/scripts/have-ubsan
+++ b/testing/scripts/have-ubsan
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if grep -q "ZEEK_SANITIZERS:STRING=.*undefined.*" "${BUILD}"/CMakeCache.txt; then
+    exit 0
+fi
+
+exit 1


### PR DESCRIPTION
This test fails fairly consistently on CI when running under asan and ubsan. It passes for all of the other builds and consistently works running locally under those sanitizers. Extending the timeout wouldn't do anything like for other cluster tests, since it's already dropping messages (recorded via telemetry). Waiting longer for the processes to exit won't change the drops having already happened.