### PR TITLE
CI: Reset auxil/spicy to origin/main in -spicy-head tasks, not -spicy tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1148,8 +1148,6 @@ workflows:
           docker_image: zeek/zeek-ci:ubuntu-24.04
           << : *CONFIGURE_SPICY_SSL
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
-          extra_env: |
-            ZEEK_CI_PREBUILD_COMMAND="cd auxil/spicy && git fetch && git reset --hard origin/main && git submodule update --init --recursive"
           store_install_tarball: true
           install_spicy_analyzers: true
           context:
@@ -1159,6 +1157,8 @@ workflows:
           name: ubuntu-24.04-spicy-head
           docker_image: zeek/zeek-ci:ubuntu-24.04
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
+          extra_env: |
+            ZEEK_CI_PREBUILD_COMMAND="cd auxil/spicy && git fetch && git reset --hard origin/main && git submodule update --init --recursive"
           store_install_tarball: true
           install_spicy_analyzers: true
           context:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -226,13 +226,6 @@ jobs:
             ZEEK_CI_CREATE_INSTALL_TARBALL: 1
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=release --disable-broker-tests --enable-spicy-ssl --prefix=$ZEEK_CI_WORKING_DIR/install --ccache --enable-werror'
           run: |
-            (
-            cd auxil/spicy;
-            git fetch;
-            git reset --hard origin/main;
-            git submodule update --init --recursive;
-            )
-
             ./ci/pre-build.sh
             ./ci/build.sh
             ./ci/test.sh
@@ -243,6 +236,7 @@ jobs:
           env:
             ZEEK_CI_CREATE_INSTALL_TARBALL: 1
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=release --disable-broker-tests --enable-spicy-ssl --prefix=$ZEEK_CI_WORKING_DIR/install --ccache --enable-werror'
+            ZEEK_CI_PREBUILD_COMMAND: 'cd auxil/spicy && git fetch && git reset --hard origin/main && git submodule update --init --recursive'
           run: |
             ./ci/pre-build.sh
             ./ci/build.sh


### PR DESCRIPTION
Not sure if this was an oversight or whether the "head" terminology is confusing. Previously, "head" described using the latest commit of origin/main, but this changed with the new CI systems.

Currently, the build is failing when using latest main from zeek/spicy and in CI that resulted in the ubuntu-24.04-spicy task to fail, not the ubuntu-24.04-spicy-head. This had me confused. Flip these for GitHub and CircleCI.