### PR TITLE
Enable benchmarks on CircleCI

### DIFF
--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -1125,6 +1125,7 @@ workflows:
           ci_image_date: "20260702"
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           store_install_tarball: true
+          enable_benchmarks: true
           context:
             - zeek
           << : *FILTER_IF_SKIP_ALL
@@ -1158,6 +1159,7 @@ workflows:
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           store_install_tarball: true
           install_spicy_analyzers: true
+          enable_benchmarks: true
           context:
             - zeek
           << : *FILTER_IF_PR_NOT_FULL_OR_BENCHMARK
@@ -1170,6 +1172,7 @@ workflows:
             ZEEK_CI_PREBUILD_COMMAND="cd auxil/spicy && git fetch && git reset --hard origin/main && git submodule update --init --recursive"
           store_install_tarball: true
           install_spicy_analyzers: true
+          enable_benchmarks: true
           context:
             - zeek
           << : *FILTER_IF_PR_NOT_FULL_OR_BENCHMARK

--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -1124,6 +1124,7 @@ workflows:
           docker_image: zeek/zeek-ci:ubuntu-24.04
           ci_image_date: "20260702"
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
+          store_install_tarball: true
           context:
             - zeek
           << : *FILTER_IF_SKIP_ALL

--- a/ci/benchmark.sh
+++ b/ci/benchmark.sh
@@ -5,17 +5,18 @@ ZEEK_BENCHMARK_ENDPOINT="/zeek"
 # Setting this causes any command failures to immediately cause the script to fail.
 set -e
 
-# Skip running benchmarks for jobs from forks.
-if [ ${ZEEK_IS_INTERNAL_JOB:-0} -ne 1 ]; then
-    echo "Coverage upload skipped for jobs from forks"
+# Skip running benchmarks for jobs from forks, third-parties, or non-Circle builds.
+if [ ${ZEEK_IS_INTERNAL_JOB:-0} -ne 1 -o "${CIRCLE_PROJECT_REPONAME}" != "zeek" ]; then
+    echo "Benchmarking skipped for jobs from forks"
     exit 0
 fi
 
-BUILD_URL="https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}/${CIRRUS_TASK_NAME}/upload_binary/build.tgz"
+# Something like https://output.circle-artifacts.com/output/job/597ae3bd-be02-4fe2-8e83-0c0ea5aeaa17/artifacts/0/install.tgz. This will return a 302. The requestor needs to follow the redirect.
+BUILD_URL="https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/install.tgz"
 
 # Generate an md5 hash of the build file. We can do this here because the path to the
 # file still exists from the prior scripts.
-BUILD_HASH=$(sha256sum build.tgz | awk '{print $1}')
+BUILD_HASH=$(sha256sum ${ZEEK_CI_WORKING_DIR}/install.tgz | awk '{print $1}')
 
 # Generate an HMAC digest for the path plus a timestamp to send as an authentication
 # header. Openssl outputs a hex string here so there's no need to base64 encode it.
@@ -28,23 +29,26 @@ TARGET="https://${ZEEK_BENCHMARK_HOST}:${ZEEK_BENCHMARK_PORT}${ZEEK_BENCHMARK_EN
 # it fails.
 set +e
 
-# Make a request to the benchmark host.
+# Make a request to the benchmark host. A couple of notes:
+# 1. cirrus_task_name maps the CircleCI task names into the format we used on Cirrus
+#    just to keep them consistent with existing data.
+# 2. cirrus_pr reduces just to the PR number from the URL in $CIRCLE_PULL_REQUEST.
+#    Circle has $CIRCLE_PR_NUMBER also, but it's only filled in for PRs from forks
+#    and not for PRs from the main repo.
 curl -sS -G --stderr - --fail --insecure -X POST \
-    -o "/zeek/benchmark-${TIMESTAMP}.log" \
+    -o "${ZEEK_CI_WORKING_DIR}/benchmark-${TIMESTAMP}.log" \
     -H "Zeek-HMAC: ${HMAC_DIGEST}" \
     -H "Zeek-HMAC-Timestamp: ${TIMESTAMP}" \
-    --data-urlencode "branch=${CIRRUS_BRANCH}" \
+    --data-urlencode "branch=${CIRCLE_BRANCH}" \
     --data-urlencode "build=${BUILD_URL}" \
     --data-urlencode "build_hash=${BUILD_HASH}" \
-    --data-urlencode "commit=${CIRRUS_CHANGE_IN_REPO}" \
-    --data-urlencode "cirrus_repo_owner=${CIRRUS_REPO_OWNER}" \
-    --data-urlencode "cirrus_repo_name=${CIRRUS_REPO_NAME}" \
-    --data-urlencode "cirrus_task_id=${CIRRUS_TASK_ID}" \
-    --data-urlencode "cirrus_task_name=${CIRRUS_TASK_NAME}" \
-    --data-urlencode "cirrus_build_id=${CIRRUS_BUILD_ID}" \
-    --data-urlencode "cirrus_pr=${CIRRUS_PR}" \
-    --data-urlencode "cirrus_pr_labels=${CIRRUS_PR_LABELS}" \
-    --data-urlencode "github_check_suite_id=${GITHUB_CHECK_SUITE_ID}" \
+    --data-urlencode "commit=${CIRCLE_SHA1}" \
+    --data-urlencode "cirrus_repo_owner=${CIRCLE_PROJECT_USERNAME}" \
+    --data-urlencode "cirrus_repo_name=${CIRCLE_PROJECT_REPONAME}" \
+    --data-urlencode "cirrus_task_id=${CIRCLE_WORKFLOW_JOB_ID}" \
+    --data-urlencode "cirrus_task_name=$(echo ${CIRCLE_JOB} | sed 's/ubuntu-24\./ubuntu24_/' | tr '-' '_')" \
+    --data-urlencode "cirrus_build_id=${CIRCLE_BUILD_NUM}" \
+    --data-urlencode "cirrus_pr=$(echo ${CIRCLE_PULL_REQUEST} | awk -F/ '{print $NF}')" \
     --data-urlencode "repo_version=$(cat ./VERSION)" \
     "${TARGET}"
 
@@ -53,9 +57,9 @@ STATUS=$?
 # If we got a bad status back from the host, we want to make sure to mask the host
 # and port from the output.
 if [ $STATUS -ne 0 ]; then
-    cat /zeek/benchmark-${TIMESTAMP}.log | sed "s/${ZEEK_BENCHMARK_HOST}/<secret>/g" | sed "s/:${ZEEK_BENCHMARK_PORT}/:<secret>/g"
+    cat ${ZEEK_CI_WORKING_DIR}/benchmark-${TIMESTAMP}.log | sed "s/${ZEEK_BENCHMARK_HOST}/<secret>/g" | sed "s/:${ZEEK_BENCHMARK_PORT}/:<secret>/g"
 else
-    cat /zeek/benchmark-${TIMESTAMP}.log
+    cat ${ZEEK_CI_WORKING_DIR}/benchmark-${TIMESTAMP}.log
 fi
 
 exit $STATUS


### PR DESCRIPTION
This fixes the benchmarking setup in the CircleCI config to properly use our benchmarking service on os-perf-1. See also https://github.com/zeek/zeek-benchmarker/pull/36, which covers some minor changes needed on the service itself.