### PR TITLE
Fix CI tsan and libcpp builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1119,6 +1119,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           context:
             - zeek
@@ -1126,26 +1127,29 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-clang-libcpp
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
-            CC="clang-19"
-            CXX="clang++-19"
+            CC="clang-22"
+            CXX="clang++-22"
             CXXFLAGS="-stdlib=libc++"
             ZEEK_CI_CONFIGURE_FLAGS_EXTRA="--disable-javascript"
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: ubuntu-24.04-clang-tidy
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           << : *CONFIGURE_CLANG_TIDY
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
-            CC="clang-19"
-            CXX="clang++-19"
+            CC="clang-22"
+            CXX="clang++-22"
           enable_tests: false
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: ubuntu-24.04-spicy
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           << : *CONFIGURE_SPICY_SSL
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           store_install_tarball: true
@@ -1156,6 +1160,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-spicy-head
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
             ZEEK_CI_PREBUILD_COMMAND="cd auxil/spicy && git fetch && git reset --hard origin/main && git submodule update --init --recursive"
@@ -1167,6 +1172,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-zam
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
             ZEEK_CI_SKIP_UNIT_TESTS=1
@@ -1182,6 +1188,7 @@ workflows:
       - linux-build:
           name: asan-sanitizer
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           << : *CONFIGURE_ASAN
           # https://circleci.com/changelog/introducing-gen2-docker-x86-resource-classes/
           resource_class: xlarge
@@ -1198,6 +1205,7 @@ workflows:
       - linux-build:
           name: asan-sanitizer-zam
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           << : *CONFIGURE_ASAN
           # https://circleci.com/changelog/introducing-gen2-docker-x86-resource-classes/
           resource_class: xlarge
@@ -1213,11 +1221,12 @@ workflows:
       - linux-build:
           name: ubsan-sanitizer
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           << : *CONFIGURE_UBSAN
           extra_env: |
-            CC=clang-19
-            CXX=clang++-19
+            CC=clang-22
+            CXX=clang++-22
             CXXFLAGS=-DZEEK_DICT_DEBUG
             ZEEK_TAILORED_UB_CHECKS=1
             UBSAN_OPTIONS=print_stacktrace=1
@@ -1225,11 +1234,12 @@ workflows:
       - linux-build:
           name: ubsan-sanitizer-zam
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           << : *CONFIGURE_UBSAN
           extra_env: |
-            CC=clang-19
-            CXX=clang++-19
+            CC=clang-22
+            CXX=clang++-22
             CXXFLAGS=-DZEEK_DICT_DEBUG
             ZEEK_TAILORED_UB_CHECKS=1
             UBSAN_OPTIONS=print_stacktrace=1
@@ -1241,11 +1251,12 @@ workflows:
       - linux-build:
           name: tsan-sanitizer
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: 20260702
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           << : *CONFIGURE_TSAN
           extra_env: |
-            CC=clang-19
-            CXX=clang++-19
+            CC=clang-22
+            CXX=clang++-22
             ZEEK_CI_DISABLE_SCRIPT_PROFILING=1
             ZEEK_TSAN_OPTIONS=suppressions=${ZEEK_CI_WORKING_DIR}/ci/tsan_suppressions.txt
           << : *FILTER_IF_PR_NOT_FULL_CI

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -198,8 +198,8 @@ jobs:
         - id: ubuntu-24.04-clang-libcpp
           file: ci/ubuntu-24.04/Dockerfile
           env:
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang-22
+            CXX: clang++-22
             CXXFLAGS: -stdlib=libc++
             # The libnode package is linked with the system's libstdc++, making
             # it incompatible with Zeek compiled using libc++.
@@ -212,8 +212,8 @@ jobs:
         - id: ubuntu-24.04-clang-tidy
           file: ci/ubuntu-24.04/Dockerfile
           env:
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang-22
+            CXX: clang++-22
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --prefix=$ZEEK_CI_WORKING_DIR/install --ccache --enable-werror --enable-clang-tidy'
           run: |
             ./ci/pre-build.sh
@@ -294,8 +294,8 @@ jobs:
         - id: ubsan-sanitizer
           file: ci/ubuntu-24.04/Dockerfile
           env:
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang-22
+            CXX: clang++-22
             CXXFLAGS: -DZEEK_DICT_DEBUG
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --sanitizers=undefined --enable-fuzzers --ccache --enable-werror'
             ZEEK_CI_CONFIGURE_FLAGS_EXTRA: --disable-javascript
@@ -310,8 +310,8 @@ jobs:
         - id: ubsan-sanitizer-zam
           file: ci/ubuntu-24.04/Dockerfile
           env:
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang-22
+            CXX: clang++-22
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --sanitizers=undefined --enable-fuzzers --ccache --enable-werror'
             ZEEK_CI_CONFIGURE_FLAGS_EXTRA: --disable-javascript
             ZEEK_TAILORED_UB_CHECKS: 1
@@ -329,8 +329,8 @@ jobs:
         - id: tsan-sanitizer
           file: ci/ubuntu-24.04/Dockerfile
           env:
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang-22
+            CXX: clang++-22
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --sanitizers=thread --enable-fuzzers --ccache --enable-werror'
             ZEEK_CI_CONFIGURE_FLAGS_EXTRA: --disable-javascript
             ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -4,16 +4,19 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field used by Circle to create new versions on DockerHub
 # during rebuilds.
-ENV DOCKERFILE_VERSION=20260515
+ENV DOCKERFILE_VERSION=20260702
+
+RUN deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main >> /etc/apt/sources.list.d/llvm.list
+RUN deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main >> /etc/apt/sources.list.d/llvm.list
 
 RUN apt-get update && apt-get -y install \
     bc \
     bison \
     bsdmainutils \
     ccache \
-    clang-19 \
-    clang++-19 \
-    clang-tidy-19 \
+    clang-22 \
+    clang++-22 \
+    clang-tidy-22 \
     cmake \
     cppzmq-dev \
     curl \
@@ -53,7 +56,7 @@ RUN gem install coveralls-lcov
 
 # Ubuntu installs clang versions with the binaries having the version number
 # appended. Create a symlink for clang-tidy so cmake finds it correctly.
-RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-19 1000
+RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-22 1000
 
 # Download a newer pre-built ccache version that recognizes -fprofile-update=atomic
 # which is used when building with --coverage.


### PR DESCRIPTION
This PR contains fixes for the ThreadSanitizer and libcpp builds on CI. It contains two changes:

- Upgrade clang on the ubuntu-24.04 CI image to clang-22, using the LLVM apt repo instead of the version that comes with ubuntu 24.04. This should resolve the configure failure, where OpenSSL fails to check the version number correctly. Underneath, this is because ThreadSanitizer reports a `unexpected memory mapping` warning in the binary used to check the version. Upgrading to clang-22 should resolve that error (it does locally for me).
- Upgrade libkqueue to a version that fixes https://github.com/mheily/libkqueue/issues/174. If the build on our CI passes, I'll open a PR to merge that upstream.