### PR TITLE
CCI: Fix check for pushes to master to avoid double-builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,13 +25,12 @@ workflows:
       or:
         - equal: [ "pull_request", << pipeline.event.name >> ]
         - and:
-          # The check for the trigger here prevents us from doing double builds on pushes
-          # to master. If the all-pushes trigger is deleted or recreated from the project
-          # this needs to be fixed. See below for more docs on how to get this ID.
+          # The check for the trigger type here prevents us from doing double builds on
+          # pushes to master. We only want to do them from the oauth trigger, which
+          # covers pushes to the default branch. The "All pushes" trigger in the second
+          # pipeline should ignore pushes to master.
           - equal: [ master, << pipeline.git.branch >> ]
-          - or:
-            - equal: [ 593abe2f-5739-4f75-99de-b3afb2ee099d, << pipeline.trigger.id >> ] # zeek
-            - equal: [ 338ccf41-69c6-4c4f-a0cf-7be8fdd74bd3, << pipeline.trigger.id >> ] # zeek-security
+          - equal: [ github_oauth, << pipeline.trigger.type>> ]
         - matches:
             pattern: "^release/.*"
             value: << pipeline.git.branch >>


### PR DESCRIPTION
This is a follow-up to #5634, and contains a fix for a warning about `pipeline.trigger.id`. That variable doesn't exist for OAuth triggers, and anyways there's a better way to handle it now that we have to have both pipelines.