### PR TITLE
util/fmt: Make the vfmt() format buffer thread-local

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -2875,7 +2875,7 @@ TEST_SUITE("util") {
 
         std::mutex m;
         std::condition_variable cv;
-        bool captured = false; // main thread has captured its fmt() pointer
+        bool captured = false;  // main thread has captured its fmt() pointer
         bool clobbered = false; // helper thread has completed its fmt() call
 
         const char* p = fmt("%s", a.c_str());

--- a/src/util.cc
+++ b/src/util.cc
@@ -2855,55 +2855,22 @@ TEST_SUITE("util") {
         CHECK_FALSE(approx_equal(qnan, -qnan));
     }
 
-    // Regression test for the copy_string() buffer-overflow crash. util::fmt()
-    // returns a pointer into a reused buffer; that buffer must be per-thread.
-    // The main thread captures fmt()'s result and, while still holding it, a
-    // second thread calls fmt() with different content. With a process-global
-    // static buffer the second call clobbers the first thread's string in
-    // place -- the root cause of the crash when the main thread holds a fmt()
-    // pointer across a scheduling point (e.g. a log writer backend starting).
-    // With a per-thread buffer the captured pointer is unaffected.
-    //
-    // The handshake makes the interleaving deterministic: the helper's fmt()
-    // always runs after the main thread has captured its pointer and before
-    // the main thread reads it. Both strings have the same length so the
-    // static buffer is overwritten in place (never reallocated), keeping the
-    // failure a clean assertion rather than a dangling-pointer crash.
-    TEST_CASE("vfmt_thread_safety") {
-        const std::string a(512, 'A');
-        const std::string b(512, 'B');
+    TEST_CASE("fmt_thread_safety") {
+        const auto* a = "AAAAA";
 
-        std::mutex m;
-        std::condition_variable cv;
-        bool captured = false;  // main thread has captured its fmt() pointer
-        bool clobbered = false; // helper thread has completed its fmt() call
+        // Capture a view into the buffer in `fmt`.
+        std::string_view p = fmt("%s", a);
+        REQUIRE_EQ(p, std::string_view(a));
 
-        const char* p = fmt("%s", a.c_str());
+        // Another thread uses `fmt` which updates its internal buffer.
         {
-            std::lock_guard<std::mutex> lk(m);
-            captured = true;
-        }
-        cv.notify_all();
-
-        std::thread helper([&] {
-            std::unique_lock<std::mutex> lk(m);
-            cv.wait(lk, [&] { return captured; });
-            fmt("%s", b.c_str());
-            clobbered = true;
-            lk.unlock();
-            cv.notify_all();
-        });
-
-        {
-            std::unique_lock<std::mutex> lk(m);
-            cv.wait(lk, [&] { return clobbered; });
+            std::jthread([=] { REQUIRE_NE(fmt("%s", "BBBBB"), std::string_view(a)); });
         }
 
-        CHECK(std::string(p) == a);
+        // Uses of `fmt` from different threads don't clobber each others internal buffers.
+        CHECK_EQ(p, std::string_view(a));
 
-        helper.join();
     }
-}
 
 } // namespace zeek::util
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -41,11 +41,14 @@
 #include <algorithm>
 #include <array>
 #include <charconv>
+#include <condition_variable>
 #include <filesystem>
 #include <iostream>
+#include <mutex>
 #include <ranges>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "zeek/3rdparty/ConvertUTF.h"
@@ -1255,27 +1258,27 @@ const char* fmt_bytes(const char* data, int len) {
 }
 
 const char* vfmt(const char* format, va_list al) {
-    static char* buf = nullptr;
-    static int buf_len = 1024;
-
-    if ( ! buf )
-        buf = reinterpret_cast<char*>(safe_malloc(buf_len));
+    // Per-thread rather than a single process-global buffer: child threads
+    // (e.g. log writer/input reader backends) format concurrently with the
+    // main thread, which holds the returned pointer across a copy_string().
+    // A shared buffer would let one thread overwrite or reallocate it mid-copy.
+    // The std::vector frees itself at thread exit, so this leaks nothing.
+    thread_local std::vector<char> buf(1024);
 
     va_list alc;
     va_copy(alc, al);
-    int n = vsnprintf(buf, buf_len, format, al);
+    int n = vsnprintf(buf.data(), buf.size(), format, al);
 
-    if ( n > 0 && buf_len <= n ) { // Not enough room, grow the buffer.
-        buf_len = n + 32;
-        buf = reinterpret_cast<char*>(safe_realloc(buf, buf_len));
-        n = vsnprintf(buf, buf_len, format, alc);
+    if ( n > 0 && static_cast<size_t>(n) >= buf.size() ) { // Not enough room, grow the buffer.
+        buf.resize(n + 32);
+        n = vsnprintf(buf.data(), buf.size(), format, alc);
     }
 
     if ( n < 0 )
         reporter->InternalError("confusion reformatting in fmt()");
 
     va_end(alc);
-    return buf;
+    return buf.data();
 }
 
 const char* fmt(const char* format, ...) {
@@ -2850,6 +2853,55 @@ TEST_SUITE("util") {
         CHECK_FALSE(approx_equal(qnan, qnan));
         CHECK_FALSE(approx_equal(-qnan, qnan));
         CHECK_FALSE(approx_equal(qnan, -qnan));
+    }
+
+    // Regression test for the copy_string() buffer-overflow crash. util::fmt()
+    // returns a pointer into a reused buffer; that buffer must be per-thread.
+    // The main thread captures fmt()'s result and, while still holding it, a
+    // second thread calls fmt() with different content. With a process-global
+    // static buffer the second call clobbers the first thread's string in
+    // place -- the root cause of the crash when the main thread holds a fmt()
+    // pointer across a scheduling point (e.g. a log writer backend starting).
+    // With a per-thread buffer the captured pointer is unaffected.
+    //
+    // The handshake makes the interleaving deterministic: the helper's fmt()
+    // always runs after the main thread has captured its pointer and before
+    // the main thread reads it. Both strings have the same length so the
+    // static buffer is overwritten in place (never reallocated), keeping the
+    // failure a clean assertion rather than a dangling-pointer crash.
+    TEST_CASE("vfmt_thread_safety") {
+        const std::string a(512, 'A');
+        const std::string b(512, 'B');
+
+        std::mutex m;
+        std::condition_variable cv;
+        bool captured = false; // main thread has captured its fmt() pointer
+        bool clobbered = false; // helper thread has completed its fmt() call
+
+        const char* p = fmt("%s", a.c_str());
+        {
+            std::lock_guard<std::mutex> lk(m);
+            captured = true;
+        }
+        cv.notify_all();
+
+        std::thread helper([&] {
+            std::unique_lock<std::mutex> lk(m);
+            cv.wait(lk, [&] { return captured; });
+            fmt("%s", b.c_str());
+            clobbered = true;
+            lk.unlock();
+            cv.notify_all();
+        });
+
+        {
+            std::unique_lock<std::mutex> lk(m);
+            cv.wait(lk, [&] { return clobbered; });
+        }
+
+        CHECK(std::string(p) == a);
+
+        helper.join();
     }
 }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -1258,11 +1258,9 @@ const char* fmt_bytes(const char* data, int len) {
 }
 
 const char* vfmt(const char* format, va_list al) {
-    // Per-thread rather than a single process-global buffer: child threads
-    // (e.g. log writer/input reader backends) format concurrently with the
-    // main thread, which holds the returned pointer across a copy_string().
-    // A shared buffer would let one thread overwrite or reallocate it mid-copy.
-    // The std::vector frees itself at thread exit, so this leaks nothing.
+    // This function returns a pointer to an internal buffer. Use thread-local
+    // storage for the underlying value so invocations from different threads
+    // get a stable value.
     thread_local std::vector<char> buf(1024);
 
     va_list alc;


### PR DESCRIPTION
`util::vfmt()` (behind `util::fmt()`) formats into a single process-global
`static` buffer and returns a pointer into it, valid only until the next
`fmt()` call on any thread. This is a long-known thread-safety hazard: when the
main thread holds a `fmt()` result across a scheduling point and another thread
formats concurrently, the shared buffer can be overwritten or reallocated out
from under the first caller.

A concrete path: `WriterFrontend` passes `util::fmt("%s/%s", path, name)`
straight into `util::copy_string()`, which does `strlen()` -> `new[]` ->
`strcpy()`. If a log-writer or input-reader backend thread calls `util::fmt()`
in between, a longer result makes `strcpy()` run past the measured length and
`__strcpy_chk` aborts the process; a `safe_realloc()` growth turns the held
pointer into a dangling read. This shows up in the field as a worker crash
during log-writer initialization.

## Approach

Over time this has been worked around at individual call sites, notably via the
per-thread `BasicThread::Fmt()`, but `util::fmt()` itself stayed shared, so new
or overlooked call sites keep reintroducing the race. Rather than patch another
call site, this fixes it at the root: the buffer becomes `thread_local`, so each
thread formats into its own storage. `fmt()` stays lock-free and writer/reader
concurrency is preserved. Using `std::vector<char>` (rather than a raw
`thread_local` pointer) frees the per-thread buffer at thread exit, so nothing
leaks.

## Testing

Adds a deterministic doctest (`vfmt_thread_safety`): the main thread captures a
`fmt()` pointer, a condition-variable handshake forces a second thread to
`fmt()` a different equal-length string before the main thread reads its pointer
back, and the captured contents are asserted intact. It fails reliably against
the old shared buffer and passes with the thread-local one. Verified against a
local `zeek --test` build; the full `util` suite is unaffected.

## AI disclosure

The fix, regression test, and root-cause analysis were drafted with Claude Code
(Opus 4.8). I reviewed the change, built Zeek locally, and verified the
regression test fails without the fix and passes with it before submitting.