### PR TITLE
Speed up WebSocketShim unit tests

### DIFF
--- a/src/broker/WebSocketShim.cc
+++ b/src/broker/WebSocketShim.cc
@@ -221,8 +221,8 @@ TEST_CASE("tests") {
         return broker::make_data_message(broker::topic{topic}, msg);
     };
 
-    auto expect_msg_timeout = 1000ms;
-    auto expect_no_msg_timeout = 150ms;
+    constexpr auto expect_msg_timeout = 2ms;
+    constexpr auto expect_no_msg_timeout = 5ms;
 
     SUBCASE("endpoint-publish") {
         // Publishing through the endpoint is visible to hubs, but not subscribers.


### PR DESCRIPTION
These tests were using pretty large timeout values which made them the main contributors to the unit test suite's runtime. There is no reason for them to be so large, so we can decrease them substantially to speed up the test suite (on my machine before: 2.2s, after: 0.8s). With that change the runtime of the unit test suite is limited by how fast Zeek can set itself up (parse scripts, set up globals, ...).