### PR TITLE
util/fmt: Use thread-safe Fmt() in backend threads; assert main-thread-only contract

### DIFF
--- a/src/input/readers/ascii/Ascii.cc
+++ b/src/input/readers/ascii/Ascii.cc
@@ -131,7 +131,7 @@ bool Ascii::OpenFile() {
         else
             path = path_prefix.substr(0, last + 1);
 
-        fname = util::fmt("%s/%s", path.c_str(), fname.c_str());
+        fname = Fmt("%s/%s", path.c_str(), fname.c_str());
     }
 
     file.open(fname);

--- a/src/input/readers/binary/Binary.cc
+++ b/src/input/readers/binary/Binary.cc
@@ -103,7 +103,7 @@ bool Binary::DoInit(const ReaderInfo& info, int num_fields, const Field* const* 
         else
             path = path_prefix.substr(0, last + 1);
 
-        fname = util::fmt("%s/%s", path.c_str(), fname.c_str());
+        fname = Fmt("%s/%s", path.c_str(), fname.c_str());
     }
 
     if ( ! OpenInput() )

--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -826,7 +826,7 @@ string Ascii::Timestamp(double t) {
     struct tm tmbuf;
     struct tm* tm = localtime_r(&teatime, &tmbuf);
     if ( tm == nullptr )
-        Error(util::fmt("localtime_r failed: %s", strerror(errno)));
+        Error(Fmt("localtime_r failed: %s", Strerror(errno)));
 
     char tmp[128];
     const char* const date_fmt = "%Y-%m-%d-%H-%M-%S";

--- a/src/util.cc
+++ b/src/util.cc
@@ -46,6 +46,7 @@
 #include <ranges>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "zeek/3rdparty/ConvertUTF.h"
@@ -1255,6 +1256,18 @@ const char* fmt_bytes(const char* data, int len) {
 }
 
 const char* vfmt(const char* format, va_list al) {
+#ifdef DEBUG
+    // buf is process-global, so vfmt() is not thread safe.
+    // By convention, it must be called only from the main thread.
+    // The first call is known to be performed by the main thread during single-threaded startup.
+    // Check subsequent calls against that baseline.
+    static const std::thread::id main_thread_id = std::this_thread::get_id();
+    if ( std::this_thread::get_id() != main_thread_id ) {
+        fprintf(stderr, "zeek::util::fmt() called off the main thread; use threading::BasicThread::Fmt() or std::format()\n");
+        abort();
+    }
+#endif
+
     static char* buf = nullptr;
     static int buf_len = 1024;
 

--- a/src/util.h
+++ b/src/util.h
@@ -356,9 +356,11 @@ extern bool is_printable(const char* s, int len);
 
 extern const char* fmt_bytes(const char* data, int len);
 
-// Note: returns a pointer into a shared buffer.
+// Note: vfmt and fmt share the same global buffer and return a pointer to it.
+// - not thread-safe; call only from main thread or use threading::BasicThread::Fmt()
+// - returned buffer and potentially pointer invalidated by next fmt()/vfmt() call;
+//   consume or copy before next call
 extern const char* vfmt(const char* format, va_list args);
-// Note: returns a pointer into a shared buffer.
 extern const char* fmt(const char* format, ...) __attribute__((format(printf, 1, 2)));
 
 // Returns true if path exists and is a directory.


### PR DESCRIPTION
`util::fmt()`/`vfmt()` format into a process-global buffer, so they are only safe on the main thread. A backend thread calling `fmt()` can clobber that buffer while the main thread still holds a returned pointer (e.g. across the `copy_string()` in `Writer`/`ReaderFrontend`), corrupting it.

- Switch the three in-tree callers running on `Reader`/`WriterBackend` (`MsgThread`) threads to the per-thread `BasicThread::Fmt()`
- Also switch a possibly concurrent call to the non-reentrant `strerror()` to the thread-safe `Strerror()`.
- Add a DEBUG-only assertion in `vfmt()` that aborts if called off the main thread.
- Document the thread-safety and pointer-lifetime contract in `util.h`.

Tested (Debug, Spicy on): `zeek --test -ts=util`, log writing + rotation, and ascii input with a path prefix.

*AI disclosure*

Changes and tests were initially implemented and executed by Claude Code (Opus 4.8). I have manually reviewed the changes and tests and rewritten the source code comments.