### PR TITLE
Fix stall with OpenSSL check on Mac with ASAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -904,6 +904,11 @@ find_package(FLEX REQUIRED)
 find_package(BISON 2.5 REQUIRED)
 find_package(PCAP REQUIRED)
 find_package(OpenSSL 3.0 REQUIRED)
+
+# Run OpenSSL check before sanitizer flags are set so macOS SIP does not cause
+# the test to stall.
+include(OpenSSLTests)
+
 find_package(ZLIB REQUIRED)
 
 if (NOT BINARY_PACKAGING_MODE)
@@ -1268,7 +1273,6 @@ include(CheckHeaders)
 include(CheckFunctions)
 include(MiscTests)
 include(PCAPTests)
-include(OpenSSLTests)
 include(CheckNameserCompat)
 include(GetArchitecture)
 


### PR DESCRIPTION
Before, the OpenSSL check was stalling if I used `--sanitizers=address`. This is due to MacOS SIP, which causes the ASAN binaries to not load correctly. Instead, simply move the check before the sanitizer flags are set. ~Then, explicitly include the necessary directories so that the header is findable at this earlier stage.~

Include directories need a change in cmake submodule so that it doesn't change the build globally.

I used Claude to pin this down.

Should be good now, sorry bout the mishaps. I didn't fix the `spicyz` issue, but this seems more far-reaching.