### PR TITLE
Cleanup/temporary disabling of zeek-testing-private on CI

### DIFF
--- a/ci/init-external-repos.sh
+++ b/ci/init-external-repos.sh
@@ -29,26 +29,12 @@ fi
 make update-traces
 cd ..
 
-# When running in Cirrus for the main repo, try to clone the private testsuite.
+# When running in CI for the main repo, try to clone the private testsuite.
 # Note that this script is also called when populating the public cache, so
-# the zeek-testing-private dir could have been created/populated already.
+# the zeek-testing-private dir could have been created/populated already. This
+# requires the host running the build to have access to an SSH key that grants
+# access to the repo, and it will fail otherwise.
 if [[ -n "${ZEEK_CI}" ]] && [[ ! -d zeek-testing-private ]]; then
-    # If we're running this on Cirrus, the SSH key won't be available to PRs,
-    # so don't make any of this fail the task in that case.  (But technically,
-    # the key is also available in PRs for people with write access to the
-    # repo, so we can still try for those cases).
-    if [[ -n "${CIRRUS_PR}" ]]; then
-        if [[ "${CIRRUS_USER_PERMISSION}" == "write" ]]; then
-            set -e
-        elif [[ "${CIRRUS_USER_PERMISSION}" == "admin" ]]; then
-            set -e
-        else
-            set +e
-        fi
-    else
-        set -e
-    fi
-
     banner "Trying to clone zeek-testing-private git repo"
     GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone git@github.com:zeek/zeek-testing-private
 fi

--- a/ci/init-external-repos.sh
+++ b/ci/init-external-repos.sh
@@ -34,10 +34,15 @@ cd ..
 # the zeek-testing-private dir could have been created/populated already. This
 # requires the host running the build to have access to an SSH key that grants
 # access to the repo, and it will fail otherwise.
-if [[ -n "${ZEEK_CI}" ]] && [[ ! -d zeek-testing-private ]]; then
-    banner "Trying to clone zeek-testing-private git repo"
-    GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone git@github.com:zeek/zeek-testing-private
-fi
+#
+# TODO: Uncomment this and delete the message once the CI issues are resolved.
+#
+# if [[ -n "${ZEEK_CI}" ]] && [[ ! -d zeek-testing-private ]]; then
+#     banner "Trying to clone zeek-testing-private git repo"
+#     GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone git@github.com:zeek/zeek-testing-private
+# fi
+
+echo "NOTE: zeek-testing-private currently disabled due to CI issues"
 
 set -e
 


### PR DESCRIPTION
CircleCI is having problems with the SSH keys related to cloning the zeek-testing-private repo, which is causing all builds to fail. Until that gets fixed, disable cloning the repo so that at least the rest of the build continues working. This also removes some Cirrus-isms from the script use to clone repos.