### PR TITLE
Upgrade Clang on CI to v22

### DIFF
--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -1119,6 +1119,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           context:
             - zeek
@@ -1126,26 +1127,29 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-clang-libcpp
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
-            CC="clang-19"
-            CXX="clang++-19"
+            CC="clang-22"
+            CXX="clang++-22"
             CXXFLAGS="-stdlib=libc++"
             ZEEK_CI_CONFIGURE_FLAGS_EXTRA="--disable-javascript"
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: ubuntu-24.04-clang-tidy
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           << : *CONFIGURE_CLANG_TIDY
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
-            CC="clang-19"
-            CXX="clang++-19"
+            CC="clang-22"
+            CXX="clang++-22"
           enable_tests: false
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: ubuntu-24.04-spicy
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           << : *CONFIGURE_SPICY_SSL
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           store_install_tarball: true
@@ -1156,6 +1160,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-spicy-head
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
             ZEEK_CI_PREBUILD_COMMAND="cd auxil/spicy && git fetch && git reset --hard origin/main && git submodule update --init --recursive"
@@ -1167,6 +1172,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-zam
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
             ZEEK_CI_SKIP_UNIT_TESTS=1
@@ -1182,6 +1188,7 @@ workflows:
       - linux-build:
           name: asan-sanitizer
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           << : *CONFIGURE_ASAN
           # https://circleci.com/changelog/introducing-gen2-docker-x86-resource-classes/
           resource_class: xlarge
@@ -1198,6 +1205,7 @@ workflows:
       - linux-build:
           name: asan-sanitizer-zam
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           << : *CONFIGURE_ASAN
           # https://circleci.com/changelog/introducing-gen2-docker-x86-resource-classes/
           resource_class: xlarge
@@ -1213,11 +1221,12 @@ workflows:
       - linux-build:
           name: ubsan-sanitizer
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           << : *CONFIGURE_UBSAN
           extra_env: |
-            CC=clang-19
-            CXX=clang++-19
+            CC=clang-22
+            CXX=clang++-22
             CXXFLAGS=-DZEEK_DICT_DEBUG
             ZEEK_TAILORED_UB_CHECKS=1
             UBSAN_OPTIONS=print_stacktrace=1
@@ -1225,11 +1234,12 @@ workflows:
       - linux-build:
           name: ubsan-sanitizer-zam
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           << : *CONFIGURE_UBSAN
           extra_env: |
-            CC=clang-19
-            CXX=clang++-19
+            CC=clang-22
+            CXX=clang++-22
             CXXFLAGS=-DZEEK_DICT_DEBUG
             ZEEK_TAILORED_UB_CHECKS=1
             UBSAN_OPTIONS=print_stacktrace=1
@@ -1241,11 +1251,12 @@ workflows:
       - linux-build:
           name: tsan-sanitizer
           docker_image: zeek/zeek-ci:ubuntu-24.04
+          ci_image_date: "20260702"
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           << : *CONFIGURE_TSAN
           extra_env: |
-            CC=clang-19
-            CXX=clang++-19
+            CC=clang-22
+            CXX=clang++-22
             ZEEK_CI_DISABLE_SCRIPT_PROFILING=1
             ZEEK_TSAN_OPTIONS=suppressions=${ZEEK_CI_WORKING_DIR}/ci/tsan_suppressions.txt
           << : *FILTER_IF_PR_NOT_FULL_CI

--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -1065,6 +1065,7 @@ workflows:
       - linux-build:
           name: debian-12
           docker_image: zeek/zeek-ci:debian-12
+          ci_image_date: "20260708"
           requires: [fetch-test-traces, build-image-debian-12]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
@@ -1289,6 +1290,7 @@ workflows:
 
       - zeekctl-testing:
           docker_image: zeek/zeek-ci:debian-12
+          ci_image_date: "20260708"
           requires: [build-image-debian-12]
           << : *FILTER_IF_PR_NOT_FULL_OR_ZEEKCTL
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -201,8 +201,8 @@ jobs:
         - id: ubuntu-24.04-clang-libcpp
           file: ci/ubuntu-24.04/Dockerfile
           env:
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang-22
+            CXX: clang++-22
             CXXFLAGS: -stdlib=libc++
             # The libnode package is linked with the system's libstdc++, making
             # it incompatible with Zeek compiled using libc++.
@@ -215,8 +215,8 @@ jobs:
         - id: ubuntu-24.04-clang-tidy
           file: ci/ubuntu-24.04/Dockerfile
           env:
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang-22
+            CXX: clang++-22
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --prefix=$ZEEK_CI_WORKING_DIR/install --ccache --enable-werror --enable-clang-tidy'
           run: |
             ./ci/pre-build.sh
@@ -297,8 +297,8 @@ jobs:
         - id: ubsan-sanitizer
           file: ci/ubuntu-24.04/Dockerfile
           env:
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang-22
+            CXX: clang++-22
             CXXFLAGS: -DZEEK_DICT_DEBUG
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --sanitizers=undefined --enable-fuzzers --ccache --enable-werror'
             ZEEK_CI_CONFIGURE_FLAGS_EXTRA: --disable-javascript
@@ -313,8 +313,8 @@ jobs:
         - id: ubsan-sanitizer-zam
           file: ci/ubuntu-24.04/Dockerfile
           env:
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang-22
+            CXX: clang++-22
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --sanitizers=undefined --enable-fuzzers --ccache --enable-werror'
             ZEEK_CI_CONFIGURE_FLAGS_EXTRA: --disable-javascript
             ZEEK_TAILORED_UB_CHECKS: 1
@@ -332,8 +332,8 @@ jobs:
         - id: tsan-sanitizer
           file: ci/ubuntu-24.04/Dockerfile
           env:
-            CC: clang-19
-            CXX: clang++-19
+            CC: clang-22
+            CXX: clang++-22
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --sanitizers=thread --enable-fuzzers --ccache --enable-werror'
             ZEEK_CI_CONFIGURE_FLAGS_EXTRA: --disable-javascript
             ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1

--- a/ci/debian-12/Dockerfile
+++ b/ci/debian-12/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field used by Circle to create new versions on DockerHub
 # during rebuilds.
-ENV DOCKERFILE_VERSION=20260515
+ENV DOCKERFILE_VERSION=20260708
 
 RUN apt-get update && apt-get -y install \
     bison \

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -4,16 +4,26 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
 
 # A version field used by Circle to create new versions on DockerHub
 # during rebuilds.
-ENV DOCKERFILE_VERSION=20260515
+ENV DOCKERFILE_VERSION=20260702
+
+# This is needed before the rest of the apt installations below so that
+# the certificate for llvm.org exists.
+RUN apt-get update && apt-get -y install ca-certificates wget
+RUN update-ca-certificates
+
+# Add the official repository for LLVM 22, plus the key for the repository
+RUN echo deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main >> /etc/apt/sources.list.d/llvm.list
+RUN echo deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main >> /etc/apt/sources.list.d/llvm.list
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 
 RUN apt-get update && apt-get -y install \
     bc \
     bison \
     bsdmainutils \
     ccache \
-    clang-19 \
-    clang++-19 \
-    clang-tidy-19 \
+    clang-22 \
+    clang++-22 \
+    clang-tidy-22 \
     cmake \
     cppzmq-dev \
     curl \
@@ -53,7 +63,7 @@ RUN gem install coveralls-lcov
 
 # Ubuntu installs clang versions with the binaries having the version number
 # appended. Create a symlink for clang-tidy so cmake finds it correctly.
-RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-19 1000
+RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-22 1000
 
 # Download a newer pre-built ccache version that recognizes -fprofile-update=atomic
 # which is used when building with --coverage.

--- a/src/threading/SerialTypes.cc
+++ b/src/threading/SerialTypes.cc
@@ -218,7 +218,7 @@ static std::optional<std::vector<Value*>> read_elements(detail::SerializationFor
     // Only reserve up to 1024 pointers and rely on dynamic
     // reallocation of std::vector past that many elements.
     std::vector<Value*> vec;
-    vec.reserve(static_cast<size_t>(std::min(size, zeek_int_t(1024))));
+    vec.reserve(std::min<size_t>(size, 1024));
 
     for ( zeek_int_t i = 0; i < size; ++i ) {
         vec.emplace_back(new Value);


### PR DESCRIPTION
This PR upgrades the version of Clang installed on the Ubuntu 24.04 CI image to Clang v22. This brings us up to close the latest version of Clang, as well as a much newer version of Clang-Tidy for that build.