### PR TITLE
Clarify SMTP documentation

### DIFF
--- a/doc/scripts/base/protocols/smtp/main.zeek.rst
+++ b/doc/scripts/base/protocols/smtp/main.zeek.rst
@@ -159,17 +159,17 @@ Types
 
    .. zeek:field:: helo :zeek:type:`string` :zeek:attr:`&log` :zeek:attr:`&optional`
 
-      Contents of the Helo header.
+      Contents of the HELO/EHLO SMTP command.
 
 
    .. zeek:field:: mailfrom :zeek:type:`string` :zeek:attr:`&log` :zeek:attr:`&optional`
 
-      Email addresses found in the From header.
+      Email address found in the MAIL FROM SMTP command.
 
 
    .. zeek:field:: rcptto :zeek:type:`set` [:zeek:type:`string`] :zeek:attr:`&log` :zeek:attr:`&optional`
 
-      Email addresses found in the Rcpt header.
+      Email addresses found in the RCPT TO SMTP commands.
 
 
    .. zeek:field:: date :zeek:type:`string` :zeek:attr:`&log` :zeek:attr:`&optional`
@@ -194,12 +194,12 @@ Types
 
    .. zeek:field:: reply_to :zeek:type:`string` :zeek:attr:`&log` :zeek:attr:`&optional`
 
-      Contents of the ReplyTo header.
+      Contents of the Reply-To header.
 
 
    .. zeek:field:: msg_id :zeek:type:`string` :zeek:attr:`&log` :zeek:attr:`&optional`
 
-      Contents of the MsgID header.
+      Contents of the Message-ID header.
 
 
    .. zeek:field:: in_reply_to :zeek:type:`string` :zeek:attr:`&log` :zeek:attr:`&optional`

--- a/scripts/base/protocols/smtp/main.zeek
+++ b/scripts/base/protocols/smtp/main.zeek
@@ -24,11 +24,11 @@ export {
 		## A count to represent the depth of this message transaction in
 		## a single connection where multiple messages were transferred.
 		trans_depth:       count           &log;
-		## Contents of the Helo header.
+		## Contents of the HELO/EHLO SMTP command.
 		helo:              string          &log &optional;
-		## Email addresses found in the From header.
+		## Email address found in the MAIL FROM SMTP command.
 		mailfrom:          string          &log &optional;
-		## Email addresses found in the Rcpt header.
+		## Email addresses found in the RCPT TO SMTP command(s).
 		rcptto:            set[string]     &log &optional;
 		## Contents of the Date header.
 		date:              string          &log &optional;
@@ -38,9 +38,9 @@ export {
 		to:                set[string]     &log &optional;
 		## Contents of the CC header.
 		cc:                set[string]     &log &optional;
-		## Contents of the ReplyTo header.
+		## Contents of the Reply-To header.
 		reply_to:          string          &log &optional;
-		## Contents of the MsgID header.
+		## Contents of the Message-ID header.
 		msg_id:            string          &log &optional;
 		## Contents of the In-Reply-To header.
 		in_reply_to:       string          &log &optional;

--- a/scripts/base/protocols/smtp/main.zeek
+++ b/scripts/base/protocols/smtp/main.zeek
@@ -28,7 +28,7 @@ export {
 		helo:              string          &log &optional;
 		## Email address found in the MAIL FROM SMTP command.
 		mailfrom:          string          &log &optional;
-		## Email addresses found in the RCPT TO SMTP command(s).
+		## Email addresses found in the RCPT TO SMTP commands.
 		rcptto:            set[string]     &log &optional;
 		## Contents of the Date header.
 		date:              string          &log &optional;


### PR DESCRIPTION
Addresses #5656 
- Remove email header label for SMTP commands
- Expand Message-ID & Reply-To to match RFC822