### PR TITLE
Protocol/file analysis bif doc fixes

### DIFF
--- a/src/analyzer/protocol/dce-rpc/events.bif
+++ b/src/analyzer/protocol/dce-rpc/events.bif
@@ -107,7 +107,7 @@ event dce_rpc_request%(c: connection, fid: count, ctx_id: count, opnum: count, s
 ##      not transported over a pipe.
 ##
 ## ctx_id: The context identifier of the data representation.
-###
+##
 ## opnum: Number of the RPC operation.
 ##
 ## stub_len: Length of the data for the response.
@@ -141,7 +141,7 @@ event dce_rpc_request_stub%(c: connection, fid: count, ctx_id: count, opnum: cou
 ##      not transported over a pipe.
 ##
 ## ctx_id: The context identifier of the data representation.
-###
+##
 ## opnum: Number of the RPC operation.
 ##
 ## stub: The data for the response.

--- a/src/analyzer/protocol/dnp3/events.bif
+++ b/src/analyzer/protocol/dnp3/events.bif
@@ -32,7 +32,7 @@ event dnp3_application_response_header%(c: connection, is_orig: bool, applicatio
 ##
 ## qua_field: qualifier field.
 ##
-## number: TODO.
+## number: Number of objects (or items) carried by this object header.
 ##
 ## rf_low: the structure of the range field depends on the qualified field.
 ##         In some cases, the range field contains only one logic part, e.g.,

--- a/src/analyzer/protocol/dns/events.bif
+++ b/src/analyzer/protocol/dns/events.bif
@@ -156,7 +156,7 @@ event dns_A_reply%(c: connection, msg: dns_msg, ans: dns_answer, a: addr%);
 ##
 ## a: The address returned by the reply.
 ##
-## .. zeek:see::  dns_A_reply dns_A6_reply dns_CNAME_reply dns_EDNS_addl dns_HINFO_reply dns_MX_reply
+## .. zeek:see:: dns_A_reply dns_A6_reply dns_CNAME_reply dns_EDNS_addl dns_HINFO_reply dns_MX_reply
 ##    dns_NS_reply dns_PTR_reply dns_SOA_reply dns_SRV_reply dns_TSIG_addl
 ##    dns_TXT_reply dns_SPF_reply dns_WKS_reply dns_end dns_mapping_altered
 ##    dns_mapping_lost_name dns_mapping_new_name dns_mapping_unverified
@@ -181,7 +181,7 @@ event dns_AAAA_reply%(c: connection, msg: dns_msg, ans: dns_answer, a: addr%);
 ##
 ## a: The address returned by the reply.
 ##
-## .. zeek:see::  dns_A_reply dns_AAAA_reply dns_CNAME_reply dns_EDNS_addl dns_HINFO_reply dns_MX_reply
+## .. zeek:see:: dns_A_reply dns_AAAA_reply dns_CNAME_reply dns_EDNS_addl dns_HINFO_reply dns_MX_reply
 ##    dns_NS_reply dns_PTR_reply dns_SOA_reply dns_SRV_reply dns_TSIG_addl
 ##    dns_TXT_reply dns_SPF_reply dns_WKS_reply dns_end dns_mapping_altered
 ##    dns_mapping_lost_name dns_mapping_new_name dns_mapping_unverified
@@ -207,7 +207,7 @@ event dns_A6_reply%(c: connection, msg: dns_msg, ans: dns_answer, a: addr%);
 ## name: The name returned by the reply.
 ##
 ## .. zeek:see:: dns_AAAA_reply dns_A_reply dns_CNAME_reply dns_EDNS_addl
-##    dns_HINFO_reply dns_MX_reply  dns_PTR_reply dns_SOA_reply dns_SRV_reply
+##    dns_HINFO_reply dns_MX_reply dns_PTR_reply dns_SOA_reply dns_SRV_reply
 ##    dns_TSIG_addl dns_TXT_reply dns_SPF_reply dns_WKS_reply dns_end
 ##    dns_mapping_altered dns_mapping_lost_name dns_mapping_new_name
 ##    dns_mapping_unverified dns_mapping_valid dns_message dns_query_reply
@@ -231,7 +231,7 @@ event dns_NS_reply%(c: connection, msg: dns_msg, ans: dns_answer, name: string%)
 ##
 ## name: The name returned by the reply.
 ##
-## .. zeek:see:: dns_AAAA_reply dns_A_reply  dns_EDNS_addl dns_HINFO_reply dns_MX_reply
+## .. zeek:see:: dns_AAAA_reply dns_A_reply dns_EDNS_addl dns_HINFO_reply dns_MX_reply
 ##    dns_NS_reply dns_PTR_reply dns_SOA_reply dns_SRV_reply dns_TSIG_addl
 ##    dns_TXT_reply dns_SPF_reply dns_WKS_reply dns_end dns_mapping_altered
 ##    dns_mapping_lost_name dns_mapping_new_name dns_mapping_unverified
@@ -257,7 +257,7 @@ event dns_CNAME_reply%(c: connection, msg: dns_msg, ans: dns_answer, name: strin
 ## name: The name returned by the reply.
 ##
 ## .. zeek:see:: dns_AAAA_reply dns_A_reply dns_CNAME_reply dns_EDNS_addl
-##    dns_HINFO_reply dns_MX_reply dns_NS_reply  dns_SOA_reply dns_SRV_reply
+##    dns_HINFO_reply dns_MX_reply dns_NS_reply dns_SOA_reply dns_SRV_reply
 ##    dns_TSIG_addl dns_TXT_reply dns_SPF_reply dns_WKS_reply dns_end
 ##    dns_mapping_altered dns_mapping_lost_name dns_mapping_new_name
 ##    dns_mapping_unverified dns_mapping_valid dns_message dns_query_reply
@@ -265,7 +265,7 @@ event dns_CNAME_reply%(c: connection, msg: dns_msg, ans: dns_answer, name: strin
 ##    dns_skip_addl dns_skip_all_addl dns_skip_all_auth dns_skip_auth
 event dns_PTR_reply%(c: connection, msg: dns_msg, ans: dns_answer, name: string%);
 
-## Generated for DNS replies of type *CNAME*. For replies with multiple answers,
+## Generated for DNS replies of type *SOA*. For replies with multiple answers,
 ## an individual event of the corresponding type is raised for each.
 ##
 ## See `Wikipedia <https://en.wikipedia.org/wiki/Domain_Name_System>`__ for more
@@ -306,7 +306,7 @@ event dns_SOA_reply%(c: connection, msg: dns_msg, ans: dns_answer, soa: dns_soa%
 ##
 ## .. zeek:see:: dns_AAAA_reply dns_A_reply dns_CNAME_reply dns_EDNS_addl
 ##    dns_HINFO_reply dns_MX_reply dns_NS_reply dns_PTR_reply dns_SOA_reply
-##    dns_SRV_reply dns_TSIG_addl dns_TXT_reply dns_SPF_reply  dns_end
+##    dns_SRV_reply dns_TSIG_addl dns_TXT_reply dns_SPF_reply dns_end
 ##    dns_mapping_altered dns_mapping_lost_name dns_mapping_new_name
 ##    dns_mapping_unverified dns_mapping_valid dns_message dns_query_reply
 ##    dns_rejected dns_request dns_max_queries dns_session_timeout
@@ -355,7 +355,7 @@ event dns_HINFO_reply%(c: connection, msg: dns_msg, ans: dns_answer, cpu: string
 ## preference: The preference for *name* specified by the reply.
 ##
 ## .. zeek:see:: dns_AAAA_reply dns_A_reply dns_CNAME_reply dns_EDNS_addl
-##    dns_HINFO_reply  dns_NS_reply dns_PTR_reply dns_SOA_reply dns_SRV_reply
+##    dns_HINFO_reply dns_NS_reply dns_PTR_reply dns_SOA_reply dns_SRV_reply
 ##    dns_TSIG_addl dns_TXT_reply dns_SPF_reply dns_WKS_reply dns_end
 ##    dns_mapping_altered dns_mapping_lost_name dns_mapping_new_name
 ##    dns_mapping_unverified dns_mapping_valid dns_message dns_query_reply
@@ -381,7 +381,7 @@ event dns_MX_reply%(c: connection, msg: dns_msg, ans: dns_answer, name: string, 
 ##
 ## .. zeek:see:: dns_AAAA_reply dns_A_reply dns_CNAME_reply dns_EDNS_addl
 ##    dns_HINFO_reply dns_MX_reply dns_NS_reply dns_PTR_reply dns_SOA_reply
-##    dns_SRV_reply dns_TSIG_addl  dns_WKS_reply dns_end
+##    dns_SRV_reply dns_TSIG_addl dns_WKS_reply dns_end
 ##    dns_mapping_altered dns_mapping_lost_name dns_mapping_new_name
 ##    dns_mapping_unverified dns_mapping_valid dns_message dns_query_reply
 ##    dns_rejected dns_request dns_max_queries dns_session_timeout
@@ -406,7 +406,7 @@ event dns_TXT_reply%(c: connection, msg: dns_msg, ans: dns_answer, strs: string_
 ##
 ## .. zeek:see:: dns_AAAA_reply dns_A_reply dns_CNAME_reply dns_EDNS_addl
 ##    dns_HINFO_reply dns_MX_reply dns_NS_reply dns_PTR_reply dns_SOA_reply
-##    dns_SRV_reply dns_TSIG_addl  dns_WKS_reply dns_end
+##    dns_SRV_reply dns_TSIG_addl dns_TXT_reply dns_WKS_reply dns_end
 ##    dns_mapping_altered dns_mapping_lost_name dns_mapping_new_name
 ##    dns_mapping_unverified dns_mapping_valid dns_message dns_query_reply
 ##    dns_rejected dns_request dns_max_queries dns_session_timeout

--- a/src/analyzer/protocol/http/events.bif
+++ b/src/analyzer/protocol/http/events.bif
@@ -138,7 +138,7 @@ event http_end_entity%(c: connection, is_orig: bool%);
 ## at the scripting layer by concatenating it to a successively growing
 ## string; and only perform further content analysis once the corresponding
 ## :zeek:id:`http_end_entity` event has been raised. Note, however, that doing so
-## can be quite expensive for HTTP tranders. At the very least, one should
+## can be quite expensive for HTTP transfers. At the very least, one should
 ## impose an upper size limit on how much data is being buffered.
 ##
 ## See `Wikipedia <https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol>`__

--- a/src/analyzer/protocol/irc/events.bif
+++ b/src/analyzer/protocol/irc/events.bif
@@ -67,7 +67,7 @@ event irc_reply%(c: connection, is_orig: bool, prefix: string,
 ##
 ## command: The command.
 ##
-## message: TODO.
+## message: The parameters of the IRC command.
 ##
 ## .. zeek:see:: irc_channel_info irc_channel_topic irc_dcc_message irc_error_message
 ##    irc_global_users irc_invalid_nick irc_invite_message irc_join_message
@@ -557,9 +557,9 @@ event irc_who_message%(c: connection, is_orig: bool, mask: string, oper: bool%);
 ## is_orig: True if the command was sent by the originator of the TCP
 ##          connection.
 ##
-## server: TODO.
+## server: Target of the WHOIS query, or an empty string if not specified.
 ##
-## users: TODO.
+## users: Comma-separated list of nicknames (or nickname masks).
 ##
 ## .. zeek:see:: irc_channel_info irc_channel_topic irc_dcc_message irc_error_message
 ##    irc_global_users irc_invalid_nick irc_invite_message irc_join_message

--- a/src/analyzer/protocol/login/events.bif
+++ b/src/analyzer/protocol/login/events.bif
@@ -82,7 +82,7 @@ event rsh_reply%(c: connection, client_user: string, server_user: string, line: 
 ##    configuration has not yet been ported, and
 ##    the analyzer is therefore not directly usable at the moment.
 ##
-## .. todo:: Zeeks's current default configuration does not activate the protocol
+## .. todo:: Zeek's current default configuration does not activate the protocol
 ##    analyzer that generates this event; the corresponding script has not yet
 ##    been ported. To still enable this event, one needs to add a
 ##    call to :zeek:see:`Analyzer::register_for_ports` or a DPD payload
@@ -230,7 +230,7 @@ event login_terminal%(c: connection, terminal: string%);
 ##
 ## display: The DISPLAY transmitted.
 ##
-## .. zeek:see:: login_confused login_confused_text  login_failure login_input_line
+## .. zeek:see:: login_confused login_confused_text login_failure login_input_line
 ##    login_output_line login_prompt login_success login_terminal
 ##
 ## .. todo:: Zeek's current default configuration does not activate the protocol

--- a/src/analyzer/protocol/ntlm/events.bif
+++ b/src/analyzer/protocol/ntlm/events.bif
@@ -2,7 +2,7 @@
 ##
 ## c: The connection.
 ##
-## negotiate: The parsed data of the :abbr:`NTLM (NT LAN Manager)` message. See init-bare for more details.
+## negotiate: The parsed data of the :abbr:`NTLM (NT LAN Manager)` message. See :zeek:see:`NTLM::Negotiate` for more details.
 ##
 ## .. zeek:see:: ntlm_challenge ntlm_authenticate
 event ntlm_negotiate%(c: connection, negotiate: NTLM::Negotiate%);
@@ -11,7 +11,7 @@ event ntlm_negotiate%(c: connection, negotiate: NTLM::Negotiate%);
 ##
 ## c: The connection.
 ##
-## negotiate: The parsed data of the :abbr:`NTLM (NT LAN Manager)` message. See init-bare for more details.
+## challenge: The parsed data of the :abbr:`NTLM (NT LAN Manager)` message. See :zeek:see:`NTLM::Challenge` for more details.
 ##
 ## .. zeek:see:: ntlm_negotiate ntlm_authenticate
 event ntlm_challenge%(c: connection, challenge: NTLM::Challenge%);
@@ -20,7 +20,7 @@ event ntlm_challenge%(c: connection, challenge: NTLM::Challenge%);
 ##
 ## c: The connection.
 ##
-## request: The parsed data of the :abbr:`NTLM (NT LAN Manager)` message. See init-bare for more details.
+## request: The parsed data of the :abbr:`NTLM (NT LAN Manager)` message. See :zeek:see:`NTLM::Authenticate` for more details.
 ##
 ## .. zeek:see:: ntlm_negotiate ntlm_challenge
 event ntlm_authenticate%(c: connection, request: NTLM::Authenticate%);

--- a/src/analyzer/protocol/rfb/events.bif
+++ b/src/analyzer/protocol/rfb/events.bif
@@ -32,14 +32,18 @@ event rfb_share_flag%(c: connection, flag: bool%);
 ##
 ## c: The connection record for the underlying transport-layer session/flow.
 ##
-## version: of the client's rfb library
+## major_version: The major version of the client's RFB library.
+##
+## minor_version: The minor version of the client's RFB library.
 event rfb_client_version%(c: connection, major_version: string, minor_version: string%);
 
 ## Generated for RFB event server banner message
 ##
 ## c: The connection record for the underlying transport-layer session/flow.
 ##
-## version: of the server's rfb library
+## major_version: The major version of the server's RFB library.
+##
+## minor_version: The minor version of the server's RFB library.
 event rfb_server_version%(c: connection, major_version: string, minor_version: string%);
 
 ## Generated for RFB event server parameter message

--- a/src/analyzer/protocol/rpc/events.bif
+++ b/src/analyzer/protocol/rpc/events.bif
@@ -33,7 +33,7 @@ event nfs_proc_null%(c: connection, info: NFS3::info_t%);
 ##
 ## info: Reports the status of the dialogue, along with some meta information.
 ##
-## fh: TODO.
+## fh: The file handle of the file whose attributes are requested.
 ##
 ## attrs: The attributes returned in the reply. The values may not be valid if
 ##       the request was unsuccessful.
@@ -229,7 +229,7 @@ event nfs_proc_link%(c: connection, info: NFS3::info_t, req: NFS3::linkargs_t, r
 ##
 ## info: Reports the status of the dialogue, along with some meta information.
 ##
-## req: TODO.
+## req: The arguments passed in the request.
 ##
 ## rep: The response returned in the reply. The values may not be valid if the
 ##      request was unsuccessful.
@@ -258,7 +258,7 @@ event nfs_proc_write%(c: connection, info: NFS3::info_t, req: NFS3::writeargs_t,
 ##
 ## info: Reports the status of the dialogue, along with some meta information.
 ##
-## req: TODO.
+## req: The arguments passed in the request.
 ##
 ## rep: The response returned in the reply. The values may not be valid if the
 ##      request was unsuccessful.
@@ -286,7 +286,7 @@ event nfs_proc_create%(c: connection, info: NFS3::info_t, req: NFS3::diropargs_t
 ##
 ## info: Reports the status of the dialogue, along with some meta information.
 ##
-## req: TODO.
+## req: The arguments passed in the request.
 ##
 ## rep: The response returned in the reply. The values may not be valid if the
 ##      request was unsuccessful.
@@ -314,7 +314,7 @@ event nfs_proc_mkdir%(c: connection, info: NFS3::info_t, req: NFS3::diropargs_t,
 ##
 ## info: Reports the status of the dialogue, along with some meta information.
 ##
-## req: TODO.
+## req: The arguments passed in the request.
 ##
 ## rep: The response returned in the reply. The values may not be valid if the
 ##      request was unsuccessful.
@@ -342,7 +342,7 @@ event nfs_proc_remove%(c: connection, info: NFS3::info_t, req: NFS3::diropargs_t
 ##
 ## info: Reports the status of the dialogue, along with some meta information.
 ##
-## req: TODO.
+## req: The arguments passed in the request.
 ##
 ## rep: The response returned in the reply. The values may not be valid if the
 ##      request was unsuccessful.
@@ -370,7 +370,7 @@ event nfs_proc_rmdir%(c: connection, info: NFS3::info_t, req: NFS3::diropargs_t,
 ##
 ## info: Reports the status of the dialogue, along with some meta information.
 ##
-## req: TODO.
+## req: The arguments passed in the request.
 ##
 ## rep: The response returned in the reply. The values may not be valid if the
 ##      request was unsuccessful.
@@ -398,7 +398,7 @@ event nfs_proc_rename%(c: connection, info: NFS3::info_t, req: NFS3::renameoparg
 ##
 ## info: Reports the status of the dialogue, along with some meta information.
 ##
-## req: TODO.
+## req: The arguments passed in the request.
 ##
 ## rep: The response returned in the reply. The values may not be valid if the
 ##      request was unsuccessful.

--- a/src/analyzer/protocol/smb/smb1_com_session_setup_andx.bif
+++ b/src/analyzer/protocol/smb/smb1_com_session_setup_andx.bif
@@ -7,7 +7,7 @@
 ##
 ## hdr: The parsed header of the :abbr:`SMB (Server Message Block)` version 1 message.
 ##
-## request: The parsed request data of the SMB message. See init-bare for more details.
+## request: The parsed request data of the SMB message. See :zeek:see:`SMB1::SessionSetupAndXRequest` for more details.
 ##
 ## .. zeek:see:: smb1_message smb1_session_setup_andx_response
 event smb1_session_setup_andx_request%(c: connection, hdr: SMB1::Header, request: SMB1::SessionSetupAndXRequest%);
@@ -21,7 +21,7 @@ event smb1_session_setup_andx_request%(c: connection, hdr: SMB1::Header, request
 ##
 ## hdr: The parsed header of the :abbr:`SMB (Server Message Block)` version 1 message.
 ##
-## response: The parsed response data of the SMB message. See init-bare for more details.
+## response: The parsed response data of the SMB message. See :zeek:see:`SMB1::SessionSetupAndXResponse` for more details.
 ##
 ## .. zeek:see:: smb1_message smb1_session_setup_andx_request
 event smb1_session_setup_andx_response%(c: connection, hdr: SMB1::Header, response: SMB1::SessionSetupAndXResponse%);

--- a/src/analyzer/protocol/smtp/events.bif
+++ b/src/analyzer/protocol/smtp/events.bif
@@ -20,7 +20,7 @@
 ##    mime_end_entity mime_entity_data mime_event mime_one_header mime_segment_data
 ##    smtp_data smtp_reply
 ##
-## .. note:: Zeek does not support the newer ETRN extension yet.
+## .. note:: Zeek does not support the ETRN extension.
 event smtp_request%(c: connection, is_orig: bool, command: string, arg: string%);
 
 ## Generated for server-side SMTP commands.
@@ -39,7 +39,7 @@ event smtp_request%(c: connection, is_orig: bool, command: string, arg: string%)
 ##
 ## code: The reply's numerical code.
 ##
-## cmd: TODO.
+## cmd: The SMTP command this reply pertains to.
 ##
 ## msg: The reply's textual description.
 ##
@@ -51,7 +51,7 @@ event smtp_request%(c: connection, is_orig: bool, command: string, arg: string%)
 ##    mime_end_entity mime_entity_data mime_event mime_one_header mime_segment_data
 ##    smtp_data  smtp_request
 ##
-## .. note:: Zeek doesn't support the newer ETRN extension yet.
+## .. note:: Zeek doesn't support the ETRN extension.
 event smtp_reply%(c: connection, is_orig: bool, code: count, cmd: string, msg: string, cont_resp: bool%);
 
 ## Generated for DATA transmitted on SMTP sessions. This event is raised for

--- a/src/analyzer/protocol/ssh/events.bif
+++ b/src/analyzer/protocol/ssh/events.bif
@@ -70,7 +70,6 @@ event ssh_auth_successful%(c: connection, auth_method_none: bool%);
 ## as a partial success.
 ##
 ## This event will often be raised multiple times per connection.
-## In almost all connections, it will be raised once unless
 ##
 ## c: The connection over which the :abbr:`SSH (Secure Shell)`
 ##    connection took place.

--- a/src/analyzer/protocol/ssl/events.bif
+++ b/src/analyzer/protocol/ssl/events.bif
@@ -478,7 +478,7 @@ event ssl_extension_signed_certificate_timestamp%(c: connection, is_client: bool
 ## Generated for an TLS Supported Versions extension. This TLS extension
 ## is defined in :rfc:`8446` (TL1 1.3) and sent by the client in the initial handshake.
 ## It contains the TLS versions that it supports. This information can be used by
-## the server to choose the best TLS version o use.
+## the server to choose the best TLS version to use.
 ##
 ## c: The connection.
 ##

--- a/src/analyzer/protocol/syslog/legacy/events.bif
+++ b/src/analyzer/protocol/syslog/legacy/events.bif
@@ -12,6 +12,5 @@
 ##
 ## msg: The message logged.
 ##
-## .. note:: Zeek currently parses only UDP syslog traffic. Support for TCP
-##    syslog will be added soon.
+## .. note:: Zeek currently parses only UDP syslog traffic.
 event syslog_message%(c: connection, facility: count, severity: count, msg: string%);

--- a/src/analyzer/protocol/websocket/events.bif
+++ b/src/analyzer/protocol/websocket/events.bif
@@ -34,7 +34,7 @@ event websocket_frame%(c: connection, is_orig: bool, fin: bool, rsv: count, opco
 ##
 ## data: One data chunk of frame payload. The length of is at most
 ##       :zeek:see:`WebSocket::payload_chunk_size` bytes. A frame with
-##       a longer payload will result in multiple events events.
+##       a longer payload will result in multiple events.
 ##
 ## .. zeek:see:: WebSocket::payload_chunk_size
 event websocket_frame_data%(c: connection, is_orig: bool, data: string%);

--- a/src/file_analysis/analyzer/x509/functions.bif
+++ b/src/file_analysis/analyzer/x509/functions.bif
@@ -132,7 +132,7 @@ bool check_hostname(std::string_view hostname, std::string_view certname)
 		return true;
 
 	// ok, now there is still the chance that it is a wildcard cert.
-	// We go according to RFC6128 here:
+	// We go according to RFC 6125 here:
 	// * wildcards are allowed in the leftmost label
 	// * wildcards are only compared against the leftmost label
 	// * the wildcard character may not be the only part of the label (so abc* is ok)

--- a/src/file_analysis/analyzer/x509/ocsp_events.bif
+++ b/src/file_analysis/analyzer/x509/ocsp_events.bif
@@ -23,6 +23,8 @@ event ocsp_request%(f: fa_file, version: count%);
 ##
 ## hashAlgorithm: The hash algorithm used for the issuerKeyHash.
 ##
+## issuerNameHash: Hash of the issuer's distinguished name.
+##
 ## issuerKeyHash: Hash of the issuers public key.
 ##
 ## serialNumber: Serial number of the certificate for which the status is requested.


### PR DESCRIPTION
This commit applies a range of small documentation fixes to some of the analyzer and file_analyzer bifs.

This includes minor formatting changes, fixed todos, typos, unfinished sentences, and a couple of incorrect statements.

This was made with the help of Claufe Opus 4.7 (which found the issues), and then manually edited. I understand and verified all of the changes.

Contains no code changes.