### PR TITLE
ci/NEWS: Skip installing libnode-dev on Debian 12

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,10 @@ Breaking Changes
   separately with the thread and address sanitizers enabled (./configure --sanitizers=thread
   or ./configure --sanitizers=address).
 
+- The ZeekJS plugin now requires ``std::format`` from C++20 which is not available
+  in older distributions using GCC 12.x like Debian 12. If you want to use JavaScript
+  support in Zeek, please update to a more recent distribution.
+
 New Functionality
 -----------------
 

--- a/ci/debian-12/Dockerfile
+++ b/ci/debian-12/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get -y install \
     jq \
     libkrb5-dev \
     libnats-dev \
-    libnode-dev \
     libpcap-dev \
     librdkafka-dev \
     libssl-dev \


### PR DESCRIPTION
The Debian 12 build fails because GCC 12.x doesn't yet have <format>.

    <...>/zeek/auxil/zeekjs/src/Nodejs.cc:7:10: fatal error: format: No such file or directory
        7 | #include <format>
          |          ^~~~~~~~

And seems fine to me to require a more recent distribution when JavaScript is enabled. Debian 13 has been released almost a year ago, JavaScript does have the experimental sticker still, and I don't think this will affect enough users to be worth a libfmt fallback. I'd be positively surprised if that's wrong :-)