### PR TITLE
util/fmt: Remove non-main thread warning / abort() again

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1256,22 +1256,6 @@ const char* fmt_bytes(const char* data, int len) {
 }
 
 const char* vfmt(const char* format, va_list al) {
-    // buf is process-global, so vfmt() is not thread safe.
-    // By convention, it must be called only from the main thread.
-    // The first call is known to be performed by the main thread during single-threaded startup.
-    // Check subsequent calls against that baseline.
-    static const std::thread::id main_thread_id = std::this_thread::get_id();
-    static bool wrong_thread_warned = false;
-
-    if ( std::this_thread::get_id() != main_thread_id && ! wrong_thread_warned ) {
-        fprintf(stderr,
-                "zeek::util::fmt() called off the main thread; use threading::BasicThread::Fmt() or std::format()\n");
-        wrong_thread_warned = true;
-#ifdef DEBUG
-        abort();
-#endif
-    }
-
     static char* buf = nullptr;
     static int buf_len = 1024;
 


### PR DESCRIPTION
JavaScript code execution does not happen on the main thread. Execution
is offloaded to a separate thread while Zeek's main thread is fully
paused until JavaScript execution completes at which point the main
thread resumes.
    
The util::fmt() function is reachable through various paths from
JavaScript by using zeek.invoke() to execute Zeek script or builtin
functions. This triggers the just added fprintf() / abort() from commit
d6db4402db3bcdfdbd374ad70540d03e679d2d2b.
    
Revert this logic as it's a false positive for this particular case and
it wasn't the greatest idea.

---

Stack from the failing test. It calls `Log::delay_finish()` form JavaScript and that ends up creating a logging writer on demand...

```
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007ffff124527e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007ffff12288ff in __GI_abort () at ./stdlib/abort.c:79
#5  0x0000555558759815 in zeek::util::vfmt
#6  0x0000555558756538 in zeek::util::fmt
#7  0x0000555557bafc4b in zeek::logging::WriterFrontend::WriterFrontend
#8  0x0000555557b94813 in zeek::logging::Manager::CreateWriter
#9  0x0000555557b8d159 in zeek::logging::Manager::CreateWriterForFilter
#10 0x0000555557b8ace0 in zeek::logging::Manager::WriteToFilters
#11 0x0000555557b7b25c in zeek::logging::Manager::DelayCompleted
#12 0x0000555557b905f8 in zeek::logging::Manager::DelayFinish
#13 0x00005555589e4494 in zeek::BifFunc::Log::__delay_finish_bif
#14 0x0000555558a46b1a in zeek::detail::BuiltinFunc::Invoke
#15 0x000055555894a734 in zeek::detail::CallExpr::Eval
#16 0x0000555558b7416b in zeek::detail::ReturnStmt::Exec
#17 0x0000555558b74a26 in zeek::detail::StmtList::Exec
#18 0x0000555558a3e441 in zeek::detail::ScriptFunc::Invoke
#19 0x0000555558386aab in plugin::Corelight_ZeekJS::Plugin::Invoke
#20 0x000055555836ed33 in plugin::Nodejs::Instance::ZeekInvoke
#21 0x000055555836e709 in plugin::Nodejs::Instance::ZeekInvokeCallback
#22 0x00007ffff285138e in v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)

```