### PR TITLE
CCI: Fix issues with building from tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,4 +42,8 @@ workflows:
         - equal: [ "nightly", << pipeline.schedule.name >> ]
         - equal: [ "weekly", << pipeline.schedule.name >> ]
     jobs:
-      - setup_job
+      - setup_job:
+          filters:
+            tags:
+              only:
+                - /^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$/


### PR DESCRIPTION
The handling for tags in the CircleCI was missing a filter that ensured the job spawned based on the tag name. We had a `when` condition to avoid double builds, but the `filter` was needed for the job to actually spawn. Thanks to Nick O @ CircleCI for helping out with this one, as usual.

I already pushed the same commit to the 8.0 and 8.2 release branches, remade the release tags, and verified that the images are built and pushed correctly for the releases.