### PR TITLE
Use templated version of std::min vs casting arguments

### DIFF
--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -1016,7 +1016,7 @@ bool DNS_Interpreter::ParseRR_EDNS(detail::DNS_MsgInfo* msg, const u_char*& data
 
 void DNS_Interpreter::ExtractOctets(const u_char*& data, int& len, String** p) {
     auto dlen = ExtractShort(data, len);
-    dlen = std::min(len, static_cast<int>(dlen));
+    dlen = std::min<int>(len, dlen);
 
     if ( p )
         *p = new String(data, dlen, false);

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -203,8 +203,7 @@ void Gnutella_Analyzer::SendEvents(detail::GnutellaMsgState* p, bool is_orig) {
         EnqueueConnEvent(gnutella_binary_msg, ConnVal(), val_mgr->Bool(is_orig), val_mgr->Count(p->msg_type),
                          val_mgr->Count(p->msg_ttl), val_mgr->Count(p->msg_hops), val_mgr->Count(p->msg_len),
                          make_intrusive<StringVal>(p->payload), val_mgr->Count(p->payload_len),
-                         val_mgr->Bool(
-                             (p->payload_len < std::min(p->msg_len, static_cast<unsigned int>(GNUTELLA_MAX_PAYLOAD)))),
+                         val_mgr->Bool((p->payload_len < std::min<unsigned int>(p->msg_len, GNUTELLA_MAX_PAYLOAD))),
                          val_mgr->Bool((p->payload_left == 0)));
 }
 

--- a/src/analyzer/protocol/rpc/NFS.cc
+++ b/src/analyzer/protocol/rpc/NFS.cc
@@ -262,7 +262,7 @@ StringValPtr NFS_Interp::nfs3_file_data(const u_char*& buf, int& n, uint64_t off
 
     // Ok, so we want to return some data
     data_n = std::min(data_n, size);
-    data_n = std::min(data_n, static_cast<int>(BifConst::NFS3::return_data_max));
+    data_n = std::min<int>(data_n, BifConst::NFS3::return_data_max);
 
     if ( data && data_n > 0 )
         return make_intrusive<StringVal>(new String(data, data_n, false));

--- a/src/analyzer/protocol/rpc/RPC.cc
+++ b/src/analyzer/protocol/rpc/RPC.cc
@@ -351,7 +351,7 @@ bool RPC_Reasm_Buffer::ConsumeChunk(const u_char*& data, int& len) {
     // How many bytes do we want to process with this call?  Either the
     // all of the bytes available or the number of bytes that we are
     // still missing.
-    int64_t to_process = std::min(static_cast<int64_t>(len), (expected - processed));
+    auto to_process = std::min<int64_t>(len, (expected - processed));
 
     if ( fill < maxsize ) {
         // We haven't yet filled the buffer. How many bytes to copy

--- a/src/analyzer/protocol/tcp/ContentLine.cc
+++ b/src/analyzer/protocol/tcp/ContentLine.cc
@@ -154,7 +154,7 @@ void ContentLine_Analyzer::DoDeliver(int len, const u_char* data) {
         }
 
         if ( plain_delivery_length > 0 ) {
-            int deliver_plain = std::min(plain_delivery_length, static_cast<int64_t>(len));
+            auto deliver_plain = std::min<int>(plain_delivery_length, len);
 
             last_char = 0; // clear last_char
             plain_delivery_length -= deliver_plain;

--- a/src/input/readers/raw/Raw.cc
+++ b/src/input/readers/raw/Raw.cc
@@ -648,8 +648,7 @@ int64_t Raw::GetLine(FILE* arg_file) {
                     readbytes = 0; // no new data; search existing buffer below
                 }
                 else {
-                    unsigned int to_read =
-                        static_cast<unsigned int>((std::min)(bufsize - bufpos, static_cast<size_t>(avail)));
+                    unsigned int to_read = std::min<unsigned int>(bufsize - bufpos, avail);
                     int r = _read(fd, buf.get() + bufpos, to_read);
                     readbytes = (r > 0) ? static_cast<size_t>(r) : 0;
                     if ( r == 0 )

--- a/src/packet_analysis/Manager.cc
+++ b/src/packet_analysis/Manager.cc
@@ -245,7 +245,7 @@ zeek::VectorValPtr Manager::BuildAnalyzerHistory() const {
 void Manager::ReportUnknownProtocol(const std::string& analyzer, uint32_t protocol, const uint8_t* data, size_t len) {
     if ( unknown_protocol ) {
         if ( PermitUnknownProtocol(analyzer, protocol) ) {
-            int bytes_len = std::min(unknown_first_bytes_count, static_cast<uint64_t>(len));
+            auto bytes_len = std::min<uint64_t>(unknown_first_bytes_count, len);
 
             event_mgr.Enqueue(unknown_protocol, make_intrusive<StringVal>(analyzer), val_mgr->Count(protocol),
                               make_intrusive<StringVal>(bytes_len, reinterpret_cast<const char*>(data)),

--- a/src/packet_analysis/protocol/icmp/ICMP.cc
+++ b/src/packet_analysis/protocol/icmp/ICMP.cc
@@ -598,7 +598,7 @@ void ICMPAnalyzer::MLDReportV2(double t, const struct icmp* icmpp, int len, int 
     const uint8_t* record_ptr = data;
 
     auto vec = make_intrusive<VectorVal>(icmp6_mld_mar_vec_type);
-    vec->Reserve(std::min(static_cast<uint16_t>(32), num_multicast_records));
+    vec->Reserve(std::min<size_t>(32, num_multicast_records));
 
     for ( uint16_t i = 0; i < num_multicast_records && remaining > 0; i++ ) {
         if ( remaining < 4 ) {
@@ -625,7 +625,7 @@ void ICMPAnalyzer::MLDReportV2(double t, const struct icmp* icmpp, int len, int 
         remaining -= 16;
 
         auto source_vec = make_intrusive<VectorVal>(addr_vec_type);
-        source_vec->Reserve(std::min(static_cast<uint16_t>(32), num_sources));
+        source_vec->Reserve(std::min<size_t>(32, num_sources));
 
         for ( uint16_t src = 0; src < num_sources; src++ ) {
             source_vec->Append(make_intrusive<AddrVal>(IPAddr(*reinterpret_cast<const in6_addr*>(record_ptr))));
@@ -797,7 +797,7 @@ zeek::VectorValPtr ICMPAnalyzer::BuildNDOptionsVal(int caplen, const u_char* dat
         }
 
         if ( set_payload_field ) {
-            String* payload = new String(data, std::min(static_cast<int>(length), caplen), false);
+            String* payload = new String(data, std::min<int>(length, caplen), false);
             rv->Assign(6, make_intrusive<StringVal>(payload));
         }
 

--- a/src/packet_analysis/protocol/ip/IP.cc
+++ b/src/packet_analysis/protocol/ip/IP.cc
@@ -225,7 +225,7 @@ bool IPAnalyzer::AnalyzePacket(size_t len, const uint8_t* data, Packet* packet) 
     len -= ip_hdr_len;
 
     if ( packet->ip_hdr->PayloadLen() != 0 )
-        len = std::min(len, static_cast<size_t>(packet->ip_hdr->PayloadLen()));
+        len = std::min<size_t>(len, packet->ip_hdr->PayloadLen());
 
     // Session analysis assumes that the header size stored in the packet does not include the IP
     // header size. There are two reasons for this: 1) Packet::ToRawPktHdrVal() wants to look at the


### PR DESCRIPTION
This is a follow-up to https://github.com/zeek/zeek/pull/5659, changing a bunch of places where we call `static_cast` for an argument of `std::min` to instead pass the requested return type as a template argument to `std::min`.