### PR TITLE
Add inline‑enforcement clarification to what.rst

### DIFF
--- a/doc/about/what.rst
+++ b/doc/about/what.rst
@@ -75,3 +75,9 @@ traffic at the frame level, or a system for storing traffic in packet capture
 (PCAP) form. Rather, Zeek sits at the “happy medium” representing compact yet
 high fidelity network logs, generating better understanding of network traffic
 and usage.
+
+Zeek does not participate in packet-forwarding decisions and cannot block,
+drop, or modify network traffic. It is an observation and analysis platform,
+not an inline enforcement system. Preventing malicious traffic is the
+responsibility of intrusion prevention systems (IPS), such as Suricata
+operating in IPS mode.


### PR DESCRIPTION


This PR makes a small documentation improvement to doc/about/what.rst by adding one missing clarification about Zeek’s operational model. The existing section already explains what Zeek is and is not, but it does not explicitly state that Zeek cannot block, drop, or modify traffic. This PR adds a single bullet point to the end of the conceptual summary to clarify that Zeek is not an inline enforcement system.

This PR fixes the issue # 5676

AI Transparency Note:  
I used Microsoft Copilot to help structure the wording and align the content with Zeek’s RST documentation style. All technical content, explanations, and revisions were reviewed and validated by me. The updates in this PR were made based on information from the official Zeek documentation, Suricata documentation, Security Onion documentation, Malcolm documentation, and standard SOC correlation workflows.