### PR TITLE
CI: Disable tsan builds temporarily

### DIFF
--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -1255,18 +1255,18 @@ workflows:
             ZEEK_CI_BTEST_EXTRA_ARGS="-a zam"
             ZEEK_CI_BTEST_JOBS=3
           << : *FILTER_IF_PR_NOT_FULL_OR_ZAM
-      - linux-build:
-          name: tsan-sanitizer
-          docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260702"
-          requires: [fetch-test-traces, build-image-ubuntu-24.04]
-          << : *CONFIGURE_TSAN
-          extra_env: |
-            CC=clang-22
-            CXX=clang++-22
-            ZEEK_CI_DISABLE_SCRIPT_PROFILING=1
-            ZEEK_TSAN_OPTIONS=suppressions=${ZEEK_CI_WORKING_DIR}/ci/tsan_suppressions.txt
-          << : *FILTER_IF_PR_NOT_FULL_CI
+      # - linux-build:
+      #     name: tsan-sanitizer
+      #     docker_image: zeek/zeek-ci:ubuntu-24.04
+      #     ci_image_date: "20260702"
+      #     requires: [fetch-test-traces, build-image-ubuntu-24.04]
+      #     << : *CONFIGURE_TSAN
+      #     extra_env: |
+      #       CC=clang-22
+      #       CXX=clang++-22
+      #       ZEEK_CI_DISABLE_SCRIPT_PROFILING=1
+      #       ZEEK_TSAN_OPTIONS=suppressions=${ZEEK_CI_WORKING_DIR}/ci/tsan_suppressions.txt
+      #     << : *FILTER_IF_PR_NOT_FULL_CI
 
       - windows-build:
           << : *FILTER_IF_SKIP_ALL

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -329,22 +329,22 @@ jobs:
             ./ci/build.sh
             ./ci/test.sh
 
-        - id: tsan-sanitizer
-          file: ci/ubuntu-24.04/Dockerfile
-          env:
-            CC: clang-22
-            CXX: clang++-22
-            ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --sanitizers=thread --enable-fuzzers --ccache --enable-werror'
-            ZEEK_CI_CONFIGURE_FLAGS_EXTRA: --disable-javascript
-            ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1
-            # If this is defined directly in the environment, configure fails to find
-            # OpenSSL. Instead we define it with a different name and then give it
-            # the correct name in the testing scripts.
-            ZEEK_TSAN_OPTIONS: suppressions=/home/runner/work/zeek/zeek/ci/tsan_suppressions.txt
-          run: |
-            ./ci/pre-build.sh
-            ./ci/build.sh
-            ./ci/test.sh
+        # - id: tsan-sanitizer
+        #   file: ci/ubuntu-24.04/Dockerfile
+        #   env:
+        #     CC: clang-22
+        #     CXX: clang++-22
+        #     ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --sanitizers=thread --enable-fuzzers --ccache --enable-werror'
+        #     ZEEK_CI_CONFIGURE_FLAGS_EXTRA: --disable-javascript
+        #     ZEEK_CI_DISABLE_SCRIPT_PROFILING: 1
+        #     # If this is defined directly in the environment, configure fails to find
+        #     # OpenSSL. Instead we define it with a different name and then give it
+        #     # the correct name in the testing scripts.
+        #     ZEEK_TSAN_OPTIONS: suppressions=/home/runner/work/zeek/zeek/ci/tsan_suppressions.txt
+        #   run: |
+        #     ./ci/pre-build.sh
+        #     ./ci/build.sh
+        #     ./ci/test.sh
 
         - id: zeekctl-debian13
           file: ci/debian-13/Dockerfile


### PR DESCRIPTION
The thread sanitizer builds are broken on both CI providers (see https://github.com/zeek/zeek/issues/5683). This PR disables the build temporarily so that `master` builds will stop being broken for both providers.