### PR TITLE
docs: add log-permissions guidance to Security Considerations

### DIFF
--- a/doc/security-considerations.rst
+++ b/doc/security-considerations.rst
@@ -60,3 +60,10 @@ The following lists steps you can take to protect your Zeek cluster.
   systemd's `built-in capabilities management
   <https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#AmbientCapabilities=>`_
   to apply them.
+
+* Zeek logs often contain sensitive operational information, including internal
+  hostnames, URLs, protocol metadata, and other network‑derived information.
+  Ensure that both the log directory and the individual log files are not
+  world‑readable or writable, and restrict access to authorized users and
+  processes. Misconfigured permissions can expose sensitive network information
+  and undermine the confidentiality of security logs.


### PR DESCRIPTION
This update adds a new protective measure highlighting the importance of restricting permissions on Zeek’s log directory and log files. Zeek’s logs can contain sensitive operational metadata such as internal hostnames, URLs, and protocol details derived from network traffic. If these files are left world-readable or writable, they may unintentionally expose information that should remain confidential.

The added guidance reflects common security practice and aligns with widely accepted log-management recommendations, including those outlined in NIST SP 800-92. The goal is to help operators avoid accidental data exposure by ensuring that only authorized users and processes can access Zeek’s logs.

AI Disclosure: I used Microsoft Copilot to refine the wording of this PR. All technical content, references, and accuracy were reviewed and validated by me.

