### PR TITLE
Revert "CI: Temporarily disable cloning zeek-testing-private repo"

### DIFF
--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -113,9 +113,6 @@ jobs:
       - restore_cache:
           keys:
             - zeek-traces-v2
-      - add_ssh_keys:
-          fingerprints:
-            - SHA256:2YMeLODDB2fIteBZeIM6/4+OXfH1JFpURAMemyU78EY
       - run:
           name: Initializing external testing repos
           command: ci/init-external-repos.sh

--- a/ci/init-external-repos.sh
+++ b/ci/init-external-repos.sh
@@ -34,15 +34,10 @@ cd ..
 # the zeek-testing-private dir could have been created/populated already. This
 # requires the host running the build to have access to an SSH key that grants
 # access to the repo, and it will fail otherwise.
-#
-# TODO: Uncomment this and delete the message once the CI issues are resolved.
-#
-# if [[ -n "${ZEEK_CI}" ]] && [[ ! -d zeek-testing-private ]]; then
-#     banner "Trying to clone zeek-testing-private git repo"
-#     GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone git@github.com:zeek/zeek-testing-private
-# fi
-
-echo "NOTE: zeek-testing-private currently disabled due to CI issues"
+if [[ -n "${ZEEK_CI}" ]] && [[ ! -d zeek-testing-private ]]; then
+    banner "Trying to clone zeek-testing-private git repo"
+    GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone git@github.com:zeek/zeek-testing-private
+fi
 
 set -e
 


### PR DESCRIPTION
We have a GitHub bot user now with just read access to all repositories. That user has a machine-based SSH key in the Zeek CircleCI project which can be used to clone all of the repos, including the private ones. This lets us re-enable the zeek-testing-private tests.

This reverts commit 742f42feb124075cb8d39a0856aa590e2c78f925.