### PR TITLE
Fix Windows breakage caused by recent bifcl changes

### DIFF
--- a/tools/bifcl/include/bif_arg.h
+++ b/tools/bifcl/include/bif_arg.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <unistd.h>
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>


### PR DESCRIPTION
The merge of https://github.com/zeek/zeek/pull/5526 broke the Windows CI builds due to a missing include. 