### PR TITLE
Fix flood of warnings when building `spicyz`

### DIFF
--- a/src/cluster/backend/zeromq/ZeroMQ.cc
+++ b/src/cluster/backend/zeromq/ZeroMQ.cc
@@ -986,7 +986,7 @@ void ZeroMQBackend::Run() {
 
             for ( size_t i = 0; i < poll_items.size(); i++ ) {
                 const auto& item = poll_items[i];
-                ZEROMQ_DEBUG_THREAD_PRINTF(DebugFlag::POLL, "poll: items[%lu]=%s %s %s\n", i, sockets[i].name.c_str(),
+                ZEROMQ_DEBUG_THREAD_PRINTF(DebugFlag::POLL, "poll: items[%zu]=%s %s %s\n", i, sockets[i].name.c_str(),
                                            item.revents & ZMQ_POLLIN ? "pollin " : "",
                                            item.revents & ZMQ_POLLERR ? "err" : "");
 

--- a/src/spicy/spicyz/CMakeLists.txt
+++ b/src/spicy/spicyz/CMakeLists.txt
@@ -5,16 +5,9 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h DESTINATION include/zeek/spic
 
 add_executable(spicyz driver.cc glue-compiler.cc main.cc zeek-version.cc)
 
-# Don't enable /Wall on Windows because it also enables a bunch of very obnoxious
-# warnings by default. Turn it down to a smaller-but-still-loud subset.
-if (MSVC)
-    target_compile_options(spicyz PRIVATE "/W4")
-else ()
-    target_compile_options(spicyz PRIVATE "-Wall")
-endif ()
-
 target_compile_features(spicyz PRIVATE "${ZEEK_CXX_STD}")
 set_target_properties(spicyz PROPERTIES CXX_EXTENSIONS OFF)
+
 # We do not compile spicyz's own sources with sanitizers — the global linker
 # flags ensure the ASan runtime is available for the sanitized HILTI runtime
 # objects in libhilti.so.

--- a/src/spicy/spicyz/CMakeLists.txt
+++ b/src/spicy/spicyz/CMakeLists.txt
@@ -4,7 +4,15 @@ configure_file(config.h.in config.h)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h DESTINATION include/zeek/spicy/spicyz)
 
 add_executable(spicyz driver.cc glue-compiler.cc main.cc zeek-version.cc)
-target_compile_options(spicyz PRIVATE "-Wall")
+
+# Don't enable /Wall on Windows because it also enables a bunch of very obnoxious
+# warnings by default. Turn it down to a smaller-but-still-loud subset.
+if (MSVC)
+    target_compile_options(spicyz PRIVATE "/W4")
+else ()
+    target_compile_options(spicyz PRIVATE "-Wall")
+endif ()
+
 target_compile_features(spicyz PRIVATE "${ZEEK_CXX_STD}")
 set_target_properties(spicyz PROPERTIES CXX_EXTENSIONS OFF)
 # We do not compile spicyz's own sources with sanitizers — the global linker

--- a/src/spicy/spicyz/driver.h
+++ b/src/spicy/spicyz/driver.h
@@ -147,7 +147,7 @@ protected:
      *
      * @param t type's meta information
      */
-    virtual void hookNewType(const TypeInfo& ti) {}
+    virtual void hookNewType(const TypeInfo& /*ti*/) {}
 
     /** Overridden from HILTI driver. */
     void hookNewASTPreCompilation(const hilti::Plugin& plugin, hilti::ASTRoot* root) override;

--- a/src/spicy/spicyz/glue-compiler.cc
+++ b/src/spicy/spicyz/glue-compiler.cc
@@ -1458,7 +1458,7 @@ struct VisitorZeekType : spicy::visitor::PreOrder {
         return *x;
     }
 
-    void operator()(hilti::type::Address* t) final { result(base_type("zeek_rt::ZeekTypeTag::Addr")); }
+    void operator()([[maybe_unused]] hilti::type::Address* t) final { result(base_type("zeek_rt::ZeekTypeTag::Addr")); }
 
     void operator()(hilti::type::Bitfield* t) final {
         hilti::Expressions fields;
@@ -1492,15 +1492,15 @@ struct VisitorZeekType : spicy::visitor::PreOrder {
         result(create_record_type(ns, local, fields));
     }
 
-    void operator()(hilti::type::Bool* t) final { result(base_type("zeek_rt::ZeekTypeTag::Bool")); }
-    void operator()(hilti::type::Bytes* t) final { result(base_type("zeek_rt::ZeekTypeTag::String")); }
-    void operator()(hilti::type::Interval* t) final { result(base_type("zeek_rt::ZeekTypeTag::Interval")); }
-    void operator()(hilti::type::Port* t) final { result(base_type("zeek_rt::ZeekTypeTag::Port")); }
-    void operator()(hilti::type::Real* t) final { result(base_type("zeek_rt::ZeekTypeTag::Double")); }
-    void operator()(hilti::type::SignedInteger* t) final { result(base_type("zeek_rt::ZeekTypeTag::Int")); }
-    void operator()(hilti::type::String* t) final { result(base_type("zeek_rt::ZeekTypeTag::String")); }
-    void operator()(hilti::type::Time* t) final { result(base_type("zeek_rt::ZeekTypeTag::Time")); }
-    void operator()(hilti::type::UnsignedInteger* t) final { result(base_type("zeek_rt::ZeekTypeTag::Count")); }
+    void operator()(hilti::type::Bool* /*t*/) final { result(base_type("zeek_rt::ZeekTypeTag::Bool")); }
+    void operator()(hilti::type::Bytes* /*t*/) final { result(base_type("zeek_rt::ZeekTypeTag::String")); }
+    void operator()(hilti::type::Interval* /*t*/) final { result(base_type("zeek_rt::ZeekTypeTag::Interval")); }
+    void operator()(hilti::type::Port* /*t*/) final { result(base_type("zeek_rt::ZeekTypeTag::Port")); }
+    void operator()(hilti::type::Real* /*t*/) final { result(base_type("zeek_rt::ZeekTypeTag::Double")); }
+    void operator()(hilti::type::SignedInteger* /*t*/) final { result(base_type("zeek_rt::ZeekTypeTag::Int")); }
+    void operator()(hilti::type::String* /*t*/) final { result(base_type("zeek_rt::ZeekTypeTag::String")); }
+    void operator()(hilti::type::Time* /*t*/) final { result(base_type("zeek_rt::ZeekTypeTag::Time")); }
+    void operator()(hilti::type::UnsignedInteger* /*t*/) final { result(base_type("zeek_rt::ZeekTypeTag::Count")); }
 
     void operator()(hilti::type::Enum* t) final {
         assert(id());

--- a/src/spicy/spicyz/glue-compiler.cc
+++ b/src/spicy/spicyz/glue-compiler.cc
@@ -924,7 +924,7 @@ glue::Export GlueCompiler::parseExport(const std::string& chunk) {
     }
 
     bool expect_fields = false;
-    bool include_fields;
+    bool include_fields = true;
 
     if ( looking_at(chunk, i, "without") ) {
         eat_token(chunk, &i, "without");
@@ -933,7 +933,6 @@ glue::Export GlueCompiler::parseExport(const std::string& chunk) {
     }
     else if ( looking_at(chunk, i, "with") ) {
         eat_token(chunk, &i, "with");
-        include_fields = true;
         expect_fields = true;
     }
 

--- a/src/val-convert.cc
+++ b/src/val-convert.cc
@@ -56,7 +56,7 @@ std::optional<zeek_uint_t> convert_double_to_native_count(double d, std::string&
         err = "bad conversion to count";
         return std::nullopt;
     }
-    return rint(d);
+    return llrint(d);
 }
 
 ValPtr convert_string_to_double(const StringVal* sv, std::string& err) {


### PR DESCRIPTION
This is the Zeek-side counterpart to https://github.com/zeek/spicy/pull/2440. It pulls in the submodule update to fix the warnings fixed there. 

The main change here is that currently `spicyz` is built with `-Wall`, where the rest of the Zeek build isn't. This is fine on Linux, but on Windows `-Wall` includes a lot of additional warnings that are somewhat obnoxious (things like implicit deletion of assignment/copy/move). I changed it to drop back to `/W4` which keeps the important warnings but removes a lot of others.

It also fixes some additional warnings not caught by the upstream Spicy changes.