### PR TITLE
NFA: Drop the static closuremap

### DIFF
--- a/src/IntSet.h
+++ b/src/IntSet.h
@@ -22,8 +22,6 @@ public:
     void Remove(unsigned int i);
     bool Contains(unsigned int i) const;
 
-    void Clear();
-
 private:
     void Expand(unsigned int i);
 
@@ -54,7 +52,5 @@ inline void IntSet::Remove(unsigned int i) {
 }
 
 inline bool IntSet::Contains(unsigned int i) const { return i / 8 < size ? set[i / 8] & (1 << (i % 8)) : false; }
-
-inline void IntSet::Clear() { memset(set, 0, size); }
 
 } // namespace zeek::detail

--- a/src/NFA.cc
+++ b/src/NFA.cc
@@ -282,9 +282,7 @@ NFA_Machine* make_alternate(NFA_Machine* m1, NFA_Machine* m2) {
 }
 
 NFA_state_list* epsilon_closure(NFA_state_list* states) {
-    // We just keep one of this as it may get quite large.
-    static IntSet closuremap;
-    closuremap.Clear();
+    IntSet closuremap(states->size());
 
     NFA_state_list* closure = new NFA_state_list;
 


### PR DESCRIPTION
Since 54b687a83adb5c97437d02c1cdb2e523f1fdfbdb, the closuremap is cleared and identifiers re-used, but remained a static instance.

@initconf reports the memset() call within Clear() of the IntSet becomes significant overhead for subsequent trivial string_to_pattern() calls once the closuremap grew large. This is due to always zeroing out all of the allocated memory.

Seem easiest to just use a new instance and select the initial size to be the number of NFA states and rely on the allocator to be fast, rather than trying to find some magic constant.

---

cc @vpax - does that look reasonable to you?