### PR TITLE
CI: Return/use additional tags as a bash array during image creation

### DIFF
--- a/ci/container-images-addl-tags.sh
+++ b/ci/container-images-addl-tags.sh
@@ -3,7 +3,7 @@
 # This script produces output in the form of
 #
 #     $ REMOTE=awelzel ./ci/container-images-addl-tags.sh v7.0.5
-#     ADDITIONAL_MANIFEST_TAGS= lts 7.0 latest
+#     ADDITIONAL_MANIFEST_TAGS="lts 7.0 latest"
 #
 # This scripts expects visibility to all tags and release branches
 # to work correctly. See the find-current-version.sh for details.
@@ -29,16 +29,19 @@ feature_pat="^v$(echo $feature_ver | sed 's,\.,\\.,g')\.[0-9]+\$"
 # Construct additional tags for the image. At most this will
 # be "lts x.0 feature" for an lts branch x.0 that is currently
 # also the latest feature branch.
-ADDL_MANIFEST_TAGS=
+ADDL_MANIFEST_TAGS=()
 if echo "${TAG}" | grep -q -E "${lts_pat}"; then
-    ADDL_MANIFEST_TAGS="${ADDL_MANIFEST_TAGS} lts ${lts_ver}"
+    ADDL_MANIFEST_TAGS+=(lts)
+    ADDL_MANIFEST_TAGS+=(${lts_ver})
 fi
 
 if echo "${TAG}" | grep -q -E "${feature_pat}"; then
-    ADDL_MANIFEST_TAGS="${ADDL_MANIFEST_TAGS} latest"
+    ADDL_MANIFEST_TAGS+=(latest)
     if [ "${feature_ver}" != "${lts_ver}" ]; then
-        ADDL_MANIFEST_TAGS="${ADDL_MANIFEST_TAGS} ${feature_ver}"
+        ADDL_MANIFEST_TAGS+=(${feature_ver})
     fi
 fi
 
-echo "ADDITIONAL_MANIFEST_TAGS=${ADDL_MANIFEST_TAGS}"
+# Output the array as a space-separated string. Arrays can't be exported
+# into the environment in bash, so it has to be converted back.
+echo "ADDITIONAL_MANIFEST_TAGS=\"${ADDL_MANIFEST_TAGS[*]}\""


### PR DESCRIPTION
The `ci/container-images-addl-tags.sh` script was returning something like `ADDITIONAL_MANIFEST_TAGS= lts 8.0` when called during the container builds, and the Circle build configuration then tried to append that to `BASH_ENV` so that it could persist to the next step in the job. The problem is that that's not valid bash script at all, and so the task just ignored it and the additional tags weren't created for the 8.0.9/8.2.1 images during the release.

This PR changes the script to handle `ADDITIONAL_MANIFEST_TAGS` as a bash array, and outputs it in a format that can be correctly appended to `BASH_ENV`.

I'm not entirely sure how the heck this worked on Cirrus, but it definitely doesn't work on Circle.