### PR TITLE
Upgrade GitPython to 3.1.55 to fix dependabot warnings

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,4 +4,4 @@ sphinx-rtd-theme==3.0.2
 # This version is the last version that supports Python 3.9.
 # 8.1.x is the last version series that supports Python 3.10.
 Sphinx==7.4.7
-GitPython==3.1.51
+GitPython==3.1.55


### PR DESCRIPTION
It figures right after I merged https://github.com/zeek/zeek/pull/5718, dependabot decided to create 2 more findings based on a later version. This bumps GitPython to the latest version. Again, I'll merge this after CI passes.