### PR TITLE
CircleCI: Use different environment variable for access to build images

### DIFF
--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -1120,8 +1120,6 @@ workflows:
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           store_install_tarball: true
           enable_benchmarks: true
-          context:
-            - zeek
           << : *FILTER_IF_SKIP_ALL
       - linux-build:
           name: ubuntu-24.04-clang-libcpp
@@ -1154,8 +1152,6 @@ workflows:
           store_install_tarball: true
           install_spicy_analyzers: true
           enable_benchmarks: true
-          context:
-            - zeek
           << : *FILTER_IF_PR_NOT_FULL_OR_BENCHMARK
       - linux-build:
           name: ubuntu-24.04-spicy-head
@@ -1167,8 +1163,6 @@ workflows:
           store_install_tarball: true
           install_spicy_analyzers: true
           enable_benchmarks: true
-          context:
-            - zeek
           << : *FILTER_IF_PR_NOT_FULL_OR_BENCHMARK
       - linux-build:
           name: ubuntu-24.04-zam
@@ -1196,8 +1190,6 @@ workflows:
           enable_coverage: true
           enable_fuzzer_tests: true
           cpu_count: 8
-          context:
-            - zeek
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
             CXXFLAGS=-DZEEK_DICT_DEBUG

--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -284,7 +284,7 @@ jobs:
       ZEEK_TEST_ULIMIT_OPEN_FILES: 256
       ZEEK_CIRCLE_EXTRA_ENV: << parameters.extra_env >>
       ZEEK_CI_CCACHE_PRUNE_SIZE: 700M
-      HILTI_CXX_COMPILER_LAUNCER: ccache
+      HILTI_CXX_COMPILER_LAUNCHER: ccache
     docker:
       - image: << parameters.docker_image >>-<< parameters.ci_image_date >>
     resource_class: << parameters.resource_class >>
@@ -404,7 +404,7 @@ jobs:
       ZEEK_CI_CCACHE_PRUNE_SIZE: 700M
       CTEST_OUTPUT_ON_FAILURE: 1
       VSINSTALLDIR: 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\'
-      HILTI_CXX_COMPILER_LAUNCER: ccache
+      HILTI_CXX_COMPILER_LAUNCHER: ccache
     machine:
       image: windows-server-2025-gui:edge
     resource_class: windows.large
@@ -495,7 +495,7 @@ jobs:
       ZEEK_CI_BTEST_RETRIES: 2
       ZEEK_CI_RUNNER_OS: macos
       ZEEK_CI_CCACHE_PRUNE_SIZE: 700M
-      HILTI_CXX_COMPILER_LAUNCER: ccache
+      HILTI_CXX_COMPILER_LAUNCHER: ccache
     macos:
       xcode: << parameters.xcode_version >>
     resource_class: m4pro.medium

--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -114,6 +114,17 @@ jobs:
       ZEEK_CI: 1
     steps:
       - checkout
+      - run:
+          name: Set extra environment variables
+          command: |
+            # This could be done in the environment block of the job definition, but
+            # we pass 0/1 for consistency with other environment variables in the rest
+            # of the config.
+            if [[ "<< pipeline.parameters.is_internal_build >>" == "true" ]]; then
+              echo "export ZEEK_CI_INTERNAL_BUILD=1" >> "$BASH_ENV"
+            else
+              echo "export ZEEK_CI_INTERNAL_BUILD=0" >> "$BASH_ENV"
+            fi
       - restore_cache:
           keys:
             - zeek-traces-v2

--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -171,9 +171,6 @@ jobs:
             docker buildx create --use --name multiarch-builder --driver docker-container
             docker buildx inspect --bootstrap
       - run:
-          name: Log in to Docker Hub
-          command: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_LOGIN" --password-stdin
-      - run:
           name: Check if image exists remotely
           command: |
             # set +e prevents this script from exiting immediately if one of the commands fails.
@@ -199,6 +196,15 @@ jobs:
                  echo "$FULL_IMAGE_TAG is missing, continuing with build"
                fi
             fi
+      - run:
+          name: Log in to Docker Hub
+          command: |
+            if [ -z "${DOCKER_BUILDIMAGE_LOGIN}" -o -z "${DOCKER_BUILDIMAGE_PASSWORD}" ]; then
+               echo "User doesn't have access to Docker credentials, later builds will fail"
+               circleci-agent step halt
+            fi
+
+            echo "$DOCKER_BUILDIMAGE_PASSWORD" | docker login -u "$DOCKER_BUILDIMAGE_LOGIN" --password-stdin
       - run:
           name: Build and push multi-arch image
           command: |
@@ -277,9 +283,6 @@ jobs:
       HILTI_CXX_COMPILER_LAUNCER: ccache
     docker:
       - image: << parameters.docker_image >>-<< parameters.ci_image_date >>
-        auth:
-          username: $DOCKER_LOGIN
-          password: $DOCKER_PASSWORD
     resource_class: << parameters.resource_class >>
     steps:
       - run:
@@ -796,9 +799,6 @@ jobs:
       ZEEK_CI_CCACHE_PRUNE_SIZE: 700M
     docker:
       - image: << parameters.docker_image >>-<< parameters.ci_image_date >>
-        auth:
-          username: $DOCKER_LOGIN
-          password: $DOCKER_PASSWORD
     resource_class: << parameters.resource_class >>
     steps:
       - run:
@@ -863,9 +863,6 @@ jobs:
       ZEEK_CI_CONFIGURE_FLAGS: --build-type=release --disable-broker-tests --prefix=${ZEEK_CI_WORKING_DIR}/install --ccache --enable-werror
     docker:
       - image: << parameters.docker_image >>-<< parameters.ci_image_date >>
-        auth:
-          username: $DOCKER_LOGIN
-          password: $DOCKER_PASSWORD
     resource_class: << parameters.resource_class >>
     steps:
       - run:

--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -38,6 +38,10 @@ parameters:
     description: True if running for a tag of the form v1.2.3 or v1.2.3-rc1
     type: boolean
     default: false
+  is_internal_build:
+    description: True if the requesting user is a member of the Zeek Github organization
+    type: boolean
+    default: false
 
 commands:
   clone_repo:
@@ -297,6 +301,13 @@ jobs:
               echo "export ZEEK_CI_CREATE_INSTALL_TARBALL=1" >> "$BASH_ENV"
             else
               echo "export ZEEK_CI_CREATE_INSTALL_TARBALL=0" >> "$BASH_ENV"
+            fi
+
+            # Same here
+            if [[ "<< pipeline.parameters.is_internal_build >>" == "true" ]]; then
+              echo "export ZEEK_CI_INTERNAL_BUILD=1" >> "$BASH_ENV"
+            else
+              echo "export ZEEK_CI_INTERNAL_BUILD=0" >> "$BASH_ENV"
             fi
 
             IFS=$'\n'

--- a/.circleci/generate-workflow-params.py
+++ b/.circleci/generate-workflow-params.py
@@ -8,13 +8,13 @@ import urllib.request
 PR_NUMBER = os.getenv("CIRCLE_PULL_REQUEST", "")
 GH_API_TOKEN = os.getenv("GH_TOKEN", "")
 GIT_TAG = os.getenv("CIRCLE_TAG", "")
+GIT_BRANCH = os.getenv("CIRCLE_BRANCH", "")
 
 params = {}
 if PR_NUMBER:
     url = PR_NUMBER
     url = url.replace("https://github.com", "https://api.github.com/repos")
     url = url.replace("/pull/", "/issues/")
-    url += "/labels"
 
     print(f"Requesting {url} to get PR labels from GitHub")
 
@@ -29,7 +29,7 @@ if PR_NUMBER:
     response = urllib.request.urlopen(req)
     resp_json = json.loads(response.read().decode("utf8"))
 
-    for label in resp_json:
+    for label in resp_json.get("labels", []):
         name = label.get("name", "")
         print(f"Found GitHub label {name} on PR, enabling flag")
         if name == "CI: Benchmark":
@@ -51,6 +51,15 @@ if PR_NUMBER:
 
     if not params:
         print("No GitHub labels found on PR")
+
+    # This field will be set to MEMBER if the user that opened a PR is a member of the
+    # Zeek github organization. This lets us track internal builds.
+    if resp_json.get("author_association", "NONE") == "MEMBER":
+        params["is_internal_build"] = True
+
+elif GIT_BRANCH == "master" or re.match(r"^release/.*$", GIT_BRANCH):
+    # Builds from master should always be considered internal builds.
+    params["is_internal_build"] = True
 
 if GIT_TAG and re.match(r"^v\d+\.\d+\.\d+(-rc[0-9]+)?$", GIT_TAG):
     params["has_release_tag"] = True

--- a/ci/benchmark.sh
+++ b/ci/benchmark.sh
@@ -6,7 +6,7 @@ ZEEK_BENCHMARK_ENDPOINT="/zeek"
 set -e
 
 # Skip running benchmarks for jobs from forks, third-parties, or non-Circle builds.
-if [ ${ZEEK_IS_INTERNAL_JOB:-0} -ne 1 -o "${CIRCLE_PROJECT_REPONAME}" != "zeek" ]; then
+if [[ ${ZEEK_CI_INTERNAL_BUILD:-0} != 1 || "${CIRCLE_PROJECT_REPONAME}" != "zeek" ]]; then
     echo "Benchmarking skipped for jobs from forks"
     exit 0
 fi

--- a/ci/init-external-repos.sh
+++ b/ci/init-external-repos.sh
@@ -29,12 +29,12 @@ fi
 make update-traces
 cd ..
 
-# When running in CI for the main repo, try to clone the private testsuite.
+# When running in CI for internal builds, try to clone the private testsuite.
 # Note that this script is also called when populating the public cache, so
 # the zeek-testing-private dir could have been created/populated already. This
 # requires the host running the build to have access to an SSH key that grants
 # access to the repo, and it will fail otherwise.
-if [[ -n "${ZEEK_CI}" ]] && [[ ! -d zeek-testing-private ]]; then
+if [[ -n "${ZEEK_CI}" && ${ZEEK_CI_INTERNAL_BUILD} == 1 && ! -d zeek-testing-private ]]; then
     banner "Trying to clone zeek-testing-private git repo"
     GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" git clone git@github.com:zeek/zeek-testing-private
 fi

--- a/ci/upload-coverage.sh
+++ b/ci/upload-coverage.sh
@@ -4,7 +4,7 @@
 # correctly. On Circle, this is provided via the Zeek context.
 
 # Only do this on the main repo to avoid having a ton of data in Coveralls.
-if [ ${ZEEK_IS_INTERNAL_JOB:-0} -ne 1 ]; then
+if [ ${ZEEK_CI_INTERNAL_BUILD:-0} -ne 1 ]; then
     echo "Coverage upload skipped for jobs from forks"
     exit 0
 fi


### PR DESCRIPTION
This started out as a change just to switch how we access to the tokens for DockerHub on CircleCI, and turned into more. This PR:

- Moves to a different token for the build images with more restricted access, which also removes the need to pass the login information into a few jobs that don't need it anymore.
- Moves the information for the benchmarker and coverage into the regular environment instead of putting those in the org context. This removes the need for a few of the jobs (including the ubuntu-24.04 one that runs on every PR) to have access to the context. This should be nicer for external contributors.
- Removes the ZEEK_IS_INTERNAL job environment variable and replaces it with one that is based on the information we get from GitHub as part of the builds. We also assume that any build that's done from master is also an internal job.
- Fixes a typo that was introduced in https://github.com/zeek/zeek/pull/5685 that I missed in the review.
- Stop attempting to clone zeek-testing-private for external builds. Those builds don't have access to the SSH key that would be required for them to clone it.