### PR TITLE
Switch Docker layer cache from GHA to GHCR

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,7 @@ name: Check
 
 permissions:
   contents: read
+  packages: write
 
 on:
   push:
@@ -386,9 +387,15 @@ jobs:
         submodules: recursive
         persist-credentials: false
 
-    # This step enables caching in `docker/build-push-action` below.
     - name: Prepare Docker
       uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    - name: Log in to GHCR
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build Docker image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -396,8 +403,8 @@ jobs:
         file: ${{ matrix.file }}
         context: . # Reuse the current checkout instead of doing a full recursive clone again.
         tags: zeek-ci-${{ hashFiles(matrix.file) }}
-        cache-to: type=gha
-        cache-from: type=gha
+        cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/zeek-ci:${{ matrix.id }},mode=max
+        cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/zeek-ci:${{ matrix.id }}
         load: true
         push: false
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -388,10 +388,10 @@ jobs:
 
     # This step enables caching in `docker/build-push-action` below.
     - name: Prepare Docker
-      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Build Docker image
-      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         file: ${{ matrix.file }}
         context: . # Reuse the current checkout instead of doing a full recursive clone again.


### PR DESCRIPTION
The GHA cache has a 10 GB limit shared across all workflows, causing frequent evictions and poor hit rates for our large CI matrix. GHCR container storage is currently free with no stated cap (GitHub commits to one month notice before changing this).

> [!NOTE]
> All code changes in this PR were generated with Claude Sonnet 4.6. I reviewed all changes and am accountable.