### PR TITLE
Run Windows btests under winpty for better output

### DIFF
--- a/ci/windows/run-btests.sh
+++ b/ci/windows/run-btests.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 export MSYS=disable_pcon
 
-BTEST="python ../../auxil/btest/btest"
+BTEST="winpty python ../../auxil/btest/btest"
 JOBS=${ZEEK_CI_CPUS:-8}
 RETRIES=${ZEEK_CI_BTEST_RETRIES:-3}
 


### PR DESCRIPTION
Running under Git Bash without winpty results in Python saying the terminal isn't a TTY, and we lose the percent-complete output that we have on all of the other platforms. Running under winpty fixes this and Python reports the terminal as a TTY.

Related to https://github.com/zeek/btest/issues/143