### PR TITLE
Fix assertion when inserting Dict elements while under robust iteration

### DIFF
--- a/src/Dict.h
+++ b/src/Dict.h
@@ -1420,6 +1420,15 @@ private:
         for ( int i = prev_capacity; i < capacity; i++ )
             table[i].SetEmpty();
 
+        // If iterator exist while increasing the capacity, they won't reach into the new section
+        // of data. Upgrade the capacity on all of the existing iterators.
+        if ( iterators && ! iterators->empty() ) {
+            for ( auto c : *iterators ) {
+                if ( c->next >= prev_capacity )
+                    c->next = capacity;
+            }
+        }
+
         // REmap from last to first in reverse order. SizeUp can be triggered by 2 conditions, one
         // of which is that the last space in the table is occupied and there's nowhere to put new
         // items. In this case, the table doubles in capacity and the item is put at the
@@ -1500,15 +1509,6 @@ private:
             iter->next = Next(-1);
 
         if ( iter->next < Capacity() && table[iter->next].Empty() ) {
-            // [Robin] I believe this means that the table has resized in a way
-            // that we're now inside the overflow area where elements are empty,
-            // because elsewhere empty slots aren't allowed. Assuming that's right,
-            // then it means we'll always be at the end of the table now and could
-            // also just set `next` to capacity. However, just to be sure, we
-            // instead reuse logic from below to move forward "to a valid position"
-            // and then double check, through an assertion in debug mode, that it's
-            // actually the end. If this ever triggered, the above assumption would
-            // be wrong (but the Next() call would probably still be right).
             iter->next = Next(iter->next);
             ASSERT(iter->next == Capacity());
         }

--- a/testing/btest/core/dict-iteration-expire-3538.zeek
+++ b/testing/btest/core/dict-iteration-expire-3538.zeek
@@ -1,0 +1,35 @@
+# @TEST-DOC: Regression test for #3538; inserting during robust iteration with a resize should not trigger an assertion.
+#
+# @TEST-EXEC: zcat <$TRACES/echo-connections.pcap.gz | zeek --load-seeds seeds -b -r - %INPUT table_expire_delay=0.01sec table_incremental_step=10 table_expire_interval=0.5sec
+
+redef record connection += {
+	recent_tcp: set[string] &default=set() &read_expire=3min;
+};
+
+event new_packet(c: connection, pkt: pkt_hdr) {
+	add c$recent_tcp[cat(pkt$tcp)];
+}
+
+# @TEST-START-FILE seeds
+4140628182
+4291381284
+402700558
+353966048
+3712867326
+1664171646
+1208542792
+3074875631
+3029468528
+1747472994
+1495181363
+3103230416
+3627798802
+3491157209
+3035073649
+2328185080
+1698783300
+2050917226
+208721007
+2336112920
+1412171239
+# @TEST-END-FILE


### PR DESCRIPTION
These changes were entirely generated by Claude Opus-4.7 but I understand the reasoning for all of the changes. The description is below. I spent a while debugging this one in 2024. Claude's original reasoning was wrong about the original comment and assertion, but I was able to drive it towards a correct solution.

>   Root cause: SizeUp() expands the table's capacity (e.g., from 70 to 135) and marks new positions as empty,
>   but never adjusts active iterators. An iterator that had next == old_capacity (meaning "iteration complete")
>    suddenly has next < new_capacity, pointing into the newly-empty overflow area. The assertion then fires
>   because there happens to be a non-empty entry further in the overflow (from a subsequent insertion).
>                                                              
>   Fix in SizeUp(): After expanding the table, advance any iterator whose next >= prev_capacity to the new
>   capacity. This preserves the "iteration complete" semantic.

Fixes #3538 