### PR TITLE
Tweaks to be more tolerant to missing type information

### DIFF
--- a/src/EventHandler.cc
+++ b/src/EventHandler.cc
@@ -30,7 +30,7 @@ const FuncTypePtr& EventHandler::GetType(bool check_export) {
 
     const auto& id = detail::lookup_ID(name.data(), detail::current_module.c_str(), false, false, check_export);
 
-    if ( ! id )
+    if ( ! id || ! id->GetType() )
         return FuncType::nil;
 
     if ( id->GetType()->Tag() != TYPE_FUNC )

--- a/src/Expr.cc
+++ b/src/Expr.cc
@@ -4895,7 +4895,7 @@ ExprPtr check_and_promote_expr(ExprPtr e, TypePtr t) {
         return nullptr;
     }
 
-    if ( ! same_type(t, et) ) {
+    if ( ! same_type(t, et, false, false) ) {
         if ( t->Tag() == TYPE_TABLE && et->Tag() == TYPE_TABLE && et->AsTableType()->IsUnspecifiedTable() ) {
             if ( e->Tag() == EXPR_TABLE_CONSTRUCTOR ) {
                 auto& attrs = cast_intrusive<TableConstructorExpr>(e)->GetAttrs();

--- a/src/script_opt/UsageAnalyzer.cc
+++ b/src/script_opt/UsageAnalyzer.cc
@@ -43,7 +43,7 @@ UsageAnalyzer::UsageAnalyzer(std::vector<FuncInfo>& funcs) {
         auto& id = gpair.second;
         auto& t = id->GetType();
 
-        if ( t->Tag() != TYPE_FUNC )
+        if ( ! t || t->Tag() != TYPE_FUNC )
             continue;
 
         if ( auto gv = id->GetVal() )
@@ -131,7 +131,9 @@ public:
         if ( attr_depth > 0 )
             ids.insert(id);
 
-        id->GetType()->Traverse(this);
+        auto& t = id->GetType();
+        if ( t )
+            t->Traverse(this);
 
         if ( auto& attrs = id->GetAttrs() )
             attrs->Traverse(this);
@@ -179,7 +181,7 @@ void UsageAnalyzer::FindSeeds(IDSet& seeds) const {
 
 const Func* UsageAnalyzer::GetFuncIfAny(const IDPtr& id) const {
     auto& t = id->GetType();
-    if ( t->Tag() != TYPE_FUNC )
+    if ( ! t || t->Tag() != TYPE_FUNC )
         return nullptr;
 
     auto fv = cast_intrusive<FuncVal>(id->GetVal());
@@ -248,7 +250,9 @@ TraversalCode UsageAnalyzer::PreID(const ID* raw_id) {
         // Haven't seen this function before.
         new_reachables.insert(id);
 
-    id->GetType()->Traverse(this);
+    auto& t = id->GetType();
+    if ( t )
+        t->Traverse(this);
 
     auto& attrs = id->GetAttrs();
     if ( attrs )


### PR DESCRIPTION
This is a first of a number of PRs reflecting adjustments I found myself making to Zeek while trying to add a significant AST-manipulating extension. This one provides guard rails for identifiers that don't have types and enables low-level record equivalence (like for C++ creating events) in expressions.