### PR TITLE
Streaming regex matching

### DIFF
--- a/src/DFA.cc
+++ b/src/DFA.cc
@@ -52,11 +52,14 @@ void DFA_State::SymPartition(const EquivClass* ec) {
                 sym = ec->SymEquivClass(sym);
                 meta_ec->UniqueChar(sym);
             }
+            if ( n->TransSym() != SYM_BOL && n->TransSym() != SYM_EOL )
+                has_byte_xtion = true;
             continue;
         }
 
         // Character class.
         meta_ec->CCL_Use(n->TransCCL());
+        has_byte_xtion = true;
     }
 
     meta_ec->BuildECs();

--- a/src/DFA.h
+++ b/src/DFA.h
@@ -33,6 +33,13 @@ public:
     inline DFA_State* Xtion(int sym, DFA_Machine* machine);
 
     const AcceptingSet* Accept() const { return accept; }
+
+    // True when no byte-driven out-transition leaves this state: the only
+    // surviving transitions (if any) are on SYM_BOL / SYM_EOL. Once a
+    // stream matcher is in this state, no further input byte can extend
+    // or resurrect the match, allowing immediate recognition of being done.
+    bool IsTerminal() const { return ! has_byte_xtion; }
+
     void SymPartition(const EquivClass* ec);
 
     // ec_sym is an equivalence class, not a character.
@@ -65,6 +72,10 @@ protected:
     NFA_state_list* nfa_states;
     EquivClass* meta_ec; // which ec's make same transition
     DFA_State* mark;
+
+    // True if the state has a transition that's not on an anchor
+    // (i.e., not SYM_BOL/SYM_EOL);
+    bool has_byte_xtion = false;
 };
 
 using DigestStr = std::string;

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -359,65 +359,15 @@ Streaming_RE_Matcher::Streaming_RE_Matcher(Specific_RE_Matcher* matcher) {
 }
 
 Streaming_RE_Matcher::Status Streaming_RE_Matcher::FeedForFirstMatch(const u_char* bv, int n, bool bol, bool eol) {
-    if ( ! dfa ) {
-        if ( current_pos == -1 ) {
-            current_pos = 0;
-            last_accept_pos = 0;
-        }
-        return JAMMED;
-    }
-
-    if ( current_pos == -1 ) {
-        current_pos = 0;
-        current_state = dfa->StartState();
-
-        if ( bol ) {
-            current_state = current_state->Xtion(ecs[SYM_BOL], dfa);
-            if ( ! current_state )
-                return JAMMED;
-        }
-
-        if ( current_state->Accept() ) {
-            last_accept_pos = 0;
-            current_state = nullptr;
-            return JAMMED;
-        }
-    }
-
-    if ( ! current_state )
-        return JAMMED;
-
-    for ( int i = 0; i < n; ++i ) {
-        int ec = ecs[bv[i]];
-        DFA_State* next_state = current_state->Xtion(ec, dfa);
-
-        if ( ! next_state ) {
-            current_state = nullptr;
-            return JAMMED;
-        }
-
-        current_state = next_state;
-        ++current_pos;
-
-        if ( current_state->Accept() ) {
-            last_accept_pos = current_pos;
-            current_state = nullptr;
-            return JAMMED;
-        }
-    }
-
-    if ( eol ) {
-        DFA_State* eol_state = current_state->Xtion(ecs[SYM_EOL], dfa);
-        if ( eol_state && eol_state->Accept() )
-            last_accept_pos = current_pos;
-        current_state = nullptr;
-        return JAMMED;
-    }
-
-    return ALIVE;
+    return DoFeed</*JamOnFirstMatch=*/true>(bv, n, bol, eol);
 }
 
 Streaming_RE_Matcher::Status Streaming_RE_Matcher::Feed(const u_char* bv, int n, bool bol, bool eol) {
+    return DoFeed</*JamOnFirstMatch=*/false>(bv, n, bol, eol);
+}
+
+template<bool JamOnFirstMatch>
+Streaming_RE_Matcher::Status Streaming_RE_Matcher::DoFeed(const u_char* bv, int n, bool bol, bool eol) {
     if ( ! dfa ) {
         if ( current_pos == -1 ) {
             current_pos = 0;
@@ -438,7 +388,7 @@ Streaming_RE_Matcher::Status Streaming_RE_Matcher::Feed(const u_char* bv, int n,
 
         if ( current_state->Accept() ) {
             last_accept_pos = 0;
-            if ( current_state->IsTerminal() ) {
+            if ( JamOnFirstMatch || current_state->IsTerminal() ) {
                 current_state = nullptr;
                 return JAMMED;
             }
@@ -462,7 +412,7 @@ Streaming_RE_Matcher::Status Streaming_RE_Matcher::Feed(const u_char* bv, int n,
 
         if ( current_state->Accept() ) {
             last_accept_pos = current_pos;
-            if ( current_state->IsTerminal() ) {
+            if ( JamOnFirstMatch || current_state->IsTerminal() ) {
                 current_state = nullptr;
                 return JAMMED;
             }

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -3,6 +3,7 @@
 #include "zeek/RE.h"
 
 #include <cstdlib>
+#include <memory>
 #include <utility>
 
 #include "zeek/CCL.h"
@@ -707,6 +708,100 @@ TEST_SUITE("re_matcher") {
 
         RE_Matcher match9("a\\\"b");
         CHECK(match9.Compile());
+    }
+}
+
+TEST_SUITE("streaming_re_matcher") {
+    using detail::Streaming_RE_Matcher::ALIVE;
+    using detail::Streaming_RE_Matcher::JAMMED;
+
+    // easy "a"_b for a the uchar* type
+    inline const u_char* operator""_b(const char* s, std::size_t) { return reinterpret_cast<const u_char*>(s); }
+
+    auto make_streaming_matcher = [](const char* pat) {
+        // Use MATCH_ANYWHERE so ^ or $ must be explicit in pattern when wanted.
+        auto specific_re_matcher = std::make_unique<detail::Specific_RE_Matcher>(detail::MATCH_ANYWHERE);
+        specific_re_matcher->AddPat(pat);
+        REQUIRE(specific_re_matcher->Compile());
+        auto streaming_re_matcher = std::make_unique<detail::Streaming_RE_Matcher>(specific_re_matcher.get());
+        return std::pair{std::move(specific_re_matcher), std::move(streaming_re_matcher)};
+    };
+
+    TEST_CASE("feed eol jams") {
+        auto [m, sm] = make_streaming_matcher("^ab$");
+        auto r = sm->Feed("a"_b, 1, /*bol=*/true, /*eol=*/false);
+        CHECK_EQ(r, ALIVE);
+        CHECK_EQ(sm->Length(), 1);
+        CHECK_EQ(sm->LastAccept(), -1);
+
+        r = sm->Feed("b"_b, 1, /*bol=*/false, /*eol=*/false);
+        CHECK_EQ(r, ALIVE);
+        CHECK_EQ(sm->Length(), 2);
+        CHECK_EQ(sm->LastAccept(), -1);
+
+        // eol completes the match and jams.
+        r = sm->Feed(""_b, 0, /*bol=*/false, /*eol=*/true);
+        CHECK_EQ(r, JAMMED);
+        CHECK_EQ(sm->Length(), 2);
+        CHECK_EQ(sm->LastAccept(), 2);
+    }
+
+    TEST_CASE("feed longer match") {
+        auto [m, sm] = make_streaming_matcher("^(ab)+");
+        auto r = sm->Feed("ab"_b, 2, /*bol=*/true, /*eol=*/false);
+        CHECK_EQ(r, ALIVE);
+        CHECK_EQ(sm->Length(), 2);
+        CHECK_EQ(sm->LastAccept(), 2);
+
+        r = sm->Feed("a"_b, 1, /*bol=*/false, /*eol=*/false);
+        CHECK_EQ(r, ALIVE);
+        CHECK_EQ(sm->Length(), 3);
+        CHECK_EQ(sm->LastAccept(), 2);
+
+        r = sm->Feed("b"_b, 1, /*bol=*/false, /*eol=*/false);
+        CHECK_EQ(r, ALIVE);
+        CHECK_EQ(sm->Length(), 4);
+        CHECK_EQ(sm->LastAccept(), 4);
+    }
+
+    TEST_CASE("feed longer match eol jams") {
+        auto [m, sm] = make_streaming_matcher("^(ab)+");
+        auto r = sm->Feed("ab"_b, 2, /*bol=*/true, /*eol=*/false);
+        CHECK_EQ(r, ALIVE);
+        CHECK_EQ(sm->Length(), 2);
+        CHECK_EQ(sm->LastAccept(), 2);
+
+        r = sm->Feed("a"_b, 1, /*bol=*/false, /*eol=*/false);
+        CHECK_EQ(r, ALIVE);
+        CHECK_EQ(sm->Length(), 3);
+        CHECK_EQ(sm->LastAccept(), 2);
+
+        r = sm->Feed("b"_b, 1, /*bol=*/false, /*eol=*/true);
+        CHECK_EQ(r, JAMMED); // eol always jams
+        CHECK_EQ(sm->Length(), 4);
+        CHECK_EQ(sm->LastAccept(), 4);
+
+        // once jammed, won't make progress anymore
+        r = sm->Feed("ab"_b, 2, /*bol=*/false, /*eol=*/false);
+        CHECK_EQ(r, JAMMED);
+        CHECK_EQ(sm->Length(), 4);
+        CHECK_EQ(sm->LastAccept(), 4);
+    }
+
+    TEST_CASE("feed bol without bol in pattern") {
+        auto [m, sm] = make_streaming_matcher("ab+");
+        auto r = sm->Feed("ab"_b, 2, /*bol=*/true, /*eol=*/false);
+        CHECK_EQ(r, ALIVE);
+        CHECK_EQ(sm->Length(), 2);
+        CHECK_EQ(sm->LastAccept(), 2);
+    }
+
+    TEST_CASE("feed for first match jams after match") {
+        auto [m, sm] = make_streaming_matcher("^ab+");
+        auto r = sm->FeedForFirstMatch("abb"_b, 3, /*bol=*/true, /*eol=*/false);
+        CHECK_EQ(r, JAMMED);
+        CHECK_EQ(sm->Length(), 2); // only 2 bytes consumed, then jammed.
+        CHECK_EQ(sm->LastAccept(), 2);
     }
 }
 

--- a/src/RE.cc
+++ b/src/RE.cc
@@ -349,6 +349,136 @@ bool RE_Match_State::Match(const u_char* bv, int n, bool bol, bool eol, bool cle
     return accepted_matches.size() != old_matches;
 }
 
+Streaming_RE_Matcher::Streaming_RE_Matcher(Specific_RE_Matcher* matcher) {
+    dfa = matcher->DFA();
+    ecs = matcher->EC()->EquivClasses();
+    current_state = nullptr;
+    current_pos = -1;
+    last_accept_pos = -1;
+}
+
+Streaming_RE_Matcher::Status Streaming_RE_Matcher::FeedForFirstMatch(const u_char* bv, int n, bool bol, bool eol) {
+    if ( ! dfa ) {
+        if ( current_pos == -1 ) {
+            current_pos = 0;
+            last_accept_pos = 0;
+        }
+        return JAMMED;
+    }
+
+    if ( current_pos == -1 ) {
+        current_pos = 0;
+        current_state = dfa->StartState();
+
+        if ( bol ) {
+            current_state = current_state->Xtion(ecs[SYM_BOL], dfa);
+            if ( ! current_state )
+                return JAMMED;
+        }
+
+        if ( current_state->Accept() ) {
+            last_accept_pos = 0;
+            current_state = nullptr;
+            return JAMMED;
+        }
+    }
+
+    if ( ! current_state )
+        return JAMMED;
+
+    for ( int i = 0; i < n; ++i ) {
+        int ec = ecs[bv[i]];
+        DFA_State* next_state = current_state->Xtion(ec, dfa);
+
+        if ( ! next_state ) {
+            current_state = nullptr;
+            return JAMMED;
+        }
+
+        current_state = next_state;
+        ++current_pos;
+
+        if ( current_state->Accept() ) {
+            last_accept_pos = current_pos;
+            current_state = nullptr;
+            return JAMMED;
+        }
+    }
+
+    if ( eol ) {
+        DFA_State* eol_state = current_state->Xtion(ecs[SYM_EOL], dfa);
+        if ( eol_state && eol_state->Accept() )
+            last_accept_pos = current_pos;
+        current_state = nullptr;
+        return JAMMED;
+    }
+
+    return ALIVE;
+}
+
+Streaming_RE_Matcher::Status Streaming_RE_Matcher::Feed(const u_char* bv, int n, bool bol, bool eol) {
+    if ( ! dfa ) {
+        if ( current_pos == -1 ) {
+            current_pos = 0;
+            last_accept_pos = 0;
+        }
+        return JAMMED;
+    }
+
+    if ( current_pos == -1 ) {
+        current_pos = 0;
+        current_state = dfa->StartState();
+
+        if ( bol ) {
+            current_state = current_state->Xtion(ecs[SYM_BOL], dfa);
+            if ( ! current_state )
+                return JAMMED;
+        }
+
+        if ( current_state->Accept() ) {
+            last_accept_pos = 0;
+            if ( current_state->IsTerminal() ) {
+                current_state = nullptr;
+                return JAMMED;
+            }
+        }
+    }
+
+    if ( ! current_state )
+        return JAMMED;
+
+    for ( int i = 0; i < n; ++i ) {
+        int ec = ecs[bv[i]];
+        DFA_State* next_state = current_state->Xtion(ec, dfa);
+
+        if ( ! next_state ) {
+            current_state = nullptr;
+            return JAMMED;
+        }
+
+        current_state = next_state;
+        ++current_pos;
+
+        if ( current_state->Accept() ) {
+            last_accept_pos = current_pos;
+            if ( current_state->IsTerminal() ) {
+                current_state = nullptr;
+                return JAMMED;
+            }
+        }
+    }
+
+    if ( eol ) {
+        DFA_State* eol_state = current_state->Xtion(ecs[SYM_EOL], dfa);
+        if ( eol_state && eol_state->Accept() )
+            last_accept_pos = current_pos;
+        current_state = nullptr;
+        return JAMMED;
+    }
+
+    return ALIVE;
+}
+
 int Specific_RE_Matcher::LongestMatch(const u_char* bv, int n, bool bol, bool eol) {
     if ( ! dfa )
         // An empty pattern matches anything.

--- a/src/RE.h
+++ b/src/RE.h
@@ -195,6 +195,54 @@ protected:
     int current_pos;
 };
 
+// Incremental matcher that can be used for shorted or longest match/prefix.
+// You feed in bytes in chunks and the matcher tracks the last accepting
+// position seen so far.
+class Streaming_RE_Matcher {
+public:
+    enum Status : uint8_t {
+        // DFA is still live; more input could yield a (longer) match.
+        ALIVE,
+
+        // DFA has jammed. No further input can produce a match.
+        JAMMED,
+    };
+
+    explicit Streaming_RE_Matcher(Specific_RE_Matcher* matcher);
+
+    // Feed n more bytes for longest-prefix matching. bol=true is honored
+    // only on the first call (or the first after Clear()). eol=true signals
+    // end of input, after which the returned status is always JAMMED.
+    Status Feed(const u_char* bv, int n, bool bol, bool eol);
+
+    // Feed n more bytes with first-match semantics: as soon as the DFA
+    // reaches an accepting state, latch last_accept_pos and return JAMMED,
+    // ignoring any subsequent longer accept that might arise from feeding
+    // more bytes.  Same eol / bol semantics as Feed().
+    Status FeedForFirstMatch(const u_char* bv, int n, bool bol, bool eol);
+
+    // Longest accepting prefix seen so far, or -1 if none yet.
+    // Valid in either status.
+    int LastAccept() const { return last_accept_pos; }
+
+    // Total bytes fed so far, whether or not they extended the last accept.
+    int Length() const { return current_pos < 0 ? 0 : current_pos; }
+
+    // Resets the matcher for fresh use.
+    void Clear() {
+        current_state = nullptr;
+        current_pos = -1;
+        last_accept_pos = -1;
+    }
+
+protected:
+    DFA_Machine* dfa;
+    int* ecs;
+    DFA_State* current_state;
+    int current_pos;
+    int last_accept_pos;
+};
+
 extern RE_Matcher* RE_Matcher_conjunction(const RE_Matcher* re1, const RE_Matcher* re2);
 extern RE_Matcher* RE_Matcher_disjunction(const RE_Matcher* re1, const RE_Matcher* re2);
 
@@ -244,6 +292,13 @@ public:
 
     const char* PatternText() const { return re_exact->PatternText(); }
     const char* AnywherePatternText() const { return re_anywhere->PatternText(); }
+
+    // Underlying exact-match DFA. Exposed for streaming callers that build
+    // a Streaming_RE_Matcher on top of it. Const-callable because the
+    // caller intends to walk the DFA, not mutate the RE_Matcher itself,
+    // but Streaming_RE_Matcher's ctor takes non-const (it caches the
+    // equivalence class map on itself).
+    detail::Specific_RE_Matcher* ExactMatcher() const { return re_exact; }
 
     // Original text used to construct this matcher.  Empty unless
     // the main ("explicit") constructor was used.

--- a/src/RE.h
+++ b/src/RE.h
@@ -241,6 +241,10 @@ protected:
     DFA_State* current_state;
     int current_pos;
     int last_accept_pos;
+
+private:
+    template<bool JamOnFirstMatch>
+    Status DoFeed(const u_char* bv, int n, bool bol, bool eol);
 };
 
 extern RE_Matcher* RE_Matcher_conjunction(const RE_Matcher* re1, const RE_Matcher* re2);

--- a/testing/btest/Baseline/language.pattern-tables-stats/out
+++ b/testing/btest/Baseline/language.pattern-tables-stats/out
@@ -2,20 +2,20 @@
 initial stats, [matchers=1, nfa_states=0, dfa_states=0, computed=0, mem=0, hits=0, misses=0]
 populated stats, [matchers=1, nfa_states=0, dfa_states=0, computed=0, mem=0, hits=0, misses=0]
 [1], [], T, F
-after lookup stats, [matchers=1, nfa_states=10, dfa_states=6, computed=6, mem=2368, hits=0, misses=6]
+after lookup stats, [matchers=1, nfa_states=10, dfa_states=6, computed=6, mem=2464, hits=0, misses=6]
 reset stats, [matchers=1, nfa_states=0, dfa_states=0, computed=0, mem=0, hits=0, misses=0]
 [], [3], [1, 3], T, F
-after more lookup stats, [matchers=1, nfa_states=34, dfa_states=13, computed=13, mem=7720, hits=0, misses=13]
+after more lookup stats, [matchers=1, nfa_states=34, dfa_states=13, computed=13, mem=7928, hits=0, misses=13]
 reset stats after delete, [matchers=1, nfa_states=0, dfa_states=0, computed=0, mem=0, hits=0, misses=0]
 [], [3], [1, 3]
-after even more lookup stats, [matchers=1, nfa_states=29, dfa_states=13, computed=13, mem=7056, hits=0, misses=13]
+after even more lookup stats, [matchers=1, nfa_states=29, dfa_states=13, computed=13, mem=7264, hits=0, misses=13]
 reset after reassignment, [matchers=1, nfa_states=0, dfa_states=0, computed=0, mem=0, hits=0, misses=0]
 set initial stats, [matchers=1, nfa_states=0, dfa_states=0, computed=0, mem=0, hits=0, misses=0]
 set populated stats, [matchers=1, nfa_states=0, dfa_states=0, computed=0, mem=0, hits=0, misses=0]
 T, F
-set after lookup stats, [matchers=1, nfa_states=10, dfa_states=6, computed=6, mem=2368, hits=0, misses=6]
+set after lookup stats, [matchers=1, nfa_states=10, dfa_states=6, computed=6, mem=2464, hits=0, misses=6]
 set reset stats, [matchers=1, nfa_states=0, dfa_states=0, computed=0, mem=0, hits=0, misses=0]
 F, T
-set after more lookup stats, [matchers=1, nfa_states=24, dfa_states=9, computed=9, mem=5336, hits=0, misses=9]
-set reset stats after delete, [matchers=1, nfa_states=24, dfa_states=9, computed=9, mem=5336, hits=0, misses=9]
+set after more lookup stats, [matchers=1, nfa_states=24, dfa_states=9, computed=9, mem=5480, hits=0, misses=9]
+set reset stats after delete, [matchers=1, nfa_states=24, dfa_states=9, computed=9, mem=5480, hits=0, misses=9]
 set reset after reassignment, [matchers=1, nfa_states=0, dfa_states=0, computed=0, mem=0, hits=0, misses=0]


### PR DESCRIPTION
To date, Zeek's regex engine has only supported single-shot matching: provide a string and find out whether it has a match. This PR adds a new type of streaming matcher that can be fed bytes in chunks, remembering its state between each batch. It also supports find-shortest as opposed to the other matchers always doing find-longest (which it also supports). 

This does _not_ provide any script-level access to the functionality. That'll take some thought regarding syntax etc.