### PR TITLE
For-loop variant that returns all of the indices in a single variable

### DIFF
--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -1012,7 +1012,6 @@ ValPtr WhileStmt::Exec(Frame* f, StmtFlowType& flow) {
 
 ForStmt::ForStmt(IDPList* arg_loop_vars, ExprPtr loop_expr) : ExprStmt(STMT_FOR, std::move(loop_expr)) {
     loop_vars = arg_loop_vars;
-    body = nullptr;
 
     if ( e->GetType()->Tag() == TYPE_TABLE ) {
         const auto& indices = e->GetType()->AsTableType()->GetIndexTypes();
@@ -1124,6 +1123,36 @@ ForStmt::ForStmt(IDPList* arg_loop_vars, ExprPtr loop_expr, IDPtr val_var)
         add_local(value_var, yield_type, INIT_SKIP, nullptr, nullptr, VAR_REGULAR);
 }
 
+ForStmt::ForStmt(IDPtr idx_var, IDPtr val_var, ExprPtr loop_expr) : ExprStmt(STMT_FOR, std::move(loop_expr)) {
+    loop_vars = new IDPList;
+    index_var = std::move(idx_var);
+    value_var = std::move(val_var);
+
+    auto t = e->GetType();
+    if ( ! t->IsTable() ) {
+        e->Error("whole-index for loop requires a table/set iterable");
+        return;
+    }
+
+    auto* tt = t->AsTableType();
+    TypePtr idx_type = tt->GetIndices();
+    TypePtr yield_type = tt->Yield();
+
+    if ( index_var->GetType() ) {
+        if ( ! same_type(index_var->GetType(), idx_type) )
+            e->Error("type clash in iteration", index_var->GetType().get());
+    }
+    else
+        add_local(index_var, idx_type, INIT_SKIP, nullptr, nullptr, VAR_REGULAR);
+
+    if ( value_var->GetType() ) {
+        if ( ! same_type(value_var->GetType(), yield_type) )
+            e->Error("type clash in iteration", value_var->GetType().get());
+    }
+    else
+        add_local(value_var, yield_type, INIT_SKIP, nullptr, nullptr, VAR_REGULAR);
+}
+
 ForStmt::~ForStmt() { delete loop_vars; }
 
 ValPtr ForStmt::DoExec(Frame* f, Val* v, StmtFlowType& flow) {
@@ -1149,7 +1178,10 @@ ValPtr ForStmt::DoExec(Frame* f, Val* v, StmtFlowType& flow) {
             if ( value_var )
                 f->SetElement(value_var, current_tev->GetVal());
 
-            if ( ! all_loop_vars_blank ) {
+            if ( index_var )
+                f->SetElement(index_var, tv->RecreateIndex(*k));
+
+            else if ( ! all_loop_vars_blank ) {
                 auto ind_lv = tv->RecreateIndex(*k);
                 for ( int i = 0; i < ind_lv->Length(); i++ ) {
                     const auto& lv = (*loop_vars)[i];

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -303,8 +303,14 @@ protected:
 class ForStmt final : public ExprStmt {
 public:
     ForStmt(IDPList* loop_vars, ExprPtr loop_expr);
-    // Special constructor for key value for loop.
+
+    // Build a key-value loop.
     ForStmt(IDPList* loop_vars, ExprPtr loop_expr, IDPtr val_var);
+
+    // Build a loop with a single index variable that holds a ListVal
+    // giving the different key components.
+    ForStmt(IDPtr index_var, IDPtr val_var, ExprPtr loop_expr);
+
     ~ForStmt() override;
 
     void AddBody(StmtPtr arg_body) { body = std::move(arg_body); }
@@ -337,9 +343,13 @@ protected:
 
     IDPList* loop_vars;
     StmtPtr body;
+
     // Stores the value variable being used for a key value for loop.
     // Always set to nullptr unless special constructor is called.
     IDPtr value_var;
+
+    // Stores the "whole index as one ListVal" variable.
+    IDPtr index_var;
 };
 
 class NextStmt final : public Stmt {

--- a/src/script_opt/Stmt.cc
+++ b/src/script_opt/Stmt.cc
@@ -567,15 +567,22 @@ bool WhileStmt::CouldReturn(bool ignore_break) const { return body->CouldReturn(
 StmtPtr ForStmt::Duplicate() {
     auto expr_copy = e->Duplicate();
 
-    auto new_loop_vars = new IDPList;
-    for ( auto id : *loop_vars )
-        new_loop_vars->emplace_back(std::move(id));
-
     ForStmt* f;
-    if ( value_var )
-        f = new ForStmt(new_loop_vars, expr_copy, value_var);
-    else
-        f = new ForStmt(new_loop_vars, expr_copy);
+    if ( loop_vars->empty() && index_var && value_var )
+        // Whole-index for-loop - rebuild via the matching 3-arg ctor
+        // so the vanilla loop_vars / index-size check doesn't trip.
+        f = new ForStmt(index_var, value_var, expr_copy);
+
+    else {
+        auto new_loop_vars = new IDPList;
+        for ( auto id : *loop_vars )
+            new_loop_vars->emplace_back(std::move(id));
+
+        if ( value_var )
+            f = new ForStmt(new_loop_vars, expr_copy, value_var);
+        else
+            f = new ForStmt(new_loop_vars, expr_copy);
+    }
 
     f->AddBody(body->Duplicate());
 


### PR DESCRIPTION
This PR adds internal support for `for` loops of the form
```
global my_multi_index_table: table[count, addr, string, bool] of MyJunk;

for ( all_indices in my_multi_index_table )
    .... here all_indices is a ListVar with 4 elements, one per index
```
so it captures the indices in a single location rather than splitting them into _N_ variables.

There's a separate issue of just how this would work at Zeek scripting level, which this PR does not aim to address.