### PR TITLE
Fix cluster.websockets.ping-timeout btest when using websockets >= 17.0

### DIFF
--- a/testing/btest/cluster/websocket/ping-timeout.zeek
+++ b/testing/btest/cluster/websocket/ping-timeout.zeek
@@ -53,7 +53,13 @@ import wstest
 
 from websockets.sync.client import connect
 from websockets.sync.client import ClientConnection
-from websockets.frames import OP_PONG
+
+# Try importing the PONG operation from webosckets 17.0 first. If that fails,
+# fall back to OP_PONG from prior to 17.0.
+try:
+	from websockets.frames import PONG as OP_PONG
+except ImportError:
+	from websockets.frames import OP_PONG
 
 class MyClientConnection(ClientConnection):
     """


### PR DESCRIPTION
Python Websockets 17.0 was released on 2026/07/29 and removed the `OP_*` operations. They were replaced with versions without the `OP_` prefix. This broke the `cluster.websockets.ping-timeout` btest that was using that symbol. See https://github.com/python-websockets/websockets/commit/e769bad94acf8452066f9e4c06cf046d15d2e2dc. I tested this PR with both websockets 16.1 and 17.0 and the btest passed on both versions.