### PR TITLE
doc: add "Zeek in the SOC" section to why.rst (#5676)

### DIFF
--- a/doc/about/why.rst
+++ b/doc/about/why.rst
@@ -45,6 +45,28 @@ that job is best suited for packages like the open source Snort or Suricata
 engines. Zeek has other capabilities however that are capable of providing
 judgements in the form of alerts, through its notice mechanism.
 
+.. _why-zeek-in-the-soc:
+
+Zeek in the SOC
+===============
+
+Zeek is often deployed alongside other security tools in Security Operations
+Centers. Tools like Suricata complement Zeek by providing signature-based
+detection, while Zeek generates detailed protocol metadata and behavioral
+context for investigation.
+
+When Suricata raises an alert, analysts can use `Community ID
+<https://github.com/corelight/community-id-spec>`_ to correlate the alert
+with Zeek's transaction logs (``conn.log``, ``http.log``, ``dns.log``,
+``ssl.log``, etc.) for deeper investigation. Community ID provides a common
+hash across tools, enabling analysts to pivot between Suricata alerts and
+Zeek's rich protocol context without manual correlation.
+
+Platforms like `Security Onion <https://securityonionsolutions.com/>`_ and
+`Malcolm <https://github.com/cisagov/Malcolm>`_ provide this correlation out
+of the box, but it can also be achieved through custom pipelines using
+Community ID as the primary correlation key.
+
 Zeek is not optimized for writing traffic to disk in the spirit of a full
 content data collection, and that task is best handled by software written to
 fulfill that requirement.


### PR DESCRIPTION
## Summary

Add a "Zeek in the SOC" section to `doc/about/why.rst` explaining how Zeek complements signature-based IDS tools like Suricata in SOC environments.

Fixes #5676

## Changes

- Added new `.. _why-zeek-in-the-soc:` subsection after the existing Snort/Suricata paragraph
- **Community ID** covered as the primary correlation mechanism between Suricata alerts and Zeek logs
- Brief mention of Security Onion and Malcolm as platforms providing out-of-box correlation
- Kept Zeek-centric language: other tools complement Zeek, not the other way around

## Reviewer Notes

- Maintainer feedback from @evantypanski and @ckreibich incorporated:
  - Community ID as primary correlation key
  - No IPS details (not in Zeek's scope)
  - No home lab references
  - Broader "Zeek in the SOC" framing
- The section is intentionally concise — a focused addition, not a comprehensive SOC guide
