### PR TITLE
doc: consolidate WebSocket documentation (#5518)

### DIFF
--- a/doc/advanced/devel/cluster/architectures.rst
+++ b/doc/advanced/devel/cluster/architectures.rst
@@ -204,23 +204,15 @@ publish/subscribe layer will not have these limitations.
 WebSocket API to the Publish/Subscribe Layer
 ============================================
 
-Interacting with Zeek's publish/subscribe layer using external non-Zeek
-applications is possible using :ref:`Zeek's WebSocket API <websocket-api>`.
-The WebSocket API provides a cluster backend agnostic entry point for non-Zeek
-processes to publish and receive Zeek events.
-
-Starting with version 8.1, the Zeek manager process listens for incoming
-WebSocket connections on::
-
-        ws://127.0.0.1:27759
-
+External non-Zeek applications can interact with Zeek's publish/subscribe
+layer via :ref:`Zeek's WebSocket API <websocket-api>`, which provides a
+cluster backend agnostic entry point for publishing and receiving Zeek events.
 The following diagram sketches the idea.
 
 .. figure:: /images/cluster/single-system-websocket.svg
 
-It is possible to start WebSocket entrypoints on other Zeek processes in
-a cluster (even workers) using the :zeek:see:`Cluster::listen_websocket`
-function explicitly.
+For details on setup, the protocol format, security considerations, and
+language bindings, see :ref:`websocket-api`.
 
 
 Operational Metrics via Prometheus

--- a/doc/advanced/devel/websocket-api.rst
+++ b/doc/advanced/devel/websocket-api.rst
@@ -224,7 +224,7 @@ Golang
 Rust
 ^^^^
 
-* `Rust types for interacting with Zeek over WebSocket <https://github.com/bbannier/zeek-websocket-rs>`_ (not an official Zeek project)
+* `Rust types for interacting with Zeek over WebSocket <https://github.com/zeek/zeek-websocket-rs>`_
 
 Python
 ^^^^^^


### PR DESCRIPTION
## Summary

Consolidate the duplicate WebSocket documentation across two files into a single authoritative reference.

Fixes #5518

## Changes

### `doc/advanced/devel/cluster/architectures.rst`
- Slimmed the "WebSocket API to the Publish/Subscribe Layer" section from ~20 lines to a brief architectural pointer (5 lines + diagram)
- Retained the cluster architecture diagram and cross-reference to `websocket-api.rst`
- Removed duplicated setup/usage details that belong in the main reference page

### `doc/advanced/devel/websocket-api.rst`
- Updated Rust language binding: `zeek-websocket-rs` is now an official Zeek project (moved from `bbannier/zeek-websocket-rs` to `zeek/zeek-websocket-rs`)
- Updated Python section: `zeek-websocket-rs` now provides Python bindings via PyO3 with both sync (`Client`) and async (`ZeekClient`) interfaces

## Reviewer Notes

- Maintainer feedback from @ckreibich incorporated:
  - Single authoritative reference in `websocket-api.rst`
  - `architectures.rst` focuses on architectural context with diagram
  - Language bindings updated to reflect current state of the ecosystem
- Encryption/TLS coverage already exists in `websocket-api.rst` (Security Considerations section)
