### PR TITLE
Generalizing skipping certain expressions for "ignored expression value" warnings

### DIFF
--- a/src/Stmt.cc
+++ b/src/Stmt.cc
@@ -357,8 +357,15 @@ void do_print_stmt(const std::vector<ValPtr>& vals) {
     }
 }
 
+// Tags for which "expression value ignored" is fine.
+static std::set<ExprTag> ignorable_expr_tags = {EXPR_CALL, EXPR_INLINE};
+
+void add_ignorable_expr_tag(ExprTag t) { ignorable_expr_tags.insert(t); }
+
+void add_ignorable_expr_tags(const std::set<ExprTag>& tags) { ignorable_expr_tags.insert(tags.begin(), tags.end()); }
+
 ExprStmt::ExprStmt(ExprPtr arg_e) : Stmt(STMT_EXPR), e(std::move(arg_e)) {
-    if ( e && e->Tag() != EXPR_CALL && e->Tag() != EXPR_INLINE && e->IsPure() && e->GetType()->Tag() != TYPE_ERROR )
+    if ( e && ! ignorable_expr_tags.contains(e->Tag()) && e->IsPure() && e->GetType()->Tag() != TYPE_ERROR )
         Warn("expression value ignored");
 
     SetLocationInfo(e->GetLocationInfo());

--- a/src/Stmt.h
+++ b/src/Stmt.h
@@ -4,6 +4,8 @@
 
 // Zeek statements.
 
+#include <set>
+
 #include "zeek/Dict.h"
 #include "zeek/Expr.h"
 #include "zeek/ID.h"
@@ -783,5 +785,10 @@ public:
 private:
     std::function<void(const zeek::Args&, StmtFlowType&)> func;
 };
+
+// Register additional Expr tags for which ExprStmt should suppress its
+// "expression value ignored" warning.
+extern void add_ignorable_expr_tag(ExprTag t);
+extern void add_ignorable_expr_tags(const std::set<ExprTag>& tags);
 
 } // namespace zeek::detail


### PR DESCRIPTION
Zeek warns of expressions that if evaluated the value is discarded. For example:
```
5;
```
produces the warning:
```
warning in <stdin>, line 1: expression value ignored (5)
```
Currently, the way it determines which expressions are okay in this regard is a hardwired list holding calls and inlining (essentially also calls). This simple PR allows those doing AST extensions to add to that list.