### PR TITLE
CI: Avoid restoring the wrong ccache

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -411,7 +411,7 @@ jobs:
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       with:
-        key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.id }}
+        key: ${{ matrix.id }}-${{ github.workflow }}-${{ github.job }}
 
     # TODO: add ./ci/init-external-repos.sh with caching, maybe in actual job below
     # - name: Clone external test suites


### PR DESCRIPTION
While looking at the ccache effectiveness of the GitHub actions, found that the ubuntu-24.04 job would sometimes restore the ccache of the ubuntu-24.04-clang-libcpp, ubuntu-24.04-spicy, or other tasks.

That happens because cache restoration is prefix based, and ubuntu-24.04 is a prefix of a number of other entries. Flip the key to have {{ matrix.id }} in front to avoid this.

Example is here [1] for the ubuntu-24.04 entry (which also took the longest to compile among the others):

    Restore cache
      Cache hit for restore-key: ccache-Check-linux-ubuntu-24.04-clang-libcpp-2026-07-31T09:22:41.642Z
      [...]

[1] https://github.com/zeek/zeek/actions/runs/30614408132/job/91141152945