### PR TITLE
ZAM: Fix `cat()` self-assignment corrupted refcount

### DIFF
--- a/src/script_opt/ZAM/OPs/ZBI.op
+++ b/src/script_opt/ZAM/OPs/ZBI.op
@@ -253,8 +253,13 @@ macro Cat1Op(lhs, val)
 
 internal-op Cat1
 classes VV VC
-eval	Cat1Op($$, $1)
-	zeek::Ref(v1.AsString());
+# Ref the source before deleting the destination, in case they alias the
+# same frame slot (e.g. "s = cat(s)"); otherwise the delete could free the
+# string before we re-reference it.
+eval	auto v = $1;
+	zeek::Ref(v.AsString());
+	ZVal::DeleteManagedType($$);
+	$$ = v;
 
 internal-op Cat1Full
 classes VV VC

--- a/testing/btest/opt/regress-cat-self-assign.zeek
+++ b/testing/btest/opt/regress-cat-self-assign.zeek
@@ -1,0 +1,24 @@
+# @TEST-DOC: ZAM cat() self-assignment must not corrupt managed string references.
+# @TEST-REQUIRES: test "${ZEEK_USE_CPP}" != "1"
+# @TEST-EXEC: zeek -b -O ZAM %INPUT >output 2>stderr
+# @TEST-EXEC: test ! -s stderr
+
+# "s = cat(s)" compiles to a Cat1 op sharing one frame slot for source and dest;
+# churn many iterations so allocator reuse reliably surfaces any refcount bug.
+function churn(n: count)
+	{
+	local i: count = 0;
+
+	while ( i < n )
+		{
+		local s = fmt("%s-%d", "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+		    i);
+		s = cat(s);
+		++i;
+		}
+	}
+
+event zeek_init()
+	{
+	churn(10000);
+	}


### PR DESCRIPTION
The one-argument `cat()` fast path compiles `s = cat(s)` into a `Cat1` op that shares a frame slot for source and destination. The op deleted the destination before referencing the source, freeing the live string and then re-referencing freed memory ("bad reference count" abort). Reference the source first so an aliased slot survives the delete.

this turns out to be just a noop in this case, but it should not crash. Maybe @vpax could chime in if this seems wrong, I don't have as strong of an intuition.

Code generated by Claude Opus 4.8. Used to test the `AGENTS.md` file in #5748. This one the LLM *did* reference the AI policy, but just one sentence at the end of its output, after I made it write the commit message. It did not reiterate when I made it rewrite the commit message when it was far too long.

Found with LLM scanning of Zeek, but this isn't a security issue.

The test maybe should just not churn and we rely on sanitizers to catch the issue? But the churn makes it reliably crash without a sanitizer and it finishes quickly for me.