### PR TITLE
CCI: Use the right endpoint for requesting GH API info

### DIFF
--- a/.circleci/generate-workflow-params.py
+++ b/.circleci/generate-workflow-params.py
@@ -14,7 +14,7 @@ params = {}
 if PR_NUMBER:
     url = PR_NUMBER
     url = url.replace("https://github.com", "https://api.github.com/repos")
-    url = url.replace("/pull/", "/issues/")
+    url = url.replace("/pull/", "/pulls/")
 
     print(f"Requesting {url} to get PR labels from GitHub")
 


### PR DESCRIPTION
The `/issues` endpoint works fine for public repos (since the PAT isn't actually needed) but for private repos that's the wrong endpoint for our token. This switches it to the right one.