### PR TITLE
GHCI: Skip cache-to of Build Docker image for forks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -403,7 +403,9 @@ jobs:
         file: ${{ matrix.file }}
         context: . # Reuse the current checkout instead of doing a full recursive clone again.
         tags: zeek-ci-${{ hashFiles(matrix.file) }}
-        cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/zeek-ci:${{ matrix.id }},mode=max
+        # Skip caching to GHCR for PRs from forks as they do not have permissions
+        # to write to GHCR. For fork, cache-to will evaluate to '' instead.
+        cache-to: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('type=registry,ref=ghcr.io/{0}/zeek-ci:{1},mode=max', github.repository, matrix.id) || '' }}
         cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/zeek-ci:${{ matrix.id }}
         load: true
         push: false


### PR DESCRIPTION
@Mohan-Dhawan reports his pipelines failing not being able to push the build images to GHCR [1]:

    ERROR: failed to build: failed to solve: error writing layer blob: denied: installation not allowed to Write organization package

Use ternary magic to set cache-to to an empty string. This was produced by Gemini. The PR from fork check is discussed at [2].

Don't know if that's great. Could also switch back to the gha caching.

[1] https://github.com/zeek/zeek/actions/runs/30877083285/job/91890641906#step:5:2776
[2] https://github.com/orgs/community/discussions/25217#discussioncomment-32469020