### PR TITLE
btest/plugins/opaque-type: Skip with ZAM enabled

### DIFF
--- a/testing/btest/plugins/opaque-type.zeek
+++ b/testing/btest/plugins/opaque-type.zeek
@@ -1,8 +1,13 @@
+# @TEST-DOC: The plugin installs a new NanoTime type that is a derived OpaqueType with custom hashing, cast and default value implementations.
+#
 # @TEST-EXEC: ${DIST}/auxil/zeek-aux/plugin-support/init-plugin -u . Demo Foo
 # @TEST-EXEC: cp -r %DIR/opaque-type-plugin/* .
 # @TEST-EXEC: ./configure --zeek-dist=${DIST} && make
-# @TEST-EXEC: ZEEK_PLUGIN_PATH=`pwd` zeek -r $TRACES/socks.pcap %INPUT >>output;
+# @TEST-EXEC: ZEEK_PLUGIN_PATH=`pwd` zeek %INPUT >>output;
 # @TEST-EXEC: TEST_DIFF_CANONIFIER= btest-diff output
+#
+# The OpaqueType::DefaultVal() isn't handled by ZAM at this point.
+# @TEST-REQUIRES: test "${ZEEK_ZAM}" != "1"
 
 event zeek_init()
 	{
@@ -31,6 +36,6 @@ event zeek_init() &priority=-2
 	local tbl: table[NanoTime] of count;
 	tbl[nanos1] = 1;
 	tbl[nanos2] = 2;
-	tbl[nanos1] = 3;  # overwerite the entry with 1
+	tbl[nanos1] = 3;  # overwrite nanos1 entry with value 3
 	print "zeek_init tbl:", |tbl|, tbl;
 	}


### PR DESCRIPTION
I had made the test to actually be able to reference NanoTime in script and the default initialization path works with the tree-walking interpreter, but the ZAM side isn't hooked up, so skip for now to prevent this error:

    error: <...>/zeek/testing/btest/.tmp/plugins.opaque-type/opaque-type.zeek,
    line 23: value used but not set: nanos
    fatal error: Optimized script execution aborted due to errors


---

@vpax - maybe I went a bit overboard with that script-side test, but it actually works for the tree-walking interpreter. Skipping it for ZAM seems fine, unless you know how/where to directly fix this and wanted to?