### PR TITLE
Analyzer: Add LimitReachedWeird() helper

### DIFF
--- a/src/analyzer/Analyzer.cc
+++ b/src/analyzer/Analyzer.cc
@@ -729,6 +729,12 @@ void Analyzer::EnqueueConnEvent(EventHandlerPtr f, Args args) { conn->EnqueueEve
 
 void Analyzer::Weird(const char* name, const char* addl) { conn->Weird(name, addl, GetAnalyzerName()); }
 
+void Analyzer::LimitReachedWeird(const char* name, size_t limit, size_t limit_max) {
+    const char* addl = limit_max > 0 ? util::fmt("%zu > %zu", limit, limit_max) : util::fmt("%zu", limit);
+    conn->Weird(name, addl, GetAnalyzerName());
+    conn->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
+}
+
 SupportAnalyzer* SupportAnalyzer::Sibling(bool only_active) const {
     if ( ! only_active )
         return sibling;

--- a/src/analyzer/Analyzer.h
+++ b/src/analyzer/Analyzer.h
@@ -635,6 +635,20 @@ public:
      */
     void Weird(const char* name, const char* addl = "");
 
+    /**
+     * Convenience wrapper around Weird() for reporting that a protocol
+     * analysis limit was reached.
+     *
+     * Formats the addl string as "limit" when limit_max is zero, or
+     * "limit > limit_max" when limit_max is non-zero, and adds the 'X'
+     * character to the connection's history.
+     *
+     * @param name Name of the weird.
+     * @param limit The observed value for which the weird is raised.
+     * @param limit_max The maximum allowed value (0 to omit from output).
+     */
+    void LimitReachedWeird(const char* name, size_t limit, size_t limit_max = 0);
+
 protected:
     friend class AnalyzerTimer;
     friend class Manager;

--- a/src/analyzer/protocol/dns/DNS.cc
+++ b/src/analyzer/protocol/dns/DNS.cc
@@ -100,10 +100,8 @@ void DNS_Interpreter::ParseMessage(const u_char* data, int len, int is_query) {
     // There is a great deal of non-DNS traffic that runs on port 53.
     // This should weed out most of it.
     if ( zeek::detail::dns_max_queries > 0 && msg.qd_zo_count > zeek::detail::dns_max_queries ) {
-        analyzer->Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
         analyzer->AnalyzerViolation("DNS_Conn_count_too_large");
-        analyzer->Weird("DNS_Conn_count_too_large",
-                        util::fmt("%d > %d", msg.qd_zo_count, zeek::detail::dns_max_queries));
+        analyzer->LimitReachedWeird("DNS_Conn_count_too_large", msg.qd_zo_count, zeek::detail::dns_max_queries);
         EndMessage(&msg);
         return;
     }
@@ -471,8 +469,7 @@ bool DNS_Interpreter::ParseAnswer(detail::DNS_MsgInfo* msg, const u_char*& data,
 u_char* DNS_Interpreter::ExtractName(const u_char*& data, int& len, u_char* name, int name_len, const u_char* msg_start,
                                      bool downcase, int compression_depth) {
     if ( compression_depth > zeek::detail::dns_max_compression_chain_depth ) {
-        analyzer->Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-        analyzer->Weird("DNS_max_compression_chain_depth_exceeded");
+        analyzer->LimitReachedWeird("DNS_max_compression_chain_depth_exceeded", compression_depth);
         return name;
     }
 

--- a/src/analyzer/protocol/ftp/FTP.cc
+++ b/src/analyzer/protocol/ftp/FTP.cc
@@ -104,11 +104,8 @@ void FTP_Analyzer::DeliverStream(int length, const u_char* data, bool orig) {
             // If the FTP command is unusually long, log a weird if the analyzer
             // has previously been confirmed, but otherwise just ignore the whole
             // line and move on to the next.
-            if ( AnalyzerConfirmed() ) {
-                Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-                Weird("FTP_max_command_length_exceeded",
-                      util::fmt("%d > %" PRIu64, cmd_len, BifConst::FTP::max_command_length));
-            }
+            if ( AnalyzerConfirmed() )
+                LimitReachedWeird("FTP_max_command_length_exceeded", cmd_len, BifConst::FTP::max_command_length);
 
             return;
         }

--- a/src/analyzer/protocol/gnutella/Gnutella.cc
+++ b/src/analyzer/protocol/gnutella/Gnutella.cc
@@ -92,9 +92,7 @@ bool Gnutella_Analyzer::NextLine(const u_char* data, int len) {
 
         if ( zeek::BifConst::Gnutella::max_line_length > 0 &&
              ms->buffer.length() >= zeek::BifConst::Gnutella::max_line_length ) {
-            Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-            const char* addl = zeek::util::fmt("%lu", ms->buffer.length());
-            Weird("exceeded_gnutella_max_line_length", addl);
+            LimitReachedWeird("exceeded_gnutella_max_line_length", ms->buffer.length());
 
             return false;
         }
@@ -172,9 +170,7 @@ void Gnutella_Analyzer::DeliverLines(int len, const u_char* data, bool orig) {
             auto new_headers_len = ms->headers.length() + 2 + ms->buffer.length();
             if ( zeek::BifConst::Gnutella::max_header_length > 0 &&
                  new_headers_len >= zeek::BifConst::Gnutella::max_header_length ) {
-                Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-                const char* addl = zeek::util::fmt("%lu", new_headers_len);
-                Weird("exceeded_gnutella_max_headers_length", addl);
+                LimitReachedWeird("exceeded_gnutella_max_headers_length", new_headers_len);
                 return;
             }
 

--- a/src/analyzer/protocol/login/NVT.cc
+++ b/src/analyzer/protocol/login/NVT.cc
@@ -410,8 +410,7 @@ void NVT_Analyzer::DeliverChunk(int& len, const u_char*& data) {
     for ( ; len > 0; --len, ++data ) {
         if ( offset >= buf_len ) {
             if ( ! InitBufferSafe(buf_len * 2) ) {
-                Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-                Weird("nvt_line_size_exceeded", util::fmt("%u", buf_len));
+                LimitReachedWeird("nvt_line_size_exceeded", buf_len);
 
                 // Reset the offset to keep going. Try to forward the data, since
                 // it's handling lines.
@@ -566,8 +565,7 @@ void NVT_Analyzer::ScanOption(int& len, const u_char*& data) {
     for ( ; len > 0; --len, ++data ) {
         if ( offset >= buf_len ) {
             if ( ! InitBufferSafe(buf_len * 2) ) {
-                Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-                Weird("nvt_option_size_exceeded", util::fmt("%u", buf_len));
+                LimitReachedWeird("nvt_option_size_exceeded", buf_len);
 
                 // Just abort suboption parsing; we aren't getting anything useful anyway.
                 pending_IAC = false;

--- a/src/analyzer/protocol/login/RSH.cc
+++ b/src/analyzer/protocol/login/RSH.cc
@@ -34,8 +34,7 @@ void Contents_Rsh_Analyzer::DoDeliver(int len, const u_char* data) {
     for ( ; len > 0; --len, ++data ) {
         if ( offset >= buf_len ) {
             if ( ! InitBufferSafe(buf_len * 2) ) {
-                Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-                Weird("rsh_line_size_exceeded", util::fmt("%u", buf_len));
+                LimitReachedWeird("rsh_line_size_exceeded", buf_len);
                 state = RSH_UNKNOWN;
                 offset = 0;
 

--- a/src/analyzer/protocol/login/Rlogin.cc
+++ b/src/analyzer/protocol/login/Rlogin.cc
@@ -31,8 +31,7 @@ void Contents_Rlogin_Analyzer::DoDeliver(int len, const u_char* data) {
     for ( ; len > 0; --len, ++data ) {
         if ( offset >= buf_len ) {
             if ( ! InitBufferSafe(buf_len * 2) ) {
-                Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-                Weird("rlogin_line_size_exceeded", util::fmt("%u", buf_len));
+                LimitReachedWeird("rlogin_line_size_exceeded", buf_len);
 
                 state = RLOGIN_UNKNOWN;
                 offset = 0;

--- a/src/analyzer/protocol/mime/MIME.cc
+++ b/src/analyzer/protocol/mime/MIME.cc
@@ -639,11 +639,9 @@ void MIME_Entity::ContHeader(int len, const char* data) {
 
     if ( zeek::BifConst::MIME::max_header_bytes > 0 &&
          current_header_line->get_total_bytes() >= zeek::BifConst::MIME::max_header_bytes ) {
-        if ( message->GetAnalyzer() ) {
-            message->GetAnalyzer()->Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-            const char* addl = zeek::util::fmt("%" PRIu64, current_header_line->get_total_bytes());
-            message->GetAnalyzer()->Weird("exceeded_mime_max_header_bytes", addl);
-        }
+        if ( message->GetAnalyzer() )
+            message->GetAnalyzer()->LimitReachedWeird("exceeded_mime_max_header_bytes",
+                                                      current_header_line->get_total_bytes());
 
         return;
     }
@@ -1094,11 +1092,8 @@ void MIME_Entity::BeginChildEntity() {
     // child entity. Instead, its header/body will be delivered to the
     // current entity.
     if ( zeek::BifConst::MIME::max_depth > 0 && Depth() >= zeek::BifConst::MIME::max_depth ) {
-        if ( message->GetAnalyzer() ) {
-            message->GetAnalyzer()->Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-            const char* addl = zeek::util::fmt("%" PRIu64, Depth());
-            message->GetAnalyzer()->Weird("exceeded_mime_max_depth", addl);
-        }
+        if ( message->GetAnalyzer() )
+            message->GetAnalyzer()->LimitReachedWeird("exceeded_mime_max_depth", Depth());
 
         return;
     }

--- a/src/analyzer/protocol/ssh/ssh-analyzer.pac
+++ b/src/analyzer/protocol/ssh/ssh-analyzer.pac
@@ -85,8 +85,7 @@ refine flow SSH_Flow += {
 
 		if ( max_len > 0 && len > max_len ) {
 			auto *a = connection()->zeek_analyzer();
-			a->Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-			a->Weird("SSH_max_packet_length_exceeded", zeek::util::fmt("%u > %u", len, max_len));
+			a->LimitReachedWeird("SSH_max_packet_length_exceeded", len, max_len);
 
 			len = max_len;
 		}
@@ -100,8 +99,7 @@ refine flow SSH_Flow += {
 
 		if ( max_len > 0 && len > max_len ) {
 			auto *a = connection()->zeek_analyzer();
-			a->Conn()->CheckHistory(zeek::session::detail::HIST_UNKNOWN_PKT, 'X');
-			a->Weird("SSH_max_string_length_exceeded", zeek::util::fmt("%u > %u", len, max_len));
+			a->LimitReachedWeird("SSH_max_string_length_exceeded", len, max_len);
 
 			len = max_len;
 		}


### PR DESCRIPTION
There is this evolving pattern of limiting protocol analysis to certain
configurable limits. When such limits are reached, Zeek raises a weird
mentioning the analyzer name, the limit's variable name and "exceeded" or
"reached" and also places a big X into the connection's history. This hasn't
been around for very long and only started with the Tunnel::max_depth setting,
but has been extended to more protocol analyzers (MIME depth, FTP command length, ...)
recently and we're introducing more and more limits.

This change adds a new LimitReachedWeird() method to the protocol Analyzer class
to do both steps at the same time and updates all existing protocol analyzer
users where the limit is known. We have some users in packet analysis, too,
but it's not always clear if there's a session/connection, so skipping it
there for now.

---
Used Claude Opus 4.8 for review and docstring tweaking.

---

@timwoj / @evantypanski - thoughts?
