### PR TITLE
tools/systemd-generator: build the systemd generator on Linux only

### DIFF
--- a/tools/systemd-generator/CMakeLists.txt
+++ b/tools/systemd-generator/CMakeLists.txt
@@ -19,21 +19,22 @@ else ()
     set(DOCTEST_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../src/3rdparty/")
 endif ()
 
+# The systemd generator only does something where systemd runs, and working on
+# it needs a Linux container or VM anyway, so it is off by default elsewhere.
 set(_default ON)
-if (MSVC)
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(_default OFF)
 endif ()
 
-# Build the generator everywhere unless explicitly disabled. Mostly
-# for developer testing.
 option(ENABLE_ZEEK_SYSTEMD_GENERATOR "Enable building and installing zeek-systemd-generator"
        ${_default})
-if (ENABLE_ZEEK_SYSTEMD_GENERATOR)
 
-    # Separate supporting libraries in preparation for if there's
-    # ever a non-systemd generator split out from this.
+# zeek-cluster-layout-generator and the parsing it shares with the systemd
+# generator are not systemd-specific and are useful on their own, so they are
+# built wherever the sources compile.  They need unistd.h and friends, which
+# rules out MSVC.
+if (NOT MSVC)
     add_library(utils OBJECT src/utils.cc)
-    add_library(systemd-unit OBJECT src/systemd-unit.cc)
     add_library(zeek-cluster-config OBJECT src/zeek-cluster-config.cc)
 
     if (DOCTEST_INCLUDE_DIR)
@@ -42,18 +43,22 @@ if (ENABLE_ZEEK_SYSTEMD_GENERATOR)
         target_link_libraries(utils-test utils)
     endif ()
 
-    add_executable(zeek-systemd-generator src/zeek-systemd-generator.cc)
-    target_compile_definitions(
-        zeek-systemd-generator PRIVATE DEFAULT_ETC_DIR=\"${_default_etc_dir}\"
-                                       DEFAULT_BASE_DIR=\"${_default_base_dir}\")
-
-    target_link_libraries(zeek-systemd-generator zeek-cluster-config systemd-unit utils)
-
     add_executable(zeek-cluster-layout-generator src/zeek-cluster-layout-generator.cc)
     target_link_libraries(zeek-cluster-layout-generator zeek-cluster-config utils)
-
-    install(TARGETS zeek-systemd-generator RUNTIME DESTINATION bin)
     install(TARGETS zeek-cluster-layout-generator RUNTIME DESTINATION bin)
+
+    if (ENABLE_ZEEK_SYSTEMD_GENERATOR)
+        add_library(systemd-unit OBJECT src/systemd-unit.cc)
+
+        add_executable(zeek-systemd-generator src/zeek-systemd-generator.cc)
+        target_compile_definitions(
+            zeek-systemd-generator PRIVATE DEFAULT_ETC_DIR=\"${_default_etc_dir}\"
+                                           DEFAULT_BASE_DIR=\"${_default_base_dir}\")
+
+        target_link_libraries(zeek-systemd-generator zeek-cluster-config systemd-unit utils)
+
+        install(TARGETS zeek-systemd-generator RUNTIME DESTINATION bin)
+    endif ()
 
     if (is_subproject)
         # Install a default configuration at <PREFXI>etc/default/zeek

--- a/tools/systemd-generator/src/utils.cc
+++ b/tools/systemd-generator/src/utils.cc
@@ -3,6 +3,7 @@
 #include "utils.h"
 
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <algorithm>
 #include <charconv>


### PR DESCRIPTION
The systemd generator is only useful where systemd runs, so it now builds
and installs on Linux only. The rest of the directory is not
systemd-specific and keeps building everywhere.

zeek-cluster-layout-generator describes itself as "a zero-dependency
cluster-layout.zeek generator" and pulls in nothing systemd-related; the
only mention of systemd outside systemd-unit.* and
zeek-systemd-generator.cc is a comment in zeek-cluster-config.cc about
MemoryMax notation. So:

  utils, zeek-cluster-config, utils-test, zeek-cluster-layout-generator
      built under "if (NOT MSVC)" -- MSVC only because they need unistd.h

  systemd-unit, zeek-systemd-generator
      behind ENABLE_ZEEK_SYSTEMD_GENERATOR, which now defaults ON on
      Linux and OFF elsewhere

zeek.conf installs as before: -C reads it, and the layout generator is
installed everywhere.

The <netinet/in.h> include stays. utils.cc is in the portable half, so
without it zeek-cluster-layout-generator does not compile on FreeBSD
either:

  utils.cc:145:23: error: invalid application of 'sizeof' to an
  incomplete type 'struct in6_addr'

POSIX (IEEE Std 1003.1-2024) has <netinet/in.h> "shall define the
in6_addr structure", while <arpa/inet.h> only "may also make visible all
symbols from <netinet/in.h>". glibc does, FreeBSD does not.

Built tools/systemd-generator standalone, three ways on each platform:

                        FreeBSD 15.1              Linux
  master                fails, nothing built      both binaries, option ON
  split, no include     fails, same error         both binaries, option ON
  this PR               layout generator only,    both binaries, option ON
                        option OFF

The FreeBSD-built zeek-cluster-layout-generator runs and produces the
same cluster-layout.zeek as the Linux one.
