### PR TITLE
Expose HILTI runtime include paths to dynamic plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1155,6 +1155,23 @@ else ()
 endif ()
 
 set(USE_SPICY_ANALYZERS "${USE_SPICY_ANALYZERS}" CACHE BOOL "Use built-in Spicy analyzers")
+
+# Plugin code can transitively reach HILTI runtime headers (e.g., via
+# zeek/spicy/manager.h), so plugins need the HILTI include paths.
+if (HAVE_SPICY)
+    if (SPICY_ROOT_DIR)
+        target_include_directories(zeek_dynamic_plugin_base SYSTEM
+                                   INTERFACE ${SPICY_INCLUDE_DIRS_RUNTIME})
+    else ()
+        add_zeek_dynamic_plugin_build_interface_include_directories(
+            ${PROJECT_SOURCE_DIR}/auxil/spicy/hilti/runtime/include
+            ${PROJECT_SOURCE_DIR}/auxil/spicy/3rdparty)
+    endif ()
+
+    target_include_directories(zeek_dynamic_plugin_base SYSTEM
+                               INTERFACE $<INSTALL_INTERFACE:include/hilti/rt/3rdparty>)
+endif ()
+
 include(BuiltInSpicyAnalyzer)
 
 include_directories(BEFORE ${PCAP_INCLUDE_DIR} ${BIND_INCLUDE_DIR} ${BinPAC_INCLUDE_DIR}

--- a/testing/btest/plugins/hilti-include.zeek
+++ b/testing/btest/plugins/hilti-include.zeek
@@ -1,0 +1,52 @@
+# @TEST-DOC: Validate that plugins can include hilti runtime headers
+# @TEST-REQUIRES: have-spicy
+# @TEST-EXEC: ${DIST}/auxil/zeek-aux/plugin-support/init-plugin -u . Demo HiltiInclude
+# @TEST-EXEC: cp Plugin.h Plugin.cc src/
+#
+# @TEST-EXEC: ./configure --zeek-dist=${DIST} && make
+#
+# @TEST-EXEC: ZEEK_PLUGIN_PATH=`pwd` zeek -b -e 'event zeek_init() { }'
+
+# @TEST-START-FILE Plugin.h
+#pragma once
+
+#include "zeek/plugin/Plugin.h"
+
+namespace btest::plugin::Demo_HiltiInclude {
+
+class Plugin : public zeek::plugin::Plugin {
+protected:
+    zeek::plugin::Configuration Configure() override;
+};
+
+extern Plugin plugin;
+
+} // namespace btest::plugin::Demo_HiltiInclude
+# @TEST-END-FILE
+
+# @TEST-START-FILE Plugin.cc
+#include "Plugin.h"
+
+#include <iostream>
+
+#include <hilti/rt/fmt.h>
+
+namespace btest::plugin::Demo_HiltiInclude {
+Plugin plugin;
+}
+
+using namespace btest::plugin::Demo_HiltiInclude;
+
+zeek::plugin::Configuration Plugin::Configure() {
+    zeek::plugin::Configuration config;
+    config.name = "Demo::HiltiInclude";
+    config.description = "Test that hilti runtime headers are usable from plugins";
+    config.version.major = 1;
+    config.version.minor = 0;
+    config.version.patch = 0;
+
+    std::cout << hilti::rt::fmt("hilti::rt::fmt works: %d", 42) << std::endl;
+
+    return config;
+}
+# @TEST-END-FILE


### PR DESCRIPTION
Out-of-tree plugins that transitively include HILTI runtime headers (e.g., `hilti/rt/fmt.h` via `zeek/spicy/manager.h`) fail to compile because `zeek_dynamic_plugin_base` did not propagate the necessary include paths. Add both the HILTI runtime include directory and its 3rdparty subdirectory to the dynamic plugin interface target.

The issue was introduced by zeek/spicy@307d94c43, first pulled into Zeek via 1f85a507d4.

Closes #5769.

> [!NOTE]
> All code changes in this PR were generated with Claude Opus 4.6. I reviewed all changes and am accountable.