### PR TITLE
docs: add security guidance for Zeek core dumps

### DIFF
--- a/doc/security-considerations.rst
+++ b/doc/security-considerations.rst
@@ -68,7 +68,7 @@ The following lists steps you can take to protect your Zeek cluster.
   processes. Misconfigured permissions can expose sensitive network information
   and undermine the confidentiality of security logs.
 
-*  Core dumps contain a snapshot of a process's memory at the time of a crash
+* Core dumps contain a snapshot of a process's memory at the time of a crash
   and may therefore include sensitive information handled by Zeek. Because
   Zeek processes network traffic, its process memory may contain network‑derived
   data or other sensitive information from the monitored environment. If core

--- a/doc/security-considerations.rst
+++ b/doc/security-considerations.rst
@@ -67,3 +67,11 @@ The following lists steps you can take to protect your Zeek cluster.
   world‑readable or writable, and restrict access to authorized users and
   processes. Misconfigured permissions can expose sensitive network information
   and undermine the confidentiality of security logs.
+
+*  Core dumps contain a snapshot of a process's memory at the time of a crash
+  and may therefore include sensitive information handled by Zeek. Because
+  Zeek processes network traffic, its process memory may contain network‑derived
+  data or other sensitive information from the monitored environment. If core
+  dumps are enabled, ensure they are stored in locations accessible only to
+  authorized users and processes, and configure their retention appropriately.
+  If they are not needed for crash investigation, consider disabling them.


### PR DESCRIPTION
## Summary

Add security guidance for Zeek core dumps.

Core dumps contain a snapshot of a process's memory at the time of a crash and may therefore include sensitive information handled by Zeek. Zeek's systemd deployment documentation describes core dumps as part of crash investigation, but the Security Considerations documentation does not currently provide guidance on protecting them.

This change recommends restricting access to core dumps, configuring appropriate retention, and considering disabling them when they are not needed for crash investigation.

## Scope

- Documentation-only change.
- No changes to Zeek's core-dump or crash-handling behavior.

AI Transparency Note: Used Microsoft Copilot to refine English in rst format. 