### PR TITLE
CCI: Add hashes of Dockerfiles to setup parameters

### DIFF
--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -42,6 +42,45 @@ parameters:
     description: True if the requesting user is a member of the Zeek Github organization
     type: boolean
     default: false
+  alpine_image_version:
+    type: string
+    default: ""
+  centos_stream_10_image_version:
+    type: string
+    default: ""
+  centos_stream_9_image_version:
+    type: string
+    default: ""
+  debian_12_image_version:
+    type: string
+    default: ""
+  debian_13_image_version:
+    type: string
+    default: ""
+  debian_unstable_image_version:
+    type: string
+    default: ""
+  fedora_43_image_version:
+    type: string
+    default: ""
+  fedora_44_image_version:
+    type: string
+    default: ""
+  opensuse_leap_16_0_image_version:
+    type: string
+    default: ""
+  opensuse_tumbleweed_image_version:
+    type: string
+    default: ""
+  ubuntu_22_04_image_version:
+    type: string
+    default: ""
+  ubuntu_24_04_image_version:
+    type: string
+    default: ""
+  ubuntu_26_04_image_version:
+    type: string
+    default: ""
 
 commands:
   clone_repo:
@@ -146,6 +185,9 @@ jobs:
         description: Flag for whether to build an ARM variant of the image
         type: boolean
         default: false
+      docker_image_version:
+        description: The version of the Docker image used to create the image for this job
+        type: string
     docker:
       - image: cimg/base:current
     resource_class: medium
@@ -165,18 +207,10 @@ jobs:
 
             IMAGE_NAME=$(echo $CIRCLE_JOB | cut -d- -f 3-)
             DOCKERFILE_PATH=ci/$IMAGE_NAME/Dockerfile
-            IMAGE_VERSION=$(awk -F= '/DOCKERFILE_VERSION/ {print $2}' $DOCKERFILE_PATH)
-
-            if [ -z "${IMAGE_VERSION}" ]; then
-               echo "DOCKERFILE_VERSION environment variable was missing from ${DOCKERFILE_PATH}. This is"
-               echo "needed in order to build the images used later in the build process."
-               exit 1
-            fi
 
             echo "export IMAGE_NAME=$IMAGE_NAME" >> "$BASH_ENV"
             echo "export DOCKERFILE_PATH=$DOCKERFILE_PATH" >> "$BASH_ENV"
-            echo "export IMAGE_VERSION=$IMAGE_VERSION" >> "$BASH_ENV"
-            echo "export FULL_IMAGE_TAG=zeek/zeek-ci:$IMAGE_NAME-$IMAGE_VERSION" >> "$BASH_ENV"
+            echo "export FULL_IMAGE_TAG=zeek/zeek-ci:$IMAGE_NAME-<< parameters.docker_image_version >>" >> "$BASH_ENV"
       # See https://circleci.com/docs/guides/execution-managed/building-docker-images/ for docs
       # on what this does.
       - setup_remote_docker
@@ -235,6 +269,9 @@ jobs:
       docker_image:
         description: The Docker image to be used as the base for building
         type: string
+      docker_image_version:
+        description: The version of the Docker image in the docker_image parameter
+        type: string
       resource_class:
         description: The CircleCI resource class the Docker instance is run under
         type: string
@@ -281,10 +318,6 @@ jobs:
         description: Flag for whether to install the latest compilers on the image before building
         type: boolean
         default: false
-      ci_image_date:
-        description: The date in DOCKERFILE_VERSION in the Dockerfile for the image in the docker_image parameter
-        type: string
-        default: "20260515"
     environment:
       ZEEK_CI: 1
       ZEEK_CI_CONFIGURE_FLAGS: << parameters.configure_flags >>
@@ -297,7 +330,7 @@ jobs:
       ZEEK_CI_CCACHE_PRUNE_SIZE: 700M
       HILTI_CXX_COMPILER_LAUNCHER: ccache
     docker:
-      - image: << parameters.docker_image >>-<< parameters.ci_image_date >>
+      - image: << parameters.docker_image >>-<< parameters.docker_image_version >>
     resource_class: << parameters.resource_class >>
     steps:
       - run:
@@ -800,10 +833,9 @@ jobs:
       docker_image:
         description: The Docker image to be used as the base for building
         type: string
-      ci_image_date:
-        description: The date in DOCKERFILE_VERSION in the Dockerfile for the image in the docker_image parameter
+      docker_image_version:
+        description: The version of the Docker image in the docker_image parameter
         type: string
-        default: "20260515"
       resource_class:
         description: The CircleCI resource class the Docker instance is run under
         type: string
@@ -820,7 +852,7 @@ jobs:
       ZEEK_CI_RUNNER_OS: linux
       ZEEK_CI_CCACHE_PRUNE_SIZE: 700M
     docker:
-      - image: << parameters.docker_image >>-<< parameters.ci_image_date >>
+      - image: << parameters.docker_image >>-<< parameters.docker_image_version >>
     resource_class: << parameters.resource_class >>
     steps:
       - run:
@@ -863,10 +895,9 @@ jobs:
       docker_image:
         description: The Docker image to be used as the base for building
         type: string
-      ci_image_date:
-        description: The date in DOCKERFILE_VERSION in the Dockerfile for the image in the docker_image parameter
+      docker_image_version:
+        description: The version of the Docker image in the docker_image parameter
         type: string
-        default: "20260515"
       resource_class:
         description: The CircleCI resource class the Docker instance is run under
         type: string
@@ -884,7 +915,7 @@ jobs:
       ZEEK_CI_CCACHE_PRUNE_SIZE: 700M
       ZEEK_CI_CONFIGURE_FLAGS: --build-type=release --disable-broker-tests --prefix=${ZEEK_CI_WORKING_DIR}/install --ccache --enable-werror
     docker:
-      - image: << parameters.docker_image >>-<< parameters.ci_image_date >>
+      - image: << parameters.docker_image >>-<< parameters.docker_image_version >>
     resource_class: << parameters.resource_class >>
     steps:
       - run:
@@ -1019,40 +1050,52 @@ workflows:
       # directory in the repo.
       - create-build-image:
           name: build-image-alpine
+          docker_image_version: << pipeline.parameters.alpine_image_version >>
           << : *FILTER_IF_PR_NOT_FULL_CI
       - create-build-image:
           name: build-image-centos-stream-9
+          docker_image_version: << pipeline.parameters.centos_stream_9_image_version >>
           << : *FILTER_IF_PR_NOT_FULL_CI
       - create-build-image:
           name: build-image-centos-stream-10
+          docker_image_version: << pipeline.parameters.centos_stream_10_image_version >>
           << : *FILTER_IF_PR_NOT_FULL_CI
       - create-build-image:
           name: build-image-debian-12
+          docker_image_version: << pipeline.parameters.debian_12_image_version >>
           << : *FILTER_IF_PR_NOT_FULL_OR_ZEEKCTL
       - create-build-image:
           name: build-image-debian-13
+          docker_image_version: << pipeline.parameters.debian_13_image_version >>
           build_arm: true
           << : *FILTER_IF_PR_NOT_FULL_CI
       - create-build-image:
           name: build-image-fedora-43
+          docker_image_version: << pipeline.parameters.fedora_43_image_version >>
           << : *FILTER_IF_PR_NOT_FULL_CI
       - create-build-image:
           name: build-image-fedora-44
+          docker_image_version: << pipeline.parameters.fedora_44_image_version >>
           << : *FILTER_IF_SKIP_ALL
       - create-build-image:
           name: build-image-opensuse-leap-16.0
+          docker_image_version: << pipeline.parameters.opensuse_leap_16_0_image_version >>
           << : *FILTER_IF_PR_NOT_FULL_CI
       - create-build-image:
           name: build-image-opensuse-tumbleweed
+          docker_image_version: << pipeline.parameters.opensuse_tumbleweed_image_version >>
           << : *FILTER_IF_PR_NOT_FULL_CI
       - create-build-image:
           name: build-image-ubuntu-22.04
+          docker_image_version: << pipeline.parameters.ubuntu_22_04_image_version >>
           << : *FILTER_IF_PR_NOT_FULL_CI
       - create-build-image:
           name: build-image-ubuntu-24.04
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           << : *FILTER_IF_SKIP_ALL
       - create-build-image:
           name: build-image-ubuntu-26.04
+          docker_image_version: << pipeline.parameters.ubuntu_26_04_image_version >>
           << : *FILTER_IF_PR_NOT_FULL_CI
 
       - macos-build:
@@ -1068,82 +1111,89 @@ workflows:
       - linux-build:
           name: alpine
           docker_image: zeek/zeek-ci:alpine
+          docker_image_version: << pipeline.parameters.alpine_image_version >>
           requires: [fetch-test-traces, build-image-alpine]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: centos-stream-9
           docker_image: zeek/zeek-ci:centos-stream-9
+          docker_image_version: << pipeline.parameters.centos_stream_9_image_version >>
           requires: [fetch-test-traces, build-image-centos-stream-9]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: centos-stream-10
           docker_image: zeek/zeek-ci:centos-stream-10
+          docker_image_version: << pipeline.parameters.centos_stream_10_image_version >>
           requires: [fetch-test-traces, build-image-centos-stream-10]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: debian-12
           docker_image: zeek/zeek-ci:debian-12
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.debian_12_image_version >>
           requires: [fetch-test-traces, build-image-debian-12]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: debian-13
           docker_image: zeek/zeek-ci:debian-13
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.debian_13_image_version >>
           requires: [fetch-test-traces, build-image-debian-13]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: debian-13-arm
           docker_image: zeek/zeek-ci:debian-13
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.debian_13_image_version >>
           resource_class: arm.large
           requires: [fetch-test-traces, build-image-debian-13]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: debian-13-binary
           docker_image: zeek/zeek-ci:debian-13
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.debian_13_image_version >>
           << : *CONFIGURE_BINARY_BUILD
           requires: [fetch-test-traces, build-image-debian-13]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: debian-13-static
           docker_image: zeek/zeek-ci:debian-13
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.debian_13_image_version >>
           << : *CONFIGURE_STATIC_BUILD
           requires: [fetch-test-traces, build-image-debian-13]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: fedora-43
           docker_image: zeek/zeek-ci:fedora-43
+          docker_image_version: << pipeline.parameters.fedora_43_image_version >>
           requires: [fetch-test-traces, build-image-fedora-43]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: fedora-44
           docker_image: zeek/zeek-ci:fedora-44
+          docker_image_version: << pipeline.parameters.fedora_44_image_version >>
           << : *CONFIGURE_BINARY_BUILD
           requires: [fetch-test-traces, build-image-fedora-44]
           << : *FILTER_IF_SKIP_ALL
       - linux-build:
           name: opensuse-leap-16.0
           docker_image: zeek/zeek-ci:opensuse-leap-16.0
+          docker_image_version: << pipeline.parameters.opensuse_leap_16_0_image_version >>
           requires: [fetch-test-traces, build-image-opensuse-leap-16.0]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: opensuse-tumbleweed
           docker_image: zeek/zeek-ci:opensuse-tumbleweed
+          docker_image_version: << pipeline.parameters.opensuse_tumbleweed_image_version >>
           requires: [fetch-test-traces, build-image-opensuse-tumbleweed]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: ubuntu-22.04
           docker_image: zeek/zeek-ci:ubuntu-22.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_22_04_image_version >>
           requires: [fetch-test-traces, build-image-ubuntu-22.04]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: ubuntu-24.04
           docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           store_install_tarball: true
           enable_benchmarks: true
@@ -1151,7 +1201,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-clang-libcpp
           docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
             CC="clang-22"
@@ -1162,7 +1212,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-clang-tidy
           docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           << : *CONFIGURE_CLANG_TIDY
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
@@ -1173,7 +1223,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-spicy
           docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           << : *CONFIGURE_SPICY_SSL
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           store_install_tarball: true
@@ -1183,7 +1233,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-spicy-head
           docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
             ZEEK_CI_PREBUILD_COMMAND="cd auxil/spicy && git fetch && git reset --hard origin/main && git submodule update --init --recursive"
@@ -1194,7 +1244,7 @@ workflows:
       - linux-build:
           name: ubuntu-24.04-zam
           docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           extra_env: |
             ZEEK_CI_SKIP_UNIT_TESTS=1
@@ -1205,13 +1255,13 @@ workflows:
       - linux-build:
           name: ubuntu-26.04
           docker_image: zeek/zeek-ci:ubuntu-26.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_26_04_image_version >>
           requires: [fetch-test-traces, build-image-ubuntu-26.04]
           << : *FILTER_IF_PR_NOT_FULL_CI
       - linux-build:
           name: asan-sanitizer
           docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           << : *CONFIGURE_ASAN
           # https://circleci.com/changelog/introducing-gen2-docker-x86-resource-classes/
           resource_class: xlarge
@@ -1226,7 +1276,7 @@ workflows:
       - linux-build:
           name: asan-sanitizer-zam
           docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           << : *CONFIGURE_ASAN
           # https://circleci.com/changelog/introducing-gen2-docker-x86-resource-classes/
           resource_class: xlarge
@@ -1242,7 +1292,7 @@ workflows:
       - linux-build:
           name: ubsan-sanitizer
           docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           << : *CONFIGURE_UBSAN
           extra_env: |
@@ -1255,7 +1305,7 @@ workflows:
       - linux-build:
           name: ubsan-sanitizer-zam
           docker_image: zeek/zeek-ci:ubuntu-24.04
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.ubuntu_24_04_image_version >>
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           << : *CONFIGURE_UBSAN
           extra_env: |
@@ -1310,13 +1360,13 @@ workflows:
 
       - zeekctl-testing:
           docker_image: zeek/zeek-ci:debian-12
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.debian_12_image_version >>
           requires: [build-image-debian-12]
           << : *FILTER_IF_PR_NOT_FULL_OR_ZEEKCTL
 
       - include-plugins-testing:
           docker_image: zeek/zeek-ci:debian-13
-          ci_image_date: "20260813"
+          docker_image_version: << pipeline.parameters.debian_13_image_version >>
           requires: [build-image-debian-13]
           << : *FILTER_IF_PR_NOT_FULL_CI
 
@@ -1326,10 +1376,12 @@ workflows:
       - fetch-test-traces
       - create-build-image:
           name: build-image-debian-unstable
+          docker_image_version: << pipeline.parameters.debian_unstable_image_version >>
 
       - linux-build:
           name: latest-gcc-version
           docker_image: zeek/zeek-ci:debian-unstable
+          docker_image_version: << pipeline.parameters.debian_unstable_image_version >>
           install_latest_compiler: true
           requires: [fetch-test-traces, build-image-debian-unstable]
           extra_env: |
@@ -1338,6 +1390,7 @@ workflows:
       - linux-build:
           name: latest-clang-version
           docker_image: zeek/zeek-ci:debian-unstable
+          docker_image_version: << pipeline.parameters.debian_unstable_image_version >>
           install_latest_compiler: true
           requires: [fetch-test-traces, build-image-debian-unstable]
           extra_env: |

--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -248,12 +248,16 @@ jobs:
       - run:
           name: Log in to Docker Hub
           command: |
-            if [ -z "${DOCKER_BUILDIMAGE_LOGIN}" -o -z "${DOCKER_BUILDIMAGE_PASSWORD}" ]; then
+            if [ -z "${DOCKER_BUILDIMAGE_PASSWORD}" ]; then
                echo "User doesn't have access to Docker credentials, later builds will fail"
                circleci-agent step halt
             fi
 
-            echo "$DOCKER_BUILDIMAGE_PASSWORD" | docker login -u "$DOCKER_BUILDIMAGE_LOGIN" --password-stdin
+            # The username here is the name of the organization we're logging into since
+            # the password is a scoped token within that org. The token isn't associated
+            # with an actual user account. This also keeps the word "zeek" from being
+            # masked by CircleCI logs since it's not an environment variable.
+            echo "$DOCKER_BUILDIMAGE_PASSWORD" | docker login -u zeek --password-stdin
       - run:
           name: Build and push multi-arch image
           command: |

--- a/.circleci/generate-workflow-params.py
+++ b/.circleci/generate-workflow-params.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import glob
+import hashlib
 import json
 import os
 import re
@@ -63,6 +65,31 @@ elif GIT_BRANCH == "master" or re.match(r"^release/.*$", GIT_BRANCH):
 
 if GIT_TAG and re.match(r"^v\d+\.\d+\.\d+(-rc[0-9]+)?$", GIT_TAG):
     params["has_release_tag"] = True
+
+# Build up a set of hashes on the Dockerfiles for the build images to be used as version
+# numbers in the dockerhub repo. Remove windows because it's not used, but we keep the
+# Dockerfile for historical reasons.
+platforms = sorted([p.split("/")[1] for p in glob.glob("ci/*/Dockerfile")])
+if "windows" in platforms:
+    platforms.remove("windows")
+
+# Build a version string for each platform. For release branches, we prepend the version number so
+# the cleanup task doesn't nuke versions from the release branches.
+image_version = ""
+m = re.match(r"^release/(\d+\.\d+)$", GIT_BRANCH)
+if m:
+    image_version = m.group(1)
+else:
+    image_version = "master"
+
+for p in platforms:
+    with open(f"ci/{p}/Dockerfile", "rb") as df:
+        # I tried to use hashlib.file_digest here, but apparently the standard python on Circle's
+        # runners is old enough that it doesn't support that.
+        df_str = df.read()
+        params[f"{p.replace('-', '_').replace('.', '_')}_image_version"] = (
+            f"{image_version}-{hashlib.sha256(df_str).hexdigest()[:7]}"
+        )
 
 with open("/tmp/parameters.json", "w") as params_file:
     json.dump(params, params_file)


### PR DESCRIPTION
This PR switches the image versioning for CircleCI to use hashes of the Dockerfiles instead of a date field inside them. This prevents us from having to update the version in the build configuration in the case one of the Dockerfiles changes. It should help ease maintenance a bit.

There still isn't a script for cleaning up old images, but that's next on my list for this.