### PR TITLE
Guard `hilti/rt/3rdparty` include path against absent Spicy headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1168,8 +1168,6 @@ if (HAVE_SPICY)
             ${PROJECT_SOURCE_DIR}/auxil/spicy/3rdparty)
     endif ()
 
-    target_include_directories(zeek_dynamic_plugin_base SYSTEM
-                               INTERFACE $<INSTALL_INTERFACE:include/hilti/rt/3rdparty>)
 endif ()
 
 include(BuiltInSpicyAnalyzer)

--- a/cmake_templates/ZeekConfig.cmake.in
+++ b/cmake_templates/ZeekConfig.cmake.in
@@ -34,6 +34,17 @@ endforeach (  )
 
 include("${CMAKE_CURRENT_LIST_DIR}/ZeekTargets.cmake")
 
+# Spicy's 3rdparty headers may not be installed alongside Zeek's core
+# development files. Only add the include path if it is actually present.
+if (TARGET Zeek::DynamicPluginBase)
+    set(_hilti_3rdparty "${PACKAGE_PREFIX_DIR}/include/hilti/rt/3rdparty")
+    if (IS_DIRECTORY "${_hilti_3rdparty}")
+        set_property(TARGET Zeek::DynamicPluginBase APPEND PROPERTY
+            INTERFACE_INCLUDE_DIRECTORIES "${_hilti_3rdparty}")
+    endif ()
+    unset(_hilti_3rdparty)
+endif ()
+
 # On Windows/MSVC, dynamic plugins (DLLs) must link against the zeek
 # executable's import library to resolve symbols at link time.
 if (MSVC AND TARGET Zeek::DynamicPluginBase)


### PR DESCRIPTION
Zeek's install tree may split Spicy development headers into a separate component (e.g., a dedicated `-spicy-devel` package). When only the core development files are installed, the `include/hilti/rt/3rdparty` directory does not exist. Previously, `9dbcbc7c08` baked this path into `Zeek::DynamicPluginBase`'s `INTERFACE_INCLUDE_DIRECTORIES` via an `INSTALL_INTERFACE` generator expression. CMake validates all such paths at configure time, so external plugins failed to configure when the Spicy headers were not present.

Move the include path addition from the exported target into `ZeekConfig.cmake` where we can check whether the directory actually exists before appending it. Plugins that do need HILTI runtime headers still get the path when available; plugins that do not (or installs without Spicy development files) no longer fail at configure time.

Closes #5787.

> [!NOTE]
> All code changes in this PR were generated with Claude Opus 4.6. I reviewed all changes and am accountable. 