### PR TITLE
Guard against missing backend-specific options in storage `DoOpen`

### DIFF
--- a/src/storage/backend/redis/Redis.cc
+++ b/src/storage/backend/redis/Redis.cc
@@ -262,6 +262,8 @@ std::string Redis::DoGetConfigMetricsLabel() const {
  */
 OperationResult Redis::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
     RecordValPtr backend_options = options->GetField<RecordVal>("redis");
+    if ( ! backend_options )
+        return {ReturnCode::INITIALIZATION_FAILED, "redis backend options not provided"};
 
     key_prefix = backend_options->GetField<StringVal>("key_prefix")->ToStdString();
 

--- a/src/storage/backend/sqlite/SQLite.cc
+++ b/src/storage/backend/sqlite/SQLite.cc
@@ -93,6 +93,9 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
 #endif
 
     RecordValPtr backend_options = options->GetField<RecordVal>("sqlite");
+    if ( ! backend_options )
+        return {ReturnCode::INITIALIZATION_FAILED, "sqlite backend options not provided"};
+
     StringValPtr path = backend_options->GetField<StringVal>("database_path");
     full_path = std::filesystem::path(path->ToStdString()).string();
     table_name = backend_options->GetField<StringVal>("table_name")->ToStdString();

--- a/testing/btest/scripts/base/frameworks/storage/redis/missing-options.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis/missing-options.zeek
@@ -1,0 +1,14 @@
+# @TEST-DOC: Opening a backend with default options reports an error instead of crashing
+
+# @TEST-REQUIRES: have-redis
+
+# @TEST-EXEC: zeek -b %INPUT
+
+@load base/frameworks/storage/sync
+@load policy/frameworks/storage/backend/redis
+
+event zeek_init() {
+	local opts: Storage::BackendOptions;
+	local open_res = Storage::Sync::open_backend(Storage::STORAGE_BACKEND_REDIS, opts, string, string);
+	assert open_res$code == Storage::INITIALIZATION_FAILED;
+}

--- a/testing/btest/scripts/base/frameworks/storage/sqlite/missing-options.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite/missing-options.zeek
@@ -1,0 +1,11 @@
+# @TEST-DOC: Opening a backend with default options reports an error instead of crashing
+# @TEST-EXEC: zeek -b %INPUT
+
+@load base/frameworks/storage/sync
+@load policy/frameworks/storage/backend/sqlite
+
+event zeek_init() {
+	local opts: Storage::BackendOptions;
+	local open_res = Storage::Sync::open_backend(Storage::STORAGE_BACKEND_SQLITE, opts, string, string);
+	assert open_res$code == Storage::INITIALIZATION_FAILED;
+}


### PR DESCRIPTION
`Storage::Sync::open_backend` with a default `BackendOptions` record (backend-specific field unset) dereferences a null pointer from `GetField`. Add a null check in both `SQLite::DoOpen` and `Redis::DoOpen` to return `INITIALIZATION_FAILED` instead of crashing.

Closes #5779

> [!NOTE]
> All code changes in this PR were generated with Claude Opus 4.6. I reviewed all changes and am accountable.