### PR TITLE
Bump zeekctl for zeek/zeekctl#108

### DIFF
--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -1028,7 +1028,7 @@ workflows:
           << : *FILTER_IF_PR_NOT_FULL_CI
       - create-build-image:
           name: build-image-debian-12
-          << : *FILTER_IF_PR_NOT_FULL_CI
+          << : *FILTER_IF_PR_NOT_FULL_OR_ZEEKCTL
       - create-build-image:
           name: build-image-debian-13
           build_arm: true

--- a/doc/advanced/devel/cluster/spawning.rst
+++ b/doc/advanced/devel/cluster/spawning.rst
@@ -104,9 +104,13 @@ individual cluster processes as follows:
   * Change into the working directory and set the ``CLUSTER_NODE`` environment
     variable to the name of the cluster process.
 
-  * Execute the ``zeek`` process, passing arguments as needed. Record its PID.
-    All processes should receive ``local`` by default to load the ``local.zeek``
-    file. Workers will generally also receive the ``-i <interface>`` argument,
+  * Execute the ``zeek`` process, passing process arguments as needed.
+    All processes should minimally receive the cluster backend policy script
+    (e.g. ``policy/frameworks/cluster/backend/zeromq``) as first script argument,
+    followed by ``local`` to load the ``local.zeek`` file. Loading the cluster
+    backend script first allows users to tweak cluster backend specific options
+    using :zeek:keyword:`redef` within ``local.zeek``.
+    Worker processes will also receive the ``-i <interface>`` argument,
     with the interface possibly prefixed by the packet source plugin to use.
     On Linux, using AF_PACKET and interface ``eth0``, this would then end up
     as ``-i af_packet::eth0``.
@@ -138,15 +142,15 @@ cluster process tree you might be used to from elsewhere.
 
     $ ZEEK_WORKERS=2 ZEEK_INTERFACE=af_packet::lo ./supervisor.sh
 
-    $ pstree -acT  44168
+    $ pstree -A -acT 1163012
     bash
-      └─supervisor.sh ./supervisor.sh
-          ├─zeek local policy/frameworks/cluster/backend/zeromq
-          ├─zeek local policy/frameworks/cluster/backend/zeromq
-          ├─zeek local policy/frameworks/cluster/backend/zeromq
-          ├─zeek local policy/frameworks/cluster/backend/zeromq
-          ├─zeek -C -i af_packet::lo local policy/frameworks/cluster/backend/zeromq
-          └─zeek -C -i af_packet::lo local policy/frameworks/cluster/backend/zeromq
+      `-supervisor.sh ./supervisor.sh
+          |-zeek policy/frameworks/cluster/backend/zeromq local Log::default_rotation_interval=0sec
+          |-zeek policy/frameworks/cluster/backend/zeromq local Log::default_rotation_interval=0sec
+          |-zeek policy/frameworks/cluster/backend/zeromq local Log::default_rotation_interval=0sec
+          |-zeek policy/frameworks/cluster/backend/zeromq local Log::default_rotation_interval=0sec
+          |-zeek policy/frameworks/cluster/backend/zeromq -C -i lo local Log::default_rotation_interval=0sec
+          |-zeek policy/frameworks/cluster/backend/zeromq -C -i lo local Log::default_rotation_interval=0sec
 
 Hopefully this removes some of the magic around what a Zeek cluster is, how
 it is spawned, etc. If you're now tempted to write systemd service units,

--- a/doc/advanced/devel/cluster/spawning.rst
+++ b/doc/advanced/devel/cluster/spawning.rst
@@ -154,6 +154,5 @@ cluster process tree you might be used to from elsewhere.
           |-zeek policy/frameworks/cluster/backend/zeromq -C -i lo local Log::default_rotation_interval=0sec
 
 Hopefully this removes some of the magic around what a Zeek cluster is, how
-it is spawned, etc. If you're now tempted to write systemd service units,
-take a look at the `zeek-systemd-generator <https://github.com/zeek/zeek/tree/master/tools/systemd-generator>`_
-first!
+it is spawned, etc. If you're now tempted to write systemd unit files,
+take a look at the :ref:`zeek-systemd-generator <deploy-systemd>` first!

--- a/doc/advanced/devel/cluster/spawning.rst
+++ b/doc/advanced/devel/cluster/spawning.rst
@@ -117,7 +117,8 @@ individual cluster processes as follows:
 
   * For pinning processes to CPUs, one common approach is to use the
     `taskset <https://man7.org/linux/man-pages/man1/taskset.1.html>`_
-    utility and execute ``zeek`` using it instead.
+    utility and execute ``zeek`` using it instead, or, to also control
+    memory allocation policies , use `numactl <https://linux.die.net/man/8/numactl>`_.
 
 
 Minimal Shell-Based Supervisor

--- a/doc/advanced/devel/cluster/supervisor.sh
+++ b/doc/advanced/devel/cluster/supervisor.sh
@@ -28,7 +28,8 @@ CLUSTER_BACKEND_ARGS=${ZEEK_CLUSTER_BACKEND_ARGS:-policy/frameworks/cluster/back
 # spawn_process <name> <args...>
 #
 # Creates the working directory and launches a Zeek process in
-# the background the given cluster name, passing args to it.
+# the background the given cluster name, passing $CLUSTER_BACKEND_ARGS
+# followed by args to it.
 function spawn_process {
     local name=$1
     shift # make "$@" in the sub shell work
@@ -41,7 +42,7 @@ function spawn_process {
     (
         cd $wdir
         export CLUSTER_NODE=$name
-        exec zeek "$@" $CLUSTER_BACKEND_ARGS
+        exec zeek $CLUSTER_BACKEND_ARGS "$@"
     ) &
 }
 


### PR DESCRIPTION
Bump for https://github.com/zeek/zeekctl/issues/108 / https://github.com/zeek/zeekctl/pull/109 and a small Circle CI fixup for the debian-12 image dependency.

Also adds documentation about putting the cluster backend policy script as the first scripting argument into the development section and update the bare-bones example `supervisor.sh` script. ZeekControl is updated with this bump and the zeek-systemd-generator already passes the cluster_backend_args value first.