### PR TITLE
Deprecate Broker

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -287,6 +287,16 @@ Changed Functionality
 Deprecated Functionality
 ------------------------
 
+- The Broker messaging backend is now deprecated. ZeroMQ has been the default
+  cluster messaging backend used by zeekctl since Zeek 8.1, and we encourage
+  everyone to switch their clusters over to ZeroMQ at this time. We are not
+  going to remove Broker with 9.1, but Broker will become a build-time opt-in
+  feature over the course of the 9.x cycle and likely see removal in 10.1.
+
+  Third-party applications should focus on Zeek's WebSocket stack for connecting
+  into the Zeek cluster, while JavaScript offers support for reaching out to
+  HTTP APIs from Zeek scripts.
+
 - Development of the Management Framework has been discontinued and its scripting
   code will be moved into an external package with Zeek 9.1. If you've been deploying
   Zeek clusters using the Management Framework, you can continue to do so with Zeek 9.0,

--- a/doc/frameworks/broker.rst
+++ b/doc/frameworks/broker.rst
@@ -6,20 +6,27 @@
 Broker Communication Framework
 ==============================
 
+.. note::
+
+   As of Zeek 9.0 this framework is deprecated, for removal during the Zeek 10
+   release cycle. Clusters managed via zeekctl have used the alternative
+   :ref:`ZeroMQ backend <cluster_backend_zeromq>` by default since Zeek 8.1. We
+   encourage all users to switch their clusters to the ZeroMQ backend at this
+   time.
+
 .. rst-class:: opening
 
-    Zeek uses the `Broker Library
-    <https://docs.zeek.org/projects/broker>`_ to exchange information with
-    other Zeek processes.  Broker itself uses CAF_ (C++ Actor Framework)
-    internally for connecting nodes and exchanging arbitrary data over
-    networks.  Broker then introduces, on top of CAF, a topic-based
-    publish/subscribe communication pattern using a data model that is
-    compatible to Zeek's.  Broker itself can be utilized outside the
-    context of Zeek, with Zeek itself making use of only a few predefined
-    Broker message formats that represent Zeek events, log entries, etc.
+    The `Broker Library <https://docs.zeek.org/projects/broker>`_ is Zeek's
+    legacy framework for exchanging information with other Zeek processes.  It
+    uses CAF_ (C++ Actor Framework) internally for connecting nodes and
+    exchanging data.  Broker then introduces, on top of CAF's physical topology,
+    a topic-based publish/subscribe communication pattern using its own data
+    model.  Broker can be utilized outside the context of Zeek, with Zeek itself
+    making use of only a few predefined Broker message formats that represent
+    Zeek events, log entries, etc.
 
-    In summary, the Zeek's Broker framework provides basic facilities for
-    connecting broker-enabled peers (e.g. Zeek instances) to each other
+    In summary, Zeek's Broker framework provides basic facilities for
+    connecting Broker-enabled peers (e.g. Zeek instances) to each other
     and exchanging messages (e.g. events and logs).
 
 Cluster Layout / API

--- a/doc/frameworks/cluster.rst
+++ b/doc/frameworks/cluster.rst
@@ -213,11 +213,15 @@ to aggregate results across workers to see if that count crosses a threshold,
 such as using scan detection. Finally, you might want to extract URLs from
 emails and then redistribute the extracted URLs to all workers to be able to
 find which of these extracted URLs got clicked on. All these examples tend to
-introduce challenges in a Zeek cluster setup due to data centrality issues. In
-other words, the very advantageous divide-and-conquer approach of
+introduce challenges in a Zeek cluster setup due to data centrality issues.
+
+In other words, the very advantageous divide-and-conquer approach of
 clusterization also introduces complexity in Zeek scripts. Using such scripting,
 you can use topic-based publish/subscribe communication of Zeek events to
-communicate state. Zeek also provides language primitives such as
+communicate state: Zeek nodes first *subscribe* to events published to a given
+*topic*. Another node may now *publish* a Zeek event to this topic, and all of
+the subscribed nodes will receive it. Zeek provides explicit APIs to this
+effect, but also provides built-in language primitives such as
 :zeek:attr:`&publish_on_change` to communicate state automatically.
 
 When clustering your scripts, the fundamental work to move data or events in
@@ -226,14 +230,15 @@ communication patterns, such as manager-to-worker, worker-to-manager, etc.
 
 All the communication between workers, proxies and manager is established by
 Zeek via a *cluster backend*. Zeek ships with two such backends, :ref:`ZeroMQ
-<cluster_backend_zeromq>` and :ref:`Broker <broker-framework>`.  They differ in
-their underlying connectivity but provide conceptually similar high-level
-pub/sub messaging.
+<cluster_backend_zeromq>` and :ref:`Broker <broker-framework>`, and users may
+implement their own via Zeek plugins.
 
-Importantly, the ZeroMQ backend provides a logically fully meshed network, while
-Broker only establishes a partial, physical point-to-point topology among the
-nodes. This means that ZeroMQ allows certain communication patterns that Broker
-does not, such as direct worker-to-worker broadcasts.
+Importantly, the ZeroMQ backend provides a logically fully meshed network over
+which it provides pub/sub messaging, while Broker only establishes a partial
+point-to-point topology among the nodes. This means that ZeroMQ permits certain
+topic-based communication patterns that Broker does not, such as direct
+worker-to-worker broadcasts. See the Broker framework documentation for more
+details on its physical connectivity.
 
 Cluster Topics
 --------------
@@ -322,7 +327,7 @@ the proxies of a cluster. Examples of its use are listed in the following table.
 Publishing Events Across the Cluster
 ------------------------------------
 
-Zeek’s cluster framework provides a set of function to publish events, including:
+Zeek’s cluster framework provides a set of functions to publish events:
 
 .. list-table::
   :header-rows: 1

--- a/doc/frameworks/cluster.rst
+++ b/doc/frameworks/cluster.rst
@@ -215,36 +215,35 @@ emails and then redistribute the extracted URLs to all workers to be able to
 find which of these extracted URLs got clicked on. All these examples tend to
 introduce challenges in a Zeek cluster setup due to data centrality issues. In
 other words, the very advantageous divide-and-conquer approach of
-clusterization also introduces complexity in Zeek scripts. However, with the
-introduction of the Broker communication framework and additional helper
-functions, data centrality complexities can be addressed efficiently. One must
-rely on clusterization techniques provided by Zeek scripting, the Broker API,
-and clusterization components.
+clusterization also introduces complexity in Zeek scripts. Using such scripting,
+you can use topic-based publish/subscribe communication of Zeek events to
+communicate state. Zeek also provides language primitives such as
+:zeek:attr:`&publish_on_change` to communicate state automatically.
 
 When clustering your scripts, the fundamental work to move data or events in
 the context of a cluster falls primarily on few high level abstractions of
-communication patterns:
-
-  1. Manager-to-worker
-  2. Worker-to-manager
-  3. Worker-to-proxy
-  4. Worker-to-manager-to-worker
-  5. Manager-to-worker-to-manager
+communication patterns, such as manager-to-worker, worker-to-manager, etc.
 
 All the communication between workers, proxies and manager is established by
-Zeek via the Broker framework. The Broker framework provides basic facilities
-for connecting Zeek instances to each other and exchanging messages, events or
-data.
+Zeek via a *cluster backend*. Zeek ships with two such backends, :ref:`ZeroMQ
+<cluster_backend_zeromq>` and :ref:`Broker <broker-framework>`.  They differ in
+their underlying connectivity but provide conceptually similar high-level
+pub/sub messaging.
+
+Importantly, the ZeroMQ backend provides a logically fully meshed network, while
+Broker only establishes a partial, physical point-to-point topology among the
+nodes. This means that ZeroMQ allows certain communication patterns that Broker
+does not, such as direct worker-to-worker broadcasts.
 
 Cluster Topics
 --------------
 
-All Broker-based messaging involves two components: the information you want to
+All messaging involves two components: the information you want to
 send, such as an event with its arguments, along with an associated topic name
-string. The topic strings are used as a filtering mechanism: Broker uses a
+string. The topic strings are used as a filtering mechanism: the backends use a
 publish-subscribe communication pattern where peers advertise interest in topic
 prefixes and only receive messages which match one of their prefix
-subscriptions. Broker itself supports arbitrary topic strings. However, Zeek
+subscriptions. Zeek supports arbitrary topic strings, but
 generally follows certain conventions in choosing these topics to help avoid
 conflicts and generally make them easier to remember.
 
@@ -323,8 +322,7 @@ the proxies of a cluster. Examples of its use are listed in the following table.
 Publishing Events Across the Cluster
 ------------------------------------
 
-Broker, as well as Zeek’s higher-level cluster framework, provide a set of
-function to publish events, including:
+Zeek’s cluster framework provides a set of function to publish events, including:
 
 .. list-table::
   :header-rows: 1
@@ -379,12 +377,9 @@ An example sending an event from worker to manager:
 
   event some_event_handled_on_worker()
       {
-      Broker::publish(Cluster::manager_topic, worker_to_manager,
-                      Cluster::node);
+      Cluster::publish(Cluster::manager_topic, worker_to_manager,
+                       Cluster::node);
       }
-
-More details and code snippets and documentation on Broker communication
-frameworks are available at :ref:`broker-framework`.
 
 
 .. _cluster-framework-proxies-uniform:
@@ -451,9 +446,8 @@ when working with aggregate and threshold functions.
   scoping.  See :ref:`event-namespacing-pitfall` for further explanation and
   examples.
 
-Clusterization of Zeek scripts can be an intimidating task for beginners.
-However, with reliance on the new Broker framework, clusterization has become
-simpler and straightforward.  Consider the following:
+Clusterization of Zeek scripts can be an intimidating task for beginners,
+but topic-based pub/sub quickly feels natural.  Consider the following:
 
 1. Communication overhead: Be sure not to generate unnecessary communication
    overhead. For example, scan detection is one of the worst cases for


### PR DESCRIPTION
This adds deprecation notices to the docs and NEWS, and de-Brokerizes some of the core cluster documentation. It does not add `&deprecated` tags on any APIs, so this is pretty "soft".

@awelzel, @bbannier, fyi.