### PR TITLE
docs: add security guidance for ZeekControl SSH access

### DIFF
--- a/doc/security-considerations.rst
+++ b/doc/security-considerations.rst
@@ -67,3 +67,9 @@ The following lists steps you can take to protect your Zeek cluster.
   world‑readable or writable, and restrict access to authorized users and
   processes. Misconfigured permissions can expose sensitive network information
   and undermine the confidentiality of security logs.
+
+* In a multi-host cluster, ZeekControl uses SSH from the manager to run commands
+  and deploy configuration and policy files on the other cluster hosts. The account
+  used by ZeekControl therefore has administrative access across the cluster. 
+  Protect its SSH credentials and restrict the account's access to the systems 
+  and operations required to manage the Zeek cluster.

--- a/doc/security-considerations.rst
+++ b/doc/security-considerations.rst
@@ -68,7 +68,7 @@ The following lists steps you can take to protect your Zeek cluster.
   processes. Misconfigured permissions can expose sensitive network information
   and undermine the confidentiality of security logs.
 
-* In a multi-host cluster, ZeekControl uses SSH from the manager to run commands
+* When using ZeekControl to manage a multi-host cluster, ZeekControl uses SSH from the manager to run commands
   and deploy configuration and policy files on the other cluster hosts. The account
   used by ZeekControl therefore has administrative access across the cluster. 
   Protect its SSH credentials and restrict the account's access to the systems 

--- a/doc/security-considerations.rst
+++ b/doc/security-considerations.rst
@@ -70,6 +70,6 @@ The following lists steps you can take to protect your Zeek cluster.
 
 * When using ZeekControl to manage a multi-host cluster, ZeekControl uses SSH from the manager to run commands
   and deploy configuration and policy files on the other cluster hosts. The account
-  used by ZeekControl therefore has administrative access across the cluster. 
+  used by ZeekControl therefore must have administrative access across the cluster. 
   Protect its SSH credentials and restrict the account's access to the systems 
   and operations required to manage the Zeek cluster.


### PR DESCRIPTION
ZeekControl uses SSH from the manager to manage nodes in a multi-host cluster, including deploying configuration and running management commands.

Document the need to protect the SSH account and credentials used for cluster management, since compromise of this access can affect multiple cluster hosts.

AI Transparency Note: Used Microsoft Copilot to refine English in .rst format.