### PR TITLE
Cleanups to Redis storage backend

### DIFF
--- a/src/storage/backend/redis/Redis.cc
+++ b/src/storage/backend/redis/Redis.cc
@@ -538,11 +538,8 @@ void Redis::DoExpire(double current_network_time) {
     // and passing the array as a block somehow. There's no guarantee it'd be faster
     // anyways.
     for ( const auto& e : elements ) {
-        // redisAsyncCommand usually takes a printf-style string, except the parser used by
-        // hiredis doesn't handle lengths passed with strings correctly (it hangs indefinitely).
-        // Use util::fmt here instead it handles it.
-        status = redisAsyncCommand(async_ctx, redisGeneric, nullptr,
-                                   util::fmt("DEL %s:%.*s", key_prefix.data(), static_cast<int>(e.size()), e.data()));
+        status =
+            redisAsyncCommand(async_ctx, redisGeneric, nullptr, "DEL %s:%b", key_prefix.data(), e.data(), e.size());
         ++active_ops;
         Poll();
 

--- a/src/storage/backend/redis/Redis.cc
+++ b/src/storage/backend/redis/Redis.cc
@@ -518,6 +518,12 @@ void Redis::DoExpire(double current_network_time) {
     // Expire always happens in a synchronous fashion. Block here until we've received
     // a response.
     Poll();
+
+    if ( reply_queue.empty() ) {
+        expire_running = false;
+        return;
+    }
+
     redisReply* reply = reply_queue.front();
     reply_queue.pop_front();
 
@@ -543,10 +549,12 @@ void Redis::DoExpire(double current_network_time) {
         ++active_ops;
         Poll();
 
+        if ( reply_queue.empty() )
+            break;
+
         redisReply* del_reply = reply_queue.front();
         reply_queue.pop_front();
         freeReplyObject(del_reply);
-        // TODO: do we care if this failed?
     }
 
     IncExpiredEntriesMetric(elements.size());
@@ -560,10 +568,11 @@ void Redis::DoExpire(double current_network_time) {
     ++active_ops;
     Poll();
 
-    redisReply* rem_range_reply = reply_queue.front();
-    reply_queue.pop_front();
-    freeReplyObject(rem_range_reply);
-    // TODO: do we care if this failed?
+    if ( ! reply_queue.empty() ) {
+        redisReply* rem_range_reply = reply_queue.front();
+        reply_queue.pop_front();
+        freeReplyObject(rem_range_reply);
+    }
 }
 
 void Redis::HandlePutResult(redisReply* reply, ResultCallback* callback) {


### PR DESCRIPTION
This fixes two potential issues in the Redis storage backend:

- potential UB on race
- inconsistent handling of data with embedded NULL

The first one is a real bugfix, the second one more a consistency fix. I added no tests since the race is hard to reproduce reliably.

> [!NOTE]
> All code changes in this PR were generated with Claude Opus 4.6. I reviewed all changes and am accountable.