### PR TITLE
Allow retrieving storage-backed tables

### DIFF
--- a/scripts/base/frameworks/storage/sync.zeek
+++ b/scripts/base/frameworks/storage/sync.zeek
@@ -70,6 +70,21 @@ export {
 	##          string for failures.
 	global erase: function(backend: opaque of Storage::BackendHandle, key: any)
 	    : Storage::OperationResult;
+
+	## Retrieves all entries from the backend as a table.
+	##
+	## backend: A handle to a backend connection.
+	##
+	## max_entries: The maximum number of entries to retrieve. If the backend
+	##             contains more entries, the operation fails with
+	##             ``RESULT_TOO_LARGE``. Pass 0 for no limit.
+	##
+	## Returns: A record containing the status of the operation, an optional error
+	##          string for failures, and an optional value containing the table on
+	##          success. The table will have the key/value types that were passed
+	##          to :zeek:see:`Storage::Sync::open_backend`.
+	global get_all: function(backend: opaque of Storage::BackendHandle,
+	    max_entries: count): Storage::OperationResult;
 }
 
 function open_backend(btype: Storage::Backend, options: Storage::BackendOptions,
@@ -101,4 +116,10 @@ function erase(backend: opaque of Storage::BackendHandle, key: any)
     : Storage::OperationResult
 	{
 	return Storage::Sync::__erase(backend, key);
+	}
+
+function get_all(backend: opaque of Storage::BackendHandle, max_entries: count)
+    : Storage::OperationResult
+	{
+	return Storage::Sync::__get_all(backend, max_entries);
 	}

--- a/scripts/base/frameworks/storage/sync.zeek
+++ b/scripts/base/frameworks/storage/sync.zeek
@@ -85,6 +85,16 @@ export {
 	##          to :zeek:see:`Storage::Sync::open_backend`.
 	global get_all: function(backend: opaque of Storage::BackendHandle,
 	    max_entries: count): Storage::OperationResult;
+
+	## Returns the number of non-expired entries in the backend.
+	##
+	## backend: A handle to a backend connection.
+	##
+	## Returns: A record containing the status of the operation, an optional error
+	##          string for failures, and an optional value containing the count on
+	##          success.
+	global size: function(backend: opaque of Storage::BackendHandle)
+	    : Storage::OperationResult;
 }
 
 function open_backend(btype: Storage::Backend, options: Storage::BackendOptions,
@@ -122,4 +132,10 @@ function get_all(backend: opaque of Storage::BackendHandle, max_entries: count)
     : Storage::OperationResult
 	{
 	return Storage::Sync::__get_all(backend, max_entries);
+	}
+
+function size(backend: opaque of Storage::BackendHandle)
+    : Storage::OperationResult
+	{
+	return Storage::Sync::__size(backend);
 	}

--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -6814,6 +6814,8 @@ export {
 		## Returned from async operations when the backend is waiting
 		## for a result.
 		IN_PROGRESS,
+		## Backend does not support the requested operation.
+		NOT_SUPPORTED,
 	} &redef;
 
 	## Returned as the result of the various storage operations.

--- a/scripts/base/init-bare.zeek
+++ b/scripts/base/init-bare.zeek
@@ -6816,6 +6816,8 @@ export {
 		IN_PROGRESS,
 		## Backend does not support the requested operation.
 		NOT_SUPPORTED,
+		## Result exceeds the requested maximum number of entries.
+		RESULT_TOO_LARGE,
 	} &redef;
 
 	## Returned as the result of the various storage operations.

--- a/src/storage/Backend.cc
+++ b/src/storage/Backend.cc
@@ -214,6 +214,18 @@ OperationResult Backend::Erase(ResultCallback* cb, ValPtr key) {
     return ret;
 }
 
+OperationResult Backend::DoGetAll(ResultCallback* /* cb */, uint64_t /* max_entries */) {
+    return {ReturnCode::NOT_SUPPORTED, "backend does not support get_all"};
+}
+
+OperationResult Backend::GetAll(ResultCallback* cb, uint64_t max_entries) {
+    auto ret = DoGetAll(cb, max_entries);
+    if ( cb->IsSyncCallback() )
+        CompleteCallback(cb, ret);
+
+    return ret;
+}
+
 void Backend::CompleteCallback(ResultCallback* cb, const OperationResult& data) const {
     if ( data.code == ReturnCode::TIMEOUT )
         cb->Timeout();

--- a/src/storage/Backend.cc
+++ b/src/storage/Backend.cc
@@ -223,17 +223,21 @@ OperationResult Backend::DoSize(ResultCallback* /* cb */) {
 }
 
 OperationResult Backend::GetAll(ResultCallback* cb, uint64_t max_entries) {
+    cb->Init(get_all_metrics.get());
+
     auto ret = DoGetAll(cb, max_entries);
     if ( cb->IsSyncCallback() )
-        CompleteCallback(cb, ret);
+        cb->UpdateOperationMetrics(ret.code);
 
     return ret;
 }
 
 OperationResult Backend::Size(ResultCallback* cb) {
+    cb->Init(size_metrics.get());
+
     auto ret = DoSize(cb);
     if ( cb->IsSyncCallback() )
-        CompleteCallback(cb, ret);
+        cb->UpdateOperationMetrics(ret.code);
 
     return ret;
 }
@@ -283,6 +287,10 @@ void Backend::InitMetrics() {
         std::make_unique<detail::OperationMetrics>(results_family, latency_family, "get", Tag(), metrics_config);
     erase_metrics =
         std::make_unique<detail::OperationMetrics>(results_family, latency_family, "erase", Tag(), metrics_config);
+    get_all_metrics =
+        std::make_unique<detail::OperationMetrics>(results_family, latency_family, "get_all", Tag(), metrics_config);
+    size_metrics =
+        std::make_unique<detail::OperationMetrics>(results_family, latency_family, "size", Tag(), metrics_config);
 
     bytes_written_metric = telemetry_mgr->CounterInstance("zeek", "storage_backend_data_written",
                                                           {{"type", Tag()}, {"config", metrics_config}},

--- a/src/storage/Backend.cc
+++ b/src/storage/Backend.cc
@@ -218,8 +218,20 @@ OperationResult Backend::DoGetAll(ResultCallback* /* cb */, uint64_t /* max_entr
     return {ReturnCode::NOT_SUPPORTED, "backend does not support get_all"};
 }
 
+OperationResult Backend::DoSize(ResultCallback* /* cb */) {
+    return {ReturnCode::NOT_SUPPORTED, "backend does not support size"};
+}
+
 OperationResult Backend::GetAll(ResultCallback* cb, uint64_t max_entries) {
     auto ret = DoGetAll(cb, max_entries);
+    if ( cb->IsSyncCallback() )
+        CompleteCallback(cb, ret);
+
+    return ret;
+}
+
+OperationResult Backend::Size(ResultCallback* cb) {
+    auto ret = DoSize(cb);
     if ( cb->IsSyncCallback() )
         CompleteCallback(cb, ret);
 

--- a/src/storage/Backend.h
+++ b/src/storage/Backend.h
@@ -199,6 +199,19 @@ public:
     OperationResult Erase(ResultCallback* cb, ValPtr key);
 
     /**
+     * Retrieve all key/value pairs from the backend as a table.
+     *
+     * @param cb A callback object for returning status if being called via an async
+     * context.
+     * @param max_entries The maximum number of entries to retrieve. If the backend
+     * contains more entries than this, the operation returns RESULT_TOO_LARGE. Pass
+     * 0 for no limit.
+     * @return A struct describing the result of the operation, containing a code, an
+     * optional error string, and a ValPtr containing the table on success.
+     */
+    OperationResult GetAll(ResultCallback* cb, uint64_t max_entries);
+
+    /**
      * Returns whether the backend is opened.
      */
     virtual bool IsOpen() = 0;
@@ -362,6 +375,13 @@ private:
      * documentation of the arguments. This must be overridden by all backends.
      */
     virtual OperationResult DoErase(ResultCallback* cb, ValPtr key) = 0;
+
+    /**
+     * Workhorse method for calls to `Backend::GetAll()`. See that method for
+     * documentation of the arguments. Backends that support this operation should
+     * override this method.
+     */
+    virtual OperationResult DoGetAll(ResultCallback* cb, uint64_t max_entries);
 
     /**
      * Optional method for backends to override to provide direct polling. This should be

--- a/src/storage/Backend.h
+++ b/src/storage/Backend.h
@@ -426,6 +426,8 @@ private:
     std::unique_ptr<detail::OperationMetrics> put_metrics;
     std::unique_ptr<detail::OperationMetrics> get_metrics;
     std::unique_ptr<detail::OperationMetrics> erase_metrics;
+    std::unique_ptr<detail::OperationMetrics> get_all_metrics;
+    std::unique_ptr<detail::OperationMetrics> size_metrics;
 
     telemetry::CounterPtr bytes_written_metric;
     telemetry::CounterPtr bytes_read_metric;

--- a/src/storage/Backend.h
+++ b/src/storage/Backend.h
@@ -212,6 +212,16 @@ public:
     OperationResult GetAll(ResultCallback* cb, uint64_t max_entries);
 
     /**
+     * Query the number of non-expired entries in the backend.
+     *
+     * @param cb A callback object for returning status if being called via an async
+     * context.
+     * @return A struct describing the result of the operation, containing a code, an
+     * optional error string, and a ValPtr containing the count on success.
+     */
+    OperationResult Size(ResultCallback* cb);
+
+    /**
      * Returns whether the backend is opened.
      */
     virtual bool IsOpen() = 0;
@@ -376,12 +386,8 @@ private:
      */
     virtual OperationResult DoErase(ResultCallback* cb, ValPtr key) = 0;
 
-    /**
-     * Workhorse method for calls to `Backend::GetAll()`. See that method for
-     * documentation of the arguments. Backends that support this operation should
-     * override this method.
-     */
     virtual OperationResult DoGetAll(ResultCallback* cb, uint64_t max_entries);
+    virtual OperationResult DoSize(ResultCallback* cb);
 
     /**
      * Optional method for backends to override to provide direct polling. This should be

--- a/src/storage/ReturnCode.cc
+++ b/src/storage/ReturnCode.cc
@@ -21,6 +21,7 @@ EnumValPtr ReturnCode::INITIALIZATION_FAILED;
 EnumValPtr ReturnCode::IN_PROGRESS;
 EnumValPtr ReturnCode::SERIALIZATION_FAILED;
 EnumValPtr ReturnCode::UNSERIALIZATION_FAILED;
+EnumValPtr ReturnCode::NOT_SUPPORTED;
 
 void ReturnCode::Initialize() {
     static const auto& return_code_type = zeek::id::find_type<zeek::EnumType>("Storage::ReturnCode");
@@ -69,6 +70,9 @@ void ReturnCode::Initialize() {
 
     tmp = return_code_type->Lookup("Storage::UNSERIALIZATION_FAILED");
     UNSERIALIZATION_FAILED = return_code_type->GetEnumVal(tmp);
+
+    tmp = return_code_type->Lookup("Storage::NOT_SUPPORTED");
+    NOT_SUPPORTED = return_code_type->GetEnumVal(tmp);
 }
 
 void ReturnCode::Cleanup() {
@@ -87,6 +91,7 @@ void ReturnCode::Cleanup() {
     IN_PROGRESS.reset();
     SERIALIZATION_FAILED.reset();
     UNSERIALIZATION_FAILED.reset();
+    NOT_SUPPORTED.reset();
 }
 
 } // namespace zeek::storage

--- a/src/storage/ReturnCode.cc
+++ b/src/storage/ReturnCode.cc
@@ -22,6 +22,7 @@ EnumValPtr ReturnCode::IN_PROGRESS;
 EnumValPtr ReturnCode::SERIALIZATION_FAILED;
 EnumValPtr ReturnCode::UNSERIALIZATION_FAILED;
 EnumValPtr ReturnCode::NOT_SUPPORTED;
+EnumValPtr ReturnCode::RESULT_TOO_LARGE;
 
 void ReturnCode::Initialize() {
     static const auto& return_code_type = zeek::id::find_type<zeek::EnumType>("Storage::ReturnCode");
@@ -73,6 +74,9 @@ void ReturnCode::Initialize() {
 
     tmp = return_code_type->Lookup("Storage::NOT_SUPPORTED");
     NOT_SUPPORTED = return_code_type->GetEnumVal(tmp);
+
+    tmp = return_code_type->Lookup("Storage::RESULT_TOO_LARGE");
+    RESULT_TOO_LARGE = return_code_type->GetEnumVal(tmp);
 }
 
 void ReturnCode::Cleanup() {
@@ -92,6 +96,7 @@ void ReturnCode::Cleanup() {
     SERIALIZATION_FAILED.reset();
     UNSERIALIZATION_FAILED.reset();
     NOT_SUPPORTED.reset();
+    RESULT_TOO_LARGE.reset();
 }
 
 } // namespace zeek::storage

--- a/src/storage/ReturnCode.h
+++ b/src/storage/ReturnCode.h
@@ -37,6 +37,7 @@ public:
     ZEEK_IMPORT_DATA static EnumValPtr SERIALIZATION_FAILED;
     ZEEK_IMPORT_DATA static EnumValPtr UNSERIALIZATION_FAILED;
     ZEEK_IMPORT_DATA static EnumValPtr NOT_SUPPORTED;
+    ZEEK_IMPORT_DATA static EnumValPtr RESULT_TOO_LARGE;
 };
 
 } // namespace storage

--- a/src/storage/ReturnCode.h
+++ b/src/storage/ReturnCode.h
@@ -36,6 +36,7 @@ public:
     ZEEK_IMPORT_DATA static EnumValPtr IN_PROGRESS;
     ZEEK_IMPORT_DATA static EnumValPtr SERIALIZATION_FAILED;
     ZEEK_IMPORT_DATA static EnumValPtr UNSERIALIZATION_FAILED;
+    ZEEK_IMPORT_DATA static EnumValPtr NOT_SUPPORTED;
 };
 
 } // namespace storage

--- a/src/storage/backend/redis/Redis.cc
+++ b/src/storage/backend/redis/Redis.cc
@@ -575,6 +575,107 @@ void Redis::DoExpire(double current_network_time) {
     }
 }
 
+zeek::expected<std::vector<std::string>, OperationResult> Redis::ScanKeys(uint64_t max_keys) {
+    using ReplyPtr = std::unique_ptr<redisReply, decltype(&freeReplyObject)>;
+
+    std::string match_pattern = key_prefix + ":*";
+    std::vector<std::string> keys;
+    std::string cursor = "0";
+    uint64_t count = 0;
+
+    do {
+        int status = redisAsyncCommand(async_ctx, redisGeneric, nullptr, "SCAN %s MATCH %s COUNT 100", cursor.c_str(),
+                                       match_pattern.c_str());
+        if ( connected && status == REDIS_ERR )
+            return zeek::unexpected<OperationResult>(
+                OperationResult{ReturnCode::OPERATION_FAILED, util::fmt("SCAN failed: %s", async_ctx->errstr)});
+
+        ++active_ops;
+        Poll();
+
+        if ( reply_queue.empty() )
+            return zeek::unexpected<OperationResult>(
+                OperationResult{ReturnCode::OPERATION_FAILED, "no reply from SCAN"});
+
+        ReplyPtr reply{reply_queue.front(), freeReplyObject};
+        reply_queue.pop_front();
+
+        if ( ! reply || reply->type != REDIS_REPLY_ARRAY || reply->elements != 2 )
+            return zeek::unexpected<OperationResult>(
+                OperationResult{ReturnCode::OPERATION_FAILED, "unexpected SCAN reply format"});
+
+        cursor = std::string(reply->element[0]->str, reply->element[0]->len);
+        auto* key_array = reply->element[1];
+
+        for ( size_t i = 0; i < key_array->elements; i++ ) {
+            ++count;
+            if ( max_keys > 0 && count > max_keys )
+                return zeek::unexpected<OperationResult>(OperationResult{ReturnCode::RESULT_TOO_LARGE});
+            keys.emplace_back(key_array->element[i]->str, key_array->element[i]->len);
+        }
+    } while ( cursor != "0" );
+
+    return keys;
+}
+
+OperationResult Redis::DoGetAll(ResultCallback* /* cb */, uint64_t max_entries) {
+    if ( ! connected && ! async_ctx )
+        return {ReturnCode::NOT_CONNECTED};
+
+    auto locked_scope = conditionally_lock(zeek::run_state::reading_traces, expire_mutex);
+
+    auto scan_result = ScanKeys(max_entries);
+    if ( ! scan_result )
+        return scan_result.error();
+
+    using ReplyPtr = std::unique_ptr<redisReply, decltype(&freeReplyObject)>;
+
+    auto indices = make_intrusive<TypeList>(key_type);
+    indices->Append(key_type);
+    auto ttype = make_intrusive<TableType>(std::move(indices), val_type);
+    auto table = make_intrusive<TableVal>(std::move(ttype));
+
+    size_t prefix_len = key_prefix.size() + 1; // "prefix:"
+
+    for ( const auto& full_key : *scan_result ) {
+        int status = redisAsyncCommand(async_ctx, redisGeneric, nullptr, "GET %b", full_key.data(), full_key.size());
+        if ( connected && status == REDIS_ERR )
+            return {ReturnCode::OPERATION_FAILED, util::fmt("GET failed: %s", async_ctx->errstr)};
+
+        ++active_ops;
+        Poll();
+
+        if ( reply_queue.empty() )
+            continue;
+
+        ReplyPtr reply{reply_queue.front(), freeReplyObject};
+        reply_queue.pop_front();
+
+        if ( ! reply || reply->type == REDIS_REPLY_NIL )
+            continue;
+
+        if ( reply->type == REDIS_REPLY_ERROR )
+            return ParseReplyError("get_all", reply->str);
+
+        std::string_view raw_key(full_key.data() + prefix_len, full_key.size() - prefix_len);
+        auto key =
+            serializer->Unserialize({reinterpret_cast<const std::byte*>(raw_key.data()), raw_key.size()}, key_type);
+        if ( ! key )
+            return {ReturnCode::UNSERIALIZATION_FAILED, key.error()};
+
+        auto val =
+            serializer->Unserialize({reinterpret_cast<const std::byte*>(reply->str), static_cast<size_t>(reply->len)},
+                                    val_type);
+        if ( ! val )
+            return {ReturnCode::UNSERIALIZATION_FAILED, val.error()};
+
+        IncBytesReadMetric(raw_key.size() + reply->len);
+        table->Assign(key.value(), val.value());
+    }
+
+    return {ReturnCode::SUCCESS, "", table};
+}
+
 void Redis::HandlePutResult(redisReply* reply, ResultCallback* callback) {
     --active_ops;
 

--- a/src/storage/backend/redis/Redis.cc
+++ b/src/storage/backend/redis/Redis.cc
@@ -676,6 +676,19 @@ OperationResult Redis::DoGetAll(ResultCallback* /* cb */, uint64_t max_entries) 
     return {ReturnCode::SUCCESS, "", table};
 }
 
+OperationResult Redis::DoSize(ResultCallback* /* cb */) {
+    if ( ! connected && ! async_ctx )
+        return {ReturnCode::NOT_CONNECTED};
+
+    auto locked_scope = conditionally_lock(zeek::run_state::reading_traces, expire_mutex);
+
+    auto scan_result = ScanKeys(0);
+    if ( ! scan_result )
+        return scan_result.error();
+
+    return {ReturnCode::SUCCESS, "", val_mgr->Count(scan_result->size())};
+}
+
 void Redis::HandlePutResult(redisReply* reply, ResultCallback* callback) {
     --active_ops;
 

--- a/src/storage/backend/redis/Redis.h
+++ b/src/storage/backend/redis/Redis.h
@@ -59,6 +59,7 @@ private:
     OperationResult DoGet(ResultCallback* cb, ValPtr key) override;
     OperationResult DoErase(ResultCallback* cb, ValPtr key) override;
     OperationResult DoGetAll(ResultCallback* cb, uint64_t max_entries) override;
+    OperationResult DoSize(ResultCallback* cb) override;
     void DoExpire(double current_network_time) override;
     void DoPoll() override;
     std::string DoGetConfigMetricsLabel() const override;

--- a/src/storage/backend/redis/Redis.h
+++ b/src/storage/backend/redis/Redis.h
@@ -58,9 +58,12 @@ private:
                           double expiration_time) override;
     OperationResult DoGet(ResultCallback* cb, ValPtr key) override;
     OperationResult DoErase(ResultCallback* cb, ValPtr key) override;
+    OperationResult DoGetAll(ResultCallback* cb, uint64_t max_entries) override;
     void DoExpire(double current_network_time) override;
     void DoPoll() override;
     std::string DoGetConfigMetricsLabel() const override;
+
+    zeek::expected<std::vector<std::string>, OperationResult> ScanKeys(uint64_t max_keys);
 
     OperationResult ParseReplyError(std::string_view op_str, std::string_view reply_err_str) const;
     OperationResult CheckServerVersion();

--- a/src/storage/backend/sqlite/SQLite.cc
+++ b/src/storage/backend/sqlite/SQLite.cc
@@ -196,7 +196,7 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
 
     sqlite3_free(errorMsg);
 
-    std::array<std::pair<std::string, sqlite3*>, 9> statements =
+    std::array<std::pair<std::string, sqlite3*>, 10> statements =
         {// Normal put
          std::make_pair(util::fmt("insert into %s (key_str, value_str, expire_time) values(?, ?, ?) "
                                   "ON CONFLICT(key_str) DO UPDATE SET value_str=?, expire_time=? "
@@ -218,6 +218,10 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
          // Get all
          std::make_pair(util::fmt("select key_str, value_str from %s where "
                                   "(expire_time == 0.0 OR expire_time > ?) limit ?",
+                                  table_name.c_str()),
+                        db),
+         // Size
+         std::make_pair(util::fmt("select count(*) from %s where expire_time == 0.0 OR expire_time > ?",
                                   table_name.c_str()),
                         db),
          // Check for expired entries
@@ -257,10 +261,11 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
     get_stmt = std::move(stmt_ptrs[2]);
     erase_stmt = std::move(stmt_ptrs[3]);
     get_all_stmt = std::move(stmt_ptrs[4]);
-    check_expire_stmt = std::move(stmt_ptrs[5]);
-    expire_stmt = std::move(stmt_ptrs[6]);
-    get_expiry_last_run_stmt = std::move(stmt_ptrs[7]);
-    update_expiry_last_run_stmt = std::move(stmt_ptrs[8]);
+    size_stmt = std::move(stmt_ptrs[5]);
+    check_expire_stmt = std::move(stmt_ptrs[6]);
+    expire_stmt = std::move(stmt_ptrs[7]);
+    get_expiry_last_run_stmt = std::move(stmt_ptrs[8]);
+    update_expiry_last_run_stmt = std::move(stmt_ptrs[9]);
 
     page_count_metric =
         telemetry_mgr->GaugeInstance("zeek", "storage_sqlite_database_size", {{"config", GetConfigMetricsLabel()}},
@@ -305,6 +310,7 @@ OperationResult SQLite::DoClose(ResultCallback* cb) {
         get_stmt.reset();
         erase_stmt.reset();
         get_all_stmt.reset();
+        size_stmt.reset();
         check_expire_stmt.reset();
         expire_stmt.reset();
         get_expiry_last_run_stmt.reset();
@@ -524,6 +530,24 @@ OperationResult SQLite::DoGetAll(ResultCallback* /* cb */, uint64_t max_entries)
     }
 
     return {ReturnCode::SUCCESS, "", table};
+}
+
+OperationResult SQLite::DoSize(ResultCallback* /* cb */) {
+    if ( ! db )
+        return {ReturnCode::NOT_CONNECTED};
+
+    auto stmt = unique_stmt_ptr(size_stmt.get(), sqlite3_reset);
+
+    if ( auto res = CheckError(sqlite3_bind_double(stmt.get(), 1, run_state::network_time));
+         res.code != ReturnCode::SUCCESS )
+        return res;
+
+    int step_status = sqlite3_step(stmt.get());
+    if ( step_status != SQLITE_ROW )
+        return {ReturnCode::OPERATION_FAILED, util::fmt("sqlite3_step failed: %s", sqlite3_errmsg(db))};
+
+    auto count = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0));
+    return {ReturnCode::SUCCESS, "", val_mgr->Count(count)};
 }
 
 /**

--- a/src/storage/backend/sqlite/SQLite.cc
+++ b/src/storage/backend/sqlite/SQLite.cc
@@ -196,7 +196,7 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
 
     sqlite3_free(errorMsg);
 
-    std::array<std::pair<std::string, sqlite3*>, 8> statements =
+    std::array<std::pair<std::string, sqlite3*>, 9> statements =
         {// Normal put
          std::make_pair(util::fmt("insert into %s (key_str, value_str, expire_time) values(?, ?, ?) "
                                   "ON CONFLICT(key_str) DO UPDATE SET value_str=?, expire_time=? "
@@ -215,6 +215,11 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
                         db),
          // Erase
          std::make_pair(util::fmt("delete from %s where key_str=?", table_name.c_str()), db),
+         // Get all
+         std::make_pair(util::fmt("select key_str, value_str from %s where "
+                                  "(expire_time == 0.0 OR expire_time > ?) limit ?",
+                                  table_name.c_str()),
+                        db),
          // Check for expired entries
          std::make_pair(
              util::fmt("select count(*) from %s where expire_time > 0 and expire_time != 0 and expire_time <= ?",
@@ -251,10 +256,11 @@ OperationResult SQLite::DoOpen(OpenResultCallback* cb, RecordValPtr options) {
     put_update_stmt = std::move(stmt_ptrs[1]);
     get_stmt = std::move(stmt_ptrs[2]);
     erase_stmt = std::move(stmt_ptrs[3]);
-    check_expire_stmt = std::move(stmt_ptrs[4]);
-    expire_stmt = std::move(stmt_ptrs[5]);
-    get_expiry_last_run_stmt = std::move(stmt_ptrs[6]);
-    update_expiry_last_run_stmt = std::move(stmt_ptrs[7]);
+    get_all_stmt = std::move(stmt_ptrs[4]);
+    check_expire_stmt = std::move(stmt_ptrs[5]);
+    expire_stmt = std::move(stmt_ptrs[6]);
+    get_expiry_last_run_stmt = std::move(stmt_ptrs[7]);
+    update_expiry_last_run_stmt = std::move(stmt_ptrs[8]);
 
     page_count_metric =
         telemetry_mgr->GaugeInstance("zeek", "storage_sqlite_database_size", {{"config", GetConfigMetricsLabel()}},
@@ -298,6 +304,7 @@ OperationResult SQLite::DoClose(ResultCallback* cb) {
         put_update_stmt.reset();
         get_stmt.reset();
         erase_stmt.reset();
+        get_all_stmt.reset();
         check_expire_stmt.reset();
         expire_stmt.reset();
         get_expiry_last_run_stmt.reset();
@@ -461,6 +468,62 @@ OperationResult SQLite::DoErase(ResultCallback* cb, ValPtr key) {
     }
 
     return Step(stmt.get(), nullptr);
+}
+
+OperationResult SQLite::DoGetAll(ResultCallback* /* cb */, uint64_t max_entries) {
+    if ( ! db )
+        return {ReturnCode::NOT_CONNECTED};
+
+    auto stmt = unique_stmt_ptr(get_all_stmt.get(), sqlite3_reset);
+
+    if ( auto res = CheckError(sqlite3_bind_double(stmt.get(), 1, run_state::network_time));
+         res.code != ReturnCode::SUCCESS )
+        return res;
+
+    int64_t limit = max_entries > 0 ? static_cast<int64_t>(max_entries) + 1 : -1;
+    if ( auto res = CheckError(sqlite3_bind_int64(stmt.get(), 2, limit)); res.code != ReturnCode::SUCCESS )
+        return res;
+
+    auto indices = make_intrusive<TypeList>(key_type);
+    indices->Append(key_type);
+    auto ttype = make_intrusive<TableType>(std::move(indices), val_type);
+    auto table = make_intrusive<TableVal>(std::move(ttype));
+    uint64_t count = 0;
+
+    while ( true ) {
+        int step_status = sqlite3_step(stmt.get());
+
+        if ( step_status == SQLITE_DONE )
+            break;
+
+        if ( step_status != SQLITE_ROW ) {
+            if ( step_status == SQLITE_BUSY || step_status == SQLITE_LOCKED )
+                return {ReturnCode::TIMEOUT};
+            return {ReturnCode::OPERATION_FAILED, util::fmt("sqlite3_step failed: %s", sqlite3_errmsg(db))};
+        }
+
+        ++count;
+        if ( max_entries > 0 && count > max_entries )
+            return {ReturnCode::RESULT_TOO_LARGE};
+
+        auto key_blob = static_cast<const std::byte*>(sqlite3_column_blob(stmt.get(), 0));
+        size_t key_size = sqlite3_column_bytes(stmt.get(), 0);
+        auto val_blob = static_cast<const std::byte*>(sqlite3_column_blob(stmt.get(), 1));
+        size_t val_size = sqlite3_column_bytes(stmt.get(), 1);
+
+        auto key = serializer->Unserialize({key_blob, key_size}, key_type);
+        if ( ! key )
+            return {ReturnCode::UNSERIALIZATION_FAILED, key.error()};
+
+        auto val = serializer->Unserialize({val_blob, val_size}, val_type);
+        if ( ! val )
+            return {ReturnCode::UNSERIALIZATION_FAILED, val.error()};
+
+        IncBytesReadMetric(key_size + val_size);
+        table->Assign(key.value(), val.value());
+    }
+
+    return {ReturnCode::SUCCESS, "", table};
 }
 
 /**

--- a/src/storage/backend/sqlite/SQLite.h
+++ b/src/storage/backend/sqlite/SQLite.h
@@ -33,6 +33,7 @@ private:
     OperationResult DoGet(ResultCallback* cb, ValPtr key) override;
     OperationResult DoErase(ResultCallback* cb, ValPtr key) override;
     OperationResult DoGetAll(ResultCallback* cb, uint64_t max_entries) override;
+    OperationResult DoSize(ResultCallback* cb) override;
     void DoExpire(double current_network_time) override;
     std::string DoGetConfigMetricsLabel() const override;
 
@@ -68,6 +69,7 @@ private:
     unique_stmt_ptr erase_stmt;
 
     unique_stmt_ptr get_all_stmt;
+    unique_stmt_ptr size_stmt;
     unique_stmt_ptr check_expire_stmt;
     unique_stmt_ptr expire_stmt;
     unique_stmt_ptr get_expiry_last_run_stmt;

--- a/src/storage/backend/sqlite/SQLite.h
+++ b/src/storage/backend/sqlite/SQLite.h
@@ -32,6 +32,7 @@ private:
                           double expiration_time) override;
     OperationResult DoGet(ResultCallback* cb, ValPtr key) override;
     OperationResult DoErase(ResultCallback* cb, ValPtr key) override;
+    OperationResult DoGetAll(ResultCallback* cb, uint64_t max_entries) override;
     void DoExpire(double current_network_time) override;
     std::string DoGetConfigMetricsLabel() const override;
 
@@ -66,6 +67,7 @@ private:
     unique_stmt_ptr get_stmt;
     unique_stmt_ptr erase_stmt;
 
+    unique_stmt_ptr get_all_stmt;
     unique_stmt_ptr check_expire_stmt;
     unique_stmt_ptr expire_stmt;
     unique_stmt_ptr get_expiry_last_run_stmt;

--- a/src/storage/storage-sync.bif
+++ b/src/storage/storage-sync.bif
@@ -135,3 +135,23 @@ function Storage::Sync::__erase%(backend: opaque of Storage::BackendHandle, key:
 
 	return op_result.BuildVal();
 	%}
+
+function Storage::Sync::__get_all%(backend: opaque of Storage::BackendHandle, max_entries: count%): Storage::OperationResult
+	%{
+	OperationResult op_result;
+
+	auto b = storage::detail::BackendHandleVal::CastFromAny(backend);
+	if ( ! b )
+		op_result = b.error();
+	else {
+		auto cb = new ResultCallback();
+		op_result = (*b)->backend->GetAll(cb, max_entries);
+
+		// Potentially wait for a result if the backend only supports async.
+		wait_for_result(op_result, (*b)->backend, cb);
+
+		delete cb;
+	}
+
+	return op_result.BuildVal();
+	%}

--- a/src/storage/storage-sync.bif
+++ b/src/storage/storage-sync.bif
@@ -155,3 +155,23 @@ function Storage::Sync::__get_all%(backend: opaque of Storage::BackendHandle, ma
 
 	return op_result.BuildVal();
 	%}
+
+function Storage::Sync::__size%(backend: opaque of Storage::BackendHandle%): Storage::OperationResult
+	%{
+	OperationResult op_result;
+
+	auto b = storage::detail::BackendHandleVal::CastFromAny(backend);
+	if ( ! b )
+		op_result = b.error();
+	else {
+		auto cb = new ResultCallback();
+		op_result = (*b)->backend->Size(cb);
+
+		// Potentially wait for a result if the backend only supports async.
+		wait_for_result(op_result, (*b)->backend, cb);
+
+		delete cb;
+	}
+
+	return op_result.BuildVal();
+	%}

--- a/testing/btest/Baseline/scripts.base.frameworks.storage.redis.async/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.storage.redis.async/out
@@ -16,10 +16,18 @@ Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config,
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get, fail, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get, success, Storage::STORAGE_BACKEND_REDIS], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, error, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, fail, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, success, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, error, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, fail, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, success, Storage::STORAGE_BACKEND_REDIS], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, error, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, fail, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, success, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_data_written_bytes_total, [config, type], [server_addr-testing, Storage::STORAGE_BACKEND_REDIS], 34.0
 
 close result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=<uninitialized>]

--- a/testing/btest/Baseline/scripts.base.frameworks.storage.redis.forced-sync/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.storage.redis.forced-sync/out
@@ -19,10 +19,18 @@ Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config,
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get, fail, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get, success, Storage::STORAGE_BACKEND_REDIS], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, error, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, fail, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, success, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, error, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, fail, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, success, Storage::STORAGE_BACKEND_REDIS], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, error, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, fail, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, success, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_data_written_bytes_total, [config, type], [server_addr-testing, Storage::STORAGE_BACKEND_REDIS], 34.0
 
 close result, [code=Storage::SUCCESS, error_str=<uninitialized>, value=<uninitialized>]

--- a/testing/btest/Baseline/scripts.base.frameworks.storage.redis.sync/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.storage.redis.sync/out
@@ -24,10 +24,18 @@ Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config,
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get, fail, Storage::STORAGE_BACKEND_REDIS], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get, success, Storage::STORAGE_BACKEND_REDIS], 3.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, error, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, fail, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, success, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, get_all, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, error, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, fail, Storage::STORAGE_BACKEND_REDIS], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, success, Storage::STORAGE_BACKEND_REDIS], 2.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, put, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, error, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, fail, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, success, Storage::STORAGE_BACKEND_REDIS], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [server_addr-testing, size, timeout, Storage::STORAGE_BACKEND_REDIS], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_data_written_bytes_total, [config, type], [server_addr-testing, Storage::STORAGE_BACKEND_REDIS], 102.0
 
 Storage::backend_lost, Storage::STORAGE_BACKEND_REDIS, [serializer=Storage::STORAGE_SERIALIZER_JSON, forced_sync=F, redis=[server_host=127.0.0.1, server_port=XXXX/tcp, server_unix_socket=<uninitialized>, key_prefix=testing, connect_timeout=5.0 secs, operation_timeout=5.0 secs, username=<uninitialized>, password=<uninitialized>]], Client disconnected

--- a/testing/btest/Baseline/scripts.base.frameworks.storage.sqlite.basic/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.storage.sqlite.basic/out
@@ -24,10 +24,18 @@ Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config,
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get, fail, Storage::STORAGE_BACKEND_SQLITE], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get, success, Storage::STORAGE_BACKEND_SQLITE], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get, timeout, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get_all, error, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get_all, fail, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get_all, success, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get_all, timeout, Storage::STORAGE_BACKEND_SQLITE], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, put, error, Storage::STORAGE_BACKEND_SQLITE], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, put, fail, Storage::STORAGE_BACKEND_SQLITE], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, put, success, Storage::STORAGE_BACKEND_SQLITE], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, put, timeout, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, size, error, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, size, fail, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, size, success, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, size, timeout, Storage::STORAGE_BACKEND_SQLITE], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_data_written_bytes_total, [config, type], [test.sqlite-testing, Storage::STORAGE_BACKEND_SQLITE], 18.0
 
 closed succesfully

--- a/testing/btest/Baseline/scripts.base.frameworks.storage.sqlite.metrics/out
+++ b/testing/btest/Baseline/scripts.base.frameworks.storage.sqlite.metrics/out
@@ -19,8 +19,16 @@ Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config,
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get, fail, Storage::STORAGE_BACKEND_SQLITE], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get, success, Storage::STORAGE_BACKEND_SQLITE], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get, timeout, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get_all, error, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get_all, fail, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get_all, success, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, get_all, timeout, Storage::STORAGE_BACKEND_SQLITE], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, put, error, Storage::STORAGE_BACKEND_SQLITE], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, put, fail, Storage::STORAGE_BACKEND_SQLITE], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, put, success, Storage::STORAGE_BACKEND_SQLITE], 1.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, put, timeout, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, size, error, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, size, fail, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, size, success, Storage::STORAGE_BACKEND_SQLITE], 0.0
+Telemetry::COUNTER, zeek, zeek_storage_backend_operation_results_total, [config, operation, result, type], [test.sqlite-testing, size, timeout, Storage::STORAGE_BACKEND_SQLITE], 0.0
 Telemetry::COUNTER, zeek, zeek_storage_backend_data_written_bytes_total, [config, type], [test.sqlite-testing, Storage::STORAGE_BACKEND_SQLITE], 18.0

--- a/testing/btest/scripts/base/frameworks/storage/redis/get-all-expiration.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis/get-all-expiration.zeek
@@ -1,0 +1,49 @@
+# @TEST-DOC: get_all on Redis does not return entries whose TTL has fired
+
+# @TEST-REQUIRES: have-redis
+# @TEST-PORT: REDIS_PORT
+
+# @TEST-EXEC: btest-bg-run redis-server run-redis-server ${REDIS_PORT%/tcp}
+# @TEST-EXEC: zeek -b %INPUT
+# @TEST-EXEC: btest-bg-wait -k 0
+
+@load base/frameworks/storage/sync
+@load policy/frameworks/storage/backend/redis
+
+redef exit_only_after_terminate = T;
+
+global b: opaque of Storage::BackendHandle;
+
+event check_get_all()
+	{
+	local res = Storage::Sync::get_all(b, 0);
+	assert res$code == Storage::SUCCESS, fmt("get_all failed: %s", res$code);
+	local t = res$value as table[string] of count;
+	assert |t| == 1, fmt("expected 1 entry, got %d", |t|);
+	assert "live" in t && t["live"] == 1;
+
+	Storage::Sync::close_backend(b);
+	terminate();
+	}
+
+event setup_test()
+	{
+	local opts: Storage::BackendOptions;
+	opts$redis = [ $server_host="127.0.0.1", $server_port=to_port(getenv("REDIS_PORT")),
+	               $key_prefix="test-get-all-expire" ];
+
+	local open_res = Storage::Sync::open_backend(Storage::STORAGE_BACKEND_REDIS, opts, string, count);
+	assert open_res$code == Storage::SUCCESS, fmt("open failed: %s", open_res$code);
+	b = open_res$value;
+
+	Storage::Sync::put(b, [ $key="live", $value=1 ]);
+	Storage::Sync::put(b, [ $key="expired", $value=2, $expire_time=1sec ]);
+
+	# Wait for the TTL to fire.
+	schedule 3secs { check_get_all() };
+	}
+
+event zeek_init()
+	{
+	schedule 100msecs { setup_test() };
+	}

--- a/testing/btest/scripts/base/frameworks/storage/redis/get-all.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis/get-all.zeek
@@ -1,0 +1,44 @@
+# @TEST-DOC: Retrieve all entries from a Redis backend via get_all
+
+# @TEST-REQUIRES: have-redis
+# @TEST-PORT: REDIS_PORT
+
+# @TEST-EXEC: btest-bg-run redis-server run-redis-server ${REDIS_PORT%/tcp}
+# @TEST-EXEC: zeek -b %INPUT
+# @TEST-EXEC: btest-bg-wait -k 0
+
+@load base/frameworks/storage/sync
+@load policy/frameworks/storage/backend/redis
+
+event zeek_init()
+	{
+	local opts: Storage::BackendOptions;
+	opts$redis = [ $server_host="127.0.0.1", $server_port=to_port(getenv("REDIS_PORT")),
+	               $key_prefix="test-get-all" ];
+
+	local open_res = Storage::Sync::open_backend(Storage::STORAGE_BACKEND_REDIS, opts, string, count);
+	assert open_res$code == Storage::SUCCESS, fmt("open failed: %s", open_res$code);
+	local b = open_res$value;
+
+	local input: table[string] of count = { ["a"] = 1, ["b"] = 2, ["c"] = 3 };
+	for ( k, v in input )
+		Storage::Sync::put(b, [ $key=k, $value=v ]);
+
+	# Retrieve all entries.
+	local res = Storage::Sync::get_all(b, 0);
+	assert res$code == Storage::SUCCESS, fmt("get_all failed: %s", res$code);
+	local t = res$value as table[string] of count;
+	assert |t| == |input|, fmt("size mismatch: %d != %d", |t|, |input|);
+	for ( k, v in input )
+		assert k in t && t[k] == v, fmt("missing or wrong entry for key %s", k);
+
+	# Test max_entries exceeded.
+	local res2 = Storage::Sync::get_all(b, 2);
+	assert res2$code == Storage::RESULT_TOO_LARGE, fmt("expected RESULT_TOO_LARGE, got %s", res2$code);
+
+	# Test with exact limit.
+	local res3 = Storage::Sync::get_all(b, 3);
+	assert res3$code == Storage::SUCCESS, fmt("get_all with exact limit failed: %s", res3$code);
+
+	Storage::Sync::close_backend(b);
+	}

--- a/testing/btest/scripts/base/frameworks/storage/redis/size-expiration.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis/size-expiration.zeek
@@ -1,0 +1,47 @@
+# @TEST-DOC: size on Redis does not count entries whose TTL has fired
+
+# @TEST-REQUIRES: have-redis
+# @TEST-PORT: REDIS_PORT
+
+# @TEST-EXEC: btest-bg-run redis-server run-redis-server ${REDIS_PORT%/tcp}
+# @TEST-EXEC: zeek -b %INPUT
+# @TEST-EXEC: btest-bg-wait -k 0
+
+@load base/frameworks/storage/sync
+@load policy/frameworks/storage/backend/redis
+
+redef exit_only_after_terminate = T;
+
+global b: opaque of Storage::BackendHandle;
+
+event check_size()
+	{
+	local res = Storage::Sync::size(b);
+	assert res$code == Storage::SUCCESS, fmt("size failed: %s", res$code);
+	assert res$value as count == 1, fmt("expected 1 after expiry, got %d", res$value as count);
+
+	Storage::Sync::close_backend(b);
+	terminate();
+	}
+
+event setup_test()
+	{
+	local opts: Storage::BackendOptions;
+	opts$redis = [ $server_host="127.0.0.1", $server_port=to_port(getenv("REDIS_PORT")),
+	               $key_prefix="test-size-expire" ];
+
+	local open_res = Storage::Sync::open_backend(Storage::STORAGE_BACKEND_REDIS, opts, string, count);
+	assert open_res$code == Storage::SUCCESS, fmt("open failed: %s", open_res$code);
+	b = open_res$value;
+
+	Storage::Sync::put(b, [ $key="live", $value=1 ]);
+	Storage::Sync::put(b, [ $key="expired", $value=2, $expire_time=1sec ]);
+
+	# Wait for the TTL to fire.
+	schedule 3secs { check_size() };
+	}
+
+event zeek_init()
+	{
+	schedule 100msecs { setup_test() };
+	}

--- a/testing/btest/scripts/base/frameworks/storage/redis/size.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/redis/size.zeek
@@ -1,0 +1,38 @@
+# @TEST-DOC: Query entry count from a Redis backend via size
+
+# @TEST-REQUIRES: have-redis
+# @TEST-PORT: REDIS_PORT
+
+# @TEST-EXEC: btest-bg-run redis-server run-redis-server ${REDIS_PORT%/tcp}
+# @TEST-EXEC: zeek -b %INPUT
+# @TEST-EXEC: btest-bg-wait -k 0
+
+@load base/frameworks/storage/sync
+@load policy/frameworks/storage/backend/redis
+
+event zeek_init()
+	{
+	local opts: Storage::BackendOptions;
+	opts$redis = [ $server_host="127.0.0.1", $server_port=to_port(getenv("REDIS_PORT")),
+	               $key_prefix="test-size" ];
+
+	local open_res = Storage::Sync::open_backend(Storage::STORAGE_BACKEND_REDIS, opts, string, count);
+	assert open_res$code == Storage::SUCCESS, fmt("open failed: %s", open_res$code);
+	local b = open_res$value;
+
+	# Empty backend.
+	local res = Storage::Sync::size(b);
+	assert res$code == Storage::SUCCESS, fmt("size failed: %s", res$code);
+	assert res$value as count == 0, fmt("expected 0, got %d", res$value as count);
+
+	# Insert entries.
+	Storage::Sync::put(b, [ $key="a", $value=1 ]);
+	Storage::Sync::put(b, [ $key="b", $value=2 ]);
+	Storage::Sync::put(b, [ $key="c", $value=3 ]);
+
+	res = Storage::Sync::size(b);
+	assert res$code == Storage::SUCCESS;
+	assert res$value as count == 3, fmt("expected 3, got %d", res$value as count);
+
+	Storage::Sync::close_backend(b);
+	}

--- a/testing/btest/scripts/base/frameworks/storage/sqlite/get-all-expiration.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite/get-all-expiration.zeek
@@ -1,0 +1,27 @@
+# @TEST-DOC: get_all filters out expired entries
+# @TEST-EXEC: zeek -b %INPUT
+
+@load base/frameworks/storage/sync
+@load policy/frameworks/storage/backend/sqlite
+
+event zeek_init()
+	{
+	local opts: Storage::BackendOptions;
+	opts$sqlite = [ $database_path="test.sqlite", $table_name="testing" ];
+
+	local open_res = Storage::Sync::open_backend(Storage::STORAGE_BACKEND_SQLITE, opts, string, count);
+	local b = open_res$value;
+
+	# Insert entries: one with no expiration, one already expired.
+	Storage::Sync::put(b, [ $key="live", $value=1 ]);
+	Storage::Sync::put(b, [ $key="expired", $value=2, $expire_time=-1sec ]);
+
+	local res = Storage::Sync::get_all(b, 0);
+	assert res$code == Storage::SUCCESS, fmt("get_all failed: %s", res$code);
+	local t = res$value as table[string] of count;
+	assert |t| == 1, fmt("expected 1 entry, got %d", |t|);
+	assert "live" in t && t["live"] == 1;
+	assert "expired" !in t, "expired entry should not be present";
+
+	Storage::Sync::close_backend(b);
+	}

--- a/testing/btest/scripts/base/frameworks/storage/sqlite/get-all.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite/get-all.zeek
@@ -1,0 +1,36 @@
+# @TEST-DOC: Retrieve all entries from a SQLite backend via get_all
+# @TEST-EXEC: zeek -b %INPUT
+
+@load base/frameworks/storage/sync
+@load policy/frameworks/storage/backend/sqlite
+
+event zeek_init()
+	{
+	local opts: Storage::BackendOptions;
+	opts$sqlite = [ $database_path="test.sqlite", $table_name="testing" ];
+
+	local open_res = Storage::Sync::open_backend(Storage::STORAGE_BACKEND_SQLITE, opts, string, count);
+	local b = open_res$value;
+
+	local input: table[string] of count = { ["a"] = 1, ["b"] = 2, ["c"] = 3 };
+	for ( k, v in input )
+		Storage::Sync::put(b, [ $key=k, $value=v ]);
+
+	# Retrieve all entries.
+	local res = Storage::Sync::get_all(b, 0);
+	assert res$code == Storage::SUCCESS, fmt("get_all failed: %s", res$code);
+	local t = res$value as table[string] of count;
+	assert |t| == |input|, fmt("size mismatch: %d != %d", |t|, |input|);
+	for ( k, v in input )
+		assert k in t && t[k] == v, fmt("missing or wrong entry for key %s", k);
+
+	# Test max_entries exceeded.
+	local res2 = Storage::Sync::get_all(b, 2);
+	assert res2$code == Storage::RESULT_TOO_LARGE, fmt("expected RESULT_TOO_LARGE, got %s", res2$code);
+
+	# Test with exact limit.
+	local res3 = Storage::Sync::get_all(b, 3);
+	assert res3$code == Storage::SUCCESS, fmt("get_all with exact limit failed: %s", res3$code);
+
+	Storage::Sync::close_backend(b);
+	}

--- a/testing/btest/scripts/base/frameworks/storage/sqlite/size.zeek
+++ b/testing/btest/scripts/base/frameworks/storage/sqlite/size.zeek
@@ -1,0 +1,44 @@
+# @TEST-DOC: Query entry count from a SQLite backend via size
+# @TEST-EXEC: zeek -b %INPUT
+
+@load base/frameworks/storage/sync
+@load policy/frameworks/storage/backend/sqlite
+
+event zeek_init()
+	{
+	local opts: Storage::BackendOptions;
+	opts$sqlite = [ $database_path="test.sqlite", $table_name="testing" ];
+
+	local open_res = Storage::Sync::open_backend(Storage::STORAGE_BACKEND_SQLITE, opts, string, count);
+	local b = open_res$value;
+
+	# Empty backend.
+	local res = Storage::Sync::size(b);
+	assert res$code == Storage::SUCCESS, fmt("size failed: %s", res$code);
+	assert res$value as count == 0, fmt("expected 0, got %d", res$value as count);
+
+	# Insert entries.
+	Storage::Sync::put(b, [ $key="a", $value=1 ]);
+	Storage::Sync::put(b, [ $key="b", $value=2 ]);
+	Storage::Sync::put(b, [ $key="c", $value=3 ]);
+
+	res = Storage::Sync::size(b);
+	assert res$code == Storage::SUCCESS;
+	assert res$value as count == 3, fmt("expected 3, got %d", res$value as count);
+
+	# Insert an already-expired entry.
+	Storage::Sync::put(b, [ $key="expired", $value=4, $expire_time=-1sec ]);
+
+	res = Storage::Sync::size(b);
+	assert res$code == Storage::SUCCESS;
+	assert res$value as count == 3, fmt("expected 3 (expired not counted), got %d", res$value as count);
+
+	# Erase an entry.
+	Storage::Sync::erase(b, "a");
+
+	res = Storage::Sync::size(b);
+	assert res$code == Storage::SUCCESS;
+	assert res$value as count == 2, fmt("expected 2 after erase, got %d", res$value as count);
+
+	Storage::Sync::close_backend(b);
+	}


### PR DESCRIPTION
This is a possible implementation of #5783. I kind of like it since it didn't turn out to be that complicated. What this provides is a script-level function `Storage::get_all` which retrieves all entries from a table. To avoid blowing up memory without realizing this _always_ requires specifying how many entries should be retrieved, and to simplify working with that we also add a function `Storage::size` to query table sizes.

In order to keep backends without these calls working I added a dedicated error code so we can signal missing support in the storage framework's error return values.

This currently only comes with a sync implementation, but could be extended if we like the approach here and want async support.


> [!NOTE]
> All code changes in this PR were generated with Claude Opus 4.6. I reviewed all changes and am accountable.