### PR TITLE
Increase ccache cache sizes for GH action ASAN jobs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -272,6 +272,8 @@ jobs:
             ASAN_OPTIONS: detect_leaks=1:detect_odr_violation=0
             # Use absolute paths for coverage files.
             CCACHE_BASEDIR: /
+            # Increase cache size since ASAN build artifacts are much larger.
+            CCACHE_MAXSIZE: "4G"
           run: |
             ./ci/pre-build.sh
             ./ci/build.sh
@@ -285,6 +287,8 @@ jobs:
           env:
             ZEEK_CI_CONFIGURE_FLAGS: '--build-type=debug --disable-broker-tests --sanitizers=address --enable-fuzzers --enable-coverage --ccache --enable-werror'
             ASAN_OPTIONS: detect_leaks=1:detect_odr_violation=0
+            # Increase cache size since ASAN build artifacts are much larger.
+            CCACHE_MAXSIZE: "4G"
             ZEEK_CI_SKIP_UNIT_TESTS: 1
             ZEEK_CI_SKIP_EXTERNAL_BTESTS: 1
             ZEEK_CI_BTEST_EXTRA_ARGS: -a zam

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,72 +1,96 @@
 [submodule "auxil/zeek-aux"]
 	path = auxil/zeek-aux
 	url = https://github.com/zeek/zeek-aux
+	shallow = true
 [submodule "auxil/zeekctl"]
 	path = auxil/zeekctl
 	url = https://github.com/zeek/zeekctl
+	shallow = true
 [submodule "auxil/btest"]
 	path = auxil/btest
 	url = https://github.com/zeek/btest
+	shallow = true
 [submodule "cmake"]
 	path = cmake
 	url = https://github.com/zeek/cmake
+	shallow = true
 [submodule "auxil/broker"]
 	path = auxil/broker
 	url = https://github.com/zeek/broker
+	shallow = true
 [submodule "auxil/netcontrol-connectors"]
 	path = auxil/netcontrol-connectors
 	url = https://github.com/zeek/zeek-netcontrol
+	shallow = true
 [submodule "auxil/paraglob"]
 	path = auxil/paraglob
 	url = https://github.com/zeek/paraglob
+	shallow = true
 [submodule "auxil/rapidjson"]
 	path = auxil/rapidjson
 	url = https://github.com/zeek/rapidjson
+	shallow = true
 [submodule "auxil/libkqueue"]
 	path = auxil/libkqueue
 	url = https://github.com/zeek/libkqueue
+	shallow = true
 [submodule "auxil/highwayhash"]
 	path = auxil/highwayhash
 	url = https://github.com/google/highwayhash
+	shallow = true
 [submodule "auxil/package-manager"]
 	path = auxil/package-manager
 	url = https://github.com/zeek/package-manager
+	shallow = true
 [submodule "auxil/zeek-client"]
 	path = auxil/zeek-client
 	url = https://github.com/zeek/zeek-client
+	shallow = true
 [submodule "auxil/c-ares"]
 	path = auxil/c-ares
 	url = https://github.com/c-ares/c-ares
+	shallow = true
 [submodule "auxil/out_ptr"]
 	path = auxil/out_ptr
 	url = https://github.com/soasis/out_ptr.git
+	shallow = true
 [submodule "auxil/spicy"]
 	path = auxil/spicy
 	url = https://github.com/zeek/spicy
+	shallow = true
 [submodule "auxil/libunistd"]
 	path = auxil/libunistd
 	url = https://github.com/zeek/libunistd
+	shallow = true
 [submodule "auxil/zeekjs"]
 	path = auxil/zeekjs
 	url = https://github.com/corelight/zeekjs.git
+	shallow = true
 [submodule "auxil/vcpkg"]
 	path = auxil/vcpkg
 	url = https://github.com/microsoft/vcpkg
+	shallow = true
 [submodule "auxil/prometheus-cpp"]
 	path = auxil/prometheus-cpp
 	url = https://github.com/zeek/prometheus-cpp
+	shallow = true
 [submodule "src/cluster/backend/zeromq/auxil/cppzmq"]
 	path = src/cluster/backend/zeromq/auxil/cppzmq
 	url = https://github.com/zeromq/cppzmq
+	shallow = true
 [submodule "src/cluster/websocket/auxil/IXWebSocket"]
 	path = src/cluster/websocket/auxil/IXWebSocket
 	url = https://github.com/machinezone/IXWebSocket
+	shallow = true
 [submodule "auxil/expected-lite"]
 	path = auxil/expected-lite
 	url = https://github.com/martinmoene/expected-lite.git
+	shallow = true
 [submodule "src/iosource/pcapng/auxil/LightPcapNg"]
 	path = src/iosource/pcapng/auxil/LightPcapNg
 	url = https://github.com/Technica-Engineering/LightPcapNg
+	shallow = true
 [submodule "auxil/zeek-packet-source-udp"]
 	path = auxil/zeek-packet-source-udp
 	url = https://github.com/zeek/zeek-packet-source-udp.git
+	shallow = true


### PR DESCRIPTION
These builds always had very bad cache hit rates, even with very warm cache. Looking at the ccache statistics in the end shows lots of cleanups which strongly suggests cache trashing.

This patch increases the cache sizes for these jobs so they have a chance to benefit from ccache as well.