### PR TITLE
Add a security consideration for the systemd generator configuration

### DIFF
--- a/doc/security-considerations.rst
+++ b/doc/security-considerations.rst
@@ -75,7 +75,7 @@ The following lists steps you can take to protect your Zeek cluster.
   and operations required to manage the Zeek cluster.
 
 * When using the systemd generator, configuration values from ``zeek.conf`` are 
- used to generate systemd unit files. Newline characters in configuration values
- can break out of the intended directive and introduce unintended systemd properties.
- Protect access to ``zeek.conf`` and ensure configuration values are validated to prevent
- injection into generated unit files.
+  used to generate systemd unit files. Newline characters in configuration values
+  can break out of the intended directive and introduce unintended systemd properties.
+  Protect access to ``zeek.conf`` and ensure configuration values are validated to prevent
+  injection into generated unit files.

--- a/doc/security-considerations.rst
+++ b/doc/security-considerations.rst
@@ -80,4 +80,3 @@ The following lists steps you can take to protect your Zeek cluster.
   trusted configuration source. Ensure that access to ``zeek.conf`` is restricted
   and that configuration values are validated to avoid unintended effects in the
   generated unit files.
-

--- a/doc/security-considerations.rst
+++ b/doc/security-considerations.rst
@@ -73,3 +73,9 @@ The following lists steps you can take to protect your Zeek cluster.
   account used by ZeekControl therefore must have administrative access across the
   cluster. Protect its SSH credentials and restrict the account's access to the systems
   and operations required to manage the Zeek cluster.
+
+* When using the systemd generator, configuration values from ``zeek.conf`` are 
+ used to generate systemd unit files. Newline characters in configuration values
+ can break out of the intended directive and introduce unintended systemd properties.
+ Protect access to ``zeek.conf`` and ensure configuration values are validated to prevent
+ injection into generated unit files.

--- a/doc/security-considerations.rst
+++ b/doc/security-considerations.rst
@@ -74,8 +74,10 @@ The following lists steps you can take to protect your Zeek cluster.
   cluster. Protect its SSH credentials and restrict the account's access to the systems
   and operations required to manage the Zeek cluster.
 
-* When using the systemd generator, configuration values from ``zeek.conf`` are 
-  used to generate systemd unit files. Newline characters in configuration values
-  can break out of the intended directive and introduce unintended systemd properties.
-  Protect access to ``zeek.conf`` and ensure configuration values are validated to prevent
-  injection into generated unit files.
+* When using the systemd generator, configuration values from ``zeek.conf`` are
+  incorporated directly into generated systemd unit files. Because these values
+  influence how Zeek services are launched, ``zeek.conf`` must be treated as a
+  trusted configuration source. Ensure that access to ``zeek.conf`` is restricted
+  and that configuration values are validated to avoid unintended effects in the
+  generated unit files.
+


### PR DESCRIPTION
Add a security consideration describing how configuration values from zeek.conf are used by the systemd generator when constructing systemd unit files. Newline characters in configuration values can escape the intended directive and introduce unintended systemd properties in the generated unit file.

This documents the trust boundary between Zeek’s configuration parser and the systemd generator, and recommends protecting access to zeek.conf and validating configuration values to prevent injection into generated unit files.


AI Transparency Note: Used Microsoft Copilot to refine English in .rst format.