### PR TITLE
Make rapidjson a build-time dependency

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -62,6 +62,7 @@ jobs:
             python3 \
             python3-dev \
             python3-pip \
+            rapidjson-dev \
             sqlite3 \
             swig \
             zlib1g-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "auxil/paraglob"]
 	path = auxil/paraglob
 	url = https://github.com/zeek/paraglob
-[submodule "auxil/rapidjson"]
-	path = auxil/rapidjson
-	url = https://github.com/zeek/rapidjson
 [submodule "auxil/libkqueue"]
 	path = auxil/libkqueue
 	url = https://github.com/zeek/libkqueue

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -916,6 +916,7 @@ find_package(OpenSSL 3.0 REQUIRED)
 # the test to stall.
 include(OpenSSLTests)
 
+find_package(RapidJSON REQUIRED)
 find_package(ZLIB REQUIRED)
 
 if (NOT BINARY_PACKAGING_MODE)
@@ -1172,8 +1173,14 @@ endif ()
 
 include(BuiltInSpicyAnalyzer)
 
-include_directories(BEFORE ${PCAP_INCLUDE_DIR} ${BIND_INCLUDE_DIR} ${BinPAC_INCLUDE_DIR}
-                    ${ZLIB_INCLUDE_DIR} ${JEMALLOC_INCLUDE_DIR})
+include_directories(
+    BEFORE
+    ${PCAP_INCLUDE_DIR}
+    ${BIND_INCLUDE_DIR}
+    ${BinPAC_INCLUDE_DIR}
+    ${RAPIDJSON_INCLUDE_DIR}
+    ${ZLIB_INCLUDE_DIR}
+    ${JEMALLOC_INCLUDE_DIR})
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/auxil/prometheus-cpp/core/include/prometheus
         DESTINATION include/zeek/3rdparty/prometheus-cpp/include)
@@ -1269,7 +1276,6 @@ endif ()
 include_directories(BEFORE ${broker_includes})
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/auxil/highwayhash)
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/auxil/paraglob/include)
-include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/auxil/rapidjson/include)
 
 set(zeekdeps
     ${zeekdeps}

--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,11 @@ We'd like to thank ... for their contributions to this release.
 Breaking Changes
 ----------------
 
+- Zeek now has a build dependency on rapidjson instead of vendoring RapidJSON's
+  source code. On Linux, install the rapidjson-dev (Debian, Ubuntu, ...)
+  or rapidjson-devel (Fedora, OpenSuSE, ...) package. On FreeBSD, there's the
+  devel/rapidjson port. Homebrew and vcpkg provide ``rapidjson`` as well.
+
 New Functionality
 -----------------
 

--- a/ci/alpine/Dockerfile
+++ b/ci/alpine/Dockerfile
@@ -29,6 +29,7 @@ RUN apk add --no-cache \
   py3-pip \
   python3 \
   python3-dev \
+  rapidjson-dev \
   swig \
   zlib-dev
 

--- a/ci/centos-stream-10/Dockerfile
+++ b/ci/centos-stream-10/Dockerfile
@@ -36,6 +36,7 @@ RUN dnf -y --nobest install \
     python3 \
     python3-devel \
     python3-pip\
+    rapidjson-devel \
     sqlite \
     swig \
     tar \

--- a/ci/centos-stream-9/Dockerfile
+++ b/ci/centos-stream-9/Dockerfile
@@ -36,6 +36,7 @@ RUN dnf -y --nobest install \
     python3.13 \
     python3.13-devel \
     python3.13-pip\
+    rapidjson-devel \
     sqlite \
     swig \
     tar \

--- a/ci/debian-12/Dockerfile
+++ b/ci/debian-12/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get -y install \
     python3-dev \
     python3-pip\
     python3-venv \
+    rapidjson-dev \
     sqlite3 \
     swig \
     wget \

--- a/ci/debian-13/Dockerfile
+++ b/ci/debian-13/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get -y install \
     python3-pip\
     python3-venv \
     python3-websockets \
+    rapidjson-dev \
     sqlite3 \
     swig \
     wget \

--- a/ci/debian-unstable/Dockerfile
+++ b/ci/debian-unstable/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get -y install \
     python3-dev \
     python3-pip \
     python3-venv \
+    rapidjson-dev \
     sqlite3 \
     swig \
     wget \

--- a/ci/fedora-43/Dockerfile
+++ b/ci/fedora-43/Dockerfile
@@ -26,6 +26,7 @@ RUN dnf -y install \
     python3 \
     python3-devel \
     python3-pip\
+    rapidjson-devel \
     sqlite \
     swig \
     which \

--- a/ci/fedora-44/Dockerfile
+++ b/ci/fedora-44/Dockerfile
@@ -26,6 +26,7 @@ RUN dnf -y install \
     python3 \
     python3-devel \
     python3-pip\
+    rapidjson-devel \
     sqlite \
     swig \
     which \

--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -6,7 +6,7 @@ set -e
 set -x
 
 brew update
-brew install -y cmake cppzmq openssl@3 python@3 swig bison flex ccache libmaxminddb dnsmasq krb5
+brew install -y cmake cppzmq openssl@3 python@3 swig bison flex ccache libmaxminddb dnsmasq krb5 rapidjson
 
 which python3
 python3 --version

--- a/ci/opensuse-leap-16.0/Dockerfile
+++ b/ci/opensuse-leap-16.0/Dockerfile
@@ -25,6 +25,7 @@ RUN zypper refresh \
     python313 \
     python313-devel \
     python313-pip \
+    rapidjson-devel \
     swig \
     tar \
     which \

--- a/ci/opensuse-tumbleweed/Dockerfile
+++ b/ci/opensuse-tumbleweed/Dockerfile
@@ -32,6 +32,7 @@ RUN zypper refresh \
     python3 \
     python3-devel \
     python3-pip \
+    rapidjson-devel \
     swig \
     tar \
     util-linux \

--- a/ci/ubuntu-22.04/Dockerfile
+++ b/ci/ubuntu-22.04/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get -y install \
     python3-pip\
     python3-semantic-version \
     python3-venv \
+    rapidjson-dev \
     ruby \
     sqlite3 \
     swig \

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get -y install \
     python3-pip \
     python3-semantic-version \
     python3-venv \
+    rapidjson-dev \
     redis-server \
     ruby \
     sqlite3 \

--- a/ci/ubuntu-26.04/Dockerfile
+++ b/ci/ubuntu-26.04/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get -y install \
     python3-dev \
     python3-pip \
     python3-venv \
+    rapidjson-dev \
     ruby \
     sqlite3 \
     swig \

--- a/doc/building-from-source.rst
+++ b/doc/building-from-source.rst
@@ -46,6 +46,7 @@ development headers for libraries:
     * Make
     * OpenSSL (https://www.openssl.org)
     * Python 3.9 or greater (https://www.python.org/)
+    * RapidJSON (https://rapidjson.org/)
     * SWIG (https://www.swig.org)
     * ZeroMQ 4.3.0 or greater (https://zeromq.org)
     * Zlib (https://zlib.net/)
@@ -56,7 +57,7 @@ To install these, you can use:
 
   .. code-block:: console
 
-     sudo dnf install bison cmake cppzmq-devel gcc gcc-c++ flex libpcap-devel make openssl-devel python3 python3-devel python3-venv swig zlib-devel
+     sudo dnf install bison cmake cppzmq-devel gcc gcc-c++ flex libpcap-devel make openssl-devel python3 python3-devel python3-venv rapidjson-devel swig zlib-devel
 
   Additionally, on RHEL/CentOS 9, you can install and activate a devtoolset_ to get access
   to recent GCC versions. For example:
@@ -78,7 +79,7 @@ To install these, you can use:
 
   .. code-block:: console
 
-     sudo apt-get install bison cmake cppzmq-dev gcc g++ flex libfl-dev libpcap-dev libssl-dev make python3 python3-dev python3-venv swig zlib1g-dev
+     sudo apt-get install bison cmake cppzmq-dev gcc g++ flex libfl-dev libpcap-dev libssl-dev make python3 python3-dev python3-venv rapidjson-dev swig zlib1g-dev
 
   If your platform doesn't offer ``cppzmq-dev``, try ``libzmq3-dev``
   instead. Zeek's build will fall back to an in-tree version of C++
@@ -91,7 +92,7 @@ To install these, you can use:
 
   .. code-block:: console
 
-      sudo pkg install -y base64 bash bison cmake cppzmq git python3 swig
+      sudo pkg install -y base64 bash bison cmake cppzmq git python3 rapidjson swig
       pyver=`python3 -c 'import sys; print(f"py{sys.version_info[0]}{sys.version_info[1]}")'`
       sudo pkg install -y $pyver-sqlite3
 
@@ -115,7 +116,7 @@ To install these, you can use:
   MacPorts_, or Fink_). Specifically for Homebrew, the ``bison``, ``cmake``,
   ``cppzmq``, ``flex``, ``swig``, and ``openssl`` packages
   provide the required dependencies.  For MacPorts, use the ``bison``, ``cmake``,
-  ``cppzmq``, ``flex``, ``swig``, ``swig-python``, and ``openssl`` packages.
+  ``cppzmq``, ``flex``, ``swig``, ``swig-python``, ``rapidjson`` and ``openssl`` packages.
 
 * Windows
 

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get -q update \
      python3-minimal \
      python3-dev \
      python3-venv \
+     rapidjson-dev \
      swig \
      ninja-build \
      python3-pip \

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -1300,7 +1300,7 @@ static zeek::expected<ValPtr, std::string> BuildVal(const rapidjson::Value& j, c
 zeek::expected<ValPtr, std::string> detail::ValFromJSON(std::string_view json_str, const TypePtr& t,
                                                         const FuncPtr& key_func) {
     rapidjson::Document doc;
-    rapidjson::ParseResult ok = doc.Parse(json_str.data(), json_str.length());
+    rapidjson::ParseResult ok = doc.Parse<rapidjson::kParseFullPrecisionFlag>(json_str.data(), json_str.length());
 
     if ( ! ok )
         return zeek::unexpected<std::string>(

--- a/src/Val.cc
+++ b/src/Val.cc
@@ -350,7 +350,7 @@ static bool UsesJSONStringType(const TypePtr& t) {
 static void BuildJSON(json::detail::NullDoubleWriter& writer, Val* val, bool only_loggable = false,
                       RE_Matcher* re = nullptr, const string& key = "", bool interval_as_double = false) {
     if ( ! key.empty() )
-        writer.Key(key);
+        writer.Key(key.c_str(), static_cast<rapidjson::SizeType>(key.size()));
 
     // If the value wasn't set, write a null into the stream and return.
     if ( ! val ) {

--- a/src/supervisor/Supervisor.cc
+++ b/src/supervisor/Supervisor.cc
@@ -26,8 +26,6 @@
 #include <windows.h>
 #endif
 
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define RAPIDJSON_HAS_STDSTRING 1
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>

--- a/src/telemetry/Manager.cc
+++ b/src/telemetry/Manager.cc
@@ -2,9 +2,6 @@
 
 #include "zeek/telemetry/Manager.h"
 
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define RAPIDJSON_HAS_STDSTRING 1
-
 // CivetServer is from the civetweb submodule in prometheus-cpp
 #include <CivetServer.h>
 #include <fnmatch.h>

--- a/src/threading/formatters/JSON.cc
+++ b/src/threading/formatters/JSON.cc
@@ -115,7 +115,7 @@ Value* JSON::ParseValue(const std::string& s, const std::string& name, TypeTag t
 
 void JSON::BuildJSON(zeek::json::detail::NullDoubleWriter& writer, Value* val, const std::string& name) const {
     if ( ! name.empty() )
-        writer.Key(name);
+        writer.Key(name.c_str(), static_cast<rapidjson::SizeType>(name.size()));
 
     if ( ! val->present ) {
         writer.Null();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,7 @@
     "libpcap",
     "openssl",
     "pcre",
+    "rapidjson",
     {
       "name": "zeromq",
       "features": [


### PR DESCRIPTION
It seems all of the supported distros contain a rapidjson package and we've stopped including rapidjson headers in include/ a long time ago. Switch the build over to using find_package() instead of vendoring and update NEWS and build instructions.

Some fixups for Key(), because at least on my system, the older RapidJSON version didn't yet have Key() supporting std::string, so use c_str() and size() for backwards compat here instead.

Relates to #3131 from 3 years ago and #5698.

---

Requires https://github.com/zeek/cmake/pull/154