### PR TITLE
Modernize ReaderFrontend::name to std::string

### DIFF
--- a/src/input/ReaderFrontend.cc
+++ b/src/input/ReaderFrontend.cc
@@ -31,7 +31,7 @@ ReaderFrontend::ReaderFrontend(const ReaderBackend::ReaderInfo& arg_info, EnumVa
     info = new ReaderBackend::ReaderInfo(arg_info);
 
     const char* t = type->GetType()->AsEnumType()->Lookup(type->InternalInt());
-    name = util::copy_string(util::fmt("%s/%s", arg_info.source, t));
+    name = std::string(arg_info.source ? arg_info.source : "") + "/" + (t ? t : "");
 
     backend = input_mgr->CreateBackend(this, type);
     assert(backend);
@@ -45,10 +45,7 @@ void ReaderFrontend::Stop() {
     }
 }
 
-ReaderFrontend::~ReaderFrontend() {
-    delete[] name;
-    delete info;
-}
+ReaderFrontend::~ReaderFrontend() { delete info; }
 
 void ReaderFrontend::Init(const int arg_num_fields, const threading::Field* const* arg_fields) {
     if ( disabled )
@@ -76,6 +73,6 @@ void ReaderFrontend::Update() {
     backend->SendIn(new UpdateMessage(backend));
 }
 
-const char* ReaderFrontend::Name() const { return name; }
+const char* ReaderFrontend::Name() const { return name.c_str(); }
 
 } // namespace zeek::input

--- a/src/input/ReaderFrontend.h
+++ b/src/input/ReaderFrontend.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "zeek/input/ReaderBackend.h"
 #include "zeek/threading/SerialTypes.h"
 
@@ -133,7 +135,7 @@ private:
     int num_fields;                        // Information as passed to Init().
     bool disabled;                         // True if disabled.
     bool initialized;                      // True if initialized.
-    const char* name;                      // Descriptive name.
+    std::string name;                      // Descriptive name.
 };
 
 } // namespace input


### PR DESCRIPTION
Replace the raw char* name member with std::string, removing the manual copy_string/delete[] lifecycle and the dependency on util::fmt()'s static buffer.