### PR TITLE
Revert exclusion of doctest from tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ DIST_EXCLUDE = \
 	auxil/prometheus-cpp/3rdparty/googletest \
 	auxil/rapidjson/thirdparty/gtest \
 	auxil/spicy/3rdparty/benchmark \
-	auxil/spicy/3rdparty/doctest \
 	auxil/spicy/3rdparty/justrx/3rdparty/benchmark \
 	auxil/spicy/3rdparty/libunistd \
 	auxil/spicy/3rdparty/vcpkg


### PR DESCRIPTION
Looks like it was just doctest that was breaking tarball builds. This needs to go into the 9.0 release branch.

Fixes #5821