### PR TITLE
Fix some Clang 23 transitive includes

### DIFF
--- a/tools/bifcl/bif_arg.cc
+++ b/tools/bifcl/bif_arg.cc
@@ -4,6 +4,7 @@
 
 #include <cstdarg>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 
 const bif_type_info bif_types[] = {

--- a/tools/gen-zam/Gen-ZAM.cc
+++ b/tools/gen-zam/Gen-ZAM.cc
@@ -2,6 +2,7 @@
 
 #include "Gen-ZAM.h"
 
+#include <algorithm>
 #include <cctype>
 #include <cstring>
 #include <map>


### PR DESCRIPTION
I tried out the Clang 23.1 RC and these popped up as errors, where `transform` and `exit` were undeclared.

just getting ahead of things and why not