### PR TITLE
Remove GitPython dependency from docs builds

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,32 +65,8 @@ try:
     with open("../VERSION") as f:
         version = f.readline().strip()
 except:
-    try:
-        import re
-
-        import git
-
-        repo = git.Repo(os.path.abspath("."))
-        version = "git/master"
-
-        version_tag_re = r"v\d+\.\d+(\.\d+)?"
-        version_tags = [
-            t
-            for t in repo.tags
-            if t.commit == repo.head.commit and re.match(version_tag_re, str(t))
-        ]
-        # Note: sorting by tag date doesn't necessarily give correct
-        # order in terms of version numbers, but doubtful that will ever be
-        # a problem (if we ever do re-tag an old version number on a given
-        # commit such that it is incorrectly found as the most recent version,
-        # we can just re-tag all the other version numbers on that same commit)
-        version_tags = sorted(version_tags, key=lambda t: t.tag.tagged_date)
-
-        if version_tags:
-            version = str(version_tags[-1])
-
-    except:
-        pass
+    print("VERSION file is missing")
+    sys.exit(1)
 
 # The full version, including alpha/beta/rc tags.
 release = version

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,4 +4,3 @@ sphinx-rtd-theme==3.0.2
 # This version is the last version that supports Python 3.9.
 # 8.1.x is the last version series that supports Python 3.10.
 Sphinx==7.4.7
-GitPython==3.1.58


### PR DESCRIPTION
This is a holdover from when zeek-docs was a separate repo and the build might have to use the version tag from that repo instead of Zeek's VERSION. Now that we merged them, the VERSION file should always exist. Report an error if it doesn't and exit the build.

Having GitPython as a dependency here is annoying because we've updated it multiple times for Dependabot findings, for something we don't even need.