### PR TITLE
tools/systemd-generator: Ensure short hostname is used

### DIFF
--- a/tools/systemd-generator/src/zeek-cluster-config.cc
+++ b/tools/systemd-generator/src/zeek-cluster-config.cc
@@ -770,6 +770,12 @@ std::optional<std::string> gethostname() {
         return std::nullopt;
     }
 
+    // Use the short hostname only. The system's hostname as returned by
+    // gethostname() may contain a domain part if that was included in a
+    // call to sethostname(). Truncate by replacing the first dot with 0.
+    if ( auto* dot = strchr(buf, '.'); dot )
+        *dot = '\0';
+
     return buf;
 }
 


### PR DESCRIPTION
@dopheide-esnet reports that he needed to set the hostname part of `etc/zeek/cluster/<hostname>.zeek.conf` to the FQDN of their systems. That wasn't the intention and instead should've only used the short name. There's no guarantee that gethostname() returns the short name as that depends on what the hostname was actually set to and it's valid to include the domain part.