### PR TITLE
Adjust btest directory and file ignore lists

### DIFF
--- a/testing/btest/btest.cfg
+++ b/testing/btest/btest.cfg
@@ -7,8 +7,8 @@ build_dir = build
 TestDirs    = af_packet doc bifs language core scripts coverage signatures plugins broker spicy supervisor telemetry javascript misc opt dns_mgr cluster tools
 TmpDir      = %(testbase)s/.tmp
 BaselineDir = %(testbase)s/Baseline
-IgnoreDirs  = .svn CVS .tmp
-IgnoreFiles = *.tmp *.swp .clang-format #* *.pcap .DS_Store
+IgnoreDirs  = .tmp
+IgnoreFiles = *.tmp *.swp .clang-format *~ #* *.pcap *.pcapng .DS_Store
 MinVersion  = 0.63
 
 [environment]


### PR DESCRIPTION
This does two things:
- Removes .svn and CVS from the list of directories ignored by btest. Neither of these have existed in our tree for a long time and I don't know why we're still ignoring them.
- Fixes something about btest that's bothered me for a very long time, by ignoring emacs's `~` backup files. When I create a new file in the btest tree but haven't committed it to git yet, emacs creates an empty file with the same name with suffixed with `~`. Btest then complains because it can't tell the difference between the original file and the backup, forcing me to delete the backup file. It's an extra step I'd like to stop having to do.