### PR TITLE
Revert python3-venv dependency additions

### DIFF
--- a/ci/debian-12/Dockerfile
+++ b/ci/debian-12/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get update && apt-get -y install \
     python3 \
     python3-dev \
     python3-pip\
-    python3-venv \
     sqlite3 \
     swig \
     wget \

--- a/ci/debian-13/Dockerfile
+++ b/ci/debian-13/Dockerfile
@@ -30,7 +30,6 @@ RUN apt-get update && apt-get -y install \
     python3 \
     python3-dev \
     python3-pip\
-    python3-venv \
     python3-websockets \
     sqlite3 \
     swig \

--- a/ci/debian-unstable/Dockerfile
+++ b/ci/debian-unstable/Dockerfile
@@ -29,8 +29,7 @@ RUN apt-get update && apt-get -y install \
     make \
     python3 \
     python3-dev \
-    python3-pip \
-    python3-venv \
+    python3-pip\
     sqlite3 \
     swig \
     wget \

--- a/ci/ubuntu-22.04/Dockerfile
+++ b/ci/ubuntu-22.04/Dockerfile
@@ -30,7 +30,6 @@ RUN apt-get update && apt-get -y install \
     python3-git \
     python3-pip\
     python3-semantic-version \
-    python3-venv \
     ruby \
     sqlite3 \
     swig \

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -46,7 +46,6 @@ RUN apt-get update && apt-get -y install \
     python3-git \
     python3-pip \
     python3-semantic-version \
-    python3-venv \
     redis-server \
     ruby \
     sqlite3 \

--- a/ci/ubuntu-26.04/Dockerfile
+++ b/ci/ubuntu-26.04/Dockerfile
@@ -31,7 +31,6 @@ RUN apt-get update && apt-get -y install \
     python3 \
     python3-dev \
     python3-pip \
-    python3-venv \
     ruby \
     sqlite3 \
     swig \

--- a/doc/building-from-source.rst
+++ b/doc/building-from-source.rst
@@ -56,7 +56,7 @@ To install these, you can use:
 
   .. code-block:: console
 
-     sudo dnf install bison cmake cppzmq-devel gcc gcc-c++ flex libpcap-devel make openssl-devel python3 python3-devel python3-venv swig zlib-devel
+     sudo dnf install bison cmake cppzmq-devel gcc gcc-c++ flex libpcap-devel make openssl-devel python3 python3-devel swig zlib-devel
 
   Additionally, on RHEL/CentOS 9, you can install and activate a devtoolset_ to get access
   to recent GCC versions. For example:
@@ -78,7 +78,7 @@ To install these, you can use:
 
   .. code-block:: console
 
-     sudo apt-get install bison cmake cppzmq-dev gcc g++ flex libfl-dev libpcap-dev libssl-dev make python3 python3-dev python3-venv swig zlib1g-dev
+     sudo apt-get install bison cmake cppzmq-dev gcc g++ flex libfl-dev libpcap-dev libssl-dev make python3 python3-dev swig zlib1g-dev
 
   If your platform doesn't offer ``cppzmq-dev``, try ``libzmq3-dev``
   instead. Zeek's build will fall back to an in-tree version of C++

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -38,7 +38,6 @@ RUN apt-get -q update \
      make \
      python3-minimal \
      python3-dev \
-     python3-venv \
      swig \
      ninja-build \
      python3-pip \


### PR DESCRIPTION
At this point, the dependency isn't actually used anymore and there's been feedback from @leres  that using Python virtualenvs for bundling dependencies is problematic for the FreeBSD ports collection.

Drop the installation of `python3-venv` from the Dockerfile and remove the mention from the documentation to avoid confusion.

@timwoj - this should go into `release/9.0`.