### PR TITLE
btest/broker/remote_id: Remove Broker::PEER_UNAVAILABLE errors from stderr

### DIFF
--- a/testing/btest/broker/remote_id.zeek
+++ b/testing/btest/broker/remote_id.zeek
@@ -15,7 +15,7 @@
 #
 # @TEST-EXEC: btest-diff send/.stdout
 # @TEST-EXEC: btest-diff recv/.stdout
-# @TEST-EXEC: btest-diff send/.stderr
+# @TEST-EXEC: TEST_DIFF_CANONIFIER='grep -v PEER_UNAVAILABLE' btest-diff send/.stderr
 # @TEST-EXEC: btest-diff recv/.stderr
 
 # @TEST-START-FILE send.zeek


### PR DESCRIPTION
When sender peers too early, it produces the following output on stderr:

    Broker error (Broker::PEER_UNAVAILABLE): (00000000-0000-0000-0000-000000000000, *127.0.0.1:1618, "unable to connect to remote peer")

Remove it via TEST_DIFF_CANONIFIER from stderr as done elsewhere.