### PR TITLE
CircleCI: Move some builds out of building too often

### DIFF
--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -957,6 +957,13 @@ _filter_if_pr_not_full_or_zeekctl: &FILTER_IF_PR_NOT_FULL_OR_ZEEKCTL
              and not pipeline.parameters.pr_label_full
              and not pipeline.parameters.pr_label_zeekctl))
 
+_filter_if_pr_not_full_or_windows: &FILTER_IF_PR_NOT_FULL_OR_WINDOWS
+  filters: |
+    not (pipeline.parameters.pr_label_skip_all
+         or (pipeline.event.name == "pull_request"
+             and not pipeline.parameters.pr_label_full
+             and not pipeline.parameters.pr_label_windows))
+
 _filter_nightly_or_tagged: &FILTER_NIGHTLY_OR_TAGGED
   filters: |
     pipeline.schedule.name == "nightly" or pipeline.parameters.has_release_tag
@@ -1276,7 +1283,7 @@ workflows:
       #     << : *FILTER_IF_PR_NOT_FULL_CI
 
       - windows-build:
-          << : *FILTER_IF_SKIP_ALL
+          << : *FILTER_IF_PR_NOT_FULL_OR_WINDOWS
 
       - release-image-build:
           name: amd64-container-image

--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -1158,7 +1158,7 @@ workflows:
             CXX="clang++-22"
             CXXFLAGS="-stdlib=libc++"
             ZEEK_CI_CONFIGURE_FLAGS_EXTRA="--disable-javascript"
-          << : *FILTER_IF_PR_NOT_FULL_CI
+          << : *FILTER_NIGHTLY_OR_TAGGED
       - linux-build:
           name: ubuntu-24.04-clang-tidy
           docker_image: zeek/zeek-ci:ubuntu-24.04
@@ -1169,7 +1169,7 @@ workflows:
             CC="clang-22"
             CXX="clang++-22"
           enable_tests: false
-          << : *FILTER_IF_PR_NOT_FULL_CI
+          << : *FILTER_NIGHTLY_OR_TAGGED
       - linux-build:
           name: ubuntu-24.04-spicy
           docker_image: zeek/zeek-ci:ubuntu-24.04


### PR DESCRIPTION
This PR does two things:

- Make Windows only build on pushes to master. The Windows builds use a lot of credits, and a signal that they're failing on pushes to master is enough.
- Make libcpp and clang-tidy builds only run nightly.