### PR TITLE
Fix undefined behavior in Ascii::Timestamp when localtime_r fails

### DIFF
--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -843,8 +843,10 @@ string Ascii::Timestamp(double t) {
 
     struct tm tmbuf;
     struct tm* tm = localtime_r(&teatime, &tmbuf);
-    if ( tm == nullptr )
+    if ( tm == nullptr ) {
         Error(Fmt("localtime_r failed: %s", Strerror(errno)));
+        return string("unknown-timestamp");
+    }
 
     char tmp[128];
     const char* const date_fmt = "%Y-%m-%d-%H-%M-%S";


### PR DESCRIPTION


**Problem**
When `localtime_r()` returns `nullptr` (e.g., for very large or negative timestamps), the code calls `Error()` but does not return. Execution continues to `strftime()` with a null `tm` pointer, causing a crash. The `Error()` method in `MsgThread` only sends a message to the main thread and does not stop the current function.

**Solution**
Added a `return` statement after `Error()` to return a fallback string (`"unknown-timestamp"`). This avoids the null pointer dereference and allows the logging system to continue gracefully.



**Impact**
- Prevents segmentation faults in ASCII log writers.
- Improves robustness when handling malformed timestamps.
- No breaking changes; fallback string is clearly distinguishable.

**Merge Readiness**
This branch can be automatically merged upon approval.

@BoxStrikesTeam