### PR TITLE
mysql: Skip enqueueing mysql_auth_more_data() if not implemented

### DIFF
--- a/src/analyzer/protocol/mysql/mysql-analyzer.pac
+++ b/src/analyzer/protocol/mysql/mysql-analyzer.pac
@@ -198,10 +198,11 @@ refine flow MySQL_Flow += {
 
 	function proc_auth_more_data(msg: AuthMoreData): bool
 		%{
-		zeek::BifEvent::enqueue_mysql_auth_more_data(connection()->zeek_analyzer(),
-		                                             connection()->zeek_analyzer()->Conn(),
-		                                             ${is_orig},
-		                                             to_stringval(${msg.data}));
+		if ( mysql_auth_more_data )
+			zeek::BifEvent::enqueue_mysql_auth_more_data(connection()->zeek_analyzer(),
+								     connection()->zeek_analyzer()->Conn(),
+								     ${is_orig},
+								     to_stringval(${msg.data}));
 		return true;
 		%}
 


### PR DESCRIPTION
This seems and oversight. If there's no mysql_auth_more_data() handler, no need to enqueue any events for this.