### PR TITLE
writers/acii: Fix clang-tidy repeated return type warning

### DIFF
--- a/src/logging/writers/ascii/Ascii.cc
+++ b/src/logging/writers/ascii/Ascii.cc
@@ -845,7 +845,7 @@ string Ascii::Timestamp(double t) {
     struct tm* tm = localtime_r(&teatime, &tmbuf);
     if ( tm == nullptr ) {
         Error(Fmt("localtime_r failed: %s", Strerror(errno)));
-        return string("unknown-timestamp");
+        return "unknown-timestamp";
     }
 
     char tmp[128];


### PR DESCRIPTION
Fixup for 6434fb7b0ffa8df53e9a5975db17f0e8fa0488d2
