### PR TITLE
CCI: Run clang-tidy-diff.py on changes during ubuntu-24.04 job

### DIFF
--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -300,6 +300,10 @@ jobs:
         description: Flag for whether to run the fuzzer tests after the regular tests
         type: boolean
         default: false
+      enable_clang_tidy_diff:
+        description: Flag for whether to run clang-tidy-diff after the build on the changes in a branch.
+        type: boolean
+        default: false
       enable_benchmarks:
         description: Flag for whether the benchmarks should run after building. If this is true, the store_install_tarball parameter must be true as well.
         type: boolean
@@ -429,6 +433,12 @@ jobs:
             - run:
                 name: Run benchmarks
                 command: ci/benchmark.sh
+      - when:
+          condition: << parameters.enable_clang_tidy_diff >>
+          steps:
+            - run:
+                name: Run clang-tidy-diff.py on the changes between origin/master and HEAD
+                command: ci/run-clang-tidy-diff.sh
       - run:
           name: Show ccache statistics and prune
           command: |
@@ -1140,6 +1150,7 @@ workflows:
           requires: [fetch-test-traces, build-image-ubuntu-24.04]
           store_install_tarball: true
           enable_benchmarks: true
+          enable_clang_tidy_diff: true
           << : *FILTER_IF_SKIP_ALL
       - linux-build:
           name: ubuntu-24.04-clang-libcpp

--- a/ci/run-clang-tidy-diff.sh
+++ b/ci/run-clang-tidy-diff.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+set -e
+
+DIFF_BASE=${DIFF_BASE:-origin/master}
+DIFF_HEAD=${DIFF_HEAD:-HEAD}
+BUILD_DIR=${BUILD_DIR:-./build}
+CPUS=${ZEEK_CI_CPUS:-$(nproc)}
+
+CLANG_TIDY_DIFF=${CLANG_TIDY_DIFF:-$(which clang-tidy-diff.py)}
+
+if [ -z "${CLANG_TIDY_DIFF}" ]; then
+    echo "missing clang-tidy-diff.py" >&2
+    exit 1
+fi
+
+exec git diff -U0 "${DIFF_BASE}"..."${DIFF_HEAD}" | "$CLANG_TIDY_DIFF" -j "${CPUS}" -p 1 -path "${BUILD_DIR}"

--- a/ci/ubuntu-24.04/Dockerfile
+++ b/ci/ubuntu-24.04/Dockerfile
@@ -64,6 +64,7 @@ RUN gem install coveralls-lcov
 # Ubuntu installs clang versions with the binaries having the version number
 # appended. Create a symlink for clang-tidy so cmake finds it correctly.
 RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-22 1000
+RUN update-alternatives --install /usr/bin/clang-tidy-diff.py clang-tidy-diff.py /usr/bin/clang-tidy-diff-22.py 1000
 
 # Download a newer pre-built ccache version that recognizes -fprofile-update=atomic
 # which is used when building with --coverage.

--- a/doc/advanced/devel/hacking.rst
+++ b/doc/advanced/devel/hacking.rst
@@ -120,6 +120,21 @@ running Zeek.
 
 See also :ref:`Troubleshooting <troubleshooting>`.
 
+clang-tidy
+^^^^^^^^^^
+
+To run Zeek's configured `clang-tidy <https://clang.llvm.org/extra/clang-tidy/>`_
+checks changes in your branch (after committing), use the ``ci/run-clang-tidy-diff.sh``
+helper script to run ``clang-tidy-diff.py``:
+
+.. code-block:: shell
+
+    # ./ci/run-clang-tidy-diff.sh
+    <...>/src/logging/writers/ascii/Ascii.cc:848:16: error: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list,-warnings-as-errors]
+      848 |         return string("unknown-timestamp");
+          |                ^
+
+
 Compile Commands
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Motivated by #5874. If only a few files are changed, I don't think the job will take a lot more time. And for shotgun changes it might, but maybe that's okay or we can explicitly do an opt-out if it's annoying?