### PR TITLE
Fix missing size check for encapsulation connections

### DIFF
--- a/src/TunnelEncapsulation.h
+++ b/src/TunnelEncapsulation.h
@@ -169,7 +169,7 @@ public:
      * Return the tunnel type of the inner-most tunnel.
      */
     BifEnum::Tunnel::Type LastType() const {
-        return conns ? (*conns)[conns->size() - 1].Type() : BifEnum::Tunnel::NONE;
+        return conns && ! conns->empty() ? conns->back().Type() : BifEnum::Tunnel::NONE;
     }
 
     /**


### PR DESCRIPTION
This is a really minor fixup to the size check in `EncapsulationStack::LastType()`. `conns` is almost always valid and has elements in it, so it's unlikely this would get triggered, but it's best to check anyways.