### PR TITLE
Save existing docker image during multiarch builds

### DIFF
--- a/.circleci/builds.yml
+++ b/.circleci/builds.yml
@@ -622,7 +622,10 @@ jobs:
             LAST_SHA=$(docker inspect -f "{{ index .Config.Labels \"org.opencontainers.image.revision\" }}" ${IMAGE_TAG} 2>/dev/null || true)
 
             if [ "${LAST_SHA}" = "${CIRCLE_SHA1}" ]; then
-              echo "Image already built for this commit, skipping."
+              echo "Image already built for this commit, saving existing image."
+              mkdir -p /tmp/zeek_images/${IMAGE_ARCH}
+              docker save -o /tmp/zeek_images/${IMAGE_ARCH}/final.image ${IMAGE_TAG}
+
               circleci-agent step halt
             fi
       - run:


### PR DESCRIPTION
If an image with the right commit hash was found during the build, we don't save off the `final.image` into the cache which causes the later build multiarch step to fail. This PR changes it to save the existing image to disk instead of just skipping the job entirely. It's still a fast exit but allows the follow-up step to continue as well.

Fixes #5879 